### PR TITLE
Update peer dependency

### DIFF
--- a/blockly-ws-search/package.json
+++ b/blockly-ws-search/package.json
@@ -11,7 +11,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "blockly": ">=3.20200123.1"
+    "blockly": ">=3.20200123.0"
   },
   "files": [
     "./src",

--- a/blockly-ws-search/package.json
+++ b/blockly-ws-search/package.json
@@ -11,7 +11,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "blockly": "^3.20200123.1"
+    "blockly": ">=3.20200123.1"
   },
   "files": [
     "./src",


### PR DESCRIPTION
- Everything equal to or above 3.20200123.0. 
- Tested with earlier versions but doesn't work because the Marker Manager was introduced in last release.

Also helpful for figuring out different npm semver syntax (https://semver.npmjs.com/)