### PR TITLE
Update scripts for testing and web imports example.

### DIFF
--- a/blockly-ws-search/example/web-imports/package-lock.json
+++ b/blockly-ws-search/example/web-imports/package-lock.json
@@ -6812,14 +6812,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6834,20 +6832,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6964,8 +6959,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6977,7 +6971,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6992,7 +6985,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7113,8 +7105,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7247,7 +7238,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/blockly-ws-search/example/web-imports/webpack.config.js
+++ b/blockly-ws-search/example/web-imports/webpack.config.js
@@ -10,5 +10,6 @@ module.exports = {
   devServer: {
     contentBase: path.join(__dirname, 'dist'),
     compress: true,
+    open: true
   }
 };

--- a/blockly-ws-search/package.json
+++ b/blockly-ws-search/package.json
@@ -4,8 +4,9 @@
   "description": "Implementation of workspace search for Blockly.",
   "main": "./src/WorkspaceSearch.js",
   "scripts": {
-    "build": "webpack",
-    "start": "webpack-dev-server"
+    "prepare": "webpack --display-error-details --config webpack.config.js\n",
+    "clean": "rm -rf $npm_package_directories_build",
+    "test": "webpack-dev-server"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -15,6 +16,9 @@
     "./src",
     "./media"
   ],
+  "directories": {
+    "build": "build"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/google/blockly-samples.git",

--- a/blockly-ws-search/webpack.config.js
+++ b/blockly-ws-search/webpack.config.js
@@ -19,5 +19,9 @@ module.exports = {
         path: path.resolve(__dirname, 'build'),
         filename: 'workspace_search_bundle.js',
         libraryTarget: 'umd'
+    },
+    devServer: {
+        openPage: 'test',
+        open: true
     }
 };


### PR DESCRIPTION
- Updated test demo to open with `npm run test` command (as well as web-imports demo)
- Added clean command for built files
- Moved bundling with webpack to prepare step so that it is automatically bundled after npm install command.