### PR TITLE
Detect user disconnects and dispose markers for websocket sample.

### DIFF
--- a/blockly-rtc/server/Database.js
+++ b/blockly-rtc/server/Database.js
@@ -233,6 +233,27 @@ class Database {
       });
     });
   };
+
+  /**
+   * Delete a user from the users table.
+   * @param {string} workspaceId The workspaceId of the user to be removed from
+   * the users table.
+   * @return {!Promise} Promise object represents the success of the deletion.
+   * @public
+   */
+  deleteUser(workspaceId) {
+    return new Promise((resolve, reject) => {
+      this.db.run(
+          `DELETE FROM users WHERE workspaceId = '${workspaceId}';`,
+          (err) => {
+        if (err) {
+          console.error(err.message);
+          reject();
+        };
+        resolve();
+      });
+    });
+  };
 };
 
 module.exports = new Database();

--- a/blockly-rtc/server/websocket/users_handlers.js
+++ b/blockly-rtc/server/websocket/users_handlers.js
@@ -84,7 +84,6 @@ async function connectUserHandler(user, workspaceId, callback) {
  * @public
  */
 async function disconnectUserHandler(workspaceId, callback) {
-  console.log('User disconnected.');
   await database.deleteUser(workspaceId);
   callback();
 };

--- a/blockly-rtc/server/websocket/users_handlers.js
+++ b/blockly-rtc/server/websocket/users_handlers.js
@@ -53,6 +53,43 @@ async function getPositionUpdatesHandler(workspaceId, callback) {
   const positionUpdates = await database.getPositionUpdates(workspaceId);
   callback(positionUpdates);
 };
-  
+
+/**
+ * Handler for a connectUser message. Attach the workspaceId to the user and
+ * add the user to the users table.
+ * @param {!Object} user The user connecting.
+ * @param {string} workspaceId The workspaceId for the connecting user.
+ * @param {!Function} callback The callback passed in by WorkspaceClient to
+ * receive acknowledgement of the success of the connection.
+ * @public
+ */
+async function connectUserHandler(user, workspaceId, callback) {
+  user.workspaceId = workspaceId;
+  const positionUpdate = {
+    workspaceId: workspaceId,
+    position: {
+      type: null,
+      blockId: null,
+      fieldName: null
+    },
+  };
+  await updatePositionHandler(user, positionUpdate, callback);
+};
+
+/**
+ * Handler for a disconnect. Delete the user from the users table.
+ * @param {string} workspaceId The workspaceId for the disconnecting user.
+ * @param {!Function} callback The callback that broadcasts the disconnect to
+ * the connected users.
+ * @public
+ */
+async function disconnectUserHandler(workspaceId, callback) {
+  console.log('User disconnected.');
+  await database.deleteUser(workspaceId);
+  callback();
+};
+
 module.exports.updatePositionHandler = updatePositionHandler;
 module.exports.getPositionUpdatesHandler = getPositionUpdatesHandler;
+module.exports.disconnectUserHandler = disconnectUserHandler;
+module.exports.connectUserHandler = connectUserHandler;

--- a/blockly-rtc/server/websocket_server.js
+++ b/blockly-rtc/server/websocket_server.js
@@ -50,8 +50,14 @@ io.on('connection', (user) => {
  * @private
  */
 async function onConnect_(user) {
-  user.on('disconnect', () => {
-    console.log('User disconnected.');
+  user.on('connectUser', async (workspaceId, callback) => {
+    await UsersHandlers.connectUserHandler(user, workspaceId, callback);
+  });
+
+  user.on('disconnect', async () => {
+    await UsersHandlers.disconnectUserHandler(user.workspaceId, () => {
+      io.emit('disconnectUser', user.workspaceId);
+    });
   });
 
   user.on('addEvents', async (entry, callback) => {

--- a/blockly-rtc/src/http/index.js
+++ b/blockly-rtc/src/http/index.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const userDataManager = new UserDataManager(workspace.id, sendPositionUpdate,
       getPositionUpdates);  
-  await userDataManager.initMarkers();
+  await userDataManager.start();
 
   workspace.addChangeListener((event) => {
     if (event instanceof Blockly.Events.Ui) {

--- a/blockly-rtc/src/websocket/index.js
+++ b/blockly-rtc/src/websocket/index.js
@@ -23,7 +23,8 @@
 
 import * as Blockly from 'blockly';
 import {getEvents, writeEvents, getBroadcast} from './workspace_client_handlers';
-import {getPositionUpdates, sendPositionUpdate, getBroadcastPositionUpdates} from './user_data_handlers';
+import {getPositionUpdates, sendPositionUpdate, getBroadcastPositionUpdates,
+    connectUser, getUserDisconnects} from './user_data_handlers';
 import UserDataManager from '../UserDataManager';
 import WorkspaceClient from '../WorkspaceClient';
 
@@ -41,8 +42,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   await workspaceClient.initiateWorkspace();
 
   const userDataManager = new UserDataManager(workspace.id, sendPositionUpdate,
-      getPositionUpdates, getBroadcastPositionUpdates);  
-  await userDataManager.initMarkers();
+      getPositionUpdates, getBroadcastPositionUpdates);
+  await userDataManager.setPresenceHandlers(connectUser, getUserDisconnects);
+  await userDataManager.start();
 
   workspace.addChangeListener((event) => {
     if (event instanceof Blockly.Events.Ui) {

--- a/blockly-rtc/src/websocket/user_data_handlers.js
+++ b/blockly-rtc/src/websocket/user_data_handlers.js
@@ -64,14 +64,39 @@ export async function sendPositionUpdate(positionUpdate) {
 /**
  * Listen for PositionUpdates broadcast by the server.
  * @param {!Function} callback The callback handler that passes the
- * PositionUpdates to WorkspaceClient.
+ * PositionUpdates to UserDataManager.
  * @public
  */
-export function getBroadcastPositionUpdates(callback) {
+export async function getBroadcastPositionUpdates(callback) {
   socket.on('broadcastPosition', async (positionUpdates)=> {
     positionUpdates.forEach((positionUpdate) => {
       positionUpdate.position = Position.fromJson(positionUpdate.position);
     });
     await callback(positionUpdates);
+  });
+};
+
+/**
+ * Enable tracking of the user by sending the workspaceId to the server.
+ * @param {string} workspaceId The workspaceId of the user.
+ * @public
+ */
+export async function connectUser(workspaceId) {
+  return new Promise((resolve, reject) => {
+    socket.emit('connectUser', workspaceId, ()=> {
+      resolve();
+    });  
+  });
+};
+
+/**
+ * Listen for user disconnects broadcast by the server.
+ * @param {!Function} callback The callback handler that passes the
+ * workspaceId of the disconnected user to the UserDataManager.
+ * @public
+ */
+export function getUserDisconnects(callback) {
+  socket.on('disconnectUser', async (workspaceId)=> {
+    await callback(workspaceId);
   });
 };

--- a/blockly-rtc/test/user_data_manager_test.js
+++ b/blockly-rtc/test/user_data_manager_test.js
@@ -82,6 +82,31 @@ suite('UserDataManager', () => {
     });
   });
 
+  suite('disposeMarker', () => {
+    test('No Blockly MarkerManager, throw error.', async () => {
+      sinon.stub(this.userDataManager, 'getMarkerManager_').returns(null);
+      sinon.spy(this.userDataManager, 'disposeMarker_');
+      try {
+        this.userDataManager.disposeMarker_();
+      } catch {};
+      assert(this.userDataManager.disposeMarker_.threw());
+    });
+
+    test('No Marker with the given workspaceId, no error.', async () => {
+      sinon.spy(this.userDataManager, 'disposeMarker_');
+      this.userDataManager.disposeMarker_('mockId');
+      assert(!this.userDataManager.disposeMarker_.threw());
+    });
+
+    test('Unregister Marker from Blockly MarkerManager.', async () => {
+      sinon.spy(this.BlocklyMarkerManager, 'unregisterMarker');
+      const marker = new Blockly.Marker();
+      this.BlocklyMarkerManager.markers_['mockId'] = marker;
+      this.userDataManager.disposeMarker_('mockId');
+      assert(this.BlocklyMarkerManager.unregisterMarker.calledOnceWith('mockId'));
+    });    
+  });
+
   suite('updateMarkerPositions', () => {
     setup(() => {
       this.BlocklyMarkerManager.markers_ = {


### PR DESCRIPTION
Websocket server will attach the workspaceId to each user in order track
users and send a broadcast to users when someone disconnects. Upon
disconnecting, the user is removed from the database and the event is
broadcast to the other users.

UserDataManager disposes of markers that have disconnected.