### PR TITLE
Adding ability to skip tests.

### DIFF
--- a/plugins/dev-create/templates/field/template/test/field_test.mocha.js
+++ b/plugins/dev-create/templates/field/template/test/field_test.mocha.js
@@ -7,19 +7,22 @@
 const {testHelpers} = require('@blockly/dev-tools');
 const {FieldTemplate} = require('../dist/index');
 
+const {runConstructorSuiteTests, runFromJsonSuiteTests,
+  runSetValueTests} = testHelpers;
+
 suite('FieldTemplate', function() {
   /**
    * Configuration for field tests with invalid values.
-   * @type {Array<Run>}
+   * @type {Array<TestCase>}
    */
-  const invalidValueRuns = [
+  const invalidValueTestCases = [
     // TODO
   ];
   /**
    * Configuration for field tests with valid values.
-   * @type {Array<Run>}
+   * @type {Array<TestCase>}
    */
-  const validValueRuns = [
+  const validValueTestCases = [
     // TODO
   ];
   /**
@@ -32,41 +35,40 @@ suite('FieldTemplate', function() {
    * @param {FieldTemplate} field The field to check.
    */
   const assertFieldDefault = function(field) {
-    // TODO
+    // TODO Recommend use of assertFieldValue from testHelpers
   };
   /**
-   * Asserts that the field properties are correct based on the test run
-   *    configuration.
+   * Asserts that the field properties are correct based on the test case.
    * @param {FieldTemplate} field The field to check.
-   * @param {Run} run The run configuration.
+   * @param {TestCase} testCase The test case.
    */
-  const validRunAssertField = function(field, run) {
+  const validTestCaseAssertField = function(field, testCase) {
     // TODO
   };
 
-  testHelpers.runConstructorSuiteTests(
-      FieldTemplate, validValueRuns, invalidValueRuns, validRunAssertField,
-      assertFieldDefault);
+  runConstructorSuiteTests(
+      FieldTemplate, validValueTestCases, invalidValueTestCases,
+      validTestCaseAssertField, assertFieldDefault);
 
-  testHelpers.runFromJsonSuiteTests(
-      FieldTemplate, validValueRuns, invalidValueRuns, validRunAssertField,
-      assertFieldDefault);
+  runFromJsonSuiteTests(
+      FieldTemplate, validValueTestCases, invalidValueTestCases,
+      validTestCaseAssertField, assertFieldDefault);
 
   suite('setValue', function() {
     suite('Empty -> New Value', function() {
       setup(function() {
         this.field = new FieldTemplate();
       });
-      testHelpers.runSetValueTests(
-          validValueRuns, invalidValueRuns, defaultFieldValue);
+      runSetValueTests(
+          validValueTestCases, invalidValueTestCases, defaultFieldValue);
     });
     suite('Value -> New Value', function() {
       const initialValue = 1; // TODO update with initial value for test.
       setup(function() {
         this.field = new FieldTemplate(initialValue);
       });
-      testHelpers.runSetValueTests(
-          validValueRuns, invalidValueRuns, initialValue);
+      runSetValueTests(
+          validValueTestCases, invalidValueTestCases, initialValue);
     });
   });
 

--- a/plugins/dev-tools/src/common_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/common_test_helpers.mocha.js
@@ -25,7 +25,7 @@ export let TestCase;
 export function runTestCases(testCases, testFn) {
   testCases.forEach((testCase) => {
     let testCall = (testCase.skip ? test.skip : test);
-    testCall = (testCase.only ? test.skip : testCall);
+    testCall = (testCase.only ? test.only : testCall);
     testCall(testCase.title, testFn(testCase));
   });
 }

--- a/plugins/dev-tools/src/common_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/common_test_helpers.mocha.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * Run configuration information.
+ * Test case configuration information.
  * @typedef {{
  *            title:string,
  *            value:*
@@ -14,18 +14,18 @@
  *            expectedValue:?
  *          }}
  */
-let Run;
+export let TestCase;
 
 /**
  * Runs provided test cases.
- * @param {Array<Run>} runs The test cases to run.
- * @param {function(Run):function} testFn Function that returns test callback.
- * @private
+ * @param {Array<TestCase>} testCases The test cases to run.
+ * @param {function(TestCase):function} testFn Function that returns test
+ *  callback.
  */
-export function runTestCases(runs, testFn) {
-  runs.forEach((run) => {
-    let testCall = (run.skip ? test.skip : test);
-    testCall = (run.only ? test.skip : testCall);
-    testCall(run.title, testFn(run));
+export function runTestCases(testCases, testFn) {
+  testCases.forEach((testCase) => {
+    let testCall = (testCase.skip ? test.skip : test);
+    testCall = (testCase.only ? test.skip : testCall);
+    testCall(testCase.title, testFn(testCase));
   });
 }

--- a/plugins/dev-tools/src/common_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/common_test_helpers.mocha.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Run configuration information.
+ * @typedef {{
+ *            title:string,
+ *            value:*
+ *            skip:(boolean|undefined),
+ *            only:(boolean|undefined),
+ *            expectedValue:?
+ *          }}
+ */
+let Run;
+
+/**
+ * Runs provided test cases.
+ * @param {Array<Run>} runs The test cases to run.
+ * @param {function(Run):function} testFn Function that returns test callback.
+ * @private
+ */
+export function runTestCases(runs, testFn) {
+  runs.forEach((run) => {
+    let testCall = (run.skip ? test.skip : test);
+    testCall = (run.only ? test.skip : testCall);
+    testCall(run.title, testFn(run));
+  });
+}

--- a/plugins/dev-tools/src/field_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/field_test_helpers.mocha.js
@@ -5,7 +5,7 @@
  */
 
 import {assert} from 'chai';
-import {runTestCases, Run} from './common_test_helpers.mocha';
+import {runTestCases, TestCase} from './common_test_helpers.mocha';
 
 /**
  * Assert a field's value is the same as the expected value.
@@ -24,17 +24,17 @@ export function assertFieldValue(field, expectedValue,
 
 /**
  * Runs provided creation test cases.
- * @param {Array<Run>} runs The test cases to run.
- * @param {function(Blockly.Field, Run)} assertion The assertion to use.
- * @param {function(new:Blockly.Field,Run):Blockly.Field} creation The creation
- *    method to use.
+ * @param {Array<TestCase>} testCases The test cases to run.
+ * @param {function(Blockly.Field, TestCase)} assertion The assertion to use.
+ * @param {function(new:Blockly.Field,TestCase):Blockly.Field} creation A
+ *    function that returns an instance of the field based on the test case.
  * @private
  */
-function runCreationTests_(runs, assertion, creation) {
-  runTestCases(runs, (run) => {
+function runCreationTests_(testCases, assertion, creation) {
+  runTestCases(testCases, (testCase) => {
     return function() {
-      const field = creation(run);
-      assertion(field, run);
+      const field = creation(testCase);
+      assertion(field, testCase);
     };
   });
 }
@@ -43,27 +43,27 @@ function runCreationTests_(runs, assertion, creation) {
  * Runs suite of tests for constructor for the specified field.
  * @param {function(new:Blockly.Field, *=)} TestedField The class of the field
  *    being tested.
- * @param {Array<Run>} validValueRuns Test cases with invalid values for given
- *    field.
- * @param {Array<Run>} invalidValueRuns Test cases with valid values for given
- *    field.
- * @param {function(Blockly.Field, Run)} validRunAssertField Asserts that field
- *    has expected values.
+ * @param {Array<TestCase>} validValueTestCases Test cases with invalid values
+ *    for given field.
+ * @param {Array<TestCase>} invalidValueTestCases Test cases with valid values
+ *    for given field.
+ * @param {function(Blockly.Field, TestCase)} validRunAssertField Asserts that
+ *    field has expected values.
  * @param {function(Blockly.Field)} assertFieldDefault Asserts that field has
  *    default values.
  */
-export function runConstructorSuiteTests(TestedField, validValueRuns,
-    invalidValueRuns, validRunAssertField, assertFieldDefault) {
+export function runConstructorSuiteTests(TestedField, validValueTestCases,
+    invalidValueTestCases, validRunAssertField, assertFieldDefault) {
   suite('Constructor', function() {
     test('Empty', function() {
       const field = new TestedField();
       assertFieldDefault(field);
     });
-    const createWithJS = function(run) {
-      return new TestedField(...run.args);
+    const createWithJS = function(testCase) {
+      return new TestedField(...testCase.args);
     };
-    runCreationTests_(invalidValueRuns, assertFieldDefault, createWithJS);
-    runCreationTests_(validValueRuns, validRunAssertField, createWithJS);
+    runCreationTests_(invalidValueTestCases, assertFieldDefault, createWithJS);
+    runCreationTests_(validValueTestCases, validRunAssertField, createWithJS);
   });
 }
 
@@ -71,17 +71,17 @@ export function runConstructorSuiteTests(TestedField, validValueRuns,
  * Runs suite of tests for fromJson creation of specified field.
  * @param {function(new:Blockly.Field, *=)} TestedField The class of the field
  *    being tested.
- * @param {Array<Run>} validValueRuns Test cases with invalid values for given
- *    field.
- * @param {Array<Run>} invalidValueRuns Test cases with valid values for given
- *    field.
- * @param {function(Blockly.Field, Run)} validRunAssertField Asserts that field
- *    has expected values.
+ * @param {Array<TestCase>} validValueTestCases Test cases with invalid values
+ *    for given field.
+ * @param {Array<TestCase>} invalidValueTestCases Test cases with valid values
+ *    for given field.
+ * @param {function(Blockly.Field, TestCase)} validRunAssertField Asserts that
+ *    field has expected values.
  * @param {function(Blockly.Field)} assertFieldDefault Asserts that field has
  *    default values.
  */
-export function runFromJsonSuiteTests(TestedField, validValueRuns,
-    invalidValueRuns, validRunAssertField, assertFieldDefault) {
+export function runFromJsonSuiteTests(TestedField, validValueTestCases,
+    invalidValueTestCases, validRunAssertField, assertFieldDefault) {
   suite('fromJson', function() {
     test('Empty', function() {
       const field = TestedField.fromJson({});
@@ -90,29 +90,30 @@ export function runFromJsonSuiteTests(TestedField, validValueRuns,
     const createWithJson = function(run) {
       return TestedField.fromJson(run.json);
     };
-    runCreationTests_(invalidValueRuns, assertFieldDefault, createWithJson);
-    runCreationTests_(validValueRuns, validRunAssertField, createWithJson);
+    runCreationTests_(
+        invalidValueTestCases, assertFieldDefault, createWithJson);
+    runCreationTests_(validValueTestCases, validRunAssertField, createWithJson);
   });
 }
 
 /**
  * Runs tests for setValue calls.
- * @param {Array<Run>} validValueRuns Test cases with invalid values.
- * @param {Array<Run>} invalidValueRuns Test cases with valid values.
+ * @param {Array<TestCase>} validValueTestCases Test cases with invalid values.
+ * @param {Array<TestCase>} invalidValueTestCases Test cases with valid values.
  * @param {*} invalidRunExpectedValue Expected default value.
  */
-export function runSetValueTests(validValueRuns, invalidValueRuns,
+export function runSetValueTests(validValueTestCases, invalidValueTestCases,
     invalidRunExpectedValue) {
-  runTestCases(invalidValueRuns, (run) => {
+  runTestCases(invalidValueTestCases, (testCase) => {
     return function() {
-      this.field.setValue(run.value);
+      this.field.setValue(testCase.value);
       assertFieldValue(this.field, invalidRunExpectedValue);
     };
   });
-  runTestCases(validValueRuns, (run) => {
+  runTestCases(validValueTestCases, (testCase) => {
     return function() {
-      this.field.setValue(run.value);
-      assertFieldValue(this.field, run.expectedValue);
+      this.field.setValue(testCase.value);
+      assertFieldValue(this.field, testCase.expectedValue);
     };
   });
 }

--- a/plugins/dev-tools/src/field_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/field_test_helpers.mocha.js
@@ -5,16 +5,7 @@
  */
 
 import {assert} from 'chai';
-
-/**
- * Run configuration information.
- * @typedef {{
- *            title:string,
- *            value:*
- *            expectedValue:?
- *          }}
- */
-let Run;
+import {runTestCases, Run} from './common_test_helpers.mocha';
 
 /**
  * Assert a field's value is the same as the expected value.
@@ -40,11 +31,11 @@ export function assertFieldValue(field, expectedValue,
  * @private
  */
 function runCreationTests_(runs, assertion, creation) {
-  runs.forEach(function(run) {
-    test(run.title, function() {
+  runTestCases(runs, (run) => {
+    return function() {
       const field = creation(run);
       assertion(field, run);
-    });
+    };
   });
 }
 
@@ -112,16 +103,16 @@ export function runFromJsonSuiteTests(TestedField, validValueRuns,
  */
 export function runSetValueTests(validValueRuns, invalidValueRuns,
     invalidRunExpectedValue) {
-  invalidValueRuns.forEach(function(run) {
-    test(run.title, function() {
+  runTestCases(invalidValueRuns, (run) => {
+    return function() {
       this.field.setValue(run.value);
       assertFieldValue(this.field, invalidRunExpectedValue);
-    });
+    };
   });
-  validValueRuns.forEach(function(run) {
-    test(run.title, function() {
+  runTestCases(validValueRuns, (run) => {
+    return function() {
       this.field.setValue(run.value);
       assertFieldValue(this.field, run.expectedValue);
-    });
+    };
   });
 }

--- a/plugins/dev-tools/src/index.js
+++ b/plugins/dev-tools/src/index.js
@@ -10,7 +10,7 @@ let addGUIControls;
 if (typeof window !== 'undefined') {
   addGUIControls = require('./addGUIControls').default;
 }
-import * as testHelpers from './field_test_helpers.mocha';
+import * as testHelpers from './test_helpers.mocha';
 import {DebugRenderer} from './debugRenderer';
 import {generateFieldTestBlocks} from './generateFieldTestBlocks';
 import {populateRandom} from './populateRandom';

--- a/plugins/dev-tools/src/test_helpers.mocha.js
+++ b/plugins/dev-tools/src/test_helpers.mocha.js
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as commonHelpers from './common_test_helpers.mocha';
+import * as fieldHelpers from './field_test_helpers.mocha';
+
+const {Run} = commonHelpers;
+
+const {
+  assertFieldValue,
+  runConstructorSuiteTests,
+  runFromJsonSuiteTests,
+  runSetValueTests,
+} = fieldHelpers;
+
+export {
+  Run,
+  assertFieldValue,
+  runConstructorSuiteTests,
+  runFromJsonSuiteTests,
+  runSetValueTests,
+};

--- a/plugins/dev-tools/src/test_helpers.mocha.js
+++ b/plugins/dev-tools/src/test_helpers.mocha.js
@@ -7,7 +7,7 @@
 import * as commonHelpers from './common_test_helpers.mocha';
 import * as fieldHelpers from './field_test_helpers.mocha';
 
-const {Run} = commonHelpers;
+const {TestCase, runTestCases} = commonHelpers;
 
 const {
   assertFieldValue,
@@ -17,9 +17,10 @@ const {
 } = fieldHelpers;
 
 export {
-  Run,
   assertFieldValue,
   runConstructorSuiteTests,
   runFromJsonSuiteTests,
   runSetValueTests,
+  runTestCases,
+  TestCase,
 };

--- a/plugins/field-date/test/field_date_test.mocha.js
+++ b/plugins/field-date/test/field_date_test.mocha.js
@@ -8,14 +8,14 @@ const {testHelpers} = require('@blockly/dev-tools');
 const FieldDate = require('../dist/date_compressed');
 
 const {runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests,
-  assertFieldValue, Run} = testHelpers;
+  assertFieldValue, TestCase} = testHelpers;
 
 suite('FieldDate', function() {
   /**
    * Configuration for field tests with invalid values.
-   * @type {Array<Run>}
+   * @type {Array<TestCase>}
    */
-  const invalidValueRuns = [
+  const invalidValueTestCases = [
     {title: 'Undefined', value: undefined},
     {title: 'Null', value: null},
     {title: 'NaN', value: NaN},
@@ -25,44 +25,44 @@ suite('FieldDate', function() {
   ];
   /**
    * Configuration for field tests with valid values.
-   * @type {Array<Run>}
+   * @type {Array<TestCase>}
    */
-  const validValueRuns = [
+  const validValueTestCases = [
     {title: 'String', value: '3030-03-30', expectedValue: '3030-03-30'},
   ];
-  const addArgsAndJson = function(run) {
-    run.args = [run.value];
-    run.json = {'date': run.value};
+  const addArgsAndJson = function(testCase) {
+    testCase.args = [testCase.value];
+    testCase.json = {'date': testCase.value};
   };
-  invalidValueRuns.forEach(addArgsAndJson);
-  validValueRuns.forEach(addArgsAndJson);
+  invalidValueTestCases.forEach(addArgsAndJson);
+  validValueTestCases.forEach(addArgsAndJson);
   const defaultFieldValue = new Date().toISOString().substring(0, 10);
   const assertFieldDefault = function(field) {
     assertFieldValue(field, defaultFieldValue);
   };
-  const validRunAssertField = function(field, run) {
-    assertFieldValue(field, run.value);
+  const validTestCaseAssertField = function(field, testCase) {
+    assertFieldValue(field, testCase.value);
   };
 
   // TODO(https://github.com/google/blockly/issues/3903): Re-enable test cases
   //  after fixing.
-  invalidValueRuns[3].skip = true;
-  invalidValueRuns[4].skip = true;
-  invalidValueRuns[5].skip = true;
+  invalidValueTestCases[3].skip = true;
+  invalidValueTestCases[4].skip = true;
+  invalidValueTestCases[5].skip = true;
 
   runConstructorSuiteTests(
-      FieldDate, validValueRuns, invalidValueRuns, validRunAssertField,
-      assertFieldDefault);
+      FieldDate, validValueTestCases, invalidValueTestCases,
+      validTestCaseAssertField, assertFieldDefault);
 
   runFromJsonSuiteTests(
-      FieldDate, validValueRuns, invalidValueRuns, validRunAssertField,
-      assertFieldDefault);
+      FieldDate, validValueTestCases, invalidValueTestCases,
+      validTestCaseAssertField, assertFieldDefault);
 
   // TODO(https://github.com/google/blockly/issues/3903): Remove skip=false
   //  after removing skip=true.
-  invalidValueRuns[3].skip = false;
-  invalidValueRuns[4].skip = false;
-  invalidValueRuns[5].skip = false;
+  invalidValueTestCases[3].skip = false;
+  invalidValueTestCases[4].skip = false;
+  invalidValueTestCases[5].skip = false;
 
   suite('setValue', function() {
     suite('Empty -> New Value', function() {
@@ -70,7 +70,7 @@ suite('FieldDate', function() {
         this.field = new FieldDate();
       });
       runSetValueTests(
-          validValueRuns, invalidValueRuns, defaultFieldValue);
+          validValueTestCases, invalidValueTestCases, defaultFieldValue);
     });
     suite('Value -> New Value', function() {
       const initialValue = '2020-02-20';
@@ -78,7 +78,7 @@ suite('FieldDate', function() {
         this.field = new FieldDate(initialValue);
       });
       runSetValueTests(
-          validValueRuns, invalidValueRuns, initialValue);
+          validValueTestCases, invalidValueTestCases, initialValue);
     });
   });
 

--- a/plugins/field-date/test/field_date_test.mocha.js
+++ b/plugins/field-date/test/field_date_test.mocha.js
@@ -8,7 +8,7 @@ const {testHelpers} = require('@blockly/dev-tools');
 const FieldDate = require('../dist/date_compressed');
 
 const {runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests,
-  assertFieldValue} = testHelpers;
+  assertFieldValue, Run} = testHelpers;
 
 suite('FieldDate', function() {
   /**
@@ -19,10 +19,9 @@ suite('FieldDate', function() {
     {title: 'Undefined', value: undefined},
     {title: 'Null', value: null},
     {title: 'NaN', value: NaN},
-    // TODO(269): investigate failures and only skip for creation tests.
-    // {title: 'Non-Parsable String', value: 'bad'},
-    // {title: 'Invalid Date - Month(2020-13-20)', value: '2020-13-20'},
-    // {title: 'Invalid Date - Day(2020-02-32)', value: '2020-02-32'},
+    {title: 'Non-Parsable String', value: 'bad'},
+    {title: 'Invalid Date - Month(2020-13-20)', value: '2020-13-20'},
+    {title: 'Invalid Date - Day(2020-02-32)', value: '2020-02-32'},
   ];
   /**
    * Configuration for field tests with valid values.
@@ -45,6 +44,12 @@ suite('FieldDate', function() {
     assertFieldValue(field, run.value);
   };
 
+  // TODO(https://github.com/google/blockly/issues/3903): Re-enable test cases
+  //  after fixing.
+  invalidValueRuns[3].skip = true;
+  invalidValueRuns[4].skip = true;
+  invalidValueRuns[5].skip = true;
+
   runConstructorSuiteTests(
       FieldDate, validValueRuns, invalidValueRuns, validRunAssertField,
       assertFieldDefault);
@@ -52,6 +57,12 @@ suite('FieldDate', function() {
   runFromJsonSuiteTests(
       FieldDate, validValueRuns, invalidValueRuns, validRunAssertField,
       assertFieldDefault);
+
+  // TODO(https://github.com/google/blockly/issues/3903): Remove skip=false
+  //  after removing skip=true.
+  invalidValueRuns[3].skip = false;
+  invalidValueRuns[4].skip = false;
+  invalidValueRuns[5].skip = false;
 
   suite('setValue', function() {
     suite('Empty -> New Value', function() {

--- a/plugins/field-slider/test/field_slider_test.mocha.js
+++ b/plugins/field-slider/test/field_slider_test.mocha.js
@@ -12,7 +12,7 @@ const {testHelpers} = require('@blockly/dev-tools');
 const {FieldSlider} = require('../dist/index');
 
 const {runConstructorSuiteTests, runFromJsonSuiteTests, runSetValueTests,
-  assertFieldValue} = testHelpers;
+  assertFieldValue, Run} = testHelpers;
 
 suite('FieldSlider', function() {
   /**
@@ -23,8 +23,7 @@ suite('FieldSlider', function() {
     {title: 'Undefined', value: undefined},
     {title: 'Null', value: null},
     {title: 'NaN', value: NaN},
-    // TODO(269): investigate failures and only skip for creation tests.
-    // {title: 'Non-Parsable String', value: 'bad'},
+    {title: 'Non-Parsable String', value: 'bad'},
   ];
   /**
    * Configuration for field tests with valid values.
@@ -59,12 +58,22 @@ suite('FieldSlider', function() {
     assertSliderField(field, run.value, run.value, run.value, run.value);
   };
 
+
+  // TODO(https://github.com/google/blockly/issues/3903): Re-enable test cases
+  //  after fixing
+  invalidValueRuns[3].skip = true;
+
   runConstructorSuiteTests(
       FieldSlider, validValueRuns, invalidValueRuns, validRunAssertField,
       assertSliderFieldDefault);
 
   runFromJsonSuiteTests(FieldSlider, validValueRuns, invalidValueRuns,
       validRunAssertField, assertSliderFieldDefault);
+
+
+  // TODO(https://github.com/google/blockly/issues/3903): Remove skip=false
+  //  after removing skip=true.
+  invalidValueRuns[3].skip = false;
 
   suite('setValue', function() {
     suite('Empty -> New Value', function() {


### PR DESCRIPTION
- Refactor of test helpers, creating common_test_helpers for non-field specific test helpers and test_helpers as a common entry point for test helpers
- Added a method to run test cases with logic to skip or only the test call based on passed run information

Fixes #269