### PR TITLE
Remove placeholder character for connections in block string to search.

### DIFF
--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -296,9 +296,6 @@ class WorkspaceSearch {
         input.fieldRow.forEach(function(field) {
           topBlockText.push(field.getText());
         });
-        if (input.connection) {
-          topBlockText.push('?');
-        }
       });
       blockText = topBlockText.join(' ').trim();
     }


### PR DESCRIPTION
Remove placeholder character "?" so that strings like "if do" will match if block.