### PR TITLE
Add a common webpack config file to be used by all packages.

### DIFF
--- a/packages/webpack.config.js
+++ b/packages/webpack.config.js
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * @fileoverview Webpack base configuration file.
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+const appDirectory = fs.realpathSync(process.cwd());
+const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
+
+const packageJson = require(resolveApp('package.json'));
+console.log(`Building ${packageJson.name}`)
+
+module.exports = env => {
+    const src = {
+        name: "src",
+        mode: env.mode,
+        entry: "./src/index.js",
+        devtool: 'source-map',
+        output: {
+            path: resolveApp('dist'),
+            publicPath: '/dist/',
+            filename: 'index.js',
+            libraryTarget: 'umd',
+            globalObject: 'this'
+        },
+        module: {
+            rules: [{
+                test: /\.js$/,
+                exclude: /(node_modules)/,
+                use: {
+                    loader: "babel-loader",
+                    options: {
+                        presets: ["@babel/preset-env"]
+                    }
+                }
+            }]
+        },
+        externals: {
+            'blockly/core': {
+                root: 'Blockly',
+                commonjs: 'blockly/core',
+                commonjs2: 'blockly/core',
+                amd: 'blockly/core'
+            },
+        }
+    };
+    const webpackExports = [src];
+
+    if (env.buildTest) {
+        const test = {
+            name: "test",
+            mode: "development",
+            entry: "./test/index.js",
+            devtool: 'source-map',
+            output: {
+                path: resolveApp('build'),
+                publicPath: '/build/',
+                filename: 'test_bundle.js'
+            },
+            module: {
+                rules: [{
+                    test: /\.js$/,
+                    exclude: /(node_modules)/,
+                    use: {
+                        loader: "babel-loader",
+                        options: {
+                            presets: ["@babel/preset-env"]
+                        }
+                    }
+                }]
+            },
+            devServer: {
+                openPage: 'test',
+                port: 3000,
+                open: true
+            },
+        }
+        webpackExports.push(test);
+    }
+    return webpackExports;
+};


### PR DESCRIPTION
This should reduce duplication of webpack configuration. A package can instead call: 
``webpack --config ../../webpack.config.js`` to use this config instead of its own. 

The config does the following: 
- Builds src with babel-loader. It expects a src/index.js and outputs to dist/index.js
- If the ``--env.buildTest=true`` variable is passed in, it will also build a test directory, expecting a ``test/index.js`` and outputs that into ``build/test_bundle.js``. 


This is what I would expect the new package.jsons to configure their scripts to do: 
```
    "build": "webpack --config ../../webpack.config.js --display-error-details --env.mode=development",
    "prepublishOnly": "npm run clean && webpack --config ../../webpack.config.js --display-error-details --env.mode=production",
    "start": "webpack-dev-server --config ../../webpack.config.js --env.buildTest=true --env.mode=development",
```