### PR TITLE
Abstract event handlers away from WorkspaceClient.

### DIFF
--- a/blockly-rtc/src/WorkspaceClient.js
+++ b/blockly-rtc/src/WorkspaceClient.js
@@ -21,7 +21,6 @@
  * @author navil@google.com (Navil Perez)
  */
 
-import {getEvents, writeEvents} from './api';
 import Blockly from 'blockly';
 
 /**
@@ -45,7 +44,7 @@ import Blockly from 'blockly';
  * client corresponds to.
  */
 export default class WorkspaceClient {
-    constructor(workspaceId) {
+    constructor(workspaceId, getEventsHandler, addEventsHandler) {
         this.workspaceId = workspaceId;
         this.lastSync = 0;
         this.inProgress = [];
@@ -53,6 +52,8 @@ export default class WorkspaceClient {
         this.activeChanges = [];
         this.writeInProgress = false;
         this.counter = 0;
+        this.getEventsHandler = getEventsHandler;
+        this.addEventsHandler = addEventsHandler;
     };
 
     /**
@@ -89,7 +90,7 @@ export default class WorkspaceClient {
     async writeToDatabase() {
         this.beginWrite_();
         try {
-            await writeEvents(this.inProgress);
+            await this.addEventsHandler(this.inProgress);
             this.endWrite_(true);
         } catch {
            this.endWrite_(false);
@@ -132,7 +133,7 @@ export default class WorkspaceClient {
      */
     async queryDatabase() {
       try {
-        const rows = await getEvents(this.lastSync);
+        const rows = await this.getEventsHandler(this.lastSync);
         return this.processQueryResults_(rows);
       } catch {
         return [];

--- a/blockly-rtc/src/index.js
+++ b/blockly-rtc/src/index.js
@@ -22,6 +22,7 @@
  */
 
 import * as Blockly from 'blockly';
+import {getEvents, writeEvents} from './api';
 import WorkspaceClient from './WorkspaceClient';
 
 /**
@@ -37,7 +38,8 @@ document.addEventListener('DOMContentLoaded', () => {
             toolbox: document.getElementById('toolbox'),
             media: 'media/'
         });
-    var workspaceClient = new WorkspaceClient(workspace.id);
+    const workspaceClient = new WorkspaceClient(
+        workspace.id, getEvents, writeEvents);
 
     workspace.addChangeListener((event) => {
         if (event instanceof Blockly.Events.Ui) {


### PR DESCRIPTION
A WorkspaceClient object currently uses functions in api.js as event
handlers for interacting with the database. This change allows for
event handlers to be passed into the WorkspaceClient constructor
allowing for more modularity.