### PR TITLE
Bump patch number

### DIFF
--- a/blockly-ws-search/package.json
+++ b/blockly-ws-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-workspace-search",
-  "version": "1.20200312.0",
+  "version": "1.20200312.1",
   "description": "A Blockly plugin that adds workspace search support.",
   "author": "Blockly Team",
   "keywords": [


### PR DESCRIPTION
Because unpublishing isn't really recommended. And you can't publish twice with same version number : ( 