### PR TITLE
Populate random

### DIFF
--- a/plugins/block-plus-minus/test/index.html
+++ b/plugins/block-plus-minus/test/index.html
@@ -52,7 +52,7 @@
         <div class="bundle">
             <div id="break" style="width: 100%; display: none;"></div>
             <input class="bundle--item" type="button" id="import" value="Import" disabled="true" onclick="fromXml()">
-            <input class="bundle--item" type="button" id="export" value="Export to" onclick="exportWorkspace()">
+            <input class="bundle--item" type="button" id="exportBtn" value="Export to" onclick="exportWorkspace()">
             <select class="bundle--item" id="export-type" name="export" onchange="exportWorkspace();">
                 <option class="export-opt" value="clean-xml">Clean XML</option>
                 <option class="export-opt" value="xml">XML</option>

--- a/plugins/block-plus-minus/test/index.js
+++ b/plugins/block-plus-minus/test/index.js
@@ -9,7 +9,7 @@
  */
 
 import * as Blockly from 'blockly';
-import {addGUIControls} from '@blockly/dev-tools';
+import {addGUIControls, populateRandomButton} from '@blockly/dev-tools';
 import '../src/index.js';
 
 let workspace;
@@ -22,8 +22,11 @@ function start() {
     toolbox: document.getElementById('toolbox'),
   };
   addGUIControls((options) => {
-    return Blockly.inject('blocklyDiv', options);
+    workspace = Blockly.inject('blocklyDiv', options);
+    return workspace;
   }, defaultOptions);
+
+  populateRandomButton(workspace, document.getElementById('toolsDiv'), 10);
 }
 
 document.addEventListener('DOMContentLoaded', start);

--- a/plugins/block-plus-minus/test/index.js
+++ b/plugins/block-plus-minus/test/index.js
@@ -9,7 +9,7 @@
  */
 
 import * as Blockly from 'blockly';
-import {addGUIControls, populateRandomButton} from '@blockly/dev-tools';
+import {addGUIControls} from '@blockly/dev-tools';
 import '../src/index.js';
 
 let workspace;
@@ -25,10 +25,6 @@ function start() {
     workspace = Blockly.inject('blocklyDiv', options);
     return workspace;
   }, defaultOptions);
-
-
-  populateRandomButton(Blockly.getMainWorkspace,
-      document.getElementById('toolsDiv'), 10);
 }
 
 document.addEventListener('DOMContentLoaded', start);

--- a/plugins/block-plus-minus/test/index.js
+++ b/plugins/block-plus-minus/test/index.js
@@ -26,10 +26,13 @@ function start() {
     return workspace;
   }, defaultOptions);
 
-  populateRandomButton(workspace, document.getElementById('toolsDiv'), 10);
+
+  populateRandomButton(Blockly.getMainWorkspace,
+      document.getElementById('toolsDiv'), 10);
 }
 
 document.addEventListener('DOMContentLoaded', start);
+
 
 window.exportWorkspace = function() {
   const type = document.getElementById('export-type').value;

--- a/plugins/dev-tools/README.md
+++ b/plugins/dev-tools/README.md
@@ -56,15 +56,5 @@ import {populateRandom} from '@blockly/dev-tools';
 populateRandom(workspace, 10);
 ```
 
-The `populateRandomButton` function adds a button to the page with `populateRandom` as its onClick function.
-The first parameter is a function that returns the workspace blocks should be added to.
-The second parameter says where to add the button on the document.
-The third parameter is how many blocks to add.
-```js
-import {populateRandomButton} from '@blockly/dev-tools';
-
-populateRandomButton(Blockly.getMainWorkspace, document.getElementById('myElement'), 10);
-
-````
 ## License
 Apache 2.0

--- a/plugins/dev-tools/README.md
+++ b/plugins/dev-tools/README.md
@@ -47,5 +47,20 @@ addGUIControls((options) => {
 }, defaultOptions);
 ```
 
+### Populate Random
+
+The `populateRandom` function adds random blocks to a workspace. Blocks are selected from the full set of defined blocks. Pass in a worskpace and how many blocks should be created.
+```js
+import {populateRandom} from '@blockly/dev-tools';
+// Add 10 random blocks to the workspace.
+populateRandom(workspace, 10);
+```
+
+The `populateRandomButton` function adds a button to the page with `populateRandom` as its onClick function. The button is appended to the document after the element passed as the second parameter.
+```js
+import {populateRandomButton} from '@blockly/dev-tools';
+populateRandomButton(workspace, document.getElementById('myElement'), 10);
+
+````
 ## License
 Apache 2.0

--- a/plugins/dev-tools/README.md
+++ b/plugins/dev-tools/README.md
@@ -56,10 +56,14 @@ import {populateRandom} from '@blockly/dev-tools';
 populateRandom(workspace, 10);
 ```
 
-The `populateRandomButton` function adds a button to the page with `populateRandom` as its onClick function. The button is appended to the document after the element passed as the second parameter.
+The `populateRandomButton` function adds a button to the page with `populateRandom` as its onClick function.
+The first parameter is a function that returns the workspace blocks should be added to.
+The second parameter says where to add the button on the document.
+The third parameter is how many blocks to add.
 ```js
 import {populateRandomButton} from '@blockly/dev-tools';
-populateRandomButton(workspace, document.getElementById('myElement'), 10);
+
+populateRandomButton(Blockly.getMainWorkspace, document.getElementById('myElement'), 10);
 
 ````
 ## License

--- a/plugins/dev-tools/src/index.js
+++ b/plugins/dev-tools/src/index.js
@@ -9,6 +9,7 @@ import toolboxSimple from './toolboxSimple';
 import addGUIControls from './addGUIControls';
 import {DebugRenderer} from './debugRenderer';
 import {generateFieldTestBlocks} from './generateFieldTestBlocks';
+import {populateRandom, populateRandomButton} from './populateRandom';
 
 export {
   DebugRenderer,
@@ -16,4 +17,6 @@ export {
   toolboxSimple,
   addGUIControls,
   generateFieldTestBlocks,
+  populateRandom,
+  populateRandomButton,
 };

--- a/plugins/dev-tools/src/index.js
+++ b/plugins/dev-tools/src/index.js
@@ -9,7 +9,7 @@ import toolboxSimple from './toolboxSimple';
 import addGUIControls from './addGUIControls';
 import {DebugRenderer} from './debugRenderer';
 import {generateFieldTestBlocks} from './generateFieldTestBlocks';
-import {populateRandom, populateRandomButton} from './populateRandom';
+import {populateRandom} from './populateRandom';
 
 export {
   DebugRenderer,
@@ -18,5 +18,4 @@ export {
   addGUIControls,
   generateFieldTestBlocks,
   populateRandom,
-  populateRandomButton,
 };

--- a/plugins/dev-tools/src/populateRandom.js
+++ b/plugins/dev-tools/src/populateRandom.js
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Helper for randomly populating a workspace.
+ * @author fenichel@google.com (Rachel Fenichel)
+ */
+import Blockly from 'blockly/core';
+
+/**
+ * Populate the workspace with a random set of blocks, for testing.
+ * @param {Blockly.Workspace} workspace The workspace to populate.
+ * @param {number} count How many blocks to create.
+ */
+export function populateRandom(workspace, count) {
+  const names = [];
+  for (const blockName in Blockly.Blocks) {
+    if (Object.prototype.hasOwnProperty.call(Blockly.Blocks, blockName)) {
+      names.push(blockName);
+    }
+  }
+
+  for (let i = 0; i < count; i++) {
+    const name = names[Math.floor(Math.random() * names.length)];
+    const block = workspace.newBlock(name);
+    block.initSvg();
+    block.getSvgRoot().setAttribute('transform', 'translate(' +
+        Math.round(Math.random() * 450 + 40) + ', ' +
+        Math.round(Math.random() * 600 + 40) + ')');
+    block.render();
+  }
+}
+
+/**
+ * Add a button to randomly populate the workspace.
+ * @param {Blockly.Workspace} workspace The workspace to add blocks to.
+ * @param {Element} location Where to append the new button.
+ * @param {number} count How many blocks to create.
+ * @return {Element} The new button.
+ * @package
+ */
+export function populateRandomButton(workspace, location, count) {
+  const button = document.createElement('input');
+  button.type = 'button';
+  button.id = 'populateRandomBtn';
+  button.value = 'Add random blocks!';
+  button.onclick = function() {
+    populateRandom(workspace, count);
+  };
+
+  location.appendChild(button);
+  return button;
+}

--- a/plugins/dev-tools/src/populateRandom.js
+++ b/plugins/dev-tools/src/populateRandom.js
@@ -36,19 +36,19 @@ export function populateRandom(workspace, count) {
 
 /**
  * Add a button to randomly populate the workspace.
- * @param {Blockly.Workspace} workspace The workspace to add blocks to.
+ * @param {function():Blockly.Workspace} getWorkspaceFn A function that returns
+ *     the workspace bocks should be added to.
  * @param {Element} location Where to append the new button.
  * @param {number} count How many blocks to create.
  * @return {Element} The new button.
- * @package
  */
-export function populateRandomButton(workspace, location, count) {
+export function populateRandomButton(getWorkspaceFn, location, count) {
   const button = document.createElement('input');
   button.type = 'button';
   button.id = 'populateRandomBtn';
   button.value = 'Add random blocks!';
   button.onclick = function() {
-    populateRandom(workspace, count);
+    populateRandom(getWorkspaceFn(), count);
   };
 
   location.appendChild(button);

--- a/plugins/dev-tools/src/populateRandom.js
+++ b/plugins/dev-tools/src/populateRandom.js
@@ -33,24 +33,3 @@ export function populateRandom(workspace, count) {
     block.render();
   }
 }
-
-/**
- * Add a button to randomly populate the workspace.
- * @param {function():Blockly.Workspace} getWorkspaceFn A function that returns
- *     the workspace bocks should be added to.
- * @param {Element} location Where to append the new button.
- * @param {number} count How many blocks to create.
- * @return {Element} The new button.
- */
-export function populateRandomButton(getWorkspaceFn, location, count) {
-  const button = document.createElement('input');
-  button.type = 'button';
-  button.id = 'populateRandomBtn';
-  button.value = 'Add random blocks!';
-  button.onclick = function() {
-    populateRandom(getWorkspaceFn(), count);
-  };
-
-  location.appendChild(button);
-  return button;
-}


### PR DESCRIPTION
- Add two functions to dev-tools: `populateRandom` and `populateRandomButton`.
- Document in the README.
- Use in the blocks-plus-minus test page.
- Rename an input in blocks-plus-minus so it won't conflict with another id on the page

Points for review:
- This is probably not the best way to add a button
- (Edit: fixed) _In blocks-plus-minus, this works for the first time the workspace is injected, but fails when the workspace is changed through the gui controls. (The import/export code also breaks in that case.)_

Related to https://github.com/google/blockly/issues/3882