### PR TITLE
Keyboard accessibility

### DIFF
--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -146,6 +146,8 @@ class WorkspaceSearch {
     var btn = document.createElement('button');
     Blockly.utils.dom.addClass(btn, className);
     btn.addEventListener('click', onClickFn);
+    // TODO: Reivew Blockly's key handling to see if there is a way to avoid
+    // this.
     btn.addEventListener('keydown', function(e) {
       if (e.key === "Enter") {
         onClickFn(e);

--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -78,7 +78,6 @@ class WorkspaceSearch {
      * @private
      */
     this.textInput_ = null;
-    this.id = Math.random();
   }
 
   /**

--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -252,6 +252,10 @@ class WorkspaceSearch {
       const currBlock = this.blocks_[this.currentBlockIndex_];
       const currPath = currBlock.pathObject.svgPath;
       Blockly.utils.dom.addClass(currPath, 'searchCurrent');
+      if (this.workspace_.keyboardAccessibilityMode) {
+        let currAstNode = Blockly.navigation.getTopNode(currBlock);
+        this.workspace_.getCursor().setCurNode(currAstNode);
+      }
       // TODO: scroll to block if it is not visible on workspace
     }
   }

--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -164,7 +164,7 @@ class WorkspaceSearch {
     btn.addEventListener('click', onClickFn);
     // TODO: Review Blockly's key handling to see if there is a way to avoid
     // this.
-    btn.addEventListener('keydown', function(e) {
+    btn.addEventListener('keydown', e => function(e) {
       if (e.key === "Enter") {
         onClickFn(e);
         e.preventDefault();  
@@ -172,7 +172,7 @@ class WorkspaceSearch {
         this.close();
       }
       e.stopPropagation();
-    }.bind(this));
+    });
     btn.append(textSpan);
     return btn;
   }

--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -97,29 +97,29 @@ class WorkspaceSearch {
    * Initializes the workspace search bar.
    */
   init() {
-    var svg = this.workspace_.getParentSvg();
-    var metrics = this.workspace_.getMetrics();
+    let svg = this.workspace_.getParentSvg();
+    const metrics = this.workspace_.getMetrics();
 
     // Create the text input for search.
-    var textInput = document.createElement('input');
+    let textInput = document.createElement('input');
     Blockly.utils.dom.addClass(textInput, 'searchInput');
     textInput.type = 'text';
 
     // TODO: Figure out how we are going to deal with translating.
     textInput.setAttribute('placeholder', 'Search');
     this.textInput_ = textInput;
-    textInput.addEventListener('keydown', this.onKeyDown_.bind(this));
-    textInput.addEventListener('input', this.onInput_.bind(this));
+    textInput.addEventListener('keydown', evt => this.onKeyDown_(evt));
+    textInput.addEventListener('input', evt => this.onInput_(evt));
     svg.parentNode.addEventListener('keydown',
-        this.onWorkspaceKeyDown_.bind(this));
+        evt => this.onWorkspaceKeyDown_(evt));
 
     // Add all the buttons for the search bar
-    var upBtn = this.createBtn_('upBtn', 'Find previous', 
-        this.previous_.bind(this));
-    var downBtn = this.createBtn_('downBtn', 'Find next', 
-        this.next_.bind(this));
-    var closeBtn = this.createBtn_('closeBtn', 'Close search bar', 
-        this.close.bind(this));
+    const upBtn = this.createBtn_('upBtn', 'Find previous',
+        evt => this.previous_(evt));
+    const downBtn = this.createBtn_('downBtn', 'Find next',
+        evt => this.next_(evt));
+    const closeBtn = this.createBtn_('closeBtn', 'Close search bar',
+        evt => this.close(evt));
     this.HtmlDiv = document.createElement('div');
     Blockly.utils.dom.addClass(this.HtmlDiv, 'workspaceSearchBar');
 
@@ -154,15 +154,15 @@ class WorkspaceSearch {
    */
   createBtn_(className, text, onClickFn) {
     // Create a span holding text to be used for accessibility purposes.
-    var textSpan = document.createElement('span');
+    let textSpan = document.createElement('span');
     textSpan.innerText = text;
     Blockly.utils.dom.addClass(textSpan, 'btnText');
 
     // Create the button
-    var btn = document.createElement('button');
+    let btn = document.createElement('button');
     Blockly.utils.dom.addClass(btn, className);
     btn.addEventListener('click', onClickFn);
-    // TODO: Reivew Blockly's key handling to see if there is a way to avoid
+    // TODO: Review Blockly's key handling to see if there is a way to avoid
     // this.
     btn.addEventListener('keydown', function(e) {
       if (e.key === "Enter") {
@@ -301,12 +301,12 @@ class WorkspaceSearch {
   }
 
   /**
-   * Update the location of the cursor if the user is in keyboard naviation
+   * Updates the location of the cursor if the user is in keyboard naviation
    * mode.
    */
   updateCursor_(currBlock) {
     if (this.workspace_.keyboardAccessibilityMode) {
-      let currAstNode = Blockly.navigation.getTopNode(currBlock);
+      const currAstNode = Blockly.navigation.getTopNode(currBlock);
       this.workspace_.getCursor().setCurNode(currAstNode);
     }
   }
@@ -336,12 +336,13 @@ class WorkspaceSearch {
   }
 
   /**
-   * Mark the user's current position when opening the search bar.
+   * Marks the user's current position when opening the search bar.
    */
   updateMarker_() {
-    var marker = this.workspace_.getMarker(Blockly.navigation.MARKER_NAME);
-    if (this.workspace_.keyboardAccessibilityMode && !marker.getCurNode()) {
-      var curNode = this.workspace_.getCursor().getCurNode();
+    const marker = this.workspace_.getMarker(Blockly.navigation.MARKER_NAME);
+    if (this.workspace_.keyboardAccessibilityMode && marker &&
+        !marker.getCurNode()) {
+      const curNode = this.workspace_.getCursor().getCurNode();
       marker.setCurNode(curNode);
     }
   }

--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -424,7 +424,7 @@ class WorkspaceSearch {
       return;
     }
     const searchGroup = this.getSearchPool_();
-    const isBlockMatch = this.isBlockMatch_;
+    const isBlockMatch = this.isBlockMatch_.bind(this);
     const text = this.searchText_;
     this.blocks_ = searchGroup.filter(
         function(block) {


### PR DESCRIPTION
If the marker is not already being used marks the current location before moving the cursor to the currently selected block. 

Added keydown handler to the buttons so it does not bubble up to Blockly's keydown handler. 

Use addEventListener instead of the private Blockly.bindEventWithChecks_ 

Fixes bug with this being undefined in isBlockMatch_