### PR TITLE
Don't watch node_modules

### DIFF
--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -18,6 +18,9 @@ module.exports = (env) => {
   const devServer = {
     port: 3000,
     host: '0.0.0.0',
+    watchOptions: {
+      ignored: /node_modules/,
+    },
   };
   if (env.buildTest) {
     devServer.openPage = 'test';


### PR DESCRIPTION
Reduce CPU and memory usage.

Context: https://webpack.js.org/configuration/watch/#watchoptionsignored

More context: the reason live reloading was failing for me was not enough watchers: https://webpack.js.org/configuration/watch/#not-enough-watchers

I fixed it by increasing my max watchers, but while digging found that we were watching node_modules and don't need to.