### PR TITLE
Batch events for writing to the database.

### DIFF
--- a/blockly-rtc/server/db.js
+++ b/blockly-rtc/server/db.js
@@ -22,14 +22,14 @@
 
 const sqlite3 = require('sqlite3');
 
-const db = new sqlite3.Database('./events.sqlite', (err) => {
+const db = new sqlite3.Database('./eventsdb.sqlite', (err) => {
   if (err) {
     return console.error(err.message);
   };
   console.log('successful connection');
-  let sql = `CREATE TABLE IF NOT EXISTS events(
+  let sql = `CREATE TABLE IF NOT EXISTS eventsdb(
       serverId INTEGER PRIMARY KEY,
-      entryId TEXT, event BLOB);`;
+      entryId TEXT, events BLOB);`;
   db.run(sql, function(err) {
     if (err) {
       return console.error(err.message);

--- a/blockly-rtc/src/WorkspaceClient.js
+++ b/blockly-rtc/src/WorkspaceClient.js
@@ -22,7 +22,6 @@
  */
 
 import {getEvents, writeEvents} from './api';
-import Blockly from 'blockly';
 
 /**
  * An action to be performed on the workspace.
@@ -32,9 +31,18 @@ import Blockly from 'blockly';
  */
 
 /**
+ * A local representation of an entry in the database.
+ * @typedef {Object} LocalEntry
+ * @property {<!Array.<!Object>>} events An array of Blockly Events in JSON
+ * format.
+ * @property {string} entryId The id assigned to an event by the client.
+ */
+
+/**
  * A row from the database.
  * @typedef {Object} Row
- * @property {!Object} event The JSON of a Blockly event.
+ * @property {<!Array.<!Object>>} events An array of Blockly Events in JSON
+ * format.
  * @property {string} entryId The id assigned to an event by the client.
  * @property {string} serverId The id assigned to an event by the server.
  */
@@ -46,7 +54,7 @@ import Blockly from 'blockly';
  */
 export default class WorkspaceClient {
     constructor(workspaceId) {
-        this.workspaceId = workspaceId;
+      this.workspaceId = workspaceId;
         this.lastSync = 0;
         this.inProgress = [];
         this.notSent = [];
@@ -56,29 +64,12 @@ export default class WorkspaceClient {
     };
 
     /**
-     * Create and entry from an event and add it to active changes.
-     * An entry is of the form {"event": Blockly.Event, "entryId": string} where
-     * event is an event created on the workspace and entryId is of the form
-     * {workspaceId}{counter}.
-     * @param {!Object} event The Blockly.Event JSON created by the client.
-     * @public
-     */
-    addEvent(event) {
-        var entryId = this.workspaceId.concat(this.counter);
-        this.counter += 1;
-        this.activeChanges.push({
-            event: event,
-            entryId: entryId
-        });
-    };
-
-    /**
-     * Move events in a Blockly.Events group from activeChanges to notSent.
+     * Add the events in activeChanges to notSent.
      * @public
      */
     flushEvents() {
-        this.notSent = this.notSent.concat(this.activeChanges);
-        this.activeChanges = [];
+      this.notSent = this.notSent.concat(this.activeChanges);
+      this.activeChanges = [];
     };
 
     /**
@@ -87,39 +78,46 @@ export default class WorkspaceClient {
      * @public
      */
     async writeToDatabase() {
-        this.beginWrite_();
-        try {
-            await writeEvents(this.inProgress);
-            this.endWrite_(true);
-        } catch {
-           this.endWrite_(false);
-           throw Error('Failed to write to database.');
-        };
+      this.beginWrite_();
+      try {
+        await writeEvents(this.inProgress[0]);
+        this.endWrite_(true);
+      } catch {
+        this.endWrite_(false);
+        throw Error('Failed to write to database.');
+      };
     };
 
     /**
      * Change status of WorkspaceClient in preparation for the network call.
-     * Set writeInProgress to true and move events from notSent to inProgress.
+     * Set writeInProgress to true, adds a LocalEntry to inProgress based on
+     * the events that were notSent, and clears the notSent array.
      * @private
      */
     beginWrite_() {
-        this.writeInProgress = true;
-        this.inProgress = this.inProgress.concat(this.notSent);
-        this.notSent = [];
+      this.writeInProgress = true;
+      const entryId = this.workspaceId.concat(this.counter);
+      this.counter +=1;
+      this.inProgress.push({
+        events: this.notSent,
+        entryId: entryId
+      }); 
+      this.notSent = [];
     };
-
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
     /**
      * Change status of WorkspaceClient once network call completes.
-     * Change writeInProgress to true. If write was successful events remain in
-     * inProgress, otherwise the inProgress events are moved to the beginning of
-     * notSent.
+     * Change writeInProgress to true. If write was successful, the LocalEntry
+     * remains in inProgress, otherwise, the LocalEntry is deleted and the
+     * events move back to the front of notSent.
      * @param {boolean} success Indicates the success of the database write.
      * @private
      */
     endWrite_(success) {
         if (!success) {
-            this.notSent = this.inProgress.concat(this.notSent);
+            this.notSent = this.inProgress[0].events.concat(this.notSent);
             this.inProgress = [];
+            this.counter -=1;
         };
         this.writeInProgress = false;
     };
@@ -145,7 +143,7 @@ export default class WorkspaceClient {
      * will allow the server and local workspace to converge.
      * @param {<!Array.<!Row>>} rows Rows of event entries retrieved by
      * querying the database.
-     * @returns {<!Array.<!WorkspaceEvent>>} eventQueue An array of events and the
+     * @returns {!Array.<!WorkspaceAction>>} eventQueue An array of events and the
      * direction they should be run.
      * @private
      */
@@ -155,60 +153,69 @@ export default class WorkspaceClient {
       if (rows.length == 0) {
         return eventQueue;
       };
-  
+
       this.lastSync = rows[rows.length - 1].serverId;
   
       // No local changes.
       if (this.notSent.length == 0 && this.inProgress.length == 0) {
         rows.forEach((row) => {
-          eventQueue.push(this.createWorkspaceAction_(row.event, true));
+          eventQueue.push.apply(
+            eventQueue, this.createWorkspaceActions_(row.events, true));
         });
         return eventQueue;
       };
-    
+  
       // Common root, remove common events from server events.
       if (this.inProgress.length > 0 && rows[0].entryId == this.inProgress[0].entryId) {
-        rows = rows.slice(this.inProgress.length);
+        rows.shift();
         this.inProgress = [];
       };
   
       if (rows.length > 0) {
         // Undo local events.
-        this.notSent.slice().reverse().forEach((row) => {
-          eventQueue.push(this.createWorkspaceAction_(row.event, false));
-        });
-        this.inProgress.slice().reverse().forEach((row) => {
-          eventQueue.push(this.createWorkspaceAction_(row.event, false));
-        });
+        eventQueue.push.apply(
+          eventQueue,
+          this.createWorkspaceActions_(this.notSent.slice().reverse(), false));
+        if (this.inProgress.length > 0) {
+          eventQueue.push.apply(eventQueue,this.createWorkspaceActions_(
+            this.inProgress[0].events.slice().reverse(), false));
+        };
         // Apply server events.
         rows.forEach((row) => {
-          eventQueue.push(this.createWorkspaceAction_(row.event, true));
+          eventQueue.push.apply(
+            eventQueue, this.createWorkspaceActions_(row.events, true));
           if (this.inProgress.length > 0 && row.entryId == this.inProgress[0].entryId) {
             this.inProgress.shift();
           };
         });
         // Reapply remaining local changes.
-        this.inProgress.forEach((row) => {
-          eventQueue.push(this.createWorkspaceAction_(row.event, true));
-        });
-        this.notSent.forEach((row) => {
-          eventQueue.push(this.createWorkspaceAction_(row.event, true));
-        });
+        if (this.inProgress.length > 0) {
+          eventQueue.push.apply(
+            eventQueue,
+            this.createWorkspaceActions_(this.inProgress[0].events, true));
+        };
+        eventQueue.push.apply(
+          eventQueue, this.createWorkspaceActions_(this.notSent, true));
       };
       return eventQueue;
     };
 
     /**
-     * Create a WorkspaceAction from an event.
-     * @param {<!Array.<!Object>>} event The JSON of a Blockly event.
+     * Create WorkspaceActions from a list of events.
+     * @param {<!Array.<!Object>>} events An array of Blockly Events in JSON format.
      * @param {boolean} forward Indicates the direction to run an event.
-     * @returns {!WorkspaceEvent} An action to be performed on the workspace.
+     * @returns {<Array.<!WorkspaceEvent>>} An array of actions to be performed
+     * on the workspace.
      * @private
      */
-    createWorkspaceAction_(event, forward) {
-      return {
-        event: event,
-        forward: forward
-      };
+    createWorkspaceActions_(events, forward) {
+      const eventQueue = [];
+      events.forEach((event) => {
+        eventQueue.push({
+          event: event,
+          forward: forward
+        });
+      });
+      return eventQueue;
     };
 };

--- a/blockly-rtc/src/WorkspaceClient.js
+++ b/blockly-rtc/src/WorkspaceClient.js
@@ -52,15 +52,15 @@
  */
 export default class WorkspaceClient {
     constructor(workspaceId, getEventsHandler, addEventsHandler) {
-        this.workspaceId = workspaceId;
-        this.lastSync = 0;
-        this.inProgress = [];
-        this.notSent = [];
-        this.activeChanges = [];
-        this.writeInProgress = false;
-        this.counter = 0;
-        this.getEventsHandler = getEventsHandler;
-        this.addEventsHandler = addEventsHandler;
+      this.workspaceId = workspaceId;
+      this.lastSync = 0;
+      this.inProgress = [];
+      this.notSent = [];
+      this.activeChanges = [];
+      this.writeInProgress = false;
+      this.counter = 0;
+      this.getEventsHandler = getEventsHandler;
+      this.addEventsHandler = addEventsHandler;
     };
 
     /**
@@ -87,14 +87,14 @@ export default class WorkspaceClient {
      * @public
      */
     async writeToDatabase() {
-        this.beginWrite_();
-        try {
-            await this.addEventsHandler(this.inProgress[this.inProgress.length - 1]);
-            this.endWrite_(true);
-        } catch {
-           this.endWrite_(false);
-           throw Error('Failed to write to database.');
-        };
+      this.beginWrite_();
+      try {
+          await this.addEventsHandler(this.inProgress[this.inProgress.length - 1]);
+          this.endWrite_(true);
+      } catch {
+          this.endWrite_(false);
+          throw Error('Failed to write to database.');
+      };
     };
 
     /**
@@ -123,12 +123,12 @@ export default class WorkspaceClient {
      * @private
      */
     endWrite_(success) {
-        if (!success) {
-            this.notSent = this.inProgress[0].events.concat(this.notSent);
-            this.inProgress = [];
-            this.counter -=1;
-        };
-        this.writeInProgress = false;
+      if (!success) {
+          this.notSent = this.inProgress[0].events.concat(this.notSent);
+          this.inProgress = [];
+          this.counter -=1;
+      };
+      this.writeInProgress = false;
     };
 
     /**

--- a/blockly-rtc/src/WorkspaceClient.js
+++ b/blockly-rtc/src/WorkspaceClient.js
@@ -55,12 +55,12 @@ import {getEvents, writeEvents} from './api';
 export default class WorkspaceClient {
     constructor(workspaceId) {
       this.workspaceId = workspaceId;
-        this.lastSync = 0;
-        this.inProgress = [];
-        this.notSent = [];
-        this.activeChanges = [];
-        this.writeInProgress = false;
-        this.counter = 0;
+      this.lastSync = 0;
+      this.inProgress = [];
+      this.notSent = [];
+      this.activeChanges = [];
+      this.writeInProgress = false;
+      this.counter = 0;
     };
 
     /**

--- a/blockly-rtc/src/WorkspaceClient.js
+++ b/blockly-rtc/src/WorkspaceClient.js
@@ -64,6 +64,15 @@ export default class WorkspaceClient {
     };
 
     /**
+     * Add an event to activeChanges.
+     * @param {!Object} event The Blockly.Event JSON created by the client.
+     * @public
+     */
+    addEvent(event) {
+      this.activeChanges.push(event);
+    };
+
+    /**
      * Add the events in activeChanges to notSent.
      * @public
      */
@@ -80,7 +89,7 @@ export default class WorkspaceClient {
     async writeToDatabase() {
       this.beginWrite_();
       try {
-        await writeEvents(this.inProgress[0]);
+        await writeEvents(this.inProgress[this.inProgress.length - 1]);
         this.endWrite_(true);
       } catch {
         this.endWrite_(false);
@@ -177,8 +186,10 @@ export default class WorkspaceClient {
           eventQueue,
           this.createWorkspaceActions_(this.notSent.slice().reverse(), false));
         if (this.inProgress.length > 0) {
-          eventQueue.push.apply(eventQueue,this.createWorkspaceActions_(
-            this.inProgress[0].events.slice().reverse(), false));
+          this.inProgress.slice().reverse().forEach((row) => {
+            eventQueue.push.apply(eventQueue, this.createWorkspaceActions_(
+              row.events.slice().reverse(), false));
+          });
         };
         // Apply server events.
         rows.forEach((row) => {

--- a/blockly-rtc/src/index.js
+++ b/blockly-rtc/src/index.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (event instanceof Blockly.Events.Ui) {
             return;
         };
-        workspaceClient.activeChanges.push(event.toJson());
+        workspaceClient.addEvent(event.toJson());
         if (!Blockly.Events.getGroup()) {
             workspaceClient.flushEvents();
             sendChanges_();

--- a/blockly-rtc/src/index.js
+++ b/blockly-rtc/src/index.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (event instanceof Blockly.Events.Ui) {
             return;
         };
-        workspaceClient.addEvent(event.toJson());
+        workspaceClient.activeChanges.push(event.toJson());
         if (!Blockly.Events.getGroup()) {
             workspaceClient.flushEvents();
             sendChanges_();
@@ -94,7 +94,7 @@ document.addEventListener('DOMContentLoaded', () => {
     /**
      * Run a series of events that allow the order of events on the workspace
      * to converge with the order of events on the database.
-     * @param {<!Array.<!WorkspaceEvent>>} eventQueue An array of events and the
+     * @param {<!Array.<!WorkspaceAction>>} eventQueue An array of events and the
      * direction they should be run.
      * @private
      */

--- a/blockly-rtc/test/workspace_client_test.js
+++ b/blockly-rtc/test/workspace_client_test.js
@@ -33,9 +33,13 @@ suite('WorkspaceClient', () => {
       const workspaceClient = new WorkspaceClient('mockClient');
       workspaceClient.notSent = [1,2,3];
       await workspaceClient.writeToDatabase();
-      assert.deepStrictEqual([], workspaceClient.notSent);
-      assert.deepStrictEqual([1,2,3], workspaceClient.inProgress);
       writeEventsStub.restore();
+      assert.deepStrictEqual([], workspaceClient.notSent);
+      assert.deepStrictEqual([{
+        entryId: 'mockClient0',
+        events: [1,2,3]
+      }], workspaceClient.inProgress);
+      assert.strictEqual(1, workspaceClient.counter);
     });
 
     test('Write fails, error is thrown and events stay in notSent.', async () => {
@@ -43,44 +47,33 @@ suite('WorkspaceClient', () => {
       const workspaceClient = new WorkspaceClient('mockClient');
       workspaceClient.notSent = [1,2,3];
       await assert.rejects(workspaceClient.writeToDatabase());
+      writeEventsStub.restore();
       assert.deepStrictEqual([1,2,3], workspaceClient.notSent);
       assert.deepStrictEqual([], workspaceClient.inProgress);
-    });
-  });
-
-  suite('addEvents()', () => {
-    test('Events added to activeChanges in the correct order with the correct entryId.', async () => {
-      const workspaceClient = new WorkspaceClient('mockClient');
-      workspaceClient.addEvent('mockEvent0');
-      workspaceClient.addEvent('mockEvent1');
-      assert.deepStrictEqual([
-        {event:'mockEvent0', entryId:'mockClient0'},
-        {event:'mockEvent1', entryId:'mockClient1'}
-      ],workspaceClient.activeChanges);
+      assert.strictEqual(0, workspaceClient.counter);
     });
   });
 
   suite('flushEvents()', () => {
-    test('Events in activeChanges are moved to tne end of notSent.', async () => {
+    test('Events in activeChanges are added to the end of notSent.', async () => {
       const workspaceClient = new WorkspaceClient('mockClient');
       workspaceClient.counter = 2;
       workspaceClient.notSent = [
-        {event:'mockEvent0', entryId:'mockClient0'},
-        {event:'mockEvent1', entryId:'mockClient1'}
+        {event: 'mockEvent0'},
+        {event: 'mockEvent1'}
       ];
       workspaceClient.activeChanges = [
-        {event:'mockActiveChange2', entryId:'mockClient2'},
-        {event:'mockActiveChange3', entryId:'mockClient3'}
+        {event: 'mockActiveChange2'},
+        {event: 'mockActiveChange3'}
       ];
       workspaceClient.flushEvents();
       assert.deepStrictEqual(
         [
-          {event:'mockEvent0', entryId:'mockClient0'},
-          {event:'mockEvent1', entryId:'mockClient1'},
-          {event:'mockActiveChange2', entryId:'mockClient2'},
-          {event:'mockActiveChange3', entryId:'mockClient3'}
-        ],
-        workspaceClient.notSent);
+          {event: 'mockEvent0'},
+          {event: 'mockEvent1'},
+          {event: 'mockActiveChange2'},
+          {event: 'mockActiveChange3'}
+        ], workspaceClient.notSent);
       assert.deepStrictEqual([], workspaceClient.activeChanges);
     });
   });
@@ -89,65 +82,62 @@ suite('WorkspaceClient', () => {
     test('Rows is empty.', () => {
       const workspaceClient = new WorkspaceClient('mockClient');
       workspaceClient.inProgress = [
-        {event: {mockEvent: 'mockLocalEvent0'}, entryId:'mockClient0'}
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
       ];
       workspaceClient.notSent = [
-        {event: {mockEvent: 'mockLocalEvent1'}, entryId:'mockClient1'},
-        {event: {mockEvent: 'mockLocalEvent2'}, entryId:'mockClient2'}
+        {mockEvent: 'mockLocalEvent1'},
+        {mockEvent: 'mockLocalEvent2'}
       ];
 
       const eventQueue = workspaceClient.processQueryResults_([]);
 
       assert.deepStrictEqual([], eventQueue);
       assert.equal(0, workspaceClient.lastSync);
-      assert.deepStrictEqual(
-        [
-          {event: {mockEvent: 'mockLocalEvent0'}, entryId:'mockClient0'}
-        ], workspaceClient.inProgress);
-        assert.deepStrictEqual(
-          [
-            {event: {mockEvent: 'mockLocalEvent1'}, entryId:'mockClient1'},
-            {event: {mockEvent: 'mockLocalEvent2'}, entryId:'mockClient2'}
-          ], workspaceClient.notSent);
+      assert.deepStrictEqual([
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
+      ], workspaceClient.inProgress);
+      assert.deepStrictEqual([
+        {mockEvent: 'mockLocalEvent1'},
+        {mockEvent: 'mockLocalEvent2'}
+      ], workspaceClient.notSent);
     });
 
     test('Rows contains all local events.', () => {
       const workspaceClient = new WorkspaceClient('mockClient');
       workspaceClient.inProgress = [
-        {event: {mockEvent: 'mockLocalEvent0'}, entryId:'mockClient0'}
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
       ];
       workspaceClient.notSent = [
-        {event: {mockEvent: 'mockLocalEvent1'}, entryId:'mockClient1'},
-        {event: {mockEvent: 'mockLocalEvent2'}, entryId:'mockClient2'}
+        {mockEvent: 'mockLocalEvent1'},
+        {mockEvent: 'mockLocalEvent2'}
       ];
 
       const eventQueue = workspaceClient.processQueryResults_([
-        {event: {mockEvent:'mockLocalEvent0'}, entryId: 'mockClient0', serverId:1}
+        {events: ['mockLocalEvent0'], entryId: 'mockClient0', serverId:1}
       ]);
 
       assert.deepStrictEqual([], eventQueue);
       assert.equal(1, workspaceClient.lastSync);
       assert.deepStrictEqual([], workspaceClient.inProgress);
       assert.deepStrictEqual([
-        {event: {mockEvent: 'mockLocalEvent1'}, entryId:'mockClient1'},
-        {event: {mockEvent: 'mockLocalEvent2'}, entryId:'mockClient2'}
+        {mockEvent: 'mockLocalEvent1'},
+        {mockEvent: 'mockLocalEvent2'}
       ], workspaceClient.notSent);
     });
 
     test('Rows contains no local changes.', () => {
       const workspaceClient = new WorkspaceClient('mockClient');
       workspaceClient.inProgress = [
-        {event: {mockEvent: 'mockLocalEvent0'}, entryId:'mockClient0'}
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
       ];
       workspaceClient.notSent = [
-        {event: {mockEvent: 'mockLocalEvent1'}, entryId:'mockClient1'},
-        {event: {mockEvent: 'mockLocalEvent2'}, entryId:'mockClient2'}
+        {mockEvent: 'mockLocalEvent1'},
+        {mockEvent: 'mockLocalEvent2'}
       ];
 
       const eventQueue = workspaceClient.processQueryResults_([
-        {event: {mockEvent:'mockExternalEvent0'}, entryId: 'otherClient0', serverId:1}
+        {events: [{mockEvent:'mockExternalEvent0'}], entryId: 'otherClient0', serverId:1}
       ]);
-
       assert.deepStrictEqual([
         {event: {mockEvent: 'mockLocalEvent2'}, forward: false},
         {event: {mockEvent: 'mockLocalEvent1'}, forward: false},
@@ -158,29 +148,27 @@ suite('WorkspaceClient', () => {
         {event: {mockEvent: 'mockLocalEvent2'}, forward: true}
       ], eventQueue);
       assert.equal(1, workspaceClient.lastSync);
-      assert.deepStrictEqual(
-        [
-          {event: {mockEvent: 'mockLocalEvent0'}, entryId:'mockClient0'}
-        ], workspaceClient.inProgress);
-        assert.deepStrictEqual(
-          [
-            {event: {mockEvent: 'mockLocalEvent1'}, entryId:'mockClient1'},
-            {event: {mockEvent: 'mockLocalEvent2'}, entryId:'mockClient2'}
-          ], workspaceClient.notSent);
+      assert.deepStrictEqual([
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
+      ], workspaceClient.inProgress);
+      assert.deepStrictEqual([
+        {mockEvent: 'mockLocalEvent1'},
+        {mockEvent: 'mockLocalEvent2'}
+      ], workspaceClient.notSent);
     });
       
     test('Rows contains local changes followed by external changes.', () => {
       const workspaceClient = new WorkspaceClient('mockClient');
       workspaceClient.inProgress = [
-        {event: {mockEvent: 'mockLocalEvent0'}, entryId: 'mockClient0'}
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
       ];
       workspaceClient.notSent = [
-        {event: {mockEvent: 'mockLocalEvent1'}, entryId:'mockClient1'},
-        {event: {mockEvent: 'mockLocalEvent2'}, entryId:'mockClient2'}
+        {mockEvent:'mockLocalEvent1'},
+        {mockEvent:'mockLocalEvent2'}
       ];
       const eventQueue = workspaceClient.processQueryResults_([
-        {event: {mockEvent:'mockLocalEvent0'}, entryId: 'mockClient0', serverId:1},
-        {event: {mockEvent:'mockExternalEvent0'}, entryId: 'otherClient0', serverId:2}
+        {events: [{mockEvent:'mockLocalEvent0'}], entryId: 'mockClient0', serverId:1},
+        {events: [{mockEvent:'mockExternalEvent0'}], entryId: 'otherClient0', serverId:2}
       ]);
       assert.deepStrictEqual([
         {event: {mockEvent: 'mockLocalEvent2'}, forward: false},
@@ -192,25 +180,25 @@ suite('WorkspaceClient', () => {
       assert.equal(2, workspaceClient.lastSync);
       assert.deepStrictEqual([], workspaceClient.inProgress);
       assert.deepStrictEqual([
-        {event: {mockEvent: 'mockLocalEvent1'}, entryId:'mockClient1'},
-        {event: {mockEvent: 'mockLocalEvent2'}, entryId:'mockClient2'}
+        {mockEvent: 'mockLocalEvent1'},
+        {mockEvent: 'mockLocalEvent2'}
       ], workspaceClient.notSent);
     });
 
     test('Rows contains local changes sandwiched by external changes.', () => {
       const workspaceClient = new WorkspaceClient('mockClient');
       workspaceClient.inProgress = [
-        {event: {mockEvent: 'mockLocalEvent0'}, entryId:'mockClient0'},
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
       ];
       workspaceClient.notSent = [
-        {event: {mockEvent: 'mockLocalEvent1'}, entryId:'mockClient1'},
-        {event: {mockEvent: 'mockLocalEvent2'}, entryId:'mockClient2'}
+        {mockEvent: 'mockLocalEvent1'},
+        {mockEvent: 'mockLocalEvent2'}
       ];
 
       const eventQueue = workspaceClient.processQueryResults_([
-        {event: {mockEvent:'mockExternalEvent0'}, entryId: 'otherClient0', serverId:1},
-        {event: {mockEvent:'mockLocalEvent0'}, entryId: 'mockClient0', serverId:2},
-        {event: {mockEvent:'mockExternalEvent1'}, entryId: 'otherClient1', serverId:3}
+        {events: [{mockEvent:'mockExternalEvent0'}], entryId: 'otherClient0', serverId:1},
+        {events: [{mockEvent:'mockLocalEvent0'}], entryId: 'mockClient0', serverId:2},
+        {events: [{mockEvent:'mockExternalEvent1'}], entryId: 'otherClient1', serverId:3}
       ]);
 
       assert.deepStrictEqual([
@@ -225,11 +213,10 @@ suite('WorkspaceClient', () => {
       ], eventQueue);
       assert.equal(3, workspaceClient.lastSync);
       assert.deepStrictEqual([], workspaceClient.inProgress);
-      assert.deepStrictEqual(
-        [
-          {event: {mockEvent: 'mockLocalEvent1'}, entryId:'mockClient1'},
-          {event: {mockEvent: 'mockLocalEvent2'}, entryId:'mockClient2'}
-        ], workspaceClient.notSent);
+      assert.deepStrictEqual([
+        {mockEvent: 'mockLocalEvent1'},
+        {mockEvent: 'mockLocalEvent2'}
+      ], workspaceClient.notSent);
     });
   });
 


### PR DESCRIPTION
Currently, each event is written to the database as an individual entry.
With this change, the client batches any available events and writes
them to the database as a single entry. By writing all events to the
database in a single entry this removes the need to use a transaction.

Other:
WorkspaceClient.js: this.inProgress was an array of events, now
this.inProgress is an array of LocalEntry objects. Tracking a LocalEntry
object facilitates merging client and server events. Currently, only one
LocalEntry event will exist at a time, however, once websockets are
implemented, inProgress will hold multiple LocalEntry objects.