### PR TITLE
Store client entryIds to validate database writes.

### DIFF
--- a/blockly-rtc/server/Database.js
+++ b/blockly-rtc/server/Database.js
@@ -88,7 +88,7 @@ class Database {
    * @param {!LocalEntry} entry The entry to be added to the database.
    * @return {!Promise} Promise object with the serverId for the entry if the
    * write succeeded.
-   * @public
+   * @private
    */
   runInsertQuery_(entry) {
     return new Promise((resolve, reject) => {
@@ -116,7 +116,7 @@ class Database {
    * @param {!string} workspaceId The workspaceId of the client.
    * @return {!Promise} Promise object with the the numerical part of the
    * entryId.
-   * @public
+   * @private
    */
   getLastEntryIdNumber_(workspaceId) {
     return new Promise((resolve, reject) => {

--- a/blockly-rtc/server/db.js
+++ b/blockly-rtc/server/db.js
@@ -27,10 +27,18 @@ const db = new sqlite3.Database('./eventsdb.sqlite', (err) => {
     return console.error(err.message);
   };
   console.log('successful connection');
-  let sql = `CREATE TABLE IF NOT EXISTS eventsdb(
+  const eventsDbSql = `CREATE TABLE IF NOT EXISTS eventsdb(
       serverId INTEGER PRIMARY KEY,
       entryId TEXT, events BLOB);`;
-  db.run(sql, function(err) {
+  db.run(eventsDbSql, function(err) {
+    if (err) {
+      return console.error(err.message);
+    };
+  });
+  const clientTableSql = `CREATE TABLE IF NOT EXISTS clients(
+      workspaceId TEXT,
+      lastEntryNumber INTEGER);`
+  db.run(clientTableSql, function(err) {
     if (err) {
       return console.error(err.message);
     };

--- a/blockly-rtc/src/WorkspaceClient.js
+++ b/blockly-rtc/src/WorkspaceClient.js
@@ -105,7 +105,7 @@ export default class WorkspaceClient {
      */
     beginWrite_() {
       this.writeInProgress = true;
-      const entryId = this.workspaceId.concat(this.counter);
+      const entryId = this.workspaceId + ':' + this.counter;
       this.counter +=1;
       this.inProgress.push({
         events: this.notSent,

--- a/blockly-rtc/test/database_test.js
+++ b/blockly-rtc/test/database_test.js
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Unit tests for Database.
+ * @author navil@google.com (Navil Perez)
+ */
+
+const assert = require('assert');
+const sinon = require('sinon');
+
+const Database = require('../server/Database').Database;
+const database = new Database();
+
+suite('Database', () => {
+
+  suite('addToDatabase()', () => {
+    setup(() => {
+      this.runInsertQueryStub = sinon.stub(database, 'runInsertQuery_');
+      this.getLastEntryIdStub = sinon.stub(database, 'getLastEntryIdNumber_');
+    });
+
+    teardown(() => {
+      database.runInsertQuery_.restore();
+      database.getLastEntryIdNumber_.restore();
+    });
+
+    test('New client, add to database.', async () => {
+      this.getLastEntryIdStub.resolves(-1);
+      this.runInsertQueryStub.resolves(2);
+      const entry = {
+          entryId: 'newMockEntry:1',
+          events: [JSON.stringify({mockEvent:'event'})],
+      };
+      const serverId = await database.addToServer(entry);
+      assert.equal(2, serverId);
+      assert.equal(true, this.runInsertQueryStub.calledOnce);
+    });
+
+    test('Valid entry for existing client, add to database.', async () => {
+      this.getLastEntryIdStub.resolves(2);
+      this.runInsertQueryStub.resolves(2);
+      const entry = {
+          entryId: 'mockEntry:4',
+          events: [JSON.stringify({mockEvent:'event'})],
+      };
+      const serverId = await database.addToServer(entry);
+      assert.equal(2, serverId);
+      assert.equal(true, this.runInsertQueryStub.calledOnce);
+    });
+
+    test('Database write fails, reject.', async () => {
+      this.getLastEntryIdStub.resolves(2);
+      this.runInsertQueryStub.rejects();
+      const entry = {
+          entryId: 'mockEntry:3',
+          events: [JSON.stringify({mockEvent:'event'})],
+      };
+      assert.rejects(database.addToServer(entry));
+    });
+
+    test('Duplicate of last entry, resolve without further action.', async () => {
+      this.getLastEntryIdStub.resolves(2);
+      this.runInsertQueryStub.resolves(null);
+      const entry = {
+          entryId: 'mockEntry:2',
+          events: [JSON.stringify({mockEvent:'event'})],
+      };
+      const serverId = await database.addToServer(entry);
+      assert.equal(null, serverId);
+      assert.equal(true, this.runInsertQueryStub.notCalled);
+    });
+
+    test('Invalid entry, reject.', async () => {
+      this.getLastEntryIdStub.resolves(2);
+      this.runInsertQueryStub.resolves();
+      const entry = {
+          entryId: 'mockEntry:1',
+          events: [JSON.stringify({mockEvent:'event'})],
+      };
+      assert.rejects(database.addToServer(entry));
+      assert.equal(true, this.runInsertQueryStub.notCalled);
+    });
+  });
+});

--- a/blockly-rtc/test/workspace_client_test.js
+++ b/blockly-rtc/test/workspace_client_test.js
@@ -37,7 +37,7 @@ suite('WorkspaceClient', () => {
       writeEventsStub.restore();
       assert.deepStrictEqual([], workspaceClient.notSent);
       assert.deepStrictEqual([{
-        entryId: 'mockClient0',
+        entryId: 'mockClient:0',
         events: [1,2,3]
       }], workspaceClient.inProgress);
       assert.strictEqual(1, workspaceClient.counter);
@@ -99,7 +99,7 @@ suite('WorkspaceClient', () => {
       const workspaceClient = new WorkspaceClient(
         'mockClient', handler.getEvents, handler.writeEvents);
       workspaceClient.inProgress = [
-        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient:0'}
       ];
       workspaceClient.notSent = [
         {mockEvent: 'mockLocalEvent1'},
@@ -111,7 +111,7 @@ suite('WorkspaceClient', () => {
       assert.deepStrictEqual([], eventQueue);
       assert.equal(0, workspaceClient.lastSync);
       assert.deepStrictEqual([
-        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient:0'}
       ], workspaceClient.inProgress);
       assert.deepStrictEqual([
         {mockEvent: 'mockLocalEvent1'},
@@ -123,7 +123,7 @@ suite('WorkspaceClient', () => {
       const workspaceClient = new WorkspaceClient(
         'mockClient', handler.getEvents, handler.writeEvents);
       workspaceClient.inProgress = [
-        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient:0'}
       ];
       workspaceClient.notSent = [
         {mockEvent: 'mockLocalEvent1'},
@@ -131,7 +131,7 @@ suite('WorkspaceClient', () => {
       ];
 
       const eventQueue = workspaceClient.processQueryResults_([
-        {events: ['mockLocalEvent0'], entryId: 'mockClient0', serverId:1}
+        {events: ['mockLocalEvent0'], entryId: 'mockClient:0', serverId:1}
       ]);
 
       assert.deepStrictEqual([], eventQueue);
@@ -147,7 +147,7 @@ suite('WorkspaceClient', () => {
       const workspaceClient = new WorkspaceClient(
         'mockClient', handler.getEvents, handler.writeEvents);
       workspaceClient.inProgress = [
-        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient:0'}
       ];
       workspaceClient.notSent = [
         {mockEvent: 'mockLocalEvent1'},
@@ -155,7 +155,7 @@ suite('WorkspaceClient', () => {
       ];
 
       const eventQueue = workspaceClient.processQueryResults_([
-        {events: [{mockEvent:'mockExternalEvent0'}], entryId: 'otherClient0', serverId:1}
+        {events: [{mockEvent:'mockExternalEvent0'}], entryId: 'otherClient:0', serverId:1}
       ]);
       assert.deepStrictEqual([
         {event: {mockEvent: 'mockLocalEvent2'}, forward: false},
@@ -168,7 +168,7 @@ suite('WorkspaceClient', () => {
       ], eventQueue);
       assert.equal(1, workspaceClient.lastSync);
       assert.deepStrictEqual([
-        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient:0'}
       ], workspaceClient.inProgress);
       assert.deepStrictEqual([
         {mockEvent: 'mockLocalEvent1'},
@@ -180,15 +180,15 @@ suite('WorkspaceClient', () => {
       const workspaceClient = new WorkspaceClient(
         'mockClient', handler.getEvents, handler.writeEvents);
       workspaceClient.inProgress = [
-        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient:0'}
       ];
       workspaceClient.notSent = [
         {mockEvent:'mockLocalEvent1'},
         {mockEvent:'mockLocalEvent2'}
       ];
       const eventQueue = workspaceClient.processQueryResults_([
-        {events: [{mockEvent:'mockLocalEvent0'}], entryId: 'mockClient0', serverId:1},
-        {events: [{mockEvent:'mockExternalEvent0'}], entryId: 'otherClient0', serverId:2}
+        {events: [{mockEvent:'mockLocalEvent0'}], entryId: 'mockClient:0', serverId:1},
+        {events: [{mockEvent:'mockExternalEvent0'}], entryId: 'otherClient:0', serverId:2}
       ]);
       assert.deepStrictEqual([
         {event: {mockEvent: 'mockLocalEvent2'}, forward: false},
@@ -209,7 +209,7 @@ suite('WorkspaceClient', () => {
       const workspaceClient = new WorkspaceClient(
         'mockClient', handler.getEvents, handler.writeEvents);
       workspaceClient.inProgress = [
-        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient0'}
+        {events: [{mockEvent: 'mockLocalEvent0'}], entryId:'mockClient:0'}
       ];
       workspaceClient.notSent = [
         {mockEvent: 'mockLocalEvent1'},
@@ -217,9 +217,9 @@ suite('WorkspaceClient', () => {
       ];
 
       const eventQueue = workspaceClient.processQueryResults_([
-        {events: [{mockEvent:'mockExternalEvent0'}], entryId: 'otherClient0', serverId:1},
-        {events: [{mockEvent:'mockLocalEvent0'}], entryId: 'mockClient0', serverId:2},
-        {events: [{mockEvent:'mockExternalEvent1'}], entryId: 'otherClient1', serverId:3}
+        {events: [{mockEvent:'mockExternalEvent0'}], entryId: 'otherClient:0', serverId:1},
+        {events: [{mockEvent:'mockLocalEvent0'}], entryId: 'mockClient:0', serverId:2},
+        {events: [{mockEvent:'mockExternalEvent1'}], entryId: 'otherClient:1', serverId:3}
       ]);
 
       assert.deepStrictEqual([


### PR DESCRIPTION
A second table in the database will be used to track information about
each client. Current use is for keeping track of the last entryId of
each client. The server will use this information to verify if an entry
it recieved is in the correct order before adding it to the database.