### PR TITLE
Fix workspace reference in workspaceToCode call

### DIFF
--- a/examples/blockly-react/src/App.js
+++ b/examples/blockly-react/src/App.js
@@ -40,7 +40,9 @@ class App extends React.Component {
   }
 
   generateCode = () => {
-    var code = BlocklyJS.workspaceToCode(this.simpleWorkspace.workspace);
+    var code = BlocklyJS.workspaceToCode(
+      this.simpleWorkspace.current.workspace
+    );
     console.log(code);
   }
 


### PR DESCRIPTION
- Fix
blockly.js:861 No workspace specified in workspaceToCode call.  Guessing.
Blockly.Generator.workspaceToCode @ blockly.js:861
