### PR TITLE
Separate entryId into separate workspaceId and entryNumber fields.

### DIFF
--- a/blockly-rtc/server/Database.js
+++ b/blockly-rtc/server/Database.js
@@ -59,8 +59,8 @@ class Database {
    * For each user, an addition is valid if the entryNumber is greater than the
    * entryNumber of its last added entry.
    * @param {!LocalEntry} entry The entry to be added to the database.
-   * @return {!Promise} Promise object with the serverId the entry was written
-   * to the database.
+   * @return {!Promise} Promise object with the serverId of the entry written to
+   * the database.
    * @public
    */
   async addToServer(entry) {
@@ -74,7 +74,7 @@ class Database {
         } catch {
           reject('Failed to write to the database');
         };
-      } else if (entryNumber == lastEntryNumber) {
+      } else if (entry.entryNumber == lastEntryNumber) {
         resolve(null);
       } else {
         reject('Entry is not valid.');
@@ -92,8 +92,10 @@ class Database {
   runInsertQuery_(entry) {
     return new Promise((resolve, reject) => {
       this.db.serialize(() => {
-        this.db.run('INSERT INTO eventsdb(events, workspaceId) VALUES(?,?)',
-            [JSON.stringify(entry.events), entry.workspaceId], (err) => {
+        this.db.run(`INSERT INTO eventsdb
+            (events, workspaceId, entryNumber) VALUES(?,?,?)`,
+            [JSON.stringify(entry.events), entry.workspaceId, entry.entryNumber],
+            (err) => {
           if (err) {
             console.error(err.message);
             reject('Failed to write to the database.');

--- a/blockly-rtc/server/Database.js
+++ b/blockly-rtc/server/Database.js
@@ -56,8 +56,8 @@ class Database {
 
   /**
    * Add entry to the database if the entry is a valid next addition.
-   * For each user, an addition is valid if the entryId is greater than the
-   * entryId of its last added entry.
+   * For each user, an addition is valid if the entryNumber is greater than the
+   * entryNumber of its last added entry.
    * @param {!LocalEntry} entry The entry to be added to the database.
    * @return {!Promise} Promise object with the serverId the entry was written
    * to the database.
@@ -65,21 +65,19 @@ class Database {
    */
   async addToServer(entry) {
     return new Promise(async (resolve, reject) => {
-      const workspaceId = entry.entryId.split(':')[0];
-      const entryIdInt = entry.entryId.split(':')[1];
-      const lastEntryIdNumber = await this.getLastEntryIdNumber_(workspaceId);
-      if (entryIdInt > lastEntryIdNumber) {
+      const lastEntryNumber = await this.getLastEntryNumber_(entry.workspaceId);
+      if (entry.entryNumber > lastEntryNumber) {
         try {
           const serverId = await this.runInsertQuery_(entry);
-          await this.updateLastEntryIdNumber_(workspaceId, entryIdInt);
+          await this.updateLastEntryNumber_(entry.workspaceId, entry.entryNumber);
           resolve(serverId);
         } catch {
           reject('Failed to write to the database');
         };
-      } else if (entryIdInt == lastEntryIdNumber) {
+      } else if (entryNumber == lastEntryNumber) {
         resolve(null);
       } else {
-        reject('EntryId is not valid.');
+        reject('Entry is not valid.');
       };
     });
   };
@@ -94,8 +92,8 @@ class Database {
   runInsertQuery_(entry) {
     return new Promise((resolve, reject) => {
       this.db.serialize(() => {
-        this.db.run('INSERT INTO eventsdb(events, entryId) VALUES(?,?)',
-            [JSON.stringify(entry.events), entry.entryId], (err) => {
+        this.db.run('INSERT INTO eventsdb(events, workspaceId) VALUES(?,?)',
+            [JSON.stringify(entry.events), entry.workspaceId], (err) => {
           if (err) {
             console.error(err.message);
             reject('Failed to write to the database.');
@@ -113,17 +111,18 @@ class Database {
   };
 
   /**
-   * Update lastEntryIdNumber in the users table for a given user.
+   * Update lastEntryNumber in the users table for a given user.
    * @param {!string} workspaceId The workspaceId of the user.
-   * @param {!number} entryIdNumber The numeric part of the entryId.
+   * @param {!number} entryNumber The numeric ID assigned to an entry by the
+   * user.
    * @return {!Promise} Promise object represents the success of the update.
    * @private
    */
-  updateLastEntryIdNumber_(workspaceId, entryIdNumber) {
+  updateLastEntryNumber_(workspaceId, entryNumber) {
     return new Promise((resolve, reject) => {
       this.db.run(`UPDATE users SET lastEntryNumber = ?
           WHERE workspaceId = ?;`,
-          [entryIdNumber, workspaceId],
+          [entryNumber, workspaceId],
           async (err) => {
         if (err) {
           console.error(err.message);
@@ -135,13 +134,13 @@ class Database {
   };
 
   /**
-   * Get the numerical part of the last added entryId for a given user.
+   * Get the lastEntryNumber for a given user.
    * @param {!string} workspaceId The workspaceId of the user.
-   * @return {!Promise} Promise object with the the numerical part of the
-   * entryId.
+   * @return {!Promise} Promise object with the the numeric ID assigned to an
+   * entry by the user.
    * @private
    */
-  getLastEntryIdNumber_(workspaceId) {
+  getLastEntryNumber_(workspaceId) {
     return new Promise((resolve, reject) => {
       this.db.serialize(() => {
 
@@ -153,7 +152,7 @@ class Database {
             (err, entries) => {
           if (err) {
             console.error(err.message);
-            reject('Failed to get last entryId number.');
+            reject('Failed to get last entry number.');
           } else if (entries.length == 0) {
             this.db.run(`INSERT INTO users(workspaceId, lastEntryNumber)
                 VALUES(?, -1)`, [workspaceId]);
@@ -166,7 +165,7 @@ class Database {
             (err, result) => {
           if (err) {
             console.error(err.message);
-            reject('Failed to get last entryId number.');
+            reject('Failed to get last entry number.');
           } else {
             resolve(result.lastEntryNumber);
           };

--- a/blockly-rtc/server/db.js
+++ b/blockly-rtc/server/db.js
@@ -29,7 +29,7 @@ const db = new sqlite3.Database('./eventsdb.sqlite', (err) => {
   console.log('successful connection');
   const eventsDbSql = `CREATE TABLE IF NOT EXISTS eventsdb(
       serverId INTEGER PRIMARY KEY,
-      workspaceId TEXT, events BLOB);`;
+      workspaceId TEXT, entryNumber INTEGER, events BLOB);`;
   db.run(eventsDbSql, function(err) {
     if (err) {
       return console.error(err.message);

--- a/blockly-rtc/server/db.js
+++ b/blockly-rtc/server/db.js
@@ -29,7 +29,7 @@ const db = new sqlite3.Database('./eventsdb.sqlite', (err) => {
   console.log('successful connection');
   const eventsDbSql = `CREATE TABLE IF NOT EXISTS eventsdb(
       serverId INTEGER PRIMARY KEY,
-      entryId TEXT, events BLOB);`;
+      workspaceId TEXT, events BLOB);`;
   db.run(eventsDbSql, function(err) {
     if (err) {
       return console.error(err.message);

--- a/blockly-rtc/src/WorkspaceClient.js
+++ b/blockly-rtc/src/WorkspaceClient.js
@@ -125,12 +125,12 @@ export default class WorkspaceClient {
    */
   beginWrite_() {
     this.writeInProgress = true;
-    const entryId = this.workspaceId + ':' + this.counter;
-    this.counter += 1;
     this.inProgress.push({
+      workspaceId: this.workspaceId,
+      entryNumber: this.counter,
       events: Blockly.Events.filter(this.notSent, true),
-      entryId: entryId
     });
+    this.counter += 1;
     this.notSent = [];
   };
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
@@ -245,7 +245,8 @@ export default class WorkspaceClient {
 
     // Common root, remove common events from server events.
     if (this.inProgress.length > 0
-        && entries[0].entryId == this.inProgress[0].entryId) {
+        && entries[0].workspaceId == this.workspaceId
+        && entries[0].entryNumber == this.inProgress[0].entryNumber) {
       entries.shift();
       this.inProgress = [];
     };
@@ -264,7 +265,8 @@ export default class WorkspaceClient {
       // Apply server events.
       entries.forEach((entry) => {
         if (this.inProgress.length > 0
-            && entry.entryId == this.inProgress[0].entryId) {
+            && entry.workspaceId == this.inProgress[0].workspaceId
+            && entry.entryNumber == this.inProgress[0].entryNumber) {
           eventQueue.push.apply(
               eventQueue,
               this.createWorkspaceActions_(this.inProgress[0].events, true));

--- a/blockly-rtc/src/http/workspace_client_handlers.js
+++ b/blockly-rtc/src/http/workspace_client_handlers.js
@@ -55,7 +55,8 @@ export async function getEvents(serverId) {
  */
 export async function writeEvents(entry) {
   const entryJson = {
-    entryId: entry.entryId,
+    workspaceId: entry.workspaceId,
+    entryNumber: entry.entryNumber,
     events: entry.events.map((event) => event.toJson())
   };
   const response = await fetch('/api/events/add', {

--- a/blockly-rtc/src/websocket/workspace_client_handlers.js
+++ b/blockly-rtc/src/websocket/workspace_client_handlers.js
@@ -55,7 +55,8 @@ export async function getEvents(serverId) {
  */
 export async function writeEvents(entry) {
   const entryJson = {
-    entryId: entry.entryId,
+    workspaceId: entry.workspaceId,
+    entryNumber: entry.entryNumber,
     events: entry.events.map((event) => event.toJson())
   };
   return new Promise((resolve, reject) => {

--- a/blockly-rtc/test/database_test.js
+++ b/blockly-rtc/test/database_test.js
@@ -30,8 +30,8 @@ suite('Database', () => {
 
   suite('addToDatabase()', () => {
     setup(() => {
-      this.runInsertQueryStub = sinon.stub(database, 'runInsertQuery_');
-      this.getLastEntryStub = sinon.stub(database, 'getLastEntryNumber_');
+      sinon.stub(database, 'runInsertQuery_');
+      sinon.stub(database, 'getLastEntryNumber_');
     });
 
     teardown(() => {
@@ -40,61 +40,65 @@ suite('Database', () => {
     });
 
     test('New user, add to database.', async () => {
-      this.getLastEntryStub.resolves(-1);
-      this.runInsertQueryStub.resolves(2);
+      database.getLastEntryNumber_.resolves(-1);
+      database.runInsertQuery_.resolves(2);
       const entry = {
-          workspaceId: 'newMockEntry',
+          workspaceId: 'newUser',
           entryNumber: '1',
           events: [JSON.stringify({mockEvent:'event'})],
       };
       const serverId = await database.addToServer(entry);
       assert.equal(2, serverId);
-      assert.equal(true, this.runInsertQueryStub.calledOnce);
+      assert(database.runInsertQuery_.calledOnce);
     });
 
     test('Valid entry for existing user, add to database.', async () => {
-      this.getLastEntryIdStub.resolves(2);
-      this.runInsertQueryStub.resolves(2);
+      database.getLastEntryNumber_.resolves(2);
+      database.runInsertQuery_.resolves(2);
       const entry = {
-          entryId: 'mockEntry:4',
+          workspaceId: 'mockUser',
+          entryNumber: '4',
           events: [JSON.stringify({mockEvent:'event'})],
       };
       const serverId = await database.addToServer(entry);
       assert.equal(2, serverId);
-      assert.equal(true, this.runInsertQueryStub.calledOnce);
+      assert(database.runInsertQuery_.calledOnce);
     });
 
     test('Database write fails, reject.', async () => {
-      this.getLastEntryIdStub.resolves(2);
-      this.runInsertQueryStub.rejects();
+      database.getLastEntryNumber_.resolves(2);
+      database.runInsertQuery_.rejects();
       const entry = {
-          entryId: 'mockEntry:3',
+        workspaceId: 'mockUser',
+        entryNumber: '3',
           events: [JSON.stringify({mockEvent:'event'})],
       };
       assert.rejects(database.addToServer(entry));
     });
 
     test('Duplicate of last entry, resolve without further action.', async () => {
-      this.getLastEntryIdStub.resolves(2);
-      this.runInsertQueryStub.resolves(null);
+      database.getLastEntryNumber_.resolves(2);
+      database.runInsertQuery_.resolves(null);
       const entry = {
-          entryId: 'mockEntry:2',
+        workspaceId: 'mockUser',
+        entryNumber: '2',
           events: [JSON.stringify({mockEvent:'event'})],
       };
       const serverId = await database.addToServer(entry);
       assert.equal(null, serverId);
-      assert.equal(true, this.runInsertQueryStub.notCalled);
+      assert(database.runInsertQuery_.notCalled);
     });
 
     test('Invalid entry, reject.', async () => {
-      this.getLastEntryIdStub.resolves(2);
-      this.runInsertQueryStub.resolves();
+      database.getLastEntryNumber_.resolves(2);
+      database.runInsertQuery_.resolves();
       const entry = {
-        entryId: 'mockEntry:1',
+        workspaceId: 'mockUser',
+        entryNumber: '1',
         events: [JSON.stringify({mockEvent:'event'})],
       };
       assert.rejects(database.addToServer(entry));
-      assert.equal(true, this.runInsertQueryStub.notCalled);
+      assert(database.runInsertQuery_.notCalled);
     });
   });
 });

--- a/blockly-rtc/test/database_test.js
+++ b/blockly-rtc/test/database_test.js
@@ -31,19 +31,20 @@ suite('Database', () => {
   suite('addToDatabase()', () => {
     setup(() => {
       this.runInsertQueryStub = sinon.stub(database, 'runInsertQuery_');
-      this.getLastEntryIdStub = sinon.stub(database, 'getLastEntryIdNumber_');
+      this.getLastEntryStub = sinon.stub(database, 'getLastEntryNumber_');
     });
 
     teardown(() => {
       database.runInsertQuery_.restore();
-      database.getLastEntryIdNumber_.restore();
+      database.getLastEntryNumber_.restore();
     });
 
     test('New user, add to database.', async () => {
-      this.getLastEntryIdStub.resolves(-1);
+      this.getLastEntryStub.resolves(-1);
       this.runInsertQueryStub.resolves(2);
       const entry = {
-          entryId: 'newMockEntry:1',
+          workspaceId: 'newMockEntry',
+          entryNumber: '1',
           events: [JSON.stringify({mockEvent:'event'})],
       };
       const serverId = await database.addToServer(entry);

--- a/blockly-rtc/typedefs.js
+++ b/blockly-rtc/typedefs.js
@@ -24,7 +24,9 @@
  * An entry from the database.
  * @typedef {Object} Entry
  * @property {<!Array.<!Blockly.Event>>} events An array of Blockly Events.
- * @property {string} entryId The id assigned to an entry by the client.
+ * @property {string} workspaceId The workspaceId of the user.
+ * @property {number} entryNumber The numeric id assigned to an entry by the
+ * client.
  * @property {string} serverId The id assigned to an entry by the server.
  */
 
@@ -32,7 +34,9 @@
  * A local representation of an entry in the database.
  * @typedef {Object} LocalEntry
  * @property {<!Array.<!Blockly.Event>>} events An array of Blockly Events.
- * @property {string} entryId The id assigned to an entry by the client.
+ * @property {string} workspaceId The workspaceId of the user.
+ * @property {number} entryNumber The numeric id assigned to an entry by the
+ * client.
  */
  
  /**


### PR DESCRIPTION
Previously, `entryId` contained the `workspaceId` and `entryNumber` for an
entry in the format `workspaceId:entryNumber`. Using the colon as a
separator was problematic because `workspaceId`s can have colons in them.
To avoid parsing errors, break `entryId` into separate fields.