### PR TITLE
Create positions for fields.

### DIFF
--- a/blockly-rtc/src/Position.js
+++ b/blockly-rtc/src/Position.js
@@ -37,10 +37,12 @@ export default class Position {
    * @public
    */  
   static fromEvent(event) {
-    if (event instanceof Blockly.Events.Ui) {
-      return this.fromUiEvent_(event);
-    } else if (event instanceof Blockly.Events.Change) {
-      return this.fromChangeEvent_(event);
+    if (event instanceof Blockly.Events.Ui
+        && event.element == 'selected') {
+      return this.fromSelectedUiEvent_(event);
+    } else if (event instanceof Blockly.Events.Change
+        && event.element == 'field') {
+      return this.fromFieldChangeEvent_(event);
     } else {
       throw Error('Cannot create position from this event.');
     }
@@ -52,7 +54,7 @@ export default class Position {
    * @return {!PositionUpdate} The Position representative of the event.
    * @private
    */  
-  static fromUiEvent_(event) {
+  static fromSelectedUiEvent_(event) {
     const type = 'BLOCK';
     const blockId = event.newValue;
     const fieldName = null;
@@ -65,7 +67,7 @@ export default class Position {
    * @return {!PositionUpdate} The Position representative of the event.
    * @private
    */  
-  static fromChangeEvent_(event) {
+  static fromFieldChangeEvent_(event) {
     const type = 'FIELD';
     const blockId = event.blockId;
     const fieldName = event.name;

--- a/blockly-rtc/src/Position.js
+++ b/blockly-rtc/src/Position.js
@@ -37,11 +37,38 @@ export default class Position {
    * @public
    */  
   static fromEvent(event) {
-    // TODO: Add support for a field position on a change event.
-    const id = event.workspaceId;
+    if (event instanceof Blockly.Events.Ui) {
+      return this.fromUiEvent_(event);
+    } else if (event instanceof Blockly.Events.Change) {
+      return this.fromChangeEvent_(event);
+    } else {
+      throw Error('Cannot create position from this event.');
+    }
+  };
+
+  /**
+   * Create a Position from a Blockly UI event.
+   * @param {!Blockly.Event.Ui} event The event that creates a Position.
+   * @return {!PositionUpdate} The Position representative of the event.
+   * @private
+   */  
+  static fromUiEvent_(event) {
     const type = 'BLOCK';
     const blockId = event.newValue;
     const fieldName = null;
+    return new Position(type, blockId, fieldName);  
+  };
+
+  /**
+   * Create a Position from a Blockly Change event.
+   * @param {!Blockly.Event.Change} event The event that creates a Position.
+   * @return {!PositionUpdate} The Position representative of the event.
+   * @private
+   */  
+  static fromChangeEvent_(event) {
+    const type = 'FIELD';
+    const blockId = event.blockId;
+    const fieldName = event.name;
     return new Position(type, blockId, fieldName);  
   };
 

--- a/blockly-rtc/src/http/index.js
+++ b/blockly-rtc/src/http/index.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       };
       return;
     };
-    if (event instanceof Blockly.Events.Change) {
+    if (event instanceof Blockly.Events.Change && event.element == 'field') {
       userDataManager.handleEvent(event);
     };
     workspaceClient.activeChanges.push(event);

--- a/blockly-rtc/src/http/index.js
+++ b/blockly-rtc/src/http/index.js
@@ -52,6 +52,9 @@ document.addEventListener('DOMContentLoaded', async () => {
       };
       return;
     };
+    if (event instanceof Blockly.Events.Change) {
+      userDataManager.handleEvent(event);
+    };
     workspaceClient.activeChanges.push(event);
     if (!Blockly.Events.getGroup()) {
       workspaceClient.flushEvents();

--- a/blockly-rtc/src/websocket/index.js
+++ b/blockly-rtc/src/websocket/index.js
@@ -51,7 +51,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       };
       return;
     };
-    if (event instanceof Blockly.Events.Change) {
+    if (event instanceof Blockly.Events.Change && event.element == 'field') {
       userDataManager.handleEvent(event);
     };
     workspaceClient.activeChanges.push(event);

--- a/blockly-rtc/src/websocket/index.js
+++ b/blockly-rtc/src/websocket/index.js
@@ -51,6 +51,9 @@ document.addEventListener('DOMContentLoaded', async () => {
       };
       return;
     };
+    if (event instanceof Blockly.Events.Change) {
+      userDataManager.handleEvent(event);
+    };
     workspaceClient.activeChanges.push(event);
     if (!Blockly.Events.getGroup()) {
       workspaceClient.flushEvents();

--- a/blockly-rtc/test/position_test.js
+++ b/blockly-rtc/test/position_test.js
@@ -41,6 +41,9 @@ suite('Position', () => {
           .onSecondCall().returns(this.FAKE_BLOCK_ID);
       this.workspace = new Blockly.Workspace();
       this.block = new Blockly.Block(this.workspace, 'test_block');
+      this.field = new Blockly.Field('hello');
+      this.field.sourceBlock_ = this.block;
+      this.field.name = 'message0';
     });
 
     teardown(() => {
@@ -55,6 +58,24 @@ suite('Position', () => {
       const position = Position.fromEvent(event);
       const expectedPosition = new Position('BLOCK', this.FAKE_BLOCK_ID, null);
       assert.deepEqual(position, expectedPosition);
+    });
+
+    test('From CHANGE event on a field.', async () => {
+      const event = new Blockly.Events.Change(
+          this.block, 'field', 'message0', 'hello', 'goodbye');
+      const position = Position.fromEvent(event);
+      const expectedPosition = new Position(
+          'FIELD', this.FAKE_BLOCK_ID, 'message0');
+      assert.deepEqual(position, expectedPosition);
+    });
+
+    test('From other not supported event, throw error.', async () => {
+      sinon.spy(Position, 'fromEvent');
+      const event = new Blockly.Events.BlockMove();
+      try {
+        Position.fromEvent(event);
+      } catch {};
+      assert(Position.fromEvent.threw);
     });
   });
 

--- a/blockly-rtc/test/position_test.js
+++ b/blockly-rtc/test/position_test.js
@@ -71,7 +71,8 @@ suite('Position', () => {
 
     test('From other not supported event, throw error.', async () => {
       sinon.spy(Position, 'fromEvent');
-      const event = new Blockly.Events.BlockMove();
+      const event = new Blockly.Events.Change(
+          this.block, 'comment', 'message0', 'hello', 'goodbye');
       try {
         Position.fromEvent(event);
       } catch {};


### PR DESCRIPTION
Allow Blockly Change events to indicate a user position on a field.