### PR TITLE
Convert events between Blockly.Events and JSON format in API handlers.

### DIFF
--- a/blockly-rtc/src/WorkspaceClient.js
+++ b/blockly-rtc/src/WorkspaceClient.js
@@ -21,6 +21,7 @@
  * @author navil@google.com (Navil Perez)
  */
 
+import * as Blockly from 'blockly/dist';
 import EventEmitter from 'events';
 
 /**
@@ -127,7 +128,7 @@ export default class WorkspaceClient {
     const entryId = this.workspaceId + ':' + this.counter;
     this.counter += 1;
     this.inProgress.push({
-      events: this.notSent,
+      events: Blockly.Events.filter(this.notSent, true),
       entryId: entryId
     });
     this.notSent = [];
@@ -187,7 +188,7 @@ export default class WorkspaceClient {
   async addServerEvents_(newServerEvents) {
     if (newServerEvents.length == 0) {
       return;
-    }
+    };
     if (newServerEvents[0].serverId != this.lastSync + 1) {
       newServerEvents = await this.queryDatabase_();
     };
@@ -262,11 +263,15 @@ export default class WorkspaceClient {
       };
       // Apply server events.
       entries.forEach((entry) => {
-        eventQueue.push.apply(
-          eventQueue, this.createWorkspaceActions_(entry.events, true));
         if (this.inProgress.length > 0
             && entry.entryId == this.inProgress[0].entryId) {
+          eventQueue.push.apply(
+              eventQueue,
+              this.createWorkspaceActions_(this.inProgress[0].events, true));
           this.inProgress.shift();
+        } else {
+          eventQueue.push.apply(
+              eventQueue, this.createWorkspaceActions_(entry.events, true));
         };
       });
       // Reapply remaining local changes.

--- a/blockly-rtc/src/index.js
+++ b/blockly-rtc/src/index.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (event instanceof Blockly.Events.Ui) {
       return;
     };
-    workspaceClient.activeChanges.push(event.toJson());
+    workspaceClient.activeChanges.push(event);
     if (!Blockly.Events.getGroup()) {
       workspaceClient.flushEvents();
     };
@@ -57,10 +57,9 @@ document.addEventListener('DOMContentLoaded', () => {
    * @private
    */
   function runEvents_(eventQueue) {
-    eventQueue.forEach((event)=> {
-      const blocklyEvent = Blockly.Events.fromJson(event.event, workspace);
+    eventQueue.forEach((workspaceAction)=> {
       Blockly.Events.disable();
-      blocklyEvent.run(event.forward);
+      workspaceAction.event.run(workspaceAction.forward);
       Blockly.Events.enable();
     });
   };

--- a/blockly-rtc/src/websocket/workspace_client_handlers.js
+++ b/blockly-rtc/src/websocket/workspace_client_handlers.js
@@ -22,7 +22,8 @@
  * @author navil@google.com (Navil Perez)
  */
 
-import io from 'socket.io-client';
+import * as Blockly from 'blockly/dist';
+ import io from 'socket.io-client';
 
 const socket = io('http://localhost:3001');
 
@@ -44,6 +45,11 @@ const socket = io('http://localhost:3001');
 export async function getEvents(serverId) {
   return new Promise((resolve, reject) => {
     socket.emit('getEvents', serverId, (entries) => {
+      entries.forEach((entry) => {
+        entry.events = entry.events.map((entry) => {
+          return Blockly.Events.fromJson(entry, Blockly.getMainWorkspace());
+        });
+      });
       resolve(entries);
     });
   });
@@ -56,8 +62,12 @@ export async function getEvents(serverId) {
  * @public
  */
 export async function writeEvents(entry) {
+  const entryJson = {
+    entryId: entry.entryId,
+    events: entry.events.map((event) => event.toJson())
+  };
   return new Promise((resolve, reject) => {
-    socket.emit('addEvents', entry, () => {
+    socket.emit('addEvents', entryJson, () => {
       resolve();
     });
   });
@@ -72,6 +82,11 @@ export async function writeEvents(entry) {
  */
 export function getBroadcast(callback) {
   socket.on('broadcastEvents', (entries)=> {
+    entries.forEach((entry) => {
+      entry.events = entry.events.map((entry) => {
+        return Blockly.Events.fromJson(entry, Blockly.getMainWorkspace());
+      });
+    });
     callback(entries);
   });
 };

--- a/blockly-rtc/src/websocket/workspace_client_handlers.js
+++ b/blockly-rtc/src/websocket/workspace_client_handlers.js
@@ -23,7 +23,7 @@
  */
 
 import * as Blockly from 'blockly/dist';
- import io from 'socket.io-client';
+import io from 'socket.io-client';
 
 const socket = io('http://localhost:3001');
 

--- a/blockly-rtc/typedefs.js
+++ b/blockly-rtc/typedefs.js
@@ -23,7 +23,7 @@
 /**
  * An entry from the database.
  * @typedef {Object} Entry
- * @property {<!Array.<!Blockly.Events>>} events An array of Blockly Events.
+ * @property {<!Array.<!Blockly.Event>>} events An array of Blockly Events.
  * @property {string} entryId The id assigned to an event by the client.
  * @property {string} serverId The id assigned to an event by the server.
  */

--- a/blockly-rtc/typedefs.js
+++ b/blockly-rtc/typedefs.js
@@ -23,8 +23,7 @@
 /**
  * An entry from the database.
  * @typedef {Object} Entry
- * @property {<!Array.<!Object>>} events An array of Blockly Events in JSON
- * format.
+ * @property {<!Array.<!Blockly.Events>>} events An array of Blockly Events.
  * @property {string} entryId The id assigned to an event by the client.
  * @property {string} serverId The id assigned to an event by the server.
  */
@@ -32,8 +31,7 @@
  /**
  * A local representation of an entry in the database.
  * @typedef {Object} LocalEntry
- * @property {<!Array.<!Object>>} events An array of Blockly Events in JSON
- * format.
+ * @property {<!Array.<!Blockly.Event>>} events An array of Blockly Events.
  * @property {string} entryId The id assigned to an event by the client.
  */
  
@@ -50,6 +48,6 @@
  /**
  * An action to be performed on the workspace.
  * @typedef {Object} WorkspaceAction
- * @property {!Object} event The JSON of a Blockly event.
+ * @property {!Blockly.Event} event A Blockly Event.
  * @property {boolean} forward Indicates the direction to run an event.
  */


### PR DESCRIPTION
Previously, index.js would serialize and deserialize Blockly Events and
WorkspaceClient would handle events as JSON objects.

This change migrates serlialization to the APIs before sending to the
database allowing WorkspaceClient to handle events in their original
Blockly Events format. Fixes #45.