### PR TITLE
Configure proxy for websocket server.

### DIFF
--- a/blockly-rtc/src/websocket/user_data_handlers.js
+++ b/blockly-rtc/src/websocket/user_data_handlers.js
@@ -26,7 +26,7 @@
 import io from 'socket.io-client';
 import Position from '../Position';
 
-const socket = io('http://localhost:3001');
+const socket = io();
 
 /**
  * Get the position for a given user. If no user is specified will return the

--- a/blockly-rtc/src/websocket/workspace_client_handlers.js
+++ b/blockly-rtc/src/websocket/workspace_client_handlers.js
@@ -25,7 +25,7 @@
 import * as Blockly from 'blockly';
 import io from 'socket.io-client';
 
-const socket = io('http://localhost:3001');
+const socket = io();
 
 /**
  * Query the database a snapshot of the current workspace.

--- a/blockly-rtc/webpack.config.js
+++ b/blockly-rtc/webpack.config.js
@@ -55,7 +55,11 @@ module.exports = {
     devServer: {
         port: 3000,
         proxy: {
-            '/api': 'http://localhost:3001'
+            '/api': 'http://localhost:3001',
+            '/socket.io': {
+                target: 'ws://localhost:3001',
+                ws: true
+             }
           }
       }
 };


### PR DESCRIPTION
Currently the webpack devServer would only proxy an HTTP request. Add an
endpoint for websocket proxy requests.