### PR TITLE
Fixes to @blockly/create-package script after release testing

### DIFF
--- a/packages/dev/create/README.md
+++ b/packages/dev/create/README.md
@@ -10,7 +10,13 @@ A tool for creating a Blockly package based on a pre-existing template.
 ## Usage
 
 ```
-npx @blockly/create-package <plugin|field|block> my-plugin
+npx @blockly/create-package <plugin|field|block> <package-directory>
+```
+
+## Example Usage
+
+```
+npx @blockly/create-package plugin my-plugin
 cd my-plugin
 npm start
 ```

--- a/packages/dev/create/bin/create.js
+++ b/packages/dev/create/bin/create.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2020 Google LLC
@@ -19,22 +20,20 @@ const path = require('path');
 const execSync = require('child_process').execSync;
 
 const root = process.cwd();
+const scriptName = '@blockly/create-package';
+const usage = `  ${chalk.blue(scriptName)}\
+ ${chalk.green('<plugin|field|block>')}\
+ ${chalk.green('<package-directory>')}
 
-const usage = `
-  ${chalk.blue('blockly-scripts create')}\
-  ${chalk.green('<plugin|field|block>')}\
-  ${chalk.green('<package-directory>')}
-
-For example:
-  ${chalk.blue('blockly-scripts create')}\
-  ${chalk.green('plugin')} ${chalk.green('my-blockly-plugin')}\n`;
+For example:\n  ${chalk.blue(scriptName)}\
+ ${chalk.green('plugin')} ${chalk.green('my-blockly-plugin')}\n`;
 
 const packageType = args[0];
 // Check package type exists.
 if (!packageType) {
   console.error('Please specify the package type.');
   console.log(`It can either be ${chalk.green('plugin')},\
-  ${chalk.green('field')} or ${chalk.green('block')}.`);
+ ${chalk.green('field')} or ${chalk.green('block')}.`);
   console.log(usage);
   process.exit(1);
 }
@@ -139,7 +138,7 @@ fs.copySync(path.resolve(__dirname, templateDir, 'template'), packageDir);
 
 // Run npm install.
 console.log('Installing packages. This might take a couple of minutes.');
-// execSync(`cd ${packageName} && npm install`, {stdio: [0, 1, 2]});
+execSync(`cd ${packageName} && npm install`, {stdio: [0, 1, 2]});
 
 console.log(chalk.green('\nPackage created.\n'));
 console.log('Next steps, run:');

--- a/packages/dev/create/package-lock.json
+++ b/packages/dev/create/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/create-package",
-	"version": "0.20200407.0",
+	"version": "0.20200407.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/dev/create/package.json
+++ b/packages/dev/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/create-package",
-  "version": "0.20200407.0",
+  "version": "0.20200407.2",
   "description": "A tool for creating a Blockly plugin, field or block package based on a template.",
   "bin": "./bin/create.js",
   "author": "Blockly Team",


### PR DESCRIPTION
Fixes after publishing to ``npm`` and testing with ``npx``:
- README / usage fixes. 
- Had to add ``#!/usr/bin/env node`` for npx to recognize that its a node script.
- Uncommented npm install script.

If you'd like to try it out: 
```bash
npx @blockly/create-package plugin my-plugin
```
