### PR TITLE
Add field test blocks generator, and update field-slider to use it.

### DIFF
--- a/plugins/dev-tools/src/generateFieldTestBlocks.js
+++ b/plugins/dev-tools/src/generateFieldTestBlocks.js
@@ -39,9 +39,10 @@ export default function generateFieldTestBlocks(fieldName, options) {
     }
 
     // Define a single field block.
+    const singleFieldBlock = `${++id}test_${fieldName}_single`;
     blocks.push(
         {
-          'type': `${++id}test_${fieldName}_single`,
+          'type': singleFieldBlock,
           'message0': '%1',
           'args0': [
             {
@@ -57,14 +58,15 @@ export default function generateFieldTestBlocks(fieldName, options) {
           'output': null,
           'style': 'math_blocks',
         });
-    toolboxXml += `<block type="${id}test_${fieldName}_single"></block>`;
+    toolboxXml += `<block type="${singleFieldBlock}"></block>`;
     toolboxXml += `<sep gap="10"></sep>`;
 
     // Define a block and add the 'single field block' as a shadow.
+    const parentBlock = `${++id}test_${fieldName}_parent`;
     blocks.push(
         {
-          'type': `${++id}test_${fieldName}_parent`,
-          'message0': 'in parent %1',
+          'type': `${parentBlock}`,
+          'message0': 'parent %1',
           'args0': [
             {
               'type': 'input_value',
@@ -85,10 +87,11 @@ export default function generateFieldTestBlocks(fieldName, options) {
     toolboxXml += `<sep gap="10"></sep>`;
 
     // Define a block with the field on it.
+    const blockWithField = `${++id}test_${fieldName}_block`;
     blocks.push(
         {
-          'type': `${++id}test_${fieldName}_block`,
-          'message0': 'on block %1',
+          'type': blockWithField,
+          'message0': 'block %1',
           'args0': [
             {
               'type': fieldName,
@@ -103,29 +106,14 @@ export default function generateFieldTestBlocks(fieldName, options) {
           'output': null,
           'style': 'math_blocks',
         });
-    toolboxXml += `<block type="${id}test_${fieldName}_block"></block>`;
+    toolboxXml += `<block type="${blockWithField}"></block>`;
     toolboxXml += `<sep gap="10"></sep>`;
 
-    // Define a block and add the 'block with the field' as a shadow.
-    blocks.push(
-        {
-          'type': `${++id}test_${fieldName}_parent_block`,
-          'message0': 'in parent %1',
-          'args0': [
-            {
-              'type': 'input_value',
-              'name': 'INPUT',
-            },
-          ],
-          'previousStatement': null,
-          'nextStatement': null,
-          'style': 'loop_blocks',
-        });
-
+    // Add a block that includes the 'block with the field' as a shadow.
     toolboxXml += `
-  <block type="${id}test_${fieldName}_parent_block">
+  <block type="${parentBlock}">
       <value name="INPUT">
-        <shadow type="${id-1}test_${fieldName}_block"></shadow>
+        <shadow type="${blockWithField}"></shadow>
       </value>
   </block>`;
   });

--- a/plugins/dev-tools/src/generateFieldTestBlocks.js
+++ b/plugins/dev-tools/src/generateFieldTestBlocks.js
@@ -17,13 +17,13 @@ import * as Blockly from 'blockly/core';
  * Generates a number of field testing blocks for a specific field and returns
  * the toolbox xml string.
  * @param {string} fieldName The name of the field.
- * @param {Object|Array.<Object>=} options An options object containing a label
+ * @param {Object|Array<Object>=} options An options object containing a label
  *     and an args map that is passed to the field during initialization.  If an
  *     array is passed, multiple groups of blocks are created each with
  *     different initialization arguments.
  * @return {string} The toolbox XML string.
  */
-export default function generateFieldTestBlocks(fieldName, options) {
+export function generateFieldTestBlocks(fieldName, options) {
   if (!Array.isArray(options)) {
     options = [options || {}];
   }

--- a/plugins/dev-tools/src/generateFieldTestBlocks.js
+++ b/plugins/dev-tools/src/generateFieldTestBlocks.js
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview A field test helper that generates blocks with the field in
+ * various configurations.
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+
+import * as Blockly from 'blockly/core';
+
+
+/**
+ * Generates a number of field testing blocks for a specific field and returns
+ * the toolbox xml string.
+ * @param {string} fieldName The name of the field.
+ * @param {Object|Array.<Object>=} options An options object containing a label
+ *     and an args map that is passed to the field during initialization.  If an
+ *     array is passed, multiple groups of blocks are created each with
+ *     different initialization arguments.
+ * @return {string} The toolbox XML string.
+ */
+export default function generateFieldTestBlocks(fieldName, options) {
+  if (!Array.isArray(options)) {
+    options = [options || {}];
+  }
+
+  let id = 0;
+  let toolboxXml = '';
+  const blocks = [];
+
+  options.forEach((m) => {
+    if (m.label) {
+      // Add label.
+      toolboxXml += `<label text="${m.label}"></label>`;
+    }
+
+    // Define a single field block.
+    blocks.push(
+        {
+          'type': `${++id}test_${fieldName}_single`,
+          'message0': '%1',
+          'args0': [
+            {
+              'type': fieldName,
+              'name': 'FIELDNAME',
+              ...m.args,
+              'alt': {
+                'type': 'field_label',
+                'text': `No ${fieldName}`,
+              },
+            },
+          ],
+          'output': null,
+          'style': 'math_blocks',
+        });
+    toolboxXml += `<block type="${id}test_${fieldName}_single"></block>`;
+    toolboxXml += `<sep gap="10"></sep>`;
+
+    // Define a block and add the 'single field block' as a shadow.
+    blocks.push(
+        {
+          'type': `${++id}test_${fieldName}_parent`,
+          'message0': 'in parent %1',
+          'args0': [
+            {
+              'type': 'input_value',
+              'name': 'INPUT',
+            },
+          ],
+          'previousStatement': null,
+          'nextStatement': null,
+          'style': 'loop_blocks',
+        });
+
+    toolboxXml += `
+  <block type="${id}test_${fieldName}_parent">
+      <value name="INPUT">
+        <shadow type="${id-1}test_${fieldName}_single"></shadow>
+      </value>
+  </block>`;
+    toolboxXml += `<sep gap="10"></sep>`;
+
+    // Define a block with the field on it.
+    blocks.push(
+        {
+          'type': `${++id}test_${fieldName}_block`,
+          'message0': 'on block %1',
+          'args0': [
+            {
+              'type': fieldName,
+              'name': 'FIELDNAME',
+              ...m.args,
+              'alt': {
+                'type': 'field_label',
+                'text': `No ${fieldName}`,
+              },
+            },
+          ],
+          'output': null,
+          'style': 'math_blocks',
+        });
+    toolboxXml += `<block type="${id}test_${fieldName}_block"></block>`;
+    toolboxXml += `<sep gap="10"></sep>`;
+
+    // Define a block and add the 'block with the field' as a shadow.
+    blocks.push(
+        {
+          'type': `${++id}test_${fieldName}_parent_block`,
+          'message0': 'in parent %1',
+          'args0': [
+            {
+              'type': 'input_value',
+              'name': 'INPUT',
+            },
+          ],
+          'previousStatement': null,
+          'nextStatement': null,
+          'style': 'loop_blocks',
+        });
+
+    toolboxXml += `
+  <block type="${id}test_${fieldName}_parent_block">
+      <value name="INPUT">
+        <shadow type="${id-1}test_${fieldName}_block"></shadow>
+      </value>
+  </block>`;
+  });
+
+  Blockly.defineBlocksWithJsonArray(blocks);
+
+  return `<xml xmlns="https://developers.google.com/blockly/xml">
+    ${toolboxXml}
+    </xml>`;
+}

--- a/plugins/dev-tools/src/index.js
+++ b/plugins/dev-tools/src/index.js
@@ -8,10 +8,12 @@ import toolboxCategories from './toolboxCategories';
 import toolboxSimple from './toolboxSimple';
 import addGUIControls from './addGUIControls';
 import {DebugRenderer} from './debugRenderer';
+import generateFieldTestBlocks from './generateFieldTestBlocks';
 
 export {
   DebugRenderer,
   toolboxCategories,
   toolboxSimple,
   addGUIControls,
+  generateFieldTestBlocks,
 };

--- a/plugins/dev-tools/src/index.js
+++ b/plugins/dev-tools/src/index.js
@@ -8,7 +8,7 @@ import toolboxCategories from './toolboxCategories';
 import toolboxSimple from './toolboxSimple';
 import addGUIControls from './addGUIControls';
 import {DebugRenderer} from './debugRenderer';
-import generateFieldTestBlocks from './generateFieldTestBlocks';
+import {generateFieldTestBlocks} from './generateFieldTestBlocks';
 
 export {
   DebugRenderer,

--- a/plugins/field-slider/test/index.js
+++ b/plugins/field-slider/test/index.js
@@ -10,33 +10,43 @@
  */
 
 import * as Blockly from 'blockly';
-import {addGUIControls} from '@blockly/dev-tools';
+import {generateFieldTestBlocks, addGUIControls} from '@blockly/dev-tools';
 import '../src/index.js';
 
-Blockly.defineBlocksWithJsonArray([
+const toolbox = generateFieldTestBlocks('field_slider', [
   {
-    'type': 'test_field_slider',
-    'message0': 'slider: %1',
-    'args0': [
-      {
-        'type': 'field_slider',
-        'name': 'FIELDNAME',
-        'value': 50,
-        'alt':
-            {
-              'type': 'field_label',
-              'text': 'NO_SLIDER_FIELD',
-            },
-      },
-    ],
-    'style': 'math_blocks',
-  }]);
+    'label': 'Basic',
+    'args': {
+      'value': 50,
+    },
+  },
+  {
+    'label': 'Min',
+    'args': {
+      'value': 20,
+      'min': 10,
+    },
+  },
+  {
+    'label': 'Max',
+    'args': {
+      'value': 70,
+      'max': 80,
+    },
+  },
+  {
+    'label': 'Min and Max',
+    'args': {
+      'value': 60,
+      'min': 10,
+      'max': 80,
+    },
+  },
+]);
 
 document.addEventListener('DOMContentLoaded', function() {
   const defaultOptions = {
-    toolbox: `<xml xmlns="https://developers.google.com/blockly/xml">
-          <block type="test_field_slider"></block>
-        </xml>`,
+    toolbox,
   };
   addGUIControls((options) => {
     return Blockly.inject('blocklyDiv', options);


### PR DESCRIPTION
Add a dev tool to generate field test blocks, for each group, generate:
- A single block field
- A parent block that adds the single block field as a shadow
- A block with the field on it
- A parent block that adds that block with the field on it as a shadow

<img width="251" alt="Screen Shot 2020-05-05 at 9 59 45 AM" src="https://user-images.githubusercontent.com/16690124/81096407-2b050800-8ebb-11ea-8133-9f6d423fbbe7.png">

