### PR TITLE
Update on click

### DIFF
--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -110,7 +110,7 @@ class WorkspaceSearch {
     this.textInput_ = textInput;
     Blockly.bindEventWithChecks_(textInput, 'keydown', this, this.onKeyDown_);
     Blockly.bindEventWithChecks_(textInput, 'input', this, this.onInput_);
-    Blockly.bindEventWithChecks_(textInput, 'click', this, this.onClick_);
+    textInput.addEventListener('click', evt => this.onInputClick_(evt));
     Blockly.bindEventWithChecks_(svg.parentNode, 'keydown', this,
         this.onWorkspaceKeyDown_);
 
@@ -183,12 +183,16 @@ class WorkspaceSearch {
    * Handles clicking on the input value in search bar.
    * @param {Event} e The onclick event.
    */
-  onClick_(e) {
-    const inputValue = e.target.value;
-    const currIdx = this.currentBlockIndex_;
-    this.setSearchText_(inputValue);
+  onInputClick_() {
+    const oldBlock = this.currentBlock_;
+    let oldIdx = this.currentBlockIndex_;
     this.search();
-    this.setCurrentBlock_(currIdx);
+    const currentBlockIdx = this.blocks_.indexOf(oldBlock);
+    if (currentBlockIdx > -1) {
+      this.setCurrentBlock_(currentBlockIdx);
+    } else {
+      this.setCurrentBlock_(oldIdx);
+    }
   }
 
   /**

--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -197,15 +197,7 @@ class WorkspaceSearch {
    * @param {Event} e The onclick event.
    */
   onInputClick_() {
-    const oldBlock = this.currentBlock_;
-    let oldIdx = this.currentBlockIndex_;
-    this.search();
-    const currentBlockIdx = this.blocks_.indexOf(oldBlock);
-    if (currentBlockIdx > -1) {
-      this.setCurrentBlock_(currentBlockIdx);
-    } else {
-      this.setCurrentBlock_(oldIdx);
-    }
+    this.search(this.currentBlock_);
   }
 
   /**
@@ -293,9 +285,6 @@ class WorkspaceSearch {
       Blockly.utils.dom.addClass(currPath, 'searchCurrent');
       this.updateCursor_(this.currentBlock_);
       this.scrollToVisible_(this.currentBlock_);
-      // Blockly.WidgetDiv.hide called in scroll is taking away focus.
-      // TODO: review setFocused call in Blockly.WidgetDiv.hide.
-      this.textInput_.focus();
     }
   }
 
@@ -381,12 +370,28 @@ class WorkspaceSearch {
 
   /**
    * Searches the workspace for the current search term.
+   * @param {Blockly.Block=} opt_block Optional block to use as the current
+   *     block.
    */
-  search() {
+  search(opt_block) {
     this.clearBlocks();
     this.populateBlocks();
     this.highlightBlocks();
-    this.next_();
+    this.setCurrentBlock_(this.findNewBlockIdx_(opt_block));
+  }
+
+  /**
+   * Given a block find the correct index to use as the current index.
+   * @param {Blockly.Block=} opt_block Optional block to use as the current
+   *    block.
+   */
+  findNewBlockIdx_(opt_block) {
+    let newBlockIdx = 0;
+    if (opt_block) {
+      const blockIdx = this.blocks_.indexOf(opt_block);
+      newBlockIdx = blockIdx > -1 ? blockIdx : 0;
+    }
+    return newBlockIdx;
   }
 
   /**
@@ -529,9 +534,14 @@ class WorkspaceSearch {
       // Scroll to show bottom of block
       targetTop = bottom - metrics.viewHeight;
     }
-
+    const activeEl = document.activeElement;
     if (targetLeft !== metrics.viewLeft || targetTop !== metrics.viewTop) {
       this.workspace_.scroll(-targetLeft, -targetTop);
+      if (activeEl) {
+        // Blockly.WidgetDiv.hide called in scroll is taking away focus.
+        // TODO: review setFocused call in Blockly.WidgetDiv.hide.
+        activeEl.focus();
+      }
     }
   }
 }

--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -97,8 +97,11 @@ class WorkspaceSearch {
     this.textInput_ = textInput;
     Blockly.bindEventWithChecks_(textInput, 'keydown', this, this.onKeyDown_);
     Blockly.bindEventWithChecks_(textInput, 'input', this, this.onInput_);
+    Blockly.bindEventWithChecks_(textInput, 'click', this, this.onClick_);
     Blockly.bindEventWithChecks_(svg.parentNode, 'keydown', this,
         this.onWorkspaceKeyDown_);
+
+    // this.workspace_.addChangeListener(this.removeBlock_.bind(this));
 
     // Add all the buttons for the search bar
     var upBtn = this.createBtn_('upBtn', 'Find previous', this.previous_);
@@ -126,6 +129,17 @@ class WorkspaceSearch {
 
     svg.parentNode.insertBefore(this.HtmlDiv, svg);
     this.setVisible(false);
+  }
+
+  /**
+   * 
+   */
+  removeBlock_(e) {
+    const deletedBlock = this.workspace_.getBlockById(e.blockId);
+    const deletedIdx = this.blocks_.indexOf(deletedBlock);
+    if (deletedIdx > -1) {
+      this.blocks_.splice(deletedIdx, 1);
+    }
   }
 
   /**
@@ -163,6 +177,16 @@ class WorkspaceSearch {
         this.search();
       }
     }
+  }
+
+  onClick_(e) {
+    console.log("HERE");
+    const inputValue = e.target.value;
+    const currIdx = this.currentBlockIndex_;
+    this.setSearchText_(inputValue);
+    this.search();
+    // Could this be something I pass into the search function?
+    this.setCurrentIndex_(currIdx);
   }
 
   /**
@@ -393,6 +417,9 @@ class WorkspaceSearch {
     this.blocks_.forEach(function(/** @type {!Blockly.BlockSvg} */ block) {
       const blockPath = block.pathObject.svgPath;
       Blockly.utils.dom.removeClass(blockPath, 'searchHighlight');
+      if (Blockly.utils.dom.hasClass(blockPath, 'searchCurrent')) {
+        Blockly.utils.dom.removeClass(blockPath, 'searchCurrent');
+      }
     });
   }
 }

--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -370,8 +370,8 @@ class WorkspaceSearch {
 
   /**
    * Searches the workspace for the current search term.
-   * @param {Blockly.Block=} opt_block Optional block to use as the current
-   *     block.
+   * @param {Blockly.Block=} opt_block Block to use as the current
+   *     block if it is included in new search blocks.
    */
   search(opt_block) {
     this.clearBlocks();
@@ -522,8 +522,8 @@ class WorkspaceSearch {
       // Scroll to show bottom of block
       targetTop = bottom - metrics.viewHeight;
     }
-    const activeEl = document.activeElement;
     if (targetLeft !== metrics.viewLeft || targetTop !== metrics.viewTop) {
+      const activeEl = document.activeElement;
       this.workspace_.scroll(-targetLeft, -targetTop);
       if (activeEl) {
         // Blockly.WidgetDiv.hide called in scroll is taking away focus.

--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -114,8 +114,6 @@ class WorkspaceSearch {
     Blockly.bindEventWithChecks_(svg.parentNode, 'keydown', this,
         this.onWorkspaceKeyDown_);
 
-    // this.workspace_.addChangeListener(this.removeBlock_.bind(this));
-
     // Add all the buttons for the search bar
     var upBtn = this.createBtn_('upBtn', 'Find previous', this.previous_);
     var downBtn = this.createBtn_('downBtn', 'Find next', this.next_);
@@ -142,17 +140,6 @@ class WorkspaceSearch {
 
     svg.parentNode.insertBefore(this.HtmlDiv, svg);
     this.setVisible(false);
-  }
-
-  /**
-   * 
-   */
-  removeBlock_(e) {
-    const deletedBlock = this.workspace_.getBlockById(e.blockId);
-    const deletedIdx = this.blocks_.indexOf(deletedBlock);
-    if (deletedIdx > -1) {
-      this.blocks_.splice(deletedIdx, 1);
-    }
   }
 
   /**
@@ -197,13 +184,11 @@ class WorkspaceSearch {
    * @param {Event} e The onclick event.
    */
   onClick_(e) {
-    console.log("HERE");
     const inputValue = e.target.value;
     const currIdx = this.currentBlockIndex_;
     this.setSearchText_(inputValue);
     this.search();
-    // Could this be something I pass into the search function?
-    this.setCurrentIndex_(currIdx);
+    this.setCurrentBlock_(currIdx);
   }
 
   /**
@@ -258,9 +243,6 @@ class WorkspaceSearch {
       return;
     }
     this.setCurrentBlock_(this.currentBlockIndex_ - 1);
-    // Blockly.WidgetDiv.hide called in scroll is taking away focus.
-    // TODO: review setFocused call in Blockly.WidgetDiv.hide.
-    this.textInput_.focus();
   }
 
   /**
@@ -272,9 +254,6 @@ class WorkspaceSearch {
       return;
     }
     this.setCurrentBlock_(this.currentBlockIndex_ + 1);
-    // Blockly.WidgetDiv.hide called in scroll is taking away focus.
-    // TODO: review setFocused call in Blockly.WidgetDiv.hide.
-    this.textInput_.focus();
   }
 
   /**
@@ -296,6 +275,9 @@ class WorkspaceSearch {
       const currPath = this.currentBlock_.pathObject.svgPath;
       Blockly.utils.dom.addClass(currPath, 'searchCurrent');
       this.scrollToVisible_(this.currentBlock_);
+      // Blockly.WidgetDiv.hide called in scroll is taking away focus.
+      // TODO: review setFocused call in Blockly.WidgetDiv.hide.
+      this.textInput_.focus();
     }
   }
 
@@ -455,9 +437,6 @@ class WorkspaceSearch {
     this.blocks_.forEach(function(/** @type {!Blockly.BlockSvg} */ block) {
       const blockPath = block.pathObject.svgPath;
       Blockly.utils.dom.removeClass(blockPath, 'searchHighlight');
-      if (Blockly.utils.dom.hasClass(blockPath, 'searchCurrent')) {
-        Blockly.utils.dom.removeClass(blockPath, 'searchCurrent');
-      }
     });
   }
 

--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -377,21 +377,9 @@ class WorkspaceSearch {
     this.clearBlocks();
     this.populateBlocks();
     this.highlightBlocks();
-    this.setCurrentBlock_(this.findNewBlockIdx_(opt_block));
-  }
-
-  /**
-   * Given a block find the correct index to use as the current index.
-   * @param {Blockly.Block=} opt_block Optional block to use as the current
-   *    block.
-   */
-  findNewBlockIdx_(opt_block) {
-    let newBlockIdx = 0;
-    if (opt_block) {
-      const blockIdx = this.blocks_.indexOf(opt_block);
-      newBlockIdx = blockIdx > -1 ? blockIdx : 0;
-    }
-    return newBlockIdx;
+    let newBlockIdx = this.blocks_.indexOf(opt_block);
+    newBlockIdx = newBlockIdx > -1 ? newBlockIdx : 0;
+    this.setCurrentBlock_(newBlockIdx);
   }
 
   /**

--- a/blockly-ws-search/workspace_search.js
+++ b/blockly-ws-search/workspace_search.js
@@ -179,6 +179,10 @@ class WorkspaceSearch {
     }
   }
 
+  /**
+   * Handles clicking on the input value in search bar.
+   * @param {Event} e The onclick event.
+   */
   onClick_(e) {
     console.log("HERE");
     const inputValue = e.target.value;


### PR DESCRIPTION
Redo search when a user clicks on the input. This deals with when a user adds new blocks or deletes blocks.

When a user deletes the current block it finds the next in the list. 
When a user deletes any other block it updates itself to have the new index of the old block. 

In the future we will want to probably change to onfocus instead of onclick but can't do right now since focus is a bit messed up because of Blockly's scroll function.

![7f1a706b-654f-4c24-a69e-6fc2b53a91f7](https://user-images.githubusercontent.com/23059043/74986105-c672fa80-53ed-11ea-92c1-c0fb4b2f1a7a.gif)
