### PR TITLE
Fixing css injection logic.

### DIFF
--- a/blockly-ws-search/src/WorkspaceSearch.js
+++ b/blockly-ws-search/src/WorkspaceSearch.js
@@ -10,7 +10,7 @@
  */
 
 
-import './css.js';
+import { injectSearchCss } from './css.js';
 import * as Blockly from 'blockly/core';
 
 export class WorkspaceSearch {
@@ -85,6 +85,8 @@ export class WorkspaceSearch {
    * Initializes the workspace search bar.
    */
   init() {
+    injectSearchCss();
+
     const workspaceSvg = this.workspace_.getParentSvg();
     workspaceSvg.parentNode.addEventListener('keydown',
         evt => this.onWorkspaceKeyDown_(evt));

--- a/blockly-ws-search/src/css.js
+++ b/blockly-ws-search/src/css.js
@@ -9,8 +9,6 @@
  * @author kozbial@google.com (Monica Kozbial)
  */
 
-import * as Blockly from 'blockly/core';
-
 /**
  * Base64 encoded data uri for close icon.
  * @type {string}
@@ -44,8 +42,9 @@ const ARROW_UP_ARROW_SVG_DATAURI =
 
 /**
  * CSS for search bar.
+ * @type {Array.<string>}
  */
-Blockly.Css.register([
+const CSS_CONTENT = [
   'path.blocklyPath.search-highlight {',
     'fill: black;',
   '}',
@@ -91,4 +90,25 @@ Blockly.Css.register([
   '.ws-search-content {',
     'display: flex;',
   '}',
-]);
+];
+
+/**
+ * Injects CSS for workspace search.
+ */
+export const injectSearchCss = (function() {
+  let executed = false;
+  return function() {
+    // Only inject the CSS once.
+    if (executed) {
+      return;
+    }
+    executed = true;
+    const text = CSS_CONTENT.join('\n');
+    // Inject CSS tag at start of head.
+    const cssNode = document.createElement('style');
+    cssNode.id = 'blockly-ws-search-style';
+    const cssTextNode = document.createTextNode(text);
+    cssNode.appendChild(cssTextNode);
+    document.head.insertBefore(cssNode, document.head.firstChild);
+  }
+})();

--- a/blockly-ws-search/test/main.js
+++ b/blockly-ws-search/test/main.js
@@ -9,8 +9,6 @@
  * @author kozbial@gmail.com (Monica Kozbial)
  */
 
-
-
 const options = {
   comments: true,
   collapse: true,


### PR DESCRIPTION
Removing reliance on Blockly.Css.register in order to:
- avoid issues of referencing the "correct" Blockly
- allowing for css to be injected at init, rather than needing to happen before Blockly workspace is injected.
- injecting css in style tag with id specific to workspace search