### PR TITLE
Fix readme for importing javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If your application needs to generate code from the Blockly blocks, you'll want 
 ```js
 import 'blockly/python';
 ```
-to include the Python generator, you can also import ``blockly/js``, ``blockly/php``, ``blockly/dart`` and ``blockly/lua``.
+to include the Python generator, you can also import ``blockly/javascript``, ``blockly/php``, ``blockly/dart`` and ``blockly/lua``.
 
 #### Blockly Languages
 


### PR DESCRIPTION
Update readme to the correct path for importing the javascript generator from npm.