### PR TITLE
MarkerUpdate data model.

### DIFF
--- a/blockly-rtc/package.json
+++ b/blockly-rtc/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "npm run build:frontend",
     "build:frontend": "rimraf ./build && webpack",
+    "postinstall": "cd node_modules/blockly && python build.py -core && npm i && npm run package",
     "serve-http": "concurrently \"npm run serve:frontend\" \"npm run serve:backend-http\"",
     "serve-websocket": "concurrently \"npm run serve:frontend\" \"npm run serve:backend-websocket\"",
     "serve:backend-http": "node server/http_server.js",
@@ -15,7 +16,7 @@
     "test": "mocha test/*test.js"
   },
   "dependencies": {
-    "blockly": "^2.20190722.0",
+    "blockly": "google/blockly#develop",
     "socket.io": "2.3.0",
     "socket.io-client": "2.3.0",
     "sqlite3": "4.1.0"

--- a/blockly-rtc/src/MarkerUpdate.js
+++ b/blockly-rtc/src/MarkerUpdate.js
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Object for communicating an update to a Marker's location.
+ * @author navil@google.com (Navil Perez)
+ */
+
+import * as Blockly from 'blockly/dist';
+
+export default class MarkerUpdate {
+  constructor(id, type, blockId, fieldName) {
+    this.id = id;
+    this.type_ = type;
+    this.blockId_ = blockId;
+    this.fieldName_ = fieldName;
+  };
+
+  /**
+   * Create a MarkerUpdate from an event. Currently supports MarkerUpdates
+   * on blocks from a 'selected' UI event.
+   * @param {!Blockly.Event} event The event that creates a MarkerUpdate.
+   * @return {!MarkerUpdate} The MarkerUpdate representative of the event.
+   * @public
+   */  
+  static fromEvent(event) {
+    // TODO: Add support for a field marker on a change event.
+    const id = event.workspaceId;
+    const type = 'BLOCK';
+    const blockId = event.newValue;
+    const fieldName = null;
+    return new MarkerUpdate(id, type, blockId, fieldName);  
+  };
+
+  /**
+   * Decode the JSON into a MarkerUpdate.
+   * @param {!Object} json The JSON representation of the markerUpdate.
+   * @return {!MarkerUpdate} The MarkerUpdate represented by the JSON.
+   * @public
+   */
+  static fromJson(json) {
+    const markerLocation = json.markerLocation;
+    return new MarkerUpdate(
+        json.id,
+        markerLocation.type,
+        markerLocation.blockId,
+        markerLocation.fieldName);
+  };
+
+  /**
+   * Encode the MarkerUpdate as JSON.
+   * @return {!Object} The JSON representation of the MarkerUpdate.
+   * @public
+   */
+  toJson() {
+    return {
+      id: this.id,
+      markerLocation: this.getMarkerLocation()
+    };
+  };
+
+  /**
+   * Check if the combination of MarkerLocation properties describe a
+   * viable location.
+   * @return {!Boolean} Whether the MarkerUpdate has a viable location.
+   * @public
+   */  
+  hasLocation() {
+    if (this.type_ == 'FIELD' || this.blockId_ || this.fieldName_) {
+      return true;
+    } else if (this.type_ == 'BLOCK' || this.blockId_) {
+      return true;
+    } else {
+      return false;
+    };
+  };
+
+  /**
+   * Get the location of the MarkerUpdate.
+   * @return {!MarkerLocation} The MarkerLocation on the MarkerUpdate.
+   * @public
+   */
+  getMarkerLocation() {
+    return {
+      type: this.type_,
+      blockId: this.blockId_,
+      fieldName: this.fieldName_
+    };
+  };
+  
+  /**
+   * Decode the MarkerUpdate into a Marker object.
+   * @param {!Blockly.Workspace} workspace The workspace the user is on.
+   * @return {!MarkerUpdate} The MarkerUpdate represented by the JSON.
+   * @public
+   */
+  toMarker(workspace) {
+    const marker = new Blockly.Marker();
+    const node = this.createNode(workspace);
+    marker.setCurNode(node);
+    return marker;
+  };
+
+  /**
+   * Create an ASTNode pointing to the MarkerUpdate location.
+   * @param {!Blockly.Workspace} workspace The workspace the user is on.
+   * @return {Blockly.ASTNode} An AST Node that points to the MarkerUpdate
+   * location or null if the location is not viable.
+   * @public
+   */
+  createNode(workspace) {
+    if (!this.hasLocation()) {
+      return null;
+    };
+    if (this.type_ == 'BLOCK') {
+      return this.createBlockNode_(workspace);
+    } else if (this.type_ == 'FIELD') {
+      return this.createFieldNode_(workspace);
+    };
+  };
+
+  /**
+   * Create an ASTNode pointing to a block.
+   * @param {!Blockly.Workspace} workspace The workspace the user is on.
+   * @return {Blockly.ASTNode} An AST Node that points to a block.
+   * @public
+   */
+  createBlockNode_(workspace) {
+    const block = workspace.getBlockById(this.blockId_);
+    return Blockly.ASTNode.createBlockNode(block);
+  };
+
+  /**
+   * Create an ASTNode pointing to a field.
+   * @param {!Blockly.Workspace} workspace The workspace the user is on.
+   * @return {Blockly.ASTNode} An AST Node that points to a field.
+   * @public
+   */  
+  createFieldNode_(workspace) {
+    const block = workspace.getBlockById(this.blockId_);
+    const field = block.getField(this.fieldName_);
+    return Blockly.ASTNode.createFieldNode(field);
+  };
+};

--- a/blockly-rtc/src/MarkerUpdate.js
+++ b/blockly-rtc/src/MarkerUpdate.js
@@ -80,9 +80,9 @@ export default class MarkerUpdate {
    * @public
    */  
   hasLocation() {
-    if (this.type_ == 'FIELD' || this.blockId_ || this.fieldName_) {
+    if (this.type_ == 'FIELD' && this.blockId_ && this.fieldName_) {
       return true;
-    } else if (this.type_ == 'BLOCK' || this.blockId_) {
+    } else if (this.type_ == 'BLOCK' && this.blockId_) {
       return true;
     } else {
       return false;

--- a/blockly-rtc/test/marker_update_test.js
+++ b/blockly-rtc/test/marker_update_test.js
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Unit tests for MarkerUpdate.
+ * @author navil@google.com (Navil Perez)
+ */
+
+const assert = require('assert');
+const Blockly = require('blockly/dist');
+const sinon = require('sinon');
+
+const MarkerUpdate = require('../src/MarkerUpdate').default;
+
+suite('MarkerUpdate', () => {
+
+  suite('fromEvent()', () => {
+    setup(() => {
+      Blockly.defineBlocksWithJsonArray([{
+        'type': 'test_block',
+        'message0': 'test block'
+      }]);
+      this.FAKE_WORKSPACE_ID = 'mockWorkspaceId';
+      this.FAKE_BLOCK_ID = 'mockBlockId'
+      sinon.stub(Blockly.utils, 'genUid')
+      .onFirstCall().returns(this.FAKE_WORKSPACE_ID)
+      .onSecondCall().returns(this.FAKE_BLOCK_ID);
+      this.workspace = new Blockly.Workspace();
+      this.block = new Blockly.Block(this.workspace, 'test_block');
+    });
+
+    teardown(() => {
+      sinon.restore();
+      delete Blockly.Blocks['simple_test_block1'];
+      this.workspace.dispose();
+    });
+
+    test('From SELECT UI event on a block.', async () => {
+      const event = new Blockly.Events.Ui(this.block, 'selected', 'old', this.FAKE_BLOCK_ID);
+      const markerUpdate = MarkerUpdate.fromEvent(event);
+      const expectedMarkerUpdate = new MarkerUpdate(this.FAKE_WORKSPACE_ID, 'BLOCK', this.FAKE_BLOCK_ID, null);
+      assert.deepEqual(markerUpdate, expectedMarkerUpdate);
+    });
+  });
+
+  suite('fromJson()', () => {
+    test('JSON object to MarkerUpdate object.', async () => {
+      const json = {
+        id: 'id',
+        markerLocation: {
+          type: 'type',
+          blockId: 'blockId',
+          fieldName: 'fieldName'
+        }
+      };
+      const markerUpdate = MarkerUpdate.fromJson(json);
+      const expectedMarkerUpdate = new MarkerUpdate(
+          'id', 'type', 'blockId', 'fieldName');
+      assert.deepEqual(markerUpdate, expectedMarkerUpdate);
+    });
+  });
+
+  suite('toJson()', () => {
+    test('MarkerUpdate object to JSON object.', async () => {
+      const markerUpdate = new MarkerUpdate('id', 'type', 'blockId', 'fieldName');
+      const json = markerUpdate.toJson(markerUpdate);
+      const expectedJson = {
+        id: 'id',
+        markerLocation: {
+          type: 'type',
+          blockId:  'blockId',
+          fieldName: 'fieldName'
+        }
+      };
+      assert.deepEqual(json, expectedJson);
+    });
+  });
+
+  suite('createNode()', () => {
+    test('Location does not exists, node is undefined.', async () => {
+      const markerUpdate = new MarkerUpdate(this.FAKE_WORKSPACE_ID, null, null, null);
+      const node = markerUpdate.createNode(this.mockWorkspace);
+      assert.deepEqual(null, node);
+    });
+
+    test('Location is a block, create block node.', async () => {
+      const markerUpdate = new MarkerUpdate('workspaceId', 'BLOCK', 'blockId', null);
+      const createBlockNodeStub = sinon.stub(markerUpdate, 'createBlockNode_');
+      markerUpdate.createNode(this.mockWorkspace);
+      assert.equal(true, createBlockNodeStub.calledOnce);
+    });
+
+    test('Location is a field, create field node.', async () => {
+      const markerUpdate = new MarkerUpdate(
+          'workspaceId', 'FIELD', 'blockId', 'fieldName');
+      const createFieldNodeStub = sinon.stub(markerUpdate, 'createFieldNode_');
+      markerUpdate.createNode(this.mockWorkspace);
+      assert.equal(true, createFieldNodeStub.calledOnce);
+    });
+  });
+
+  suite('toMarker()', () => {
+    test('Create marker with correct curNode.', async () => {
+      const markerUpdate = new MarkerUpdate(
+          'workspaceId', 'type', 'blockId', 'fieldName');
+      const createNodeStub = sinon.stub(markerUpdate, 'createNode');
+      createNodeStub.returns('mockNode');
+
+      const expectedMarker = new Blockly.Marker();
+      expectedMarker.setCurNode('mockNode');
+
+      const marker = markerUpdate.toMarker('mockWorkspace');
+      assert.deepEqual(marker, expectedMarker);
+    });
+  });
+});

--- a/blockly-rtc/test/marker_update_test.js
+++ b/blockly-rtc/test/marker_update_test.js
@@ -37,15 +37,15 @@ suite('MarkerUpdate', () => {
       this.FAKE_WORKSPACE_ID = 'mockWorkspaceId';
       this.FAKE_BLOCK_ID = 'mockBlockId'
       sinon.stub(Blockly.utils, 'genUid')
-      .onFirstCall().returns(this.FAKE_WORKSPACE_ID)
-      .onSecondCall().returns(this.FAKE_BLOCK_ID);
+          .onFirstCall().returns(this.FAKE_WORKSPACE_ID)
+          .onSecondCall().returns(this.FAKE_BLOCK_ID);
       this.workspace = new Blockly.Workspace();
       this.block = new Blockly.Block(this.workspace, 'test_block');
     });
 
     teardown(() => {
       sinon.restore();
-      delete Blockly.Blocks['simple_test_block1'];
+      delete Blockly.Blocks['test_block'];
       this.workspace.dispose();
     });
 

--- a/blockly-rtc/typedefs.js
+++ b/blockly-rtc/typedefs.js
@@ -40,10 +40,10 @@
  /**
  * The location of a Marker.
  * @typedef {Object} MarkerLocation
- * @property {<string>} type The type of element.
- * @property {<string>} blockId The blockId corresponding to the Block the
+ * @property {string} type The type of element.
+ * @property {string} blockId The blockId corresponding to the Block the
  * Marker is on.
- * @property {<string>} fieldName The name of the field if location is of type
+ * @property {string} fieldName The name of the field if location is of type
  * FIELD.
  */
 

--- a/blockly-rtc/typedefs.js
+++ b/blockly-rtc/typedefs.js
@@ -38,6 +38,16 @@
  */
  
  /**
+ * The location of a Marker.
+ * @typedef {Object} MarkerLocation
+ * @property {<string>} type The type of element.
+ * @property {<string>} blockId The blockId corresponding to the Block the
+ * Marker is on.
+ * @property {<string>} fieldName The name of the field if location is of type
+ * FIELD.
+ */
+
+ /**
  * An action to be performed on the workspace.
  * @typedef {Object} WorkspaceAction
  * @property {!Object} event The JSON of a Blockly event.


### PR DESCRIPTION
Creates a MarkerUpdate class for passing marker information between the
clients and the server.
MarkerUpdate has all the information needed to create a marker and is
serializable to faciliate storage in the database.

Also in this change, Blockly is imported from the develop branch on github instead of npm as this change is dependent on unpublished changes to Markers.