### PR TITLE
Add dispose method to workspace search

### DIFF
--- a/blockly-ws-search/.eslintrc.json
+++ b/blockly-ws-search/.eslintrc.json
@@ -72,7 +72,11 @@
     }],
     "jsdoc/require-description": 1,
     "jsdoc/check-tag-names": 0,
-    "jsdoc/check-access": 1
+    "jsdoc/check-access": 1,
+    "jsdoc/check-types": 0,
+    "jsdoc/require-jsdoc": ["error",
+      {"require":{"ClassDeclaration":true,"MethodDefinition":true}}
+    ]
   },
   "settings": {
     "jsdoc": {


### PR DESCRIPTION
- I don't think WorkspaceSearch should hold the responsibility for disposing of the Workspace. I think it makes more sense for them to be separate and developers have the responsibility to call the correct dispose functions. 

- Uses Blockly's built in methods for removing and adding event listeners. 


Fixes https://github.com/google/blockly-samples/issues/117