### PR TITLE
Emit warnings in build

### DIFF
--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -58,6 +58,7 @@ module.exports = (env) => {
             {
               options: {
                 cache: true,
+                emitWarning: true,
                 eslintPath: require.resolve('eslint'),
                 resolvePluginsRelativeTo: __dirname,
                 useEslintrc: true,


### PR DESCRIPTION
This is part of https://github.com/google/blockly-samples/issues/234
and makes all errors emit warnings instead for the build eslint warnings.
