### PR TITLE
slider field precision is applied to input element

### DIFF
--- a/packages/fields/field-slider/src/field_slider.js
+++ b/packages/fields/field-slider/src/field_slider.js
@@ -116,6 +116,7 @@ export class FieldSlider extends Blockly.FieldNumber {
     sliderInput.setAttribute('type', 'range');
     sliderInput.setAttribute('min', this.min_);
     sliderInput.setAttribute('max', this.max_);
+    sliderInput.setAttribute('step', this.precision_);
     sliderInput.setAttribute('value', this.getValue());
     sliderInput.className = 'fieldSlider';
     wrapper.appendChild(sliderInput);


### PR DESCRIPTION
The slider field's precision property wasn't used by the input element.