### PR TITLE
Add toolbox switcher to playground

### DIFF
--- a/plugins/dev-tools/package-lock.json
+++ b/plugins/dev-tools/package-lock.json
@@ -493,6 +493,16 @@
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
 			"dev": true
 		},
+		"lodash.assign": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+		},
+		"lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -39,6 +39,8 @@
   "dependencies": {
     "chai": "^4.2.0",
     "dat.gui": "^0.7.7",
+    "lodash.assign": "^4.2.0",
+    "lodash.merge": "^4.6.2",
     "monaco-editor": "^0.20.0"
   },
   "devDependencies": {

--- a/plugins/dev-tools/src/addGUIControls.js
+++ b/plugins/dev-tools/src/addGUIControls.js
@@ -285,9 +285,6 @@ function saveGUIState(guiState) {
   if (guiState.toolboxName !== 'Default') {
     saveGuiState.toolboxName = guiState.toolboxName;
   }
-  if (guiState.themeName) {
-    saveGuiState.themeName = guiState.toolboxName;
-  }
   window.location.hash = HashState.save(saveGuiState);
 }
 

--- a/plugins/dev-tools/src/index.d.ts
+++ b/plugins/dev-tools/src/index.d.ts
@@ -21,6 +21,7 @@ interface PlaygroundAPI {
     folder?: string, defaultValue?: boolean) => dat.GUIController;
   addGenerator: () => void;
   getCurrentTab: () => PlaygroundTab;
+  getGUI: () => DevTools.GUI;
   getWorkspace: () => Blockly.WorkspaceSvg;
 }
 

--- a/plugins/dev-tools/src/index.d.ts
+++ b/plugins/dev-tools/src/index.d.ts
@@ -15,7 +15,10 @@ interface PlaygroundTab {
 
 interface PlaygroundAPI {
   addAction: (name: string, callback: (workspace: Blockly.Workspace) => void,
-    folder?: string) => dat.GUI;
+    folder?: string) => dat.GUIController;
+  addCheckboxAction: (name: string, callback:
+      (workspace: Blockly.Workspace, value: boolean) => void,
+    folder?: string, defaultValue?: boolean) => dat.GUIController;
   addGenerator: () => void;
   getCurrentTab: () => PlaygroundTab;
   getWorkspace: () => Blockly.WorkspaceSvg;
@@ -34,9 +37,13 @@ declare namespace DevTools {
    * An extension of dat.GUI with additional functionality.
    */
   export class GUI extends dat.GUI {
-    getWorkspace: () => Blockly.WorkspaceSvg;
     addAction(name: string, callback: (workspace: Blockly.Workspace) => void,
-      folder?: string): dat.GUI;
+      folder?: string): dat.GUIController;
+    addCheckboxAction: (name: string, callback:
+        (workspace: Blockly.Workspace, value: boolean) => void,
+      folder?: string, defaultValue?: boolean) => dat.GUIController;
+    getWorkspace: () => Blockly.WorkspaceSvg;
+    setResizeEnabled(enabled: boolean): void;
   }
 
   /**

--- a/plugins/dev-tools/src/playground/hash_state.js
+++ b/plugins/dev-tools/src/playground/hash_state.js
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview State manager for window.location.hash.
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+
+/**
+ * A class that manages loading / storing the state from a window hash.
+ */
+export class HashState {
+  /**
+   * Load the state from the window hash string.
+   * @param {string} hash The hash string.
+   * @param {Object} state The state.
+   */
+  static parse(hash, state) {
+    decodeURIComponent(hash)
+        .replace(/#?([^=&]+)=([^=&]+)/gm, function(_m0, key, value) {
+          let current = state;
+          let i;
+          while ((i = key.indexOf('.')) > -1) {
+            current[key.substr(0, i)] = current[key.substr(0, i)] || {};
+            current = current[key.substr(0, i)];
+            key = key.substr(i + 1);
+          }
+          // Parse the value.
+          if (value == 'true' || value == 'false') { // Boolean.
+            value = (value == 'true');
+          } else if (!isNaN(value)) { // Number.
+            value = Number(value);
+          }
+          current[key] = value;
+        });
+  }
+
+  /**
+   * Serialize the state into a hash string.
+   * @param {Object} state The state.
+   * @return {string} The serialized state.
+   */
+  static save(state) {
+    const result = {};
+    const flatten = (cur, prop) => {
+      if (Object(cur) !== cur) {
+        result[prop] = cur;
+      } else {
+        let isEmpty = true;
+        for (const p in cur) {
+          if (Object.prototype.hasOwnProperty.call(cur, p)) {
+            isEmpty = false;
+            flatten(cur[p], prop ? prop+'.'+p : p);
+          }
+        }
+        if (isEmpty && prop != '') {
+          result[prop] = {};
+        }
+      }
+    };
+    flatten(state, '');
+    return Object.keys(result).map((k) => `${k}=${result[k]}`).join('&');
+  }
+}

--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -53,6 +53,7 @@ let PlaygroundConfig;
  *         function(!Blockly.Workspace,boolean):void,string=,boolean=):dat.GUI,
  *     addGenerator: function(string,!Blockly.Generator,string=):void,
  *     getCurrentTab: function():!PlaygroundTab,
+ *     getGUI: function():!dat.GUI,
  *     getWorkspace: function():!Blockly.WorkspaceSvg,
  * }}
  */
@@ -274,6 +275,14 @@ export function createPlayground(container, createWorkspace,
     // Playground API.
 
     /**
+     * Get the current GUI controls.
+     * @return {!dat.GUI} The GUI controls.
+     */
+    const getGUI = function() {
+      return gui;
+    };
+
+    /**
      * Get the current workspace.
      * @return {!Blockly.WorkspaceSvg} The Blockly workspace.
      */
@@ -310,6 +319,7 @@ export function createPlayground(container, createWorkspace,
       addCheckboxAction: (/** @type {?} */ (gui)).addCheckboxAction,
       addGenerator,
       getCurrentTab,
+      getGUI,
       getWorkspace,
     };
 


### PR DESCRIPTION
Add an option to the playground to switch between toolboxes.

This adds playground / gui controls configuration to get the list of toolboxes, if no config is passed, `{categories: toolboxCategories, simple: toolboxSimple}` is used.

If the default option's toolbox is not in the list of toolboxes, a `default` option is added to the list.

Save the toolbox name into local storage / window hash.

Misc changes: 
- Add a setResizeEnabled method to GUI controls to disable auto-resizing
- Add addCheckBoxAction to the GUI controls API to add an action that is a boolean.
- Depending on what save options exist, automatically re-open GUI controls categories.

<img width="363" alt="Screen Shot 2020-06-08 at 8 52 23 AM" src="https://user-images.githubusercontent.com/16690124/84052423-6638a200-a965-11ea-8747-1ec1cb2c642e.png">
