### PR TITLE
Refactoring and type cleanup.

### DIFF
--- a/blockly-ws-search/package-lock.json
+++ b/blockly-ws-search/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "7.8.3"
       }
     },
     "@babel/compat-data": {
@@ -19,9 +19,9 @@
       "integrity": "sha512-CurCIKPTkS25Mb8mz267vU95vy+TyUpnctEX2lV33xWNmHAfjruztgiPBbXZRh3xZZy1CYvGx6XfxyTVS+sk7Q==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.8.5",
-        "invariant": "^2.2.4",
-        "semver": "^5.5.0"
+        "browserslist": "4.9.1",
+        "invariant": "2.2.4",
+        "semver": "5.7.1"
       }
     },
     "@babel/core": {
@@ -30,21 +30,21 @@
       "integrity": "sha512-Sheg7yEJD51YHAvLEV/7Uvw95AeWqYPL3Vk3zGujJKIhJ+8oLw2ALaf3hbucILhKsgSoADOvtKRJuNVdcJkOrg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.6",
-        "@babel/helpers": "^7.8.4",
-        "@babel/parser": "^7.8.6",
-        "@babel/template": "^7.8.6",
-        "@babel/traverse": "^7.8.6",
-        "@babel/types": "^7.8.6",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.13",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "@babel/code-frame": "7.8.3",
+        "@babel/generator": "7.8.6",
+        "@babel/helpers": "7.8.4",
+        "@babel/parser": "7.8.6",
+        "@babel/template": "7.8.6",
+        "@babel/traverse": "7.8.6",
+        "@babel/types": "7.8.6",
+        "convert-source-map": "1.7.0",
+        "debug": "4.1.1",
+        "gensync": "1.0.0-beta.1",
+        "json5": "2.1.1",
+        "lodash": "4.17.15",
+        "resolve": "1.15.1",
+        "semver": "5.7.1",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -53,7 +53,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "json5": {
@@ -62,7 +62,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.0"
           }
         },
         "source-map": {
@@ -79,10 +79,10 @@
       "integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.6",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
-        "source-map": "^0.5.0"
+        "@babel/types": "7.8.6",
+        "jsesc": "2.5.2",
+        "lodash": "4.17.15",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -99,7 +99,7 @@
       "integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -108,8 +108,8 @@
       "integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/helper-explode-assignable-expression": "7.8.3",
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-call-delegate": {
@@ -118,9 +118,9 @@
       "integrity": "sha512-6Q05px0Eb+N4/GTyKPPvnkig7Lylw+QzihMpws9iiZQv7ZImf84ZsZpQH7QoWN4n4tm81SnSzPgHw2qtO0Zf3A==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.8.3",
-        "@babel/traverse": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/helper-hoist-variables": "7.8.3",
+        "@babel/traverse": "7.8.6",
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-compilation-targets": {
@@ -129,11 +129,11 @@
       "integrity": "sha512-UrJdk27hKVJSnibFcUWYLkCL0ZywTUoot8yii1lsHJcvwrypagmYKjHLMWivQPm4s6GdyygCL8fiH5EYLxhQwQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.8.6",
-        "browserslist": "^4.8.5",
-        "invariant": "^2.2.4",
-        "levenary": "^1.1.1",
-        "semver": "^5.5.0"
+        "@babel/compat-data": "7.8.6",
+        "browserslist": "4.9.1",
+        "invariant": "2.2.4",
+        "levenary": "1.1.1",
+        "semver": "5.7.1"
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
@@ -142,9 +142,9 @@
       "integrity": "sha512-bPyujWfsHhV/ztUkwGHz/RPV1T1TDEsSZDsN42JPehndA+p1KKTh3npvTadux0ZhCrytx9tvjpWNowKby3tM6A==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.8.3",
-        "@babel/helper-regex": "^7.8.3",
-        "regexpu-core": "^4.6.0"
+        "@babel/helper-annotate-as-pure": "7.8.3",
+        "@babel/helper-regex": "7.8.3",
+        "regexpu-core": "4.6.0"
       }
     },
     "@babel/helper-define-map": {
@@ -153,9 +153,9 @@
       "integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "@babel/helper-function-name": "7.8.3",
+        "@babel/types": "7.8.6",
+        "lodash": "4.17.15"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -164,8 +164,8 @@
       "integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/traverse": "7.8.6",
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-function-name": {
@@ -174,9 +174,9 @@
       "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/helper-get-function-arity": "7.8.3",
+        "@babel/template": "7.8.6",
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -185,7 +185,7 @@
       "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -194,7 +194,7 @@
       "integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -203,7 +203,7 @@
       "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-module-imports": {
@@ -212,7 +212,7 @@
       "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-module-transforms": {
@@ -221,13 +221,13 @@
       "integrity": "sha512-RDnGJSR5EFBJjG3deY0NiL0K9TO8SXxS9n/MPsbPK/s9LbQymuLNtlzvDiNS7IpecuL45cMeLVkA+HfmlrnkRg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/helper-replace-supers": "^7.8.6",
-        "@babel/helper-simple-access": "^7.8.3",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/template": "^7.8.6",
-        "@babel/types": "^7.8.6",
-        "lodash": "^4.17.13"
+        "@babel/helper-module-imports": "7.8.3",
+        "@babel/helper-replace-supers": "7.8.6",
+        "@babel/helper-simple-access": "7.8.3",
+        "@babel/helper-split-export-declaration": "7.8.3",
+        "@babel/template": "7.8.6",
+        "@babel/types": "7.8.6",
+        "lodash": "4.17.15"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -236,7 +236,7 @@
       "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -251,7 +251,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.17.15"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -260,11 +260,11 @@
       "integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.8.3",
-        "@babel/helper-wrap-function": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/helper-annotate-as-pure": "7.8.3",
+        "@babel/helper-wrap-function": "7.8.3",
+        "@babel/template": "7.8.6",
+        "@babel/traverse": "7.8.6",
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-replace-supers": {
@@ -273,10 +273,10 @@
       "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.8.3",
-        "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/traverse": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/helper-member-expression-to-functions": "7.8.3",
+        "@babel/helper-optimise-call-expression": "7.8.3",
+        "@babel/traverse": "7.8.6",
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-simple-access": {
@@ -285,8 +285,8 @@
       "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/template": "7.8.6",
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -295,7 +295,7 @@
       "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helper-wrap-function": {
@@ -304,10 +304,10 @@
       "integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/helper-function-name": "7.8.3",
+        "@babel/template": "7.8.6",
+        "@babel/traverse": "7.8.6",
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/helpers": {
@@ -316,9 +316,9 @@
       "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.4",
-        "@babel/types": "^7.8.3"
+        "@babel/template": "7.8.6",
+        "@babel/traverse": "7.8.6",
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/highlight": {
@@ -327,9 +327,9 @@
       "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.4.2",
+        "esutils": "2.0.3",
+        "js-tokens": "4.0.0"
       }
     },
     "@babel/parser": {
@@ -344,9 +344,9 @@
       "integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-remap-async-to-generator": "^7.8.3",
-        "@babel/plugin-syntax-async-generators": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/helper-remap-async-to-generator": "7.8.3",
+        "@babel/plugin-syntax-async-generators": "7.8.4"
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
@@ -355,8 +355,8 @@
       "integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "7.8.3"
       }
     },
     "@babel/plugin-proposal-json-strings": {
@@ -365,8 +365,8 @@
       "integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-json-strings": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/plugin-syntax-json-strings": "7.8.3"
       }
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
@@ -375,8 +375,8 @@
       "integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "7.8.3"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
@@ -385,8 +385,8 @@
       "integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "7.8.3"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -395,8 +395,8 @@
       "integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "7.8.3"
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
@@ -405,8 +405,8 @@
       "integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "7.8.3"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -415,8 +415,8 @@
       "integrity": "sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-create-regexp-features-plugin": "7.8.6",
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -425,7 +425,7 @@
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -434,7 +434,7 @@
       "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-syntax-json-strings": {
@@ -443,7 +443,7 @@
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -452,7 +452,7 @@
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -461,7 +461,7 @@
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
@@ -470,7 +470,7 @@
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-syntax-optional-chaining": {
@@ -479,7 +479,7 @@
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-syntax-top-level-await": {
@@ -488,7 +488,7 @@
       "integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -497,7 +497,7 @@
       "integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
@@ -506,9 +506,9 @@
       "integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-remap-async-to-generator": "^7.8.3"
+        "@babel/helper-module-imports": "7.8.3",
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/helper-remap-async-to-generator": "7.8.3"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
@@ -517,7 +517,7 @@
       "integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-block-scoping": {
@@ -526,8 +526,8 @@
       "integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "@babel/helper-plugin-utils": "7.8.3",
+        "lodash": "4.17.15"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -536,14 +536,14 @@
       "integrity": "sha512-k9r8qRay/R6v5aWZkrEclEhKO6mc1CCQr2dLsVHBmOQiMpN6I2bpjX3vgnldUWeEI1GHVNByULVxZ4BdP4Hmdg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.8.3",
-        "@babel/helper-define-map": "^7.8.3",
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-replace-supers": "^7.8.6",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "globals": "^11.1.0"
+        "@babel/helper-annotate-as-pure": "7.8.3",
+        "@babel/helper-define-map": "7.8.3",
+        "@babel/helper-function-name": "7.8.3",
+        "@babel/helper-optimise-call-expression": "7.8.3",
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/helper-replace-supers": "7.8.6",
+        "@babel/helper-split-export-declaration": "7.8.3",
+        "globals": "11.12.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -552,7 +552,7 @@
       "integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-destructuring": {
@@ -561,7 +561,7 @@
       "integrity": "sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -570,8 +570,8 @@
       "integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-create-regexp-features-plugin": "7.8.6",
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -580,7 +580,7 @@
       "integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
@@ -589,8 +589,8 @@
       "integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.8.3",
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -599,7 +599,7 @@
       "integrity": "sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-function-name": {
@@ -608,8 +608,8 @@
       "integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-function-name": "7.8.3",
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-literals": {
@@ -618,7 +618,7 @@
       "integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-member-expression-literals": {
@@ -627,7 +627,7 @@
       "integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-modules-amd": {
@@ -636,9 +636,9 @@
       "integrity": "sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
+        "@babel/helper-module-transforms": "7.8.6",
+        "@babel/helper-plugin-utils": "7.8.3",
+        "babel-plugin-dynamic-import-node": "2.3.0"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
@@ -647,10 +647,10 @@
       "integrity": "sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-simple-access": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
+        "@babel/helper-module-transforms": "7.8.6",
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/helper-simple-access": "7.8.3",
+        "babel-plugin-dynamic-import-node": "2.3.0"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
@@ -659,10 +659,10 @@
       "integrity": "sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.8.3",
-        "@babel/helper-module-transforms": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "babel-plugin-dynamic-import-node": "^2.3.0"
+        "@babel/helper-hoist-variables": "7.8.3",
+        "@babel/helper-module-transforms": "7.8.6",
+        "@babel/helper-plugin-utils": "7.8.3",
+        "babel-plugin-dynamic-import-node": "2.3.0"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -671,8 +671,8 @@
       "integrity": "sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-module-transforms": "7.8.6",
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
@@ -681,7 +681,7 @@
       "integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.8.3"
+        "@babel/helper-create-regexp-features-plugin": "7.8.6"
       }
     },
     "@babel/plugin-transform-new-target": {
@@ -690,7 +690,7 @@
       "integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-object-super": {
@@ -699,8 +699,8 @@
       "integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-replace-supers": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/helper-replace-supers": "7.8.6"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -709,9 +709,9 @@
       "integrity": "sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "^7.8.3",
-        "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-call-delegate": "7.8.3",
+        "@babel/helper-get-function-arity": "7.8.3",
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-property-literals": {
@@ -720,7 +720,7 @@
       "integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -729,7 +729,7 @@
       "integrity": "sha512-qt/kcur/FxrQrzFR432FGZznkVAjiyFtCOANjkAKwCbt465L6ZCiUQh2oMYGU3Wo8LRFJxNDFwWn106S5wVUNA==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.14.0"
+        "regenerator-transform": "0.14.1"
       }
     },
     "@babel/plugin-transform-reserved-words": {
@@ -738,7 +738,7 @@
       "integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -747,7 +747,7 @@
       "integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-spread": {
@@ -756,7 +756,7 @@
       "integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -765,8 +765,8 @@
       "integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/helper-regex": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/helper-regex": "7.8.3"
       }
     },
     "@babel/plugin-transform-template-literals": {
@@ -775,8 +775,8 @@
       "integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-annotate-as-pure": "7.8.3",
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
@@ -785,7 +785,7 @@
       "integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
@@ -794,8 +794,8 @@
       "integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "@babel/helper-create-regexp-features-plugin": "7.8.6",
+        "@babel/helper-plugin-utils": "7.8.3"
       }
     },
     "@babel/preset-env": {
@@ -804,63 +804,63 @@
       "integrity": "sha512-M5u8llV9DIVXBFB/ArIpqJuvXpO+ymxcJ6e8ZAmzeK3sQeBNOD1y+rHvHCGG4TlEmsNpIrdecsHGHT8ZCoOSJg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.8.6",
-        "@babel/helper-compilation-targets": "^7.8.6",
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
-        "@babel/plugin-proposal-dynamic-import": "^7.8.3",
-        "@babel/plugin-proposal-json-strings": "^7.8.3",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-proposal-optional-chaining": "^7.8.3",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
-        "@babel/plugin-syntax-async-generators": "^7.8.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-        "@babel/plugin-syntax-json-strings": "^7.8.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
-        "@babel/plugin-syntax-top-level-await": "^7.8.3",
-        "@babel/plugin-transform-arrow-functions": "^7.8.3",
-        "@babel/plugin-transform-async-to-generator": "^7.8.3",
-        "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
-        "@babel/plugin-transform-block-scoping": "^7.8.3",
-        "@babel/plugin-transform-classes": "^7.8.6",
-        "@babel/plugin-transform-computed-properties": "^7.8.3",
-        "@babel/plugin-transform-destructuring": "^7.8.3",
-        "@babel/plugin-transform-dotall-regex": "^7.8.3",
-        "@babel/plugin-transform-duplicate-keys": "^7.8.3",
-        "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-        "@babel/plugin-transform-for-of": "^7.8.6",
-        "@babel/plugin-transform-function-name": "^7.8.3",
-        "@babel/plugin-transform-literals": "^7.8.3",
-        "@babel/plugin-transform-member-expression-literals": "^7.8.3",
-        "@babel/plugin-transform-modules-amd": "^7.8.3",
-        "@babel/plugin-transform-modules-commonjs": "^7.8.3",
-        "@babel/plugin-transform-modules-systemjs": "^7.8.3",
-        "@babel/plugin-transform-modules-umd": "^7.8.3",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
-        "@babel/plugin-transform-new-target": "^7.8.3",
-        "@babel/plugin-transform-object-super": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.8.4",
-        "@babel/plugin-transform-property-literals": "^7.8.3",
-        "@babel/plugin-transform-regenerator": "^7.8.3",
-        "@babel/plugin-transform-reserved-words": "^7.8.3",
-        "@babel/plugin-transform-shorthand-properties": "^7.8.3",
-        "@babel/plugin-transform-spread": "^7.8.3",
-        "@babel/plugin-transform-sticky-regex": "^7.8.3",
-        "@babel/plugin-transform-template-literals": "^7.8.3",
-        "@babel/plugin-transform-typeof-symbol": "^7.8.4",
-        "@babel/plugin-transform-unicode-regex": "^7.8.3",
-        "@babel/types": "^7.8.6",
-        "browserslist": "^4.8.5",
-        "core-js-compat": "^3.6.2",
-        "invariant": "^2.2.2",
-        "levenary": "^1.1.1",
-        "semver": "^5.5.0"
+        "@babel/compat-data": "7.8.6",
+        "@babel/helper-compilation-targets": "7.8.6",
+        "@babel/helper-module-imports": "7.8.3",
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/plugin-proposal-async-generator-functions": "7.8.3",
+        "@babel/plugin-proposal-dynamic-import": "7.8.3",
+        "@babel/plugin-proposal-json-strings": "7.8.3",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "7.8.3",
+        "@babel/plugin-proposal-object-rest-spread": "7.8.3",
+        "@babel/plugin-proposal-optional-catch-binding": "7.8.3",
+        "@babel/plugin-proposal-optional-chaining": "7.8.3",
+        "@babel/plugin-proposal-unicode-property-regex": "7.8.3",
+        "@babel/plugin-syntax-async-generators": "7.8.4",
+        "@babel/plugin-syntax-dynamic-import": "7.8.3",
+        "@babel/plugin-syntax-json-strings": "7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "7.8.3",
+        "@babel/plugin-syntax-top-level-await": "7.8.3",
+        "@babel/plugin-transform-arrow-functions": "7.8.3",
+        "@babel/plugin-transform-async-to-generator": "7.8.3",
+        "@babel/plugin-transform-block-scoped-functions": "7.8.3",
+        "@babel/plugin-transform-block-scoping": "7.8.3",
+        "@babel/plugin-transform-classes": "7.8.6",
+        "@babel/plugin-transform-computed-properties": "7.8.3",
+        "@babel/plugin-transform-destructuring": "7.8.3",
+        "@babel/plugin-transform-dotall-regex": "7.8.3",
+        "@babel/plugin-transform-duplicate-keys": "7.8.3",
+        "@babel/plugin-transform-exponentiation-operator": "7.8.3",
+        "@babel/plugin-transform-for-of": "7.8.6",
+        "@babel/plugin-transform-function-name": "7.8.3",
+        "@babel/plugin-transform-literals": "7.8.3",
+        "@babel/plugin-transform-member-expression-literals": "7.8.3",
+        "@babel/plugin-transform-modules-amd": "7.8.3",
+        "@babel/plugin-transform-modules-commonjs": "7.8.3",
+        "@babel/plugin-transform-modules-systemjs": "7.8.3",
+        "@babel/plugin-transform-modules-umd": "7.8.3",
+        "@babel/plugin-transform-named-capturing-groups-regex": "7.8.3",
+        "@babel/plugin-transform-new-target": "7.8.3",
+        "@babel/plugin-transform-object-super": "7.8.3",
+        "@babel/plugin-transform-parameters": "7.8.4",
+        "@babel/plugin-transform-property-literals": "7.8.3",
+        "@babel/plugin-transform-regenerator": "7.8.3",
+        "@babel/plugin-transform-reserved-words": "7.8.3",
+        "@babel/plugin-transform-shorthand-properties": "7.8.3",
+        "@babel/plugin-transform-spread": "7.8.3",
+        "@babel/plugin-transform-sticky-regex": "7.8.3",
+        "@babel/plugin-transform-template-literals": "7.8.3",
+        "@babel/plugin-transform-typeof-symbol": "7.8.4",
+        "@babel/plugin-transform-unicode-regex": "7.8.3",
+        "@babel/types": "7.8.6",
+        "browserslist": "4.9.1",
+        "core-js-compat": "3.6.4",
+        "invariant": "2.2.4",
+        "levenary": "1.1.1",
+        "semver": "5.7.1"
       }
     },
     "@babel/template": {
@@ -869,9 +869,9 @@
       "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/code-frame": "7.8.3",
+        "@babel/parser": "7.8.6",
+        "@babel/types": "7.8.6"
       }
     },
     "@babel/traverse": {
@@ -880,15 +880,15 @@
       "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.6",
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "@babel/code-frame": "7.8.3",
+        "@babel/generator": "7.8.6",
+        "@babel/helper-function-name": "7.8.3",
+        "@babel/helper-split-export-declaration": "7.8.3",
+        "@babel/parser": "7.8.6",
+        "@babel/types": "7.8.6",
+        "debug": "4.1.1",
+        "globals": "11.12.0",
+        "lodash": "4.17.15"
       },
       "dependencies": {
         "debug": {
@@ -897,7 +897,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         }
       }
@@ -908,9 +908,9 @@
       "integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.3",
+        "lodash": "4.17.15",
+        "to-fast-properties": "2.0.0"
       }
     },
     "@types/events": {
@@ -925,9 +925,9 @@
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
+        "@types/events": "3.0.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "13.7.6"
       }
     },
     "@types/minimatch": {
@@ -993,7 +993,7 @@
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
-        "mamacro": "^0.0.3"
+        "mamacro": "0.0.3"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
@@ -1020,7 +1020,7 @@
       "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
       "dev": true,
       "requires": {
-        "@xtuc/ieee754": "^1.2.0"
+        "@xtuc/ieee754": "1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
@@ -1136,7 +1136,7 @@
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.24",
+        "mime-types": "2.1.26",
         "negotiator": "0.6.2"
       }
     },
@@ -1146,10 +1146,10 @@
       "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "3.1.1",
+        "fast-json-stable-stringify": "2.1.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ajv-errors": {
@@ -1188,7 +1188,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.3"
       }
     },
     "anymatch": {
@@ -1197,8 +1197,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
+        "micromatch": "3.1.10",
+        "normalize-path": "2.1.1"
       },
       "dependencies": {
         "normalize-path": {
@@ -1207,7 +1207,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "^1.0.1"
+            "remove-trailing-separator": "1.1.0"
           }
         }
       }
@@ -1248,7 +1248,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -1269,9 +1269,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.4",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "assert": {
@@ -1280,7 +1280,7 @@
       "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "dev": true,
       "requires": {
-        "object-assign": "^4.1.1",
+        "object-assign": "4.1.1",
         "util": "0.10.3"
       },
       "dependencies": {
@@ -1313,7 +1313,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "4.17.15"
       }
     },
     "async-each": {
@@ -1340,10 +1340,10 @@
       "integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
       "dev": true,
       "requires": {
-        "find-cache-dir": "^2.0.0",
-        "loader-utils": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "pify": "^4.0.1"
+        "find-cache-dir": "2.1.0",
+        "loader-utils": "1.4.0",
+        "mkdirp": "0.5.1",
+        "pify": "4.0.1"
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -1352,7 +1352,7 @@
       "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
       "dev": true,
       "requires": {
-        "object.assign": "^4.1.0"
+        "object.assign": "4.1.0"
       }
     },
     "balanced-match": {
@@ -1367,13 +1367,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.3.0",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.2",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1382,7 +1382,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -1391,7 +1391,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -1400,7 +1400,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-descriptor": {
@@ -1409,9 +1409,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.3"
           }
         }
       }
@@ -1475,15 +1475,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.1.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.7.0",
         "raw-body": "2.4.0",
-        "type-is": "~1.6.17"
+        "type-is": "1.6.18"
       },
       "dependencies": {
         "bytes": {
@@ -1521,12 +1521,12 @@
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "dev": true,
       "requires": {
-        "array-flatten": "^2.1.0",
-        "deep-equal": "^1.0.1",
-        "dns-equal": "^1.0.0",
-        "dns-txt": "^2.0.2",
-        "multicast-dns": "^6.0.1",
-        "multicast-dns-service-types": "^1.1.0"
+        "array-flatten": "2.1.2",
+        "deep-equal": "1.1.1",
+        "dns-equal": "1.0.0",
+        "dns-txt": "2.0.2",
+        "multicast-dns": "6.2.3",
+        "multicast-dns-service-types": "1.1.0"
       }
     },
     "brace-expansion": {
@@ -1535,7 +1535,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1545,16 +1545,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.3",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1563,7 +1563,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -1580,12 +1580,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "browserify-cipher": {
@@ -1594,9 +1594,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.2.0",
+        "browserify-des": "1.0.2",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -1605,10 +1605,10 @@
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.1",
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "browserify-rsa": {
@@ -1617,8 +1617,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.1.0"
       }
     },
     "browserify-sign": {
@@ -1627,13 +1627,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.5.2",
+        "inherits": "2.0.4",
+        "parse-asn1": "5.1.5"
       }
     },
     "browserify-zlib": {
@@ -1642,7 +1642,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "~1.0.5"
+        "pako": "1.0.11"
       }
     },
     "browserslist": {
@@ -1651,9 +1651,9 @@
       "integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001030",
-        "electron-to-chromium": "^1.3.363",
-        "node-releases": "^1.1.50"
+        "caniuse-lite": "1.0.30001031",
+        "electron-to-chromium": "1.3.365",
+        "node-releases": "1.1.50"
       }
     },
     "buffer": {
@@ -1662,9 +1662,9 @@
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.3.1",
+        "ieee754": "1.1.13",
+        "isarray": "1.0.0"
       }
     },
     "buffer-from": {
@@ -1703,21 +1703,21 @@
       "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.5",
-        "chownr": "^1.1.1",
-        "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.1.15",
-        "infer-owner": "^1.0.3",
-        "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
+        "bluebird": "3.7.2",
+        "chownr": "1.1.4",
+        "figgy-pudding": "3.5.1",
+        "glob": "7.1.6",
+        "graceful-fs": "4.2.3",
+        "infer-owner": "1.0.4",
+        "lru-cache": "5.1.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.7.1",
+        "ssri": "6.0.1",
+        "unique-filename": "1.1.1",
+        "y18n": "4.0.0"
       }
     },
     "cache-base": {
@@ -1726,15 +1726,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.3.0",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.1",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.1",
+        "unset-value": "1.0.0"
       }
     },
     "camelcase": {
@@ -1755,9 +1755,9 @@
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       },
       "dependencies": {
         "supports-color": {
@@ -1766,7 +1766,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -1777,18 +1777,18 @@
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
+        "anymatch": "2.0.0",
+        "async-each": "1.0.3",
+        "braces": "2.3.2",
+        "fsevents": "1.2.11",
+        "glob-parent": "3.1.0",
+        "inherits": "2.0.4",
+        "is-binary-path": "1.0.1",
+        "is-glob": "4.0.1",
+        "normalize-path": "3.0.0",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.2.1",
+        "upath": "1.2.0"
       }
     },
     "chownr": {
@@ -1803,7 +1803,7 @@
       "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.11.1"
       }
     },
     "cipher-base": {
@@ -1812,8 +1812,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "class-utils": {
@@ -1822,10 +1822,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -1834,7 +1834,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -1845,9 +1845,9 @@
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
+        "string-width": "3.1.0",
+        "strip-ansi": "5.2.0",
+        "wrap-ansi": "5.1.0"
       }
     },
     "code-point-at": {
@@ -1862,8 +1862,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -1911,7 +1911,7 @@
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "dev": true,
       "requires": {
-        "mime-db": ">= 1.43.0 < 2"
+        "mime-db": "1.43.0"
       }
     },
     "compression": {
@@ -1920,13 +1920,13 @@
       "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.7",
         "bytes": "3.0.0",
-        "compressible": "~2.0.16",
+        "compressible": "2.0.18",
         "debug": "2.6.9",
-        "on-headers": "~1.0.2",
+        "on-headers": "1.0.2",
         "safe-buffer": "5.1.2",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "debug": {
@@ -1964,10 +1964,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7",
+        "typedarray": "0.0.6"
       }
     },
     "connect-history-api-fallback": {
@@ -2017,7 +2017,7 @@
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.1"
+        "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -2046,12 +2046,12 @@
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1",
-        "fs-write-stream-atomic": "^1.0.8",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.0"
+        "aproba": "1.2.0",
+        "fs-write-stream-atomic": "1.0.10",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.7.1",
+        "run-queue": "1.0.3"
       }
     },
     "copy-descriptor": {
@@ -2066,7 +2066,7 @@
       "integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.8.3",
+        "browserslist": "4.9.1",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -2096,8 +2096,8 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.5.2"
       }
     },
     "create-hash": {
@@ -2106,11 +2106,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.4",
+        "md5.js": "1.3.5",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -2119,12 +2119,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.4",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.2.0",
+        "sha.js": "2.4.11"
       }
     },
     "cross-spawn": {
@@ -2133,11 +2133,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.7.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "crypto-browserify": {
@@ -2146,17 +2146,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "1.0.1",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.3",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "diffie-hellman": "5.0.3",
+        "inherits": "2.0.4",
+        "pbkdf2": "3.0.17",
+        "public-encrypt": "4.0.3",
+        "randombytes": "2.1.0",
+        "randomfill": "1.0.4"
       }
     },
     "cyclist": {
@@ -2171,7 +2171,7 @@
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -2192,12 +2192,12 @@
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
       "dev": true,
       "requires": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
+        "is-arguments": "1.0.4",
+        "is-date-object": "1.0.2",
+        "is-regex": "1.0.5",
+        "object-is": "1.0.2",
+        "object-keys": "1.1.1",
+        "regexp.prototype.flags": "1.3.0"
       }
     },
     "default-gateway": {
@@ -2206,8 +2206,8 @@
       "integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
       "dev": true,
       "requires": {
-        "execa": "^1.0.0",
-        "ip-regex": "^2.1.0"
+        "execa": "1.0.0",
+        "ip-regex": "2.1.0"
       }
     },
     "define-properties": {
@@ -2216,7 +2216,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.1.1"
       }
     },
     "define-property": {
@@ -2225,8 +2225,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -2235,7 +2235,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -2244,7 +2244,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-descriptor": {
@@ -2253,9 +2253,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.3"
           }
         }
       }
@@ -2266,13 +2266,13 @@
       "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
       "dev": true,
       "requires": {
-        "@types/glob": "^7.1.1",
-        "globby": "^6.1.0",
-        "is-path-cwd": "^2.0.0",
-        "is-path-in-cwd": "^2.0.0",
-        "p-map": "^2.0.0",
-        "pify": "^4.0.1",
-        "rimraf": "^2.6.3"
+        "@types/glob": "7.1.1",
+        "globby": "6.1.0",
+        "is-path-cwd": "2.2.0",
+        "is-path-in-cwd": "2.1.0",
+        "p-map": "2.1.0",
+        "pify": "4.0.1",
+        "rimraf": "2.7.1"
       }
     },
     "depd": {
@@ -2287,8 +2287,8 @@
       "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.4",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "destroy": {
@@ -2315,9 +2315,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.1.0"
       }
     },
     "dns-equal": {
@@ -2332,8 +2332,8 @@
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "dev": true,
       "requires": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
+        "ip": "1.1.5",
+        "safe-buffer": "5.2.0"
       }
     },
     "dns-txt": {
@@ -2342,7 +2342,7 @@
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "dev": true,
       "requires": {
-        "buffer-indexof": "^1.0.0"
+        "buffer-indexof": "1.1.1"
       }
     },
     "domain-browser": {
@@ -2357,10 +2357,10 @@
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.4",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7",
+        "stream-shift": "1.0.1"
       }
     },
     "ecstatic": {
@@ -2369,10 +2369,10 @@
       "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
       "dev": true,
       "requires": {
-        "he": "^1.1.1",
-        "mime": "^1.6.0",
-        "minimist": "^1.1.0",
-        "url-join": "^2.0.5"
+        "he": "1.2.0",
+        "mime": "1.6.0",
+        "minimist": "1.2.0",
+        "url-join": "2.0.5"
       }
     },
     "ee-first": {
@@ -2393,13 +2393,13 @@
       "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.7",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.4",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "emoji-regex": {
@@ -2426,7 +2426,7 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -2435,9 +2435,9 @@
       "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
+        "graceful-fs": "4.2.3",
+        "memory-fs": "0.5.0",
+        "tapable": "1.1.3"
       },
       "dependencies": {
         "memory-fs": {
@@ -2446,8 +2446,8 @@
           "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
           "dev": true,
           "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
+            "errno": "0.1.7",
+            "readable-stream": "2.3.7"
           }
         }
       }
@@ -2458,7 +2458,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "es-abstract": {
@@ -2467,17 +2467,17 @@
       "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
-        "object-inspect": "^1.7.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "es-to-primitive": "1.2.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "has-symbols": "1.0.1",
+        "is-callable": "1.1.5",
+        "is-regex": "1.0.5",
+        "object-inspect": "1.7.0",
+        "object-keys": "1.1.1",
+        "object.assign": "4.1.0",
+        "string.prototype.trimleft": "2.1.1",
+        "string.prototype.trimright": "2.1.1"
       }
     },
     "es-to-primitive": {
@@ -2486,9 +2486,9 @@
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "1.1.5",
+        "is-date-object": "1.0.2",
+        "is-symbol": "1.0.3"
       }
     },
     "escape-html": {
@@ -2509,8 +2509,8 @@
       "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.3.0"
       }
     },
     "esrecurse": {
@@ -2519,7 +2519,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.3.0"
       }
     },
     "estraverse": {
@@ -2558,7 +2558,7 @@
       "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
       "dev": true,
       "requires": {
-        "original": "^1.0.0"
+        "original": "1.0.2"
       }
     },
     "evp_bytestokey": {
@@ -2567,8 +2567,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.5",
+        "safe-buffer": "5.2.0"
       }
     },
     "execa": {
@@ -2577,13 +2577,13 @@
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "6.0.5",
+        "get-stream": "4.1.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "executioner": {
@@ -2592,7 +2592,7 @@
       "integrity": "sha1-rdMo4DvEXdWY81j7tSn8C+Dsb80=",
       "dev": true,
       "requires": {
-        "mixly": "^1.0.0"
+        "mixly": "1.0.0"
       }
     },
     "expand-brackets": {
@@ -2601,13 +2601,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "debug": {
@@ -2625,7 +2625,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -2634,7 +2634,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "ms": {
@@ -2651,7 +2651,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.3"
       }
     },
     "express": {
@@ -2660,36 +2660,36 @@
       "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.7",
+        "accepts": "1.3.7",
         "array-flatten": "1.1.1",
         "body-parser": "1.19.0",
         "content-disposition": "0.5.3",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.2",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.3",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.5",
+        "proxy-addr": "2.0.6",
         "qs": "6.7.0",
-        "range-parser": "~1.2.1",
+        "range-parser": "1.2.1",
         "safe-buffer": "5.1.2",
         "send": "0.17.1",
         "serve-static": "1.14.1",
         "setprototypeof": "1.1.1",
-        "statuses": "~1.5.0",
-        "type-is": "~1.6.18",
+        "statuses": "1.5.0",
+        "type-is": "1.6.18",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "array-flatten": {
@@ -2733,8 +2733,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -2743,7 +2743,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -2754,14 +2754,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -2770,7 +2770,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "extend-shallow": {
@@ -2779,7 +2779,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -2788,7 +2788,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -2797,7 +2797,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-descriptor": {
@@ -2806,9 +2806,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.3"
           }
         }
       }
@@ -2831,7 +2831,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.3"
       }
     },
     "figgy-pudding": {
@@ -2853,10 +2853,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2865,7 +2865,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -2877,12 +2877,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.3",
+        "statuses": "1.5.0",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -2908,9 +2908,9 @@
       "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
       "dev": true,
       "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
+        "commondir": "1.0.1",
+        "make-dir": "2.1.0",
+        "pkg-dir": "3.0.0"
       }
     },
     "find-up": {
@@ -2919,7 +2919,7 @@
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "3.0.0"
       }
     },
     "findup-sync": {
@@ -2928,10 +2928,10 @@
       "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "4.0.1",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
       }
     },
     "flush-write-stream": {
@@ -2940,8 +2940,8 @@
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.3.6"
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7"
       }
     },
     "follow-redirects": {
@@ -2950,7 +2950,7 @@
       "integrity": "sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==",
       "dev": true,
       "requires": {
-        "debug": "^3.0.0"
+        "debug": "3.2.6"
       }
     },
     "for-in": {
@@ -2971,7 +2971,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -2986,8 +2986,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7"
       }
     },
     "fs-write-stream-atomic": {
@@ -2996,10 +2996,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
+        "graceful-fs": "4.2.3",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.7"
       }
     },
     "fs.realpath": {
@@ -3015,9 +3015,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1",
-        "node-pre-gyp": "*"
+        "bindings": "1.5.0",
+        "nan": "2.14.0",
+        "node-pre-gyp": "0.14.0"
       },
       "dependencies": {
         "abbrev": {
@@ -3029,8 +3029,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3044,23 +3043,21 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -3073,20 +3070,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3100,7 +3094,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "deep-extend": {
@@ -3127,7 +3121,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.6.0"
+            "minipass": "2.9.0"
           }
         },
         "fs.realpath": {
@@ -3142,14 +3136,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
@@ -3158,12 +3152,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.4",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -3178,7 +3172,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -3187,7 +3181,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -3196,15 +3190,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3216,9 +3209,8 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -3231,25 +3223,22 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.1.1"
           }
         },
         "minizlib": {
@@ -3258,14 +3247,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.9.0"
+            "minipass": "2.9.0"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3282,9 +3270,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "3.2.6",
+            "iconv-lite": "0.4.24",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -3293,16 +3281,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4.4.2"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.4.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.4.7",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.7.1",
+            "semver": "5.7.1",
+            "tar": "4.4.13"
           }
         },
         "nopt": {
@@ -3311,8 +3299,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -3321,7 +3309,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "npm-normalize-package-bin": "^1.0.1"
+            "npm-normalize-package-bin": "1.0.1"
           }
         },
         "npm-normalize-package-bin": {
@@ -3336,8 +3324,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.3",
+            "npm-bundled": "1.1.1"
           }
         },
         "npmlog": {
@@ -3346,17 +3334,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3368,9 +3355,8 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -3391,8 +3377,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -3413,10 +3399,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -3433,13 +3419,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.1",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -3448,14 +3434,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.6"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3491,11 +3476,10 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -3504,16 +3488,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -3528,13 +3511,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
+            "chownr": "1.1.3",
+            "fs-minipass": "1.2.7",
+            "minipass": "2.9.0",
+            "minizlib": "1.3.3",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.1.1"
           }
         },
         "util-deprecate": {
@@ -3549,20 +3532,18 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3596,7 +3577,7 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "requires": {
-        "pump": "^3.0.0"
+        "pump": "3.0.0"
       }
     },
     "get-value": {
@@ -3611,12 +3592,12 @@
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.4",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-parent": {
@@ -3625,8 +3606,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
       },
       "dependencies": {
         "is-glob": {
@@ -3635,7 +3616,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -3646,7 +3627,7 @@
       "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
       "dev": true,
       "requires": {
-        "global-prefix": "^3.0.0"
+        "global-prefix": "3.0.0"
       },
       "dependencies": {
         "global-prefix": {
@@ -3655,9 +3636,9 @@
           "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
           "dev": true,
           "requires": {
-            "ini": "^1.3.5",
-            "kind-of": "^6.0.2",
-            "which": "^1.3.1"
+            "ini": "1.3.5",
+            "kind-of": "6.0.3",
+            "which": "1.3.1"
           }
         }
       }
@@ -3668,11 +3649,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.3",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.1"
       }
     },
     "globals": {
@@ -3687,11 +3668,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.6",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "pify": {
@@ -3720,7 +3701,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-flag": {
@@ -3741,9 +3722,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -3752,8 +3733,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3762,7 +3743,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3773,8 +3754,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "hash.js": {
@@ -3783,8 +3764,8 @@
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
+        "inherits": "2.0.4",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "he": {
@@ -3799,9 +3780,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.7",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "homedir-polyfill": {
@@ -3810,7 +3791,7 @@
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hpack.js": {
@@ -3819,10 +3800,10 @@
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "obuf": "^1.0.0",
-        "readable-stream": "^2.0.1",
-        "wbuf": "^1.1.0"
+        "inherits": "2.0.4",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.7",
+        "wbuf": "1.7.3"
       }
     },
     "html-entities": {
@@ -3843,10 +3824,10 @@
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "1.5.0",
         "toidentifier": "1.0.0"
       },
       "dependencies": {
@@ -3870,9 +3851,9 @@
       "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
       "dev": true,
       "requires": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
+        "eventemitter3": "4.0.0",
+        "follow-redirects": "1.10.0",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -3881,10 +3862,10 @@
       "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
       "dev": true,
       "requires": {
-        "http-proxy": "^1.17.0",
-        "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
-        "micromatch": "^3.1.10"
+        "http-proxy": "1.18.0",
+        "is-glob": "4.0.1",
+        "lodash": "4.17.15",
+        "micromatch": "3.1.10"
       }
     },
     "http-server": {
@@ -3893,16 +3874,16 @@
       "integrity": "sha512-T0jB+7J7GJ2Vo+a4/T7P7SbQ3x2GPDnqRqQXdfEuPuUOmES/9NBxPnDm7dh1HGEeUWqUmLUNtGV63ZC5Uy3tGA==",
       "dev": true,
       "requires": {
-        "basic-auth": "^1.0.3",
-        "colors": "^1.3.3",
-        "corser": "^2.0.1",
-        "ecstatic": "^3.3.2",
-        "http-proxy": "^1.17.0",
-        "opener": "^1.5.1",
-        "optimist": "~0.6.1",
-        "portfinder": "^1.0.20",
+        "basic-auth": "1.1.0",
+        "colors": "1.4.0",
+        "corser": "2.0.1",
+        "ecstatic": "3.3.2",
+        "http-proxy": "1.18.0",
+        "opener": "1.5.1",
+        "optimist": "0.6.1",
+        "portfinder": "1.0.25",
         "secure-compare": "3.0.1",
-        "union": "~0.5.0"
+        "union": "0.5.0"
       }
     },
     "https-browserify": {
@@ -3917,7 +3898,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ieee754": {
@@ -3938,8 +3919,8 @@
       "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "^3.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "3.0.0",
+        "resolve-cwd": "2.0.0"
       }
     },
     "imurmurhash": {
@@ -3960,8 +3941,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -3982,8 +3963,8 @@
       "integrity": "sha512-scSNvF49HDOLNm2xLFwST23g/OvfsceiA087bcGBgZP/ZNCrvpSaCn5IrWNZ2XYmFFykXF/6J1Zgm+D/JgRgtA==",
       "dev": true,
       "requires": {
-        "commander": "^2.20.0",
-        "executioner": "^2.0.1"
+        "commander": "2.20.3",
+        "executioner": "2.0.1"
       }
     },
     "internal-ip": {
@@ -3992,8 +3973,8 @@
       "integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
       "dev": true,
       "requires": {
-        "default-gateway": "^4.2.0",
-        "ipaddr.js": "^1.9.0"
+        "default-gateway": "4.2.0",
+        "ipaddr.js": "1.9.1"
       }
     },
     "interpret": {
@@ -4008,7 +3989,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -4047,7 +4028,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4056,7 +4037,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4073,7 +4054,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.13.1"
       }
     },
     "is-buffer": {
@@ -4094,7 +4075,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4103,7 +4084,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4120,9 +4101,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4157,7 +4138,7 @@
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.1"
+        "is-extglob": "2.1.1"
       }
     },
     "is-number": {
@@ -4166,7 +4147,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4175,7 +4156,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4192,7 +4173,7 @@
       "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^2.1.0"
+        "is-path-inside": "2.1.0"
       }
     },
     "is-path-inside": {
@@ -4201,7 +4182,7 @@
       "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.2"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-object": {
@@ -4210,7 +4191,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-regex": {
@@ -4219,7 +4200,7 @@
       "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has": "1.0.3"
       }
     },
     "is-stream": {
@@ -4234,7 +4215,7 @@
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.1"
+        "has-symbols": "1.0.1"
       }
     },
     "is-windows": {
@@ -4303,7 +4284,7 @@
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "1.2.0"
       }
     },
     "killable": {
@@ -4324,7 +4305,7 @@
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "requires": {
-        "invert-kv": "^2.0.0"
+        "invert-kv": "2.0.0"
       }
     },
     "leven": {
@@ -4339,7 +4320,7 @@
       "integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
       "dev": true,
       "requires": {
-        "leven": "^3.1.0"
+        "leven": "3.1.0"
       }
     },
     "loader-runner": {
@@ -4354,9 +4335,9 @@
       "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
       "dev": true,
       "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
+        "big.js": "5.2.2",
+        "emojis-list": "3.0.0",
+        "json5": "1.0.1"
       }
     },
     "locate-path": {
@@ -4365,8 +4346,8 @@
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "3.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -4387,7 +4368,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "4.0.0"
       }
     },
     "lru-cache": {
@@ -4396,7 +4377,7 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
-        "yallist": "^3.0.2"
+        "yallist": "3.1.1"
       }
     },
     "make-dir": {
@@ -4405,8 +4386,8 @@
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
       "requires": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
+        "pify": "4.0.1",
+        "semver": "5.7.1"
       }
     },
     "mamacro": {
@@ -4421,7 +4402,7 @@
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
-        "p-defer": "^1.0.0"
+        "p-defer": "1.0.0"
       }
     },
     "map-cache": {
@@ -4436,7 +4417,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "md5.js": {
@@ -4445,9 +4426,9 @@
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "media-typer": {
@@ -4462,9 +4443,9 @@
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "dev": true,
       "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
+        "map-age-cleaner": "0.1.3",
+        "mimic-fn": "2.1.0",
+        "p-is-promise": "2.1.0"
       }
     },
     "memory-fs": {
@@ -4473,8 +4454,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.7"
       }
     },
     "merge-descriptors": {
@@ -4495,19 +4476,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.3",
+        "nanomatch": "1.2.13",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "miller-rabin": {
@@ -4516,8 +4497,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mime": {
@@ -4565,7 +4546,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -4580,16 +4561,16 @@
       "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.5.0",
-        "duplexify": "^3.4.2",
-        "end-of-stream": "^1.1.0",
-        "flush-write-stream": "^1.0.0",
-        "from2": "^2.1.0",
-        "parallel-transform": "^1.1.0",
-        "pump": "^3.0.0",
-        "pumpify": "^1.3.3",
-        "stream-each": "^1.1.0",
-        "through2": "^2.0.0"
+        "concat-stream": "1.6.2",
+        "duplexify": "3.7.1",
+        "end-of-stream": "1.4.4",
+        "flush-write-stream": "1.1.1",
+        "from2": "2.3.0",
+        "parallel-transform": "1.2.0",
+        "pump": "3.0.0",
+        "pumpify": "1.5.1",
+        "stream-each": "1.2.3",
+        "through2": "2.0.5"
       }
     },
     "mixin-deep": {
@@ -4598,8 +4579,8 @@
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4608,7 +4589,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -4619,7 +4600,7 @@
       "integrity": "sha1-m1ouH2Pm37oNMOZ5f/rmKrHcJO8=",
       "dev": true,
       "requires": {
-        "fulcon": "^1.0.1"
+        "fulcon": "1.0.2"
       }
     },
     "mkdirp": {
@@ -4645,12 +4626,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1",
-        "copy-concurrently": "^1.0.0",
-        "fs-write-stream-atomic": "^1.0.8",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.3"
+        "aproba": "1.2.0",
+        "copy-concurrently": "1.0.5",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.7.1",
+        "run-queue": "1.0.3"
       }
     },
     "ms": {
@@ -4665,8 +4646,8 @@
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "dev": true,
       "requires": {
-        "dns-packet": "^1.3.1",
-        "thunky": "^1.0.2"
+        "dns-packet": "1.3.1",
+        "thunky": "1.1.0"
       }
     },
     "multicast-dns-service-types": {
@@ -4688,17 +4669,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.3",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "negotiator": {
@@ -4731,29 +4712,29 @@
       "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "dev": true,
       "requires": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.2.0",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^3.0.0",
-        "https-browserify": "^1.0.0",
-        "os-browserify": "^0.3.0",
+        "assert": "1.5.0",
+        "browserify-zlib": "0.2.0",
+        "buffer": "4.9.2",
+        "console-browserify": "1.2.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "domain-browser": "1.2.0",
+        "events": "3.1.0",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.1",
-        "process": "^0.11.10",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.3.3",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.7.2",
-        "string_decoder": "^1.0.0",
-        "timers-browserify": "^2.0.4",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.7",
+        "stream-browserify": "2.0.2",
+        "stream-http": "2.8.3",
+        "string_decoder": "1.1.1",
+        "timers-browserify": "2.0.11",
         "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.11.0",
-        "vm-browserify": "^1.0.1"
+        "url": "0.11.0",
+        "util": "0.11.1",
+        "vm-browserify": "1.1.2"
       },
       "dependencies": {
         "punycode": {
@@ -4770,7 +4751,7 @@
       "integrity": "sha512-lgAmPv9eYZ0bGwUYAKlr8MG6K4CvWliWqnkcT2P8mMAgVrH3lqfBPorFlxiG1pHQnqmavJZ9vbMXUTNyMLbrgQ==",
       "dev": true,
       "requires": {
-        "semver": "^6.3.0"
+        "semver": "6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -4793,7 +4774,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
@@ -4814,9 +4795,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -4825,7 +4806,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "kind-of": {
@@ -4834,7 +4815,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4863,7 +4844,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.assign": {
@@ -4872,10 +4853,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.1",
+        "object-keys": "1.1.1"
       }
     },
     "object.pick": {
@@ -4884,7 +4865,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "obuf": {
@@ -4914,7 +4895,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "opener": {
@@ -4929,7 +4910,7 @@
       "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
       "dev": true,
       "requires": {
-        "is-wsl": "^1.1.0"
+        "is-wsl": "1.1.0"
       }
     },
     "optimist": {
@@ -4938,8 +4919,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "minimist": {
@@ -4956,7 +4937,7 @@
       "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
       "dev": true,
       "requires": {
-        "url-parse": "^1.4.3"
+        "url-parse": "1.4.7"
       }
     },
     "os-browserify": {
@@ -4971,9 +4952,9 @@
       "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
+        "execa": "1.0.0",
+        "lcid": "2.0.0",
+        "mem": "4.3.0"
       }
     },
     "p-defer": {
@@ -5000,7 +4981,7 @@
       "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
       "dev": true,
       "requires": {
-        "p-try": "^2.0.0"
+        "p-try": "2.2.0"
       }
     },
     "p-locate": {
@@ -5009,7 +4990,7 @@
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "2.2.2"
       }
     },
     "p-map": {
@@ -5024,7 +5005,7 @@
       "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
       "dev": true,
       "requires": {
-        "retry": "^0.12.0"
+        "retry": "0.12.0"
       }
     },
     "p-try": {
@@ -5045,9 +5026,9 @@
       "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
       "dev": true,
       "requires": {
-        "cyclist": "^1.0.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.1.5"
+        "cyclist": "1.0.1",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7"
       }
     },
     "parse-asn1": {
@@ -5056,12 +5037,12 @@
       "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
       "dev": true,
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3",
-        "safe-buffer": "^5.1.1"
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.17",
+        "safe-buffer": "5.2.0"
       }
     },
     "parse-passwd": {
@@ -5136,11 +5117,11 @@
       "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "dev": true,
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.2.0",
+        "sha.js": "2.4.11"
       }
     },
     "pify": {
@@ -5161,7 +5142,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-dir": {
@@ -5170,7 +5151,7 @@
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "dev": true,
       "requires": {
-        "find-up": "^3.0.0"
+        "find-up": "3.0.0"
       }
     },
     "portfinder": {
@@ -5179,9 +5160,9 @@
       "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
       "dev": true,
       "requires": {
-        "async": "^2.6.2",
-        "debug": "^3.1.1",
-        "mkdirp": "^0.5.1"
+        "async": "2.6.3",
+        "debug": "3.2.6",
+        "mkdirp": "0.5.1"
       }
     },
     "posix-character-classes": {
@@ -5220,7 +5201,7 @@
       "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
       "dev": true,
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.9.1"
       }
     },
@@ -5236,12 +5217,12 @@
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "parse-asn1": "5.1.5",
+        "randombytes": "2.1.0",
+        "safe-buffer": "5.2.0"
       }
     },
     "pump": {
@@ -5250,8 +5231,8 @@
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.4",
+        "once": "1.4.0"
       }
     },
     "pumpify": {
@@ -5260,9 +5241,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
+        "duplexify": "3.7.1",
+        "inherits": "2.0.4",
+        "pump": "2.0.1"
       },
       "dependencies": {
         "pump": {
@@ -5271,8 +5252,8 @@
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.4",
+            "once": "1.4.0"
           }
         }
       }
@@ -5313,7 +5294,7 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.2.0"
       }
     },
     "randomfill": {
@@ -5322,8 +5303,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
+        "randombytes": "2.1.0",
+        "safe-buffer": "5.2.0"
       }
     },
     "range-parser": {
@@ -5358,13 +5339,13 @@
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.4",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.1",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -5381,9 +5362,9 @@
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "graceful-fs": "4.2.3",
+        "micromatch": "3.1.10",
+        "readable-stream": "2.3.7"
       }
     },
     "regenerate": {
@@ -5398,7 +5379,7 @@
       "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0"
+        "regenerate": "1.4.0"
       }
     },
     "regenerator-transform": {
@@ -5407,7 +5388,7 @@
       "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
       "dev": true,
       "requires": {
-        "private": "^0.1.6"
+        "private": "0.1.8"
       }
     },
     "regex-not": {
@@ -5416,8 +5397,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexp.prototype.flags": {
@@ -5426,8 +5407,8 @@
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.17.4"
       }
     },
     "regexpu-core": {
@@ -5436,12 +5417,12 @@
       "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.1.0",
-        "regjsgen": "^0.5.0",
-        "regjsparser": "^0.6.0",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.1.0"
+        "regenerate": "1.4.0",
+        "regenerate-unicode-properties": "8.1.0",
+        "regjsgen": "0.5.1",
+        "regjsparser": "0.6.3",
+        "unicode-match-property-ecmascript": "1.0.4",
+        "unicode-match-property-value-ecmascript": "1.1.0"
       }
     },
     "regjsgen": {
@@ -5456,7 +5437,7 @@
       "integrity": "sha512-8uZvYbnfAtEm9Ab8NTb3hdLwL4g/LQzEYP7Xs27T96abJCCE2d6r3cPZPQEsLKy0vRSGVNG+/zVGtLr86HQduA==",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -5509,7 +5490,7 @@
       "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-cwd": {
@@ -5518,7 +5499,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-dir": {
@@ -5527,8 +5508,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       },
       "dependencies": {
         "global-modules": {
@@ -5537,9 +5518,9 @@
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
           "dev": true,
           "requires": {
-            "global-prefix": "^1.0.1",
-            "is-windows": "^1.0.1",
-            "resolve-dir": "^1.0.0"
+            "global-prefix": "1.0.2",
+            "is-windows": "1.0.2",
+            "resolve-dir": "1.0.1"
           }
         }
       }
@@ -5574,7 +5555,7 @@
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3"
+        "glob": "7.1.6"
       }
     },
     "ripemd160": {
@@ -5583,8 +5564,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.4"
       }
     },
     "run-queue": {
@@ -5593,7 +5574,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1"
+        "aproba": "1.2.0"
       }
     },
     "safe-buffer": {
@@ -5608,7 +5589,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -5623,9 +5604,9 @@
       "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
       "dev": true,
       "requires": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
+        "ajv": "6.11.0",
+        "ajv-errors": "1.0.1",
+        "ajv-keywords": "3.4.1"
       }
     },
     "secure-compare": {
@@ -5662,18 +5643,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.7.2",
+        "http-errors": "1.7.2",
         "mime": "1.6.0",
         "ms": "2.1.1",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.1",
+        "statuses": "1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -5713,13 +5694,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.7",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.26",
+        "parseurl": "1.3.3"
       },
       "dependencies": {
         "debug": {
@@ -5737,10 +5718,10 @@
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "statuses": "1.5.0"
           }
         },
         "inherits": {
@@ -5769,9 +5750,9 @@
       "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
       "dev": true,
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.3",
         "send": "0.17.1"
       }
     },
@@ -5787,10 +5768,10 @@
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5799,7 +5780,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -5822,8 +5803,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "shebang-command": {
@@ -5832,7 +5813,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -5853,14 +5834,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.3",
+        "use": "3.1.1"
       },
       "dependencies": {
         "debug": {
@@ -5878,7 +5859,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -5887,7 +5868,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "ms": {
@@ -5910,9 +5891,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -5921,7 +5902,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -5930,7 +5911,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -5939,7 +5920,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-descriptor": {
@@ -5948,9 +5929,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.3"
           }
         }
       }
@@ -5961,7 +5942,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5970,7 +5951,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5981,8 +5962,8 @@
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "dev": true,
       "requires": {
-        "faye-websocket": "^0.10.0",
-        "uuid": "^3.0.1"
+        "faye-websocket": "0.10.0",
+        "uuid": "3.4.0"
       }
     },
     "sockjs-client": {
@@ -5991,12 +5972,12 @@
       "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
       "dev": true,
       "requires": {
-        "debug": "^3.2.5",
-        "eventsource": "^1.0.7",
-        "faye-websocket": "~0.11.1",
-        "inherits": "^2.0.3",
-        "json3": "^3.3.2",
-        "url-parse": "^1.4.3"
+        "debug": "3.2.6",
+        "eventsource": "1.0.7",
+        "faye-websocket": "0.11.3",
+        "inherits": "2.0.4",
+        "json3": "3.3.3",
+        "url-parse": "1.4.7"
       },
       "dependencies": {
         "faye-websocket": {
@@ -6005,7 +5986,7 @@
           "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
           "dev": true,
           "requires": {
-            "websocket-driver": ">=0.5.1"
+            "websocket-driver": "0.7.3"
           }
         }
       }
@@ -6028,11 +6009,11 @@
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -6041,8 +6022,8 @@
       "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
+        "buffer-from": "1.1.1",
+        "source-map": "0.6.1"
       }
     },
     "source-map-url": {
@@ -6057,11 +6038,11 @@
       "integrity": "sha512-HeZS3PBdMA+sZSu0qwpCxl3DeALD5ASx8pAX0jZdKXSpPWbQ6SYGnlg3BBmYLx5LtiZrmkAZfErCm2oECBcioA==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.0",
-        "handle-thing": "^2.0.0",
-        "http-deceiver": "^1.2.7",
-        "select-hose": "^2.0.0",
-        "spdy-transport": "^3.0.0"
+        "debug": "4.1.1",
+        "handle-thing": "2.0.0",
+        "http-deceiver": "1.2.7",
+        "select-hose": "2.0.0",
+        "spdy-transport": "3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -6070,7 +6051,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         }
       }
@@ -6081,12 +6062,12 @@
       "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "hpack.js": "^2.1.6",
-        "obuf": "^1.1.2",
-        "readable-stream": "^3.0.6",
-        "wbuf": "^1.7.3"
+        "debug": "4.1.1",
+        "detect-node": "2.0.4",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.2",
+        "readable-stream": "3.6.0",
+        "wbuf": "1.7.3"
       },
       "dependencies": {
         "debug": {
@@ -6095,7 +6076,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "readable-stream": {
@@ -6104,9 +6085,9 @@
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "inherits": "2.0.4",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         }
       }
@@ -6117,7 +6098,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "ssri": {
@@ -6126,7 +6107,7 @@
       "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "dev": true,
       "requires": {
-        "figgy-pudding": "^3.5.1"
+        "figgy-pudding": "3.5.1"
       }
     },
     "static-extend": {
@@ -6135,8 +6116,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -6145,7 +6126,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -6162,8 +6143,8 @@
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7"
       }
     },
     "stream-each": {
@@ -6172,8 +6153,8 @@
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.4",
+        "stream-shift": "1.0.1"
       }
     },
     "stream-http": {
@@ -6182,11 +6163,11 @@
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.2"
       }
     },
     "stream-shift": {
@@ -6201,9 +6182,9 @@
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "requires": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
+        "emoji-regex": "7.0.3",
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "5.2.0"
       }
     },
     "string.prototype.trimleft": {
@@ -6212,8 +6193,8 @@
       "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1"
       }
     },
     "string.prototype.trimright": {
@@ -6222,8 +6203,8 @@
       "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
@@ -6232,7 +6213,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -6249,7 +6230,7 @@
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^4.1.0"
+        "ansi-regex": "4.1.0"
       }
     },
     "strip-eof": {
@@ -6264,7 +6245,7 @@
       "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "tapable": {
@@ -6279,9 +6260,9 @@
       "integrity": "sha512-5fqgBPLgVHZ/fVvqRhhUp9YUiGXhFJ9ZkrZWD9vQtFBR4QIGTnbsb+/kKqSqfgp3WnBwGWAFnedGTtmX1YTn0w==",
       "dev": true,
       "requires": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "commander": "2.20.3",
+        "source-map": "0.6.1",
+        "source-map-support": "0.5.16"
       }
     },
     "terser-webpack-plugin": {
@@ -6290,15 +6271,15 @@
       "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "dev": true,
       "requires": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
-        "source-map": "^0.6.1",
-        "terser": "^4.1.2",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
+        "cacache": "12.0.3",
+        "find-cache-dir": "2.1.0",
+        "is-wsl": "1.1.0",
+        "schema-utils": "1.0.0",
+        "serialize-javascript": "2.1.2",
+        "source-map": "0.6.1",
+        "terser": "4.6.4",
+        "webpack-sources": "1.4.3",
+        "worker-farm": "1.7.0"
       }
     },
     "through2": {
@@ -6307,8 +6288,8 @@
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.7",
+        "xtend": "4.0.2"
       }
     },
     "thunky": {
@@ -6323,7 +6304,7 @@
       "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "dev": true,
       "requires": {
-        "setimmediate": "^1.0.4"
+        "setimmediate": "1.0.5"
       }
     },
     "to-arraybuffer": {
@@ -6344,7 +6325,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6353,7 +6334,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6364,10 +6345,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -6376,8 +6357,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "toidentifier": {
@@ -6405,7 +6386,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "mime-types": "2.1.26"
       }
     },
     "typedarray": {
@@ -6426,8 +6407,8 @@
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
+        "unicode-canonical-property-names-ecmascript": "1.0.4",
+        "unicode-property-aliases-ecmascript": "1.0.5"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -6448,7 +6429,7 @@
       "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
       "dev": true,
       "requires": {
-        "qs": "^6.4.0"
+        "qs": "6.5.2"
       }
     },
     "union-value": {
@@ -6457,10 +6438,10 @@
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "2.0.1"
       }
     },
     "unique-filename": {
@@ -6469,7 +6450,7 @@
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "requires": {
-        "unique-slug": "^2.0.0"
+        "unique-slug": "2.0.2"
       }
     },
     "unique-slug": {
@@ -6478,7 +6459,7 @@
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "dev": true,
       "requires": {
-        "imurmurhash": "^0.1.4"
+        "imurmurhash": "0.1.4"
       }
     },
     "unpipe": {
@@ -6493,8 +6474,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -6503,9 +6484,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -6539,7 +6520,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
@@ -6578,8 +6559,8 @@
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "dev": true,
       "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
+        "querystringify": "2.1.1",
+        "requires-port": "1.0.0"
       }
     },
     "use": {
@@ -6647,9 +6628,9 @@
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "chokidar": "2.1.8",
+        "graceful-fs": "4.2.3",
+        "neo-async": "2.6.1"
       }
     },
     "wbuf": {
@@ -6658,7 +6639,7 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "requires": {
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "1.0.1"
       }
     },
     "webpack": {
@@ -6671,25 +6652,25 @@
         "@webassemblyjs/helper-module-context": "1.8.5",
         "@webassemblyjs/wasm-edit": "1.8.5",
         "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.2.1",
-        "ajv": "^6.10.2",
-        "ajv-keywords": "^3.4.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^4.0.3",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.4.0",
-        "loader-utils": "^1.2.3",
-        "memory-fs": "^0.4.1",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.1",
-        "neo-async": "^2.6.1",
-        "node-libs-browser": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.6.0",
-        "webpack-sources": "^1.4.1"
+        "acorn": "6.4.0",
+        "ajv": "6.11.0",
+        "ajv-keywords": "3.4.1",
+        "chrome-trace-event": "1.0.2",
+        "enhanced-resolve": "4.1.1",
+        "eslint-scope": "4.0.3",
+        "json-parse-better-errors": "1.0.2",
+        "loader-runner": "2.4.0",
+        "loader-utils": "1.4.0",
+        "memory-fs": "0.4.1",
+        "micromatch": "3.1.10",
+        "mkdirp": "0.5.1",
+        "neo-async": "2.6.1",
+        "node-libs-browser": "2.2.1",
+        "schema-utils": "1.0.0",
+        "tapable": "1.1.3",
+        "terser-webpack-plugin": "1.4.3",
+        "watchpack": "1.6.0",
+        "webpack-sources": "1.4.3"
       },
       "dependencies": {
         "acorn": {
@@ -6731,9 +6712,9 @@
           "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "memory-fs": "^0.4.0",
-            "tapable": "^1.0.0"
+            "graceful-fs": "4.2.3",
+            "memory-fs": "0.4.1",
+            "tapable": "1.1.3"
           }
         },
         "loader-utils": {
@@ -6742,9 +6723,9 @@
           "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
           "dev": true,
           "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
+            "big.js": "5.2.2",
+            "emojis-list": "2.1.0",
+            "json5": "1.0.1"
           }
         }
       }
@@ -6755,11 +6736,11 @@
       "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
       "dev": true,
       "requires": {
-        "memory-fs": "^0.4.1",
-        "mime": "^2.4.4",
-        "mkdirp": "^0.5.1",
-        "range-parser": "^1.2.1",
-        "webpack-log": "^2.0.0"
+        "memory-fs": "0.4.1",
+        "mime": "2.4.4",
+        "mkdirp": "0.5.1",
+        "range-parser": "1.2.1",
+        "webpack-log": "2.0.0"
       },
       "dependencies": {
         "mime": {
@@ -6777,37 +6758,37 @@
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
-        "bonjour": "^3.5.0",
-        "chokidar": "^2.1.8",
-        "compression": "^1.7.4",
-        "connect-history-api-fallback": "^1.6.0",
-        "debug": "^4.1.1",
-        "del": "^4.1.1",
-        "express": "^4.17.1",
-        "html-entities": "^1.2.1",
+        "bonjour": "3.5.0",
+        "chokidar": "2.1.8",
+        "compression": "1.7.4",
+        "connect-history-api-fallback": "1.6.0",
+        "debug": "4.1.1",
+        "del": "4.1.1",
+        "express": "4.17.1",
+        "html-entities": "1.2.1",
         "http-proxy-middleware": "0.19.1",
-        "import-local": "^2.0.0",
-        "internal-ip": "^4.3.0",
-        "ip": "^1.1.5",
-        "is-absolute-url": "^3.0.3",
-        "killable": "^1.0.1",
-        "loglevel": "^1.6.6",
-        "opn": "^5.5.0",
-        "p-retry": "^3.0.1",
-        "portfinder": "^1.0.25",
-        "schema-utils": "^1.0.0",
-        "selfsigned": "^1.10.7",
-        "semver": "^6.3.0",
-        "serve-index": "^1.9.1",
+        "import-local": "2.0.0",
+        "internal-ip": "4.3.0",
+        "ip": "1.1.5",
+        "is-absolute-url": "3.0.3",
+        "killable": "1.0.1",
+        "loglevel": "1.6.7",
+        "opn": "5.5.0",
+        "p-retry": "3.0.1",
+        "portfinder": "1.0.25",
+        "schema-utils": "1.0.0",
+        "selfsigned": "1.10.7",
+        "semver": "6.3.0",
+        "serve-index": "1.9.1",
         "sockjs": "0.3.19",
         "sockjs-client": "1.4.0",
-        "spdy": "^4.0.1",
-        "strip-ansi": "^3.0.1",
-        "supports-color": "^6.1.0",
-        "url": "^0.11.0",
-        "webpack-dev-middleware": "^3.7.2",
-        "webpack-log": "^2.0.0",
-        "ws": "^6.2.1",
+        "spdy": "4.0.1",
+        "strip-ansi": "3.0.1",
+        "supports-color": "6.1.0",
+        "url": "0.11.0",
+        "webpack-dev-middleware": "3.7.2",
+        "webpack-log": "2.0.0",
+        "ws": "6.2.1",
         "yargs": "12.0.5"
       },
       "dependencies": {
@@ -6823,9 +6804,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -6840,7 +6821,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -6851,7 +6832,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "get-caller-file": {
@@ -6878,8 +6859,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -6894,7 +6875,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -6905,7 +6886,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "wrap-ansi": {
@@ -6914,8 +6895,8 @@
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -6924,7 +6905,7 @@
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
               }
             },
             "string-width": {
@@ -6933,9 +6914,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -6946,7 +6927,7 @@
           "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "dev": true,
           "requires": {
-            "async-limiter": "~1.0.0"
+            "async-limiter": "1.0.1"
           }
         },
         "yargs": {
@@ -6955,18 +6936,18 @@
           "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "3.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "4.0.0",
+            "yargs-parser": "11.1.1"
           }
         },
         "yargs-parser": {
@@ -6975,8 +6956,8 @@
           "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
+            "camelcase": "5.3.1",
+            "decamelize": "1.2.0"
           }
         }
       }
@@ -6987,8 +6968,8 @@
       "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^3.0.0",
-        "uuid": "^3.3.2"
+        "ansi-colors": "3.2.4",
+        "uuid": "3.4.0"
       }
     },
     "webpack-sources": {
@@ -6997,8 +6978,8 @@
       "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
       "dev": true,
       "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
+        "source-list-map": "2.0.1",
+        "source-map": "0.6.1"
       }
     },
     "websocket-driver": {
@@ -7007,9 +6988,9 @@
       "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
       "dev": true,
       "requires": {
-        "http-parser-js": ">=0.4.0 <0.4.11",
-        "safe-buffer": ">=5.1.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.4.10",
+        "safe-buffer": "5.2.0",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -7024,7 +7005,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -7045,7 +7026,7 @@
       "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "dev": true,
       "requires": {
-        "errno": "~0.1.7"
+        "errno": "0.1.7"
       }
     },
     "wrap-ansi": {
@@ -7054,9 +7035,9 @@
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "ansi-styles": "3.2.1",
+        "string-width": "3.1.0",
+        "strip-ansi": "5.2.0"
       }
     },
     "wrappy": {
@@ -7089,17 +7070,17 @@
       "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
       "dev": true,
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "os-locale": "^3.1.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.0"
+        "cliui": "5.0.0",
+        "find-up": "3.0.0",
+        "get-caller-file": "2.0.5",
+        "os-locale": "3.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "2.0.0",
+        "set-blocking": "2.0.0",
+        "string-width": "3.1.0",
+        "which-module": "2.0.0",
+        "y18n": "4.0.0",
+        "yargs-parser": "13.1.1"
       }
     },
     "yargs-parser": {
@@ -7108,8 +7089,8 @@
       "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "camelcase": "5.3.1",
+        "decamelize": "1.2.0"
       }
     }
   }

--- a/blockly-ws-search/src/WorkspaceSearch.js
+++ b/blockly-ws-search/src/WorkspaceSearch.js
@@ -124,7 +124,7 @@ export class WorkspaceSearch {
     searchContainer.append(searchContent);
 
     const inputWrapper = this.createInputDiv_();
-    this.textInput_ = this.createTextInput();
+    this.textInput_ = this.createTextInput_();
     inputWrapper.append(this.textInput_);
     searchContent.append(inputWrapper);
 
@@ -178,7 +178,7 @@ export class WorkspaceSearch {
    * Creates the text input for the search bar.
    * @protected
    */
-  createTextInput() {
+  createTextInput_() {
     let textInput = document.createElement('input');
     textInput.type = 'text';
     textInput.setAttribute('placeholder', this.textInputPlaceholder_);

--- a/blockly-ws-search/src/WorkspaceSearch.js
+++ b/blockly-ws-search/src/WorkspaceSearch.js
@@ -7,6 +7,7 @@
 /**
  * @fileoverview Object responsible for workspace search.
  * @author aschmiedt@google.com (Abby Schmiedt)
+ * @author kozbial@google.com (Monica Kozbial)
  */
 
 
@@ -20,29 +21,36 @@ export class WorkspaceSearch {
    */
   constructor(workspace) {
     /**
-     * The workspace the trashcan sits in.
+     * The workspace the search bar sits in.
      * @type {!Blockly.WorkspaceSvg}
      * @private
      */
     this.workspace_ = workspace;
 
     /**
-     * HTML container for the workspace search bar.
+     * HTML container for the search bar.
      * @type {?HTMLElement}
      * @private
      */
     this.HtmlDiv_ = null;
 
     /**
-     * The input for the search text.
+     * The text input for the search bar.
      * @type {?HTMLInputElement}
      * @private
      */
     this.textInput_ = null;
 
     /**
+     * The placeholder text for the search bar input.
+     * @type {string}
+     * @private
+     */
+    this.textInputPlaceholder_ = 'Search';
+
+    /**
      * A list of blocks that came up in the search
-     * @type {!Array.<Blockly.Block>}
+     * @type {!Array.<Blockly.BlockSvg>}
      * @protected
      */
     this.blocks_ = [];
@@ -79,6 +87,12 @@ export class WorkspaceSearch {
      * @type {boolean}
      */
     this.caseSensitive = false;
+
+    /**
+     * Whether search should preserve the currently selected block by default.
+     * @type {boolean}
+     */
+    this.preserveSelected = true;
   }
 
   /**
@@ -86,14 +100,21 @@ export class WorkspaceSearch {
    */
   init() {
     injectSearchCss();
+    this.createDom_();
+  }
 
-    const workspaceSvg = this.workspace_.getParentSvg();
-    workspaceSvg.parentNode.addEventListener('keydown',
-        evt => this.onWorkspaceKeyDown_(evt));
+  /**
+   * Creates the search bar's DOM.
+   * @protected
+   */
+  createDom_() {
+    const parentSvg = this.workspace_.getParentSvg();
+    parentSvg.parentNode.addEventListener('keydown',
+        evt => this.onWorkspaceKeyDown_(/** @type {KeyboardEvent} */ evt));
 
     this.HtmlDiv_ = document.createElement('div');
     Blockly.utils.dom.addClass(this.HtmlDiv_, 'ws-search');
-    this.positionSearchBar_();
+    this.positionSearchBar();
 
     const searchContainer = document.createElement('div');
     Blockly.utils.dom.addClass(searchContainer, 'ws-search-container');
@@ -102,86 +123,71 @@ export class WorkspaceSearch {
     Blockly.utils.dom.addClass(searchContent, 'ws-search-content');
     searchContainer.append(searchContent);
 
-    const inputWrapper = this.getInputDiv();
-    this.textInput_ = this.getTextInput();
+    const inputWrapper = this.createInputDiv_();
+    this.textInput_ = this.createTextInput();
     inputWrapper.append(this.textInput_);
     searchContent.append(inputWrapper);
 
-    const actionDiv = this.getActionsDiv();
+    const actionDiv = this.createActionsDiv_();
     searchContent.append(actionDiv);
-    searchContainer.append(this.getCloseBtn());
+    searchContainer.append(this.createCloseBtn_());
 
     this.HtmlDiv_.append(searchContainer);
 
-    workspaceSvg.parentNode.insertBefore(this.HtmlDiv_, workspaceSvg);
+    parentSvg.parentNode.insertBefore(this.HtmlDiv_, parentSvg);
     this.setVisible(false);
   }
 
   /**
-   * Gets the div that holds all of the search bar actions.
+   * Creates the div that holds all of the search bar actions.
+   * @protected
    */
-  getActionsDiv() {
+  createActionsDiv_() {
     const actions = document.createElement('div');
     Blockly.utils.dom.addClass(actions, 'ws-search-actions');
     // Add all the buttons for the search bar
     const upBtn = this.createBtn_('up-btn', 'Find previous',
-        evt => this.previous_(evt));
+        () => this.previous_());
     const downBtn = this.createBtn_('down-btn', 'Find next',
-        evt => this.next_(evt));
+        () => this.next_());
     actions.append(upBtn);
     actions.append(downBtn);
     return actions;
   }
 
   /**
-   * Gets the button used for closing the search bar.
+   * Creates the button used for closing the search bar.
+   * @protected
    */
-  getCloseBtn() {
+  createCloseBtn_() {
     return this.createBtn_('close-btn', 'Close search bar',
-        evt => this.close(evt));
+        () => this.close());
   }
 
   /**
-   * Gets the div responsible for holding inputs.
+   * Creates the div responsible for holding inputs.
+   * @protected
    */
-  getInputDiv() {
+  createInputDiv_() {
     const inputWrapper = document.createElement('div');
     Blockly.utils.dom.addClass(inputWrapper, 'ws-search-input');
     return inputWrapper;
   }
 
   /**
-   * Gets the text input for the search bar.
+   * Creates the text input for the search bar.
+   * @protected
    */
-  getTextInput() {
+  createTextInput() {
     let textInput = document.createElement('input');
     textInput.type = 'text';
-    // TODO: Figure out how we are going to deal with translating.
-    textInput.setAttribute('placeholder', 'Search');
-    textInput.addEventListener('keydown', evt => this.onKeyDown_(evt));
-    textInput.addEventListener('input', evt => this.onInput_(evt));
-    textInput.addEventListener('click', evt => this.onInputClick_(evt));
-
+    textInput.setAttribute('placeholder', this.textInputPlaceholder_);
+    textInput.addEventListener('keydown',
+            evt => this.onKeyDown_(/** @type {KeyboardEvent} */ evt));
+    textInput.addEventListener('input', () => this.onInput_());
+    textInput.addEventListener('click',
+        () => this.search(this.preserveSelected));
     return textInput;
-  }
-
-  /**
-   * Positions the search bar based on where the workspace's toolbox is
-   * positioned.
-   * @private
-   */
-  positionSearchBar_() {
-    const metrics = this.workspace_.getMetrics();
-    if (this.workspace_.RTL) {
-      this.HtmlDiv_.style.left = metrics.absoluteLeft + 'px';
-    } else {
-      if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
-        this.HtmlDiv_.style.right = metrics.toolboxWidth + 'px';
-      } else {
-        this.HtmlDiv_.style.right = '0';
-      }
-    }
-    this.HtmlDiv_.style.top = metrics.absoluteTop + 'px';
   }
 
   /**
@@ -204,8 +210,8 @@ export class WorkspaceSearch {
     Blockly.utils.dom.addClass(btn, className);
     btn.addEventListener('click', onClickFn);
     // TODO: Review Blockly's key handling to see if there is a way to avoid
-    // this.
-    btn.addEventListener('keydown', e => function(e) {
+    //  needing to call stopPropogation().
+    btn.addEventListener('keydown', e => {
       if (e.key === "Enter") {
         onClickFn(e);
         e.preventDefault();  
@@ -219,25 +225,35 @@ export class WorkspaceSearch {
   }
 
   /**
-   * Handles input value change in search bar.
-   * @param {Event} e The oninput event.
+   * Positions the search bar based on where the workspace's toolbox is.
    */
-  onInput_(e) {
-    if (this.searchOnInput) {
-      const inputValue = e.target.value;
-      if (inputValue !== this.searchText_) {
-        this.setSearchText_(inputValue);
-        this.search();
+  positionSearchBar() {
+    // TODO: Handle positioning search bar when window is resized.
+    const metrics = this.workspace_.getMetrics();
+    if (this.workspace_.RTL) {
+      this.HtmlDiv_.style.left = metrics.absoluteLeft + 'px';
+    } else {
+      if (metrics.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
+        this.HtmlDiv_.style.right = metrics.toolboxWidth + 'px';
+      } else {
+        this.HtmlDiv_.style.right = '0';
       }
     }
+    this.HtmlDiv_.style.top = metrics.absoluteTop + 'px';
   }
 
   /**
-   * Handles clicking on the input value in search bar.
-   * @param {Event} e The onclick event.
+   * Handles input value change in search bar.
+   * @private
    */
-  onInputClick_() {
-    this.search(this.currentBlock_);
+  onInput_() {
+    if (this.searchOnInput) {
+      const inputValue = this.textInput_.value;
+      if (inputValue !== this.searchText_) {
+        this.setSearchText_(inputValue);
+        this.search(this.preserveSelected);
+      }
+    }
   }
 
   /**
@@ -252,34 +268,22 @@ export class WorkspaceSearch {
       if (this.searchOnInput) {
         this.next_();
       } else {
-        this.setSearchText_(e.target.value);
-        this.search();
+        this.setSearchText_(this.textInput_.value);
+        this.search(this.preserveSelected);
       }
     }
   }
 
   /**
    * Opens the search bar when Control F or Command F are used on the workspace.
-   * TODO: Look into handling keyboard shortcuts on workspace in Blockly.
    * @param {KeyboardEvent} e The key down event.
    * @private
    */
   onWorkspaceKeyDown_(e) {
+    // TODO: Look into handling keyboard shortcuts on workspace in Blockly.
     if ((e.ctrlKey || e.metaKey) && e.key === "f") {
       this.open();
       e.preventDefault();
-    }
-  }
-
-  /**
-   * Sets search text.
-   * @param {string} text
-   * @protected
-   */
-  setSearchText_(text) {
-    this.searchText_ = text.trim();
-    if (!this.caseSensitive) {
-      this.searchText_ =  this.searchText_.toLowerCase();
     }
   }
 
@@ -306,6 +310,29 @@ export class WorkspaceSearch {
   }
 
   /**
+   * Sets the placeholder text for the search bar text input.
+   * @param {string} placeholderText The placeholder text.
+   */
+  setSearchPlaceholder(placeholderText) {
+    this.textInputPlaceholder_ = placeholderText;
+    if (this.textInput_) {
+      this.textInput_.setAttribute('placeholder', this.textInputPlaceholder_);
+    }
+  }
+
+  /**
+   * Sets search text.
+   * @param {string} text
+   * @protected
+   */
+  setSearchText_(text) {
+    this.searchText_ = text.trim();
+    if (!this.caseSensitive) {
+      this.searchText_ =  this.searchText_.toLowerCase();
+    }
+  }
+
+  /**
    * Changes the currently "selected" block and adds extra highlight.
    * @param {number} index Index of block to set as current. Number is wrapped.
    * @protected
@@ -318,14 +345,11 @@ export class WorkspaceSearch {
     this.currentBlockIndex_ =
         (index % this.blocks_.length + this.blocks_.length) %
         this.blocks_.length;
-    this.currentBlock_ = (
-        /** @type {!Blockly.BlockSvg} */ this.blocks_[this.currentBlockIndex_]);
-    if (this.workspace_.rendered) {
-      const currPath = this.currentBlock_.pathObject.svgPath;
-      Blockly.utils.dom.addClass(currPath, 'search-current');
-      this.updateCursor_(this.currentBlock_);
-      this.scrollToVisible_(this.currentBlock_);
-    }
+    this.currentBlock_ = this.blocks_[this.currentBlockIndex_];
+    const path = this.currentBlock_.pathObject.svgPath;
+    Blockly.utils.dom.addClass(path, 'search-current');
+    this.updateCursor_(this.currentBlock_);
+    this.scrollToVisible_(this.currentBlock_);
   }
 
   /**
@@ -335,34 +359,22 @@ export class WorkspaceSearch {
   clearCurrentBlock_() {
     this.currentBlockIndex_ = -1;
     if (this.currentBlock_) {
-      if (this.workspace_.rendered) {
-        const path = this.currentBlock_.pathObject.svgPath;
-        Blockly.utils.dom.removeClass(path, 'search-current');
-      }
+      const path = this.currentBlock_.pathObject.svgPath;
+      Blockly.utils.dom.removeClass(path, 'search-current');
       this.currentBlock_ = null;
     }
   }
 
   /**
-   * Updates the location of the cursor if the user is in keyboard naviation
+   * Updates the location of the cursor if the user is in keyboard accessibility
    * mode.
+   * @protected
    */
   updateCursor_(currBlock) {
     if (this.workspace_.keyboardAccessibilityMode) {
       const currAstNode = Blockly.navigation.getTopNode(currBlock);
       this.workspace_.getCursor().setCurNode(currAstNode);
     }
-  }
-
-  /**
-   * Disposes of workspace search.
-   * Unlink from all DOM elements to prevent memory leaks.
-   * @suppress {checkTypes}
-   */
-  dispose() {
-    if (this.HtmlDiv_) {
-      Blockly.utils.dom.removeNode(this.HtmlDiv_);
-    }  
   }
 
   /**
@@ -408,26 +420,30 @@ export class WorkspaceSearch {
 
   /**
    * Searches the workspace for the current search term.
-   * @param {Blockly.Block=} opt_block Block to use as the current
-   *     block if it is included in new search blocks.
+   * @param {boolean=} preserveCurrent Whether to preserve the current block
+   *    if it is included in the new search block.
    */
-  search(opt_block) {
+  search(preserveCurrent) {
+    let oldCurrentBlock = this.currentBlock_;
     this.clearBlocks();
-    this.populateBlocks();
+    this.populateBlocks_();
     this.highlightBlocks();
-    let newBlockIdx = this.blocks_.indexOf(opt_block);
-    newBlockIdx = newBlockIdx > -1 ? newBlockIdx : 0;
-    this.setCurrentBlock_(newBlockIdx);
+    let currentIdx = 0;
+    if (preserveCurrent) {
+      currentIdx = this.blocks_.indexOf(oldCurrentBlock);
+      currentIdx = currentIdx > -1 ? currentIdx : 0;
+    }
+    this.setCurrentBlock_(currentIdx);
   }
 
   /**
    * Returns pool of blocks to search from.
-   * @return {!Array.<!Blockly.Block>}
+   * @return {!Array.<!Blockly.BlockSvg>}
    * @private
   */
   getSearchPool_() {
     const blocks = (
-        /** @type {!Array.<!Blockly.Block>} */
+        /** @type {!Array.<!Blockly.BlockSvg>} */
         this.workspace_.getAllBlocks(true));
     return blocks.filter(function(block) {
       // Filter out blocks contained inside of another collapsed block.
@@ -438,7 +454,7 @@ export class WorkspaceSearch {
 
   /**
    * Returns whether the given block matches the search text.
-   * @param {!Blockly.Block} block The block to check.
+   * @param {!Blockly.BlockSvg} block The block to check.
    * @private
    */
   isBlockMatch_(block) {
@@ -463,8 +479,9 @@ export class WorkspaceSearch {
 
   /**
    * Populates block list with blocks that match the search text.
+   * @protected
    */
-  populateBlocks() {
+  populateBlocks_() {
     if (!this.searchText_) {
       return;
     }
@@ -486,10 +503,7 @@ export class WorkspaceSearch {
    * Adds highlight to blocks in block list.
    */
   highlightBlocks() {
-    if (!this.workspace_.rendered) {
-      return;
-    }
-    this.blocks_.forEach(function(/** @type {!Blockly.BlockSvg} */ block) {
+    this.blocks_.forEach(function(block) {
       const blockPath = block.pathObject.svgPath;
       Blockly.utils.dom.addClass(blockPath, 'search-highlight');
     });
@@ -499,10 +513,7 @@ export class WorkspaceSearch {
    * Removes highlight from blocks in block list.
    */
   unHighlightBlocks() {
-    if (!this.workspace_.rendered) {
-      return;
-    }
-    this.blocks_.forEach(function(/** @type {!Blockly.BlockSvg} */ block) {
+    this.blocks_.forEach(function(block) {
       const blockPath = block.pathObject.svgPath;
       Blockly.utils.dom.removeClass(blockPath, 'search-highlight');
     });
@@ -564,7 +575,7 @@ export class WorkspaceSearch {
       this.workspace_.scroll(-targetLeft, -targetTop);
       if (activeEl) {
         // Blockly.WidgetDiv.hide called in scroll is taking away focus.
-        // TODO: review setFocused call in Blockly.WidgetDiv.hide.
+        // TODO: Review setFocused call in Blockly.WidgetDiv.hide.
         activeEl.focus();
       }
     }

--- a/blockly-ws-search/src/css.js
+++ b/blockly-ws-search/src/css.js
@@ -6,6 +6,7 @@
 
 /**
  * @fileoverview Styling for workspace search.
+ * @author aschmiedt@google.com (Abby Schmiedt)
  * @author kozbial@google.com (Monica Kozbial)
  */
 


### PR DESCRIPTION
- Cleaning up comments
  - Fixing typos
  - Rewording comments
  - Moving TODOs from method description to inside method
- Cleaning up methods
  - Reorder of declaration for some methods.
  - Reviewing private/protected annotations (following naming convention of _ for protected)
  - Removing unused parameters
  - Renaming of dom creation methods from get to create (to be more clear)
  - Removing `dispose()` as it was not actually disposing of html element
- Removing partial support for headless
  - Removing checks for `rendered`
  - Changing types from `Blockly.Block` to `Blockly.BlockSvg`
  - Removing now unnecessary casts
- Minor refactor of search preserving current block
  - Changing param from block to boolean for easier use
  - Preserving current block for more cases other than onclick
  - Exposing property to allow for turning off preserving block
- Exposing search bar placeholder text with setter method

