### PR TITLE
Less noisy build

### DIFF
--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -58,6 +58,7 @@ module.exports = (env) => {
             {
               options: {
                 cache: true,
+                formatter: 'stylish',
                 emitWarning: true,
                 eslintPath: require.resolve('eslint'),
                 resolvePluginsRelativeTo: __dirname,
@@ -74,7 +75,7 @@ module.exports = (env) => {
         // Run babel to compile both JS and TS.
         {
           test: /\.(js|mjs|ts)$/,
-          exclude: /(node_modules)/,
+          exclude: /(node_modules|build|dist)/,
           loader: require.resolve('babel-loader'),
           options: {
             babelrc: false,

--- a/plugins/dev-scripts/config/webpackDevServer.config.js
+++ b/plugins/dev-scripts/config/webpackDevServer.config.js
@@ -20,7 +20,7 @@ module.exports = () => {
     port: 3000,
     host: '0.0.0.0',
     hot: true,
-    quiet: false,
+    quiet: true,
     overlay: true,
     publicPath: resolveApp('build'),
     writeToDisk: true,

--- a/plugins/dev-scripts/package-lock.json
+++ b/plugins/dev-scripts/package-lock.json
@@ -278,6 +278,18 @@
 				"@babel/helper-validator-identifier": "^7.9.0",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"@babel/parser": {
@@ -1690,13 +1702,49 @@
 			"integrity": "sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q=="
 		},
 		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+			"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"chardet": {
@@ -2428,6 +2476,16 @@
 				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
 				"globals": {
 					"version": "12.4.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -2974,6 +3032,18 @@
 				"semver": "^5.6.0",
 				"tapable": "^1.0.0",
 				"worker-rpc": "^0.1.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"forwarded": {
@@ -3930,6 +4000,18 @@
 			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
 			"requires": {
 				"chalk": "^2.4.2"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
 			}
 		},
 		"loglevel": {
@@ -7145,6 +7227,26 @@
 				"yargs": "13.2.4"
 			},
 			"dependencies": {
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
 				"emoji-regex": {
 					"version": "7.0.3",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",

--- a/plugins/dev-scripts/package.json
+++ b/plugins/dev-scripts/package.json
@@ -26,10 +26,12 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/core": "^7.8.6",
+    "@babel/code-frame": "^7.8.3",
     "@babel/preset-env": "^7.8.6",
     "@babel/preset-typescript": "^7.9.0",
     "@blockly/eslint-config": "^1.20200426.3",
     "babel-loader": "^8.0.6",
+    "chalk": "^4.0.0",
     "eslint": "^6.8.0",
     "eslint-loader": "^4.0.0",
     "fork-ts-checker-webpack-plugin": "^4.1.3",

--- a/plugins/dev-scripts/scripts/start.js
+++ b/plugins/dev-scripts/scripts/start.js
@@ -18,16 +18,27 @@
 
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
 const webpackConfig = require('../config/webpack.config');
 const webpackDevServerConfig = require('../config/webpackDevServer.config');
 
+const chalk = require('chalk');
+const codeFrame = require('@babel/code-frame').codeFrameColumns;
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
 const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
 
+const clearConsole = () => process.stdout.write(
+    process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H'
+);
+
 const packageJson = require(resolveApp('package.json'));
+const isTypescript = fs.existsSync(resolveApp('tsconfig.json'));
+
 console.log(`Running start for ${packageJson.name}`);
 
 // Create the webpack configuration for the development environment.
@@ -35,7 +46,132 @@ console.log(`Running start for ${packageJson.name}`);
 const config = webpackConfig({
   mode: 'development',
 });
-const compiler = webpack(config);
+let compiler;
+try {
+  compiler = webpack(config);
+} catch (err) {
+  console.log(`${chalk.red('Failed to compile.')}\n${err.message || err}\n`);
+  process.exit(1);
+}
+
+const devSocket = {
+  warnings: (warnings) =>
+    devServer.sockWrite(devServer.sockets, 'warnings', warnings),
+  errors: (errors) =>
+    devServer.sockWrite(devServer.sockets, 'errors', errors),
+};
+
+compiler.hooks.invalid.tap('invalid', () => {
+  clearConsole();
+  console.log('Compiling...');
+});
+
+let tsMessagesPromise;
+let tsMessagesResolver;
+
+if (isTypescript) {
+  compiler.hooks.beforeCompile.tap('beforeCompile', () => {
+    tsMessagesPromise = new Promise((resolve) => {
+      tsMessagesResolver = (msgs) => resolve(msgs);
+    });
+  });
+
+  // Register TypeScript type checker hooks.
+  const tsCheckerHooks = ForkTsCheckerWebpackPlugin.getCompilerHooks(compiler);
+  tsCheckerHooks.receive.tap('done', (diagnostics, lints) => {
+    const allMsgs = [...diagnostics, ...lints];
+
+    const formatTypecheckerMessage = (message) => {
+      const {severity, file, line, character} = message;
+
+      const messageColor = severity == 'warning' ? chalk.yellow : chalk.red;
+
+      const source = file && fs.existsSync(file) &&
+        fs.readFileSync(file, 'utf-8');
+      const frame = source ? codeFrame(source,
+          {start: {line: line, column: character}},
+          {highlightCode: true, linesAbove: 2, linesBelow: 2})
+          .split('\n').map((str) => '  ' + str).join(os.EOL) : '';
+
+      return [
+        os.EOL,
+        messageColor.bold(`${severity.toLowerCase()} in `) +
+          chalk.cyan.bold(`${file}(${line},${character})`) +
+          messageColor(':'),
+        '',
+        frame,
+      ].join(os.EOL);
+    };
+
+    tsMessagesResolver({
+      errors: allMsgs
+          .filter((msg) => msg.severity === 'error')
+          .map(formatTypecheckerMessage),
+      warnings: allMsgs
+          .filter((msg) => msg.severity === 'warning')
+          .map(formatTypecheckerMessage),
+    });
+  });
+}
+
+// Register webpack compiler hooks.
+compiler.hooks.done.tap('done', async (stats) => {
+  clearConsole();
+
+  const statsData = stats.toJson({
+    all: false,
+    warnings: true,
+    errors: true,
+  });
+
+  if (isTypescript && statsData.errors.length === 0) {
+    const delayedMsg = setTimeout(() => {
+      console.log(chalk.yellow(
+          'Files successfully emitted, waiting for typecheck results...'));
+    }, 100);
+
+    const messages = await tsMessagesPromise;
+    clearTimeout(delayedMsg);
+
+    statsData.warnings.push(...messages.errors);
+    statsData.warnings.push(...messages.warnings);
+    stats.compilation.warnings.push(...messages.errors);
+    stats.compilation.warnings.push(...messages.warnings);
+
+    if (messages.errors.length > 0) {
+      devSocket.warnings(messages.errors);
+    } else if (messages.warnings.length > 0) {
+      devSocket.warnings(messages.warnings);
+    }
+
+    clearConsole();
+  }
+
+  const formatWebpackMessage = (message) => {
+    return message.trim();
+  };
+
+  const messages = {
+    errors: statsData.errors
+        .map(formatWebpackMessage),
+    warnings: statsData.warnings
+        .map(formatWebpackMessage),
+  };
+
+  // Emit compile output.
+  if (!messages.errors.length && !messages.warnings.length) {
+    console.log(chalk.green('Compiled successfully!'));
+  }
+  if (messages.errors.length) {
+    console.log(chalk.red('Failed to compile.\n'));
+    console.log(messages.errors.join('\n\n'));
+    return;
+  }
+  if (messages.warnings.length) {
+    console.log(chalk.yellow('Compiled with warnings.\n'));
+    console.log(messages.warnings.join('\n\n'));
+  }
+});
 
 // Read the webpack devServer configuration.
 const serverConfig = webpackDevServerConfig();

--- a/plugins/dev-scripts/scripts/start.js
+++ b/plugins/dev-scripts/scripts/start.js
@@ -32,10 +32,6 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
 
-const clearConsole = () => process.stdout.write(
-    process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H'
-);
-
 const packageJson = require(resolveApp('package.json'));
 const isTypescript = fs.existsSync(resolveApp('tsconfig.json'));
 
@@ -62,7 +58,6 @@ const devSocket = {
 };
 
 compiler.hooks.invalid.tap('invalid', () => {
-  clearConsole();
   console.log('Compiling...');
 });
 
@@ -116,8 +111,6 @@ if (isTypescript) {
 
 // Register webpack compiler hooks.
 compiler.hooks.done.tap('done', async (stats) => {
-  clearConsole();
-
   const statsData = stats.toJson({
     all: false,
     warnings: true,
@@ -143,8 +136,6 @@ compiler.hooks.done.tap('done', async (stats) => {
     } else if (messages.warnings.length > 0) {
       devSocket.warnings(messages.warnings);
     }
-
-    clearConsole();
   }
 
   const formatWebpackMessage = (message) => {


### PR DESCRIPTION
Webpack messages are too noisy, and aren't very helpful. 

Adding hooks to streamline webpack messages to a simple: 
- Successful build
- Successful with warnings / errors
- Build failure

eslint, webpack and Typechecker messages are outputted.