### PR TITLE
Return serverId when an entry is added to the database.

### DIFF
--- a/blockly-rtc/server/db_utils.js
+++ b/blockly-rtc/server/db_utils.js
@@ -23,6 +23,14 @@
 const db = require('./db');
 
 /**
+ * A local representation of an entry in the database.
+ * @typedef {Object} LocalEntry
+ * @property {<!Array.<!Object>>} events An array of Blockly Events in JSON
+ * format.
+ * @property {string} entryId The id assigned to an event by the client.
+ */
+
+/**
  * Query the database for rows since the given server id.
  * @param {number} serverId serverId for the lower bound of the query.
  * @return {!Promise} Promise object represents the rows since the last given
@@ -45,22 +53,31 @@ function queryDatabase(serverId) {
 };
 
 /**
- * Add rows to the database.
- * Rows are added transactionally.
- * @param {!Promise} Promise object represents the success of the write.
+ * Add an entry to the database.
+ * @param {!LocalEntry} entry The entry to be added to the database.
+ * @return {!Promise} Promise object with the serverId for the entry if the
+ * write succeeded.
  * @public
  */
 function addToServer(entry) {
 
   return new Promise((resolve, reject) => {
-    db.run('INSERT INTO eventsdb(events, entryId) VALUES(?,?)',
-        [JSON.stringify(entry.events), entry.entryId], (err) => {
-      if (err) {
-        console.error(err.message);
-        reject(err);
-      };
+    db.serialize(() => {
+      db.run('INSERT INTO eventsdb(events, entryId) VALUES(?,?)',
+          [JSON.stringify(entry.events), entry.entryId], (err) => {
+        if (err) {
+          console.error(err.message);
+          reject(err);
+        };
+      });
+      db.each(`SELECT last_insert_rowid() as serverId;`, (err, lastServerId) => {
+        if (err) {
+          console.error(err.message);
+          reject(err);
+        };
+        resolve(lastServerId.serverId);
+      });
     });
-    resolve();
   });
 };
 


### PR DESCRIPTION
After an entry is written to the database return its assigned serverId.
This will support the broadcasting of event once it is written to the
database.