### PR TITLE
Read Blockly renderer map in GUI control

### DIFF
--- a/plugins/dev-tools/src/addGUIControls.js
+++ b/plugins/dev-tools/src/addGUIControls.js
@@ -106,7 +106,7 @@ export default function addGUIControls(createWorkspace, defaultOptions) {
     onChange('rtl', value));
 
   // Renderer.
-  gui.add(options, 'renderer', ['geras', 'thrasos', 'zelos'])
+  gui.add(options, 'renderer', Object.keys(Blockly.blockRendering.rendererMap_))
       .onChange((value) => onChange('renderer', value));
 
   // Theme.


### PR DESCRIPTION
Part of https://github.com/google/blockly-samples/issues/263

Read the Blockly renderer map when populating list of available renderers in the GUI control.

