### PR TITLE
slider color update falls back to block color if block has no style

### DIFF
--- a/packages/fields/field-slider/src/field_slider.js
+++ b/packages/fields/field-slider/src/field_slider.js
@@ -87,8 +87,10 @@ export class FieldSlider extends Blockly.FieldNumber {
 
     Blockly.DropDownDiv.getContentDiv().appendChild(editor);
 
-    Blockly.DropDownDiv.setColour(this.sourceBlock_.style.colourPrimary,
-        this.sourceBlock_.style.colourTertiary);
+    Blockly.DropDownDiv.setColour(
+        this.sourceBlock_.style ? this.sourceBlock_.style.colourPrimary : this.sourceBlock_.colour_, 
+        this.sourceBlock_.style ? this.sourceBlock_.style.colourTertiary : this.sourceBlock_.colour_, 
+    );
 
     Blockly.DropDownDiv.showPositionedByField(
         this, this.dropdownDispose_.bind(this));

--- a/packages/fields/field-slider/src/field_slider.js
+++ b/packages/fields/field-slider/src/field_slider.js
@@ -88,8 +88,8 @@ export class FieldSlider extends Blockly.FieldNumber {
     Blockly.DropDownDiv.getContentDiv().appendChild(editor);
 
     Blockly.DropDownDiv.setColour(
-        this.sourceBlock_.style ? this.sourceBlock_.style.colourPrimary : this.sourceBlock_.colour_, 
-        this.sourceBlock_.style ? this.sourceBlock_.style.colourTertiary : this.sourceBlock_.colour_, 
+        this.sourceBlock_.style ? this.sourceBlock_.style.colourPrimary : this.sourceBlock_.getColour(),
+        this.sourceBlock_.style ? this.sourceBlock_.style.colourTertiary : this.sourceBlock_.getColour(),
     );
 
     Blockly.DropDownDiv.showPositionedByField(


### PR DESCRIPTION
The slider field currently assumes that the source block has a style property. This change lets it tolerate blocks without style by falling back to their colour_ property.