### PR TITLE
Remove .git from gitURL

### DIFF
--- a/plugins/dev-create/bin/create.js
+++ b/plugins/dev-create/bin/create.js
@@ -58,7 +58,7 @@ let gitURL = '';
 try {
   gitRoot = execSync(`git rev-parse --show-toplevel`).toString().trim();
   gitURL = execSync(`git config --get remote.origin.url`).toString().trim()
-      .replace('.git', '');
+      .replace(/\.git$/, '');
 } catch (err) {
   // NOP
 }

--- a/plugins/dev-create/bin/create.js
+++ b/plugins/dev-create/bin/create.js
@@ -57,7 +57,8 @@ let gitRoot = '';
 let gitURL = '';
 try {
   gitRoot = execSync(`git rev-parse --show-toplevel`).toString().trim();
-  gitURL = execSync(`git config --get remote.origin.url`).toString().trim();
+  gitURL = execSync(`git config --get remote.origin.url`).toString().trim()
+      .replace('.git', '');
 } catch (err) {
   // NOP
 }


### PR DESCRIPTION
Fixes these three links.

https://github.com/alschmiedt/blockly-samples.git.git
https://github.com/alschmiedt/blockly-samples.git/issues
https://github.com/alschmiedt/blockly-samples.git/tree/master/plugins