### PR TITLE
Add browserlist

### DIFF
--- a/plugins/dev-create/bin/create.js
+++ b/plugins/dev-create/bin/create.js
@@ -116,6 +116,11 @@ const packageJson = {
   engines: {
     'node': '>=8.17.0',
   },
+  browserslist: [
+    'defaults',
+    'IE 11',
+    'IE_Mob 11',
+  ],
 };
 
 // Add dev dependencies.

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -49,5 +49,10 @@
   },
   "engines": {
     "node": ">=8.0.0"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "IE 11",
+    "IE_Mob 11"
+  ]
 }

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -49,5 +49,10 @@
     },
     "engines": {
         "node": ">=8.0.0"
-    }
+    },
+    "browserslist": [
+        "defaults",
+        "IE 11",
+        "IE_Mob 11"
+    ]
 }

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -53,5 +53,10 @@
   },
   "engines": {
     "node": ">=8.0.0"
-  }
+  },
+  "browserslist": [
+      "defaults",
+      "IE 11",
+      "IE_Mob 11"
+  ]
 }

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -57,5 +57,10 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "IE 11",
+    "IE_Mob 11"
+  ]
 }

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -56,5 +56,10 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "IE 11",
+    "IE_Mob 11"
+  ]
 }


### PR DESCRIPTION
Part of https://github.com/google/blockly-samples/issues/209

Add browserlist to all packages and templates.

Using defaults: https://browserl.ist/?q=defaults

I explicitly added IE 11 and IE_MOB 11, so that we can easily choose to remove support for it by doing:
```
  browserslist: [
    'defaults',
    'not IE 11',
    'not IE_Mob 11',
  ],
```