### PR TITLE
Create a snapshot of the workspace for users to load upon connecting.

### DIFF
--- a/blockly-rtc/server/Database.js
+++ b/blockly-rtc/server/Database.js
@@ -21,6 +21,7 @@
  */
 
 const db = require('./db');
+const Blocky = require('blockly');
 
 /**
  * Class for managing interactions between the server and the database.
@@ -28,6 +29,10 @@ const db = require('./db');
 class Database {
   constructor() {
     this.db = db;
+    this.snapshot = {
+      serverId: 0,
+      xml: '<xml xmlns="https://developers.google.com/blockly/xml"/>'
+    };
   };
 
   /**
@@ -231,6 +236,51 @@ class Database {
         };
         resolve();
       });
+    });
+  };
+
+  /**
+   * Retrieve the latest snapshot of the workspace.
+   * @return {!Snapshot} The latest snapshot of the workspace.
+   * @public
+   */
+  async getSnapshot() {
+    await this.updateSnapshot_();
+    return this.snapshot;
+  };
+
+  /**
+   * Update the snapshot of the workspace.
+   * @return {!Promise} Promise object that represents the success of the
+   * update.
+   * @private
+   */
+  updateSnapshot_() {
+    return new Promise(async (resolve, reject) => {
+      const newEntries = await this.query(this.snapshot.serverId);
+      if (newEntries.length == 0) {
+        resolve();
+        return;
+      };
+      // Load last stored snapshot of the workspace.
+      const workspace = new Blocky.Workspace();
+      if (this.snapshot.xml) {
+        const xml = Blocky.Xml.textToDom(this.snapshot.xml);
+        Blocky.Xml.domToWorkspace(xml, workspace);  
+      };
+      // Play events since the last time the snapshot was generated.
+      newEntries.forEach((entry) => {
+        entry.events.forEach((event) => {
+          const blocklyEvent = Blocky.Events.fromJson(event, workspace);
+          blocklyEvent.run(true);
+        });
+      });
+      // Store the new snapshot object.
+      const newSnapshotXml = Blocky.Xml.workspaceToDom(workspace, false);
+      const newSnapshotText = Blocky.Xml.domToText(newSnapshotXml);
+      this.snapshot.xml = newSnapshotText;
+      this.snapshot.serverId = newEntries[newEntries.length -1].serverId;
+      resolve();
     });
   };
 };

--- a/blockly-rtc/server/http/events_handlers.js
+++ b/blockly-rtc/server/http/events_handlers.js
@@ -67,5 +67,25 @@ async function addEventsHandler(req, res) {
   };
 };
 
+/**
+ * Handler for a snapshot GET request. Get the latest snapshot of the
+ * workspace.
+ * @param {!Object} res The HTTP response object.
+ * @public
+ */
+async function getSnapshotHandler(res) {
+  try {
+    const snapshot = await database.getSnapshot();
+    res.setHeader('Content-Type', 'application/json');
+    res.statusCode = 200;
+    res.write(JSON.stringify({ snapshot }));
+    res.end();
+  } catch {
+    res.statusCode = 401;
+    res.end();
+  };
+};
+
 module.exports.queryEventsHandler = queryEventsHandler;
 module.exports.addEventsHandler = addEventsHandler;
+module.exports.getSnapshotHandler = getSnapshotHandler;

--- a/blockly-rtc/server/http_server.js
+++ b/blockly-rtc/server/http_server.js
@@ -34,6 +34,8 @@ http.createServer(async (req, res) => {
     await EventsHandlers.queryEventsHandler(res, parsedUrl.query.serverId);
   } else if (req.method === 'POST' && parsedUrl.pathname === '/api/events/add') {
     await EventsHandlers.addEventsHandler(req, res);
+  } else if (req.method === 'GET' && parsedUrl.pathname === '/api/snapshot/query') {
+    await EventsHandlers.getSnapshotHandler(res);
   } else if (req.method === 'GET' && parsedUrl.pathname === '/api/users/position/query') {
     await UsersHandlers.getPositionUpdatesHandler(res, parsedUrl.query.workspaceId);
   } else if (req.method === 'PUT' && parsedUrl.pathname === '/api/users/position/update') {

--- a/blockly-rtc/server/websocket/events_handlers.js
+++ b/blockly-rtc/server/websocket/events_handlers.js
@@ -49,5 +49,17 @@ async function addEventsHandler(entry, callback) {
   callback(serverId);
 };
 
+/**
+ * Handler for a getSnapshot message. Get the latest snapshot of the workspace.
+ * @param {!Function} callback The callback passed in by WorkspaceClient to
+ * recieve the snapshot.
+ * @public
+ */
+async function getSnapshotHandler(callback) {
+  const snapshot = await database.getSnapshot();
+  callback(snapshot);
+};
+
 module.exports.getEventsHandler = getEventsHandler;
 module.exports.addEventsHandler = addEventsHandler;
+module.exports.getSnapshotHandler = getSnapshotHandler;

--- a/blockly-rtc/server/websocket_server.js
+++ b/blockly-rtc/server/websocket_server.js
@@ -73,4 +73,8 @@ async function onConnect_(user) {
   user.on('getPositionUpdates', async (workspaceId, callback) => {
     await UsersHandlers.getPositionUpdatesHandler(workspaceId, callback);
   });
+
+  user.on('getSnapshot', async (callback) => {
+    await EventsHandlers.getSnapshotHandler(callback);
+  });
 };

--- a/blockly-rtc/src/http/index.js
+++ b/blockly-rtc/src/http/index.js
@@ -23,7 +23,7 @@
  */
 
 import * as Blockly from 'blockly';
-import {getEvents, writeEvents} from './workspace_client_handlers';
+import {getSnapshot, getEvents, writeEvents} from './workspace_client_handlers';
 import {getPositionUpdates, sendPositionUpdate} from './user_data_handlers';
 import UserDataManager from '../UserDataManager';
 import WorkspaceClient from '../WorkspaceClient';
@@ -35,11 +35,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         media: 'media/'
       });
   const workspaceClient = new WorkspaceClient(
-      workspace.id, getEvents, writeEvents);
+      workspace.id, getSnapshot, getEvents, writeEvents);
   workspaceClient.listener.on('runEvents', (eventQueue) => {
     runEvents_(eventQueue);
   });
-  await workspaceClient.initiateWorkspace();
+  await workspaceClient.start();
 
   const userDataManager = new UserDataManager(workspace.id, sendPositionUpdate,
       getPositionUpdates);  

--- a/blockly-rtc/src/http/workspace_client_handlers.js
+++ b/blockly-rtc/src/http/workspace_client_handlers.js
@@ -24,6 +24,23 @@
 import * as Blockly from 'blockly';
 
 /**
+ * Get a snapshot of the current workspace.
+ * @return {!Snapshot} The latest snapshot of the workspace.
+ * @public
+ */
+export async function getSnapshot() {
+  const response = await fetch('/api/snapshot/query');
+  const responseJson = await response.json();
+  const snapshot = responseJson.snapshot;
+  snapshot.xml = Blockly.Xml.textToDom(snapshot.xml);
+  if (response.status === 200) {
+    return snapshot;
+  } else {
+    throw 'Failed to get workspace snapshot.';
+  };
+};
+
+/**
  * Query the database for entries since the given server id.
  * @param {number} serverId serverId for the lower bound of the query.
  * @return {<!Array.<!Entry>>} Entries since the given serverId.

--- a/blockly-rtc/src/websocket/index.js
+++ b/blockly-rtc/src/websocket/index.js
@@ -22,7 +22,7 @@
  */
 
 import * as Blockly from 'blockly';
-import {getEvents, writeEvents, getBroadcast} from './workspace_client_handlers';
+import {getSnapshot, getEvents, writeEvents, getBroadcast} from './workspace_client_handlers';
 import {getPositionUpdates, sendPositionUpdate, getBroadcastPositionUpdates} from './user_data_handlers';
 import UserDataManager from '../UserDataManager';
 import WorkspaceClient from '../WorkspaceClient';
@@ -34,11 +34,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         media: 'media/'
       });
   const workspaceClient = new WorkspaceClient(
-      workspace.id, getEvents, writeEvents, getBroadcast);
+      workspace.id, getSnapshot, getEvents, writeEvents, getBroadcast);
   workspaceClient.listener.on('runEvents', (eventQueue) => {
     runEvents_(eventQueue);
   });
-  await workspaceClient.initiateWorkspace();
+  await workspaceClient.start();
 
   const userDataManager = new UserDataManager(workspace.id, sendPositionUpdate,
       getPositionUpdates, getBroadcastPositionUpdates);  

--- a/blockly-rtc/src/websocket/workspace_client_handlers.js
+++ b/blockly-rtc/src/websocket/workspace_client_handlers.js
@@ -28,6 +28,21 @@ import io from 'socket.io-client';
 const socket = io('http://localhost:3001');
 
 /**
+ * Query the database a snapshot of the current workspace.
+ * @return {!Promise} Promise object that represents the latest snapshot of the
+ * workspace.
+ * @public
+ */
+export async function getSnapshot() {
+  return new Promise((resolve, reject) => {
+    socket.emit('getSnapshot', (snapshot) => {
+      snapshot.xml = Blockly.Xml.textToDom(snapshot.xml);
+      resolve(snapshot);
+    });
+  });
+};
+
+/**
  * Query the database for entries since the given server id.
  * @param {number} serverId serverId for the lower bound of the query.
  * @return {!Promise} Promise object that represents the entries of events since

--- a/blockly-rtc/test/database_test.js
+++ b/blockly-rtc/test/database_test.js
@@ -26,6 +26,111 @@ const sinon = require('sinon');
 const database = require('../server/Database');
 
 suite('Database', () => {
+  teardown(() => {
+    sinon.restore();
+  })
+
+  suite('getSnapshot()', () => {
+    setup(() => {
+      this.xmlText0 = '<xml xmlns="https://developers.google.com/blockly/xml"/>';
+      this.xmlText1 = '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '<block type="controls_if" id="^EzM:}wIx;MjBTcxQ@oB" x="238" y="63"/>' +
+          '</xml>';
+      this.xmlText2 = '<xml xmlns="https://developers.google.com/blockly/xml">' +
+          '<block type="controls_if" id="^EzM:}wIx;MjBTcxQ@oB" x="238" y="63">' +
+          '<value name="IF0">' +
+          '<block type="logic_compare" id="oNVDtK2cF?jWDM+.gCR3">' +
+          '<field name="OP">EQ</field>' +
+          '</block></value></block></xml>'
+      this.entry1 = {
+        serverId: 1,
+        events: [{
+          type: "create",
+          group: "zH!7f,gfyd$ni%`Wq`Y|",
+          blockId: "^EzM:}wIx;MjBTcxQ@oB",
+          xml: '<block xmlns="https://developers.google.com/blockly/xml" ' +
+              'type="controls_if" id="^EzM:}wIx;MjBTcxQ@oB" x="16" y="10"/>',
+          ids: ["^EzM:}wIx;MjBTcxQ@oB"]
+        }, {
+          type: "move",
+          group: "zH!7f,gfyd$ni%`Wq`Y|",
+          blockId: "^EzM:}wIx;MjBTcxQ@oB",
+          newCoordinate: "228,58"
+        }, {
+          type: "move",
+          group: "zH!7f,gfyd$ni%`Wq`Y|",
+          blockId: "^EzM:}wIx;MjBTcxQ@oB",
+          newCoordinate: "238,63"
+        }]
+      };
+      this.entry2 = {
+        serverId: 2,
+        events: [{
+          type: "create",
+          group: "|r115vF03q}F@7l]*PcB",
+          blockId: "oNVDtK2cF?jWDM+.gCR3",
+          xml: '<block xmlns="https://developers.google.com/blockly/xml" ' +
+              'type="logic_compare" id="oNVDtK2cF?jWDM+.gCR3" x="8" y="97">' +
+              '<field name="OP">EQ</field></block>',
+          ids: ["oNVDtK2cF?jWDM+.gCR3"]
+        }, {
+          type: "move",
+          group: "|r115vF03q}F@7l]*PcB",
+          blockId: "oNVDtK2cF?jWDM+.gCR3",
+          newParentId: "^EzM:}wIx;MjBTcxQ@oB",
+          newInputName: "IF0"
+        }]
+      };
+    });
+
+    test('No previous snapshot, no new events', async () => {
+      database.snapshot = {
+        xml: this.xmlText0,
+        serverId: 0
+      };
+      sinon.stub(database, 'query').resolves([]);
+      const newSnapshot = await database.getSnapshot();
+      assert.equal(this.xmlText0, newSnapshot.xml);
+      assert.equal(0, newSnapshot.serverId);
+      assert(database.query.calledOnceWith(0));
+    });
+
+    test('No previous snapshot, new events', async () => {
+      database.snapshot = {
+        xml: this.xmlText0,
+        serverId: 0
+      };
+      sinon.stub(database, 'query').resolves([this.entry1, this.entry2]);
+      const newSnapshot = await database.getSnapshot();
+      assert.equal(this.xmlText2, newSnapshot.xml);
+      assert.equal(2, newSnapshot.serverId);
+      assert(database.query.calledOnceWith(0));
+    });
+
+    test('Snapshot stored, no new events.', async () => {
+      database.snapshot = {
+        xml: this.xmlText1,
+        serverId: 1
+      };
+      sinon.stub(database, 'query').resolves([]);
+      const newSnapshot = await database.getSnapshot();
+      assert.equal(this.xmlText1, newSnapshot.xml);
+      assert.equal(1, newSnapshot.serverId);
+      assert(database.query.calledOnceWith(1));
+    });
+
+    test('Snapshot stored, new events.', async () => {
+      database.snapshot = {
+        xml: this.xmlText1,
+        serverId: 1
+      };
+      sinon.stub(database, 'query').resolves([this.entry2]);
+      const newSnapshot = await database.getSnapshot();
+      assert.equal(this.xmlText2, newSnapshot.xml);
+      assert.equal(2, newSnapshot.serverId);
+      assert(database.query.calledOnceWith(1));
+    });
+  });
 
   suite('addToDatabase()', () => {
     setup(() => {

--- a/blockly-rtc/typedefs.js
+++ b/blockly-rtc/typedefs.js
@@ -47,6 +47,15 @@
  */
 
  /**
+ * A snapshot of the workspace.
+ * @typedef {Object} Snapshot
+ * @property {!Element} xml An XML DOM element that represents the current state
+ * of the workspace.
+ * @property {number} serverId The serverId of the last entry of events applied
+ * to the workspace.
+ */
+
+ /**
  * An action to be performed on the workspace.
  * @typedef {Object} WorkspaceAction
  * @property {!Blockly.Event} event A Blockly Event.


### PR DESCRIPTION
Create and store a snapshot of the current state of the workspace
whenever a new user connects. A snapshot object contains the XML of the
workspace and the serverId of the last entry represented on the
workspace.