### PR TITLE
Update React example with createRef

### DIFF
--- a/examples/blockly-react/src/App.js
+++ b/examples/blockly-react/src/App.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * 
+ *
  * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,6 +34,10 @@ import './blocks/customblocks';
 import './generator/generator';
 
 class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.simpleWorkspace = React.createRef();
+  }
 
   generateCode = () => {
     var code = BlocklyJS.workspaceToCode(this.simpleWorkspace.workspace);
@@ -46,7 +50,7 @@ class App extends React.Component {
         <header className="App-header">
           <img src={logo} className="App-logo" alt="logo" />
           <button onClick={this.generateCode}>Convert</button>
-          <BlocklyComponent ref={e => this.simpleWorkspace = e}
+          <BlocklyComponent ref={this.simpleWorkspace}
           readOnly={false} trashcan={true} media={'media/'}
           move={{
             scrollbars: true,

--- a/examples/blockly-react/src/Blockly/BlocklyComponent.jsx
+++ b/examples/blockly-react/src/Blockly/BlocklyComponent.jsx
@@ -1,6 +1,6 @@
 /**
  * @license
- * 
+ *
  * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,13 +31,18 @@ import 'blockly/blocks';
 Blockly.setLocale(locale);
 
 class BlocklyComponent extends React.Component {
+    constructor(props) {
+        super(props);
+        this.blocklyDiv = React.createRef();
+        this.toolbox = React.createRef();
+    }
 
     componentDidMount() {
         const { initialXml, children, ...rest } = this.props;
         this.primaryWorkspace = Blockly.inject(
-            this.blocklyDiv,
+            this.blocklyDiv.current,
             {
-                toolbox: this.toolbox,
+                toolbox: this.toolbox.current,
                 ...rest
             },
         );
@@ -59,8 +64,8 @@ class BlocklyComponent extends React.Component {
         const { children } = this.props;
 
         return <React.Fragment>
-            <div ref={e => this.blocklyDiv = e} id="blocklyDiv" />
-            <xml xmlns="https://developers.google.com/blockly/xml" is="blockly" style={{ display: 'none' }} ref={(toolbox) => { this.toolbox = toolbox; }}>
+            <div ref={this.blocklyDiv} id="blocklyDiv" />
+            <xml xmlns="https://developers.google.com/blockly/xml" is="blockly" style={{ display: 'none' }} ref={this.toolbox}>
                 {children}
             </xml>
         </React.Fragment>;


### PR DESCRIPTION
This PR changes the uses of React's `ref` prop to use the more modern `React.createRef` function rather than directly setting a class variable. More on this here if you're interested: https://reactjs.org/docs/refs-and-the-dom.html

I was wrong earlier, they actually do describe "callback refs" here which is how the repo was using them, but it's a much less common syntax and doesn't need to be used here (we don't need the fine-grained control it offers).