### PR TITLE
Add workspace screenshot download code

### DIFF
--- a/plugins/dev-tools/src/index.js
+++ b/plugins/dev-tools/src/index.js
@@ -10,6 +10,7 @@ import * as testHelpers from './test_helpers.mocha';
 import {DebugRenderer} from './debugRenderer';
 import {generateFieldTestBlocks} from './generateFieldTestBlocks';
 import {populateRandom} from './populateRandom';
+import {downloadWorkspaceScreenshot} from './screenshot';
 
 let addGUIControls;
 let addCodeEditor;
@@ -21,11 +22,12 @@ if (typeof window !== 'undefined') {
 }
 
 export {
-  addGUIControls,
-  DebugRenderer,
-  generateFieldTestBlocks,
-  createPlayground,
   addCodeEditor,
+  addGUIControls,
+  createPlayground,
+  DebugRenderer,
+  downloadWorkspaceScreenshot,
+  generateFieldTestBlocks,
   populateRandom,
   testHelpers,
   toolboxCategories,

--- a/plugins/dev-tools/src/screenshot.js
+++ b/plugins/dev-tools/src/screenshot.js
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Download screenshot.
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+import Blockly from 'blockly/core';
+
+/**
+ * Convert an SVG datauri into a PNG datauri.
+ * @param {string} data SVG datauri.
+ * @param {number} width Image width.
+ * @param {number} height Image height.
+ * @param {!Function} callback Callback.
+ */
+function svgToPng_(data, width, height, callback) {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+  const img = new Image();
+
+  const pixelDensity = 10;
+  canvas.width = width * pixelDensity;
+  canvas.height = height * pixelDensity;
+  img.onload = function() {
+    context.drawImage(
+        img, 0, 0, width, height, 0, 0, canvas.width, canvas.height);
+    try {
+      const dataUri = canvas.toDataURL('image/png');
+      callback(dataUri);
+    } catch (err) {
+      console.warn('Error converting the workspace svg to a png');
+      callback('');
+    }
+  };
+  img.src = data;
+}
+
+/**
+ * Create an SVG of the blocks on the workspace.
+ * @param {!Blockly.WorkspaceSvg} workspace The workspace.
+ * @param {!Function} callback Callback.
+ * @param {string=} customCss Custom CSS to append to the SVG.
+ */
+function workspaceToSvg_(workspace, callback, customCss) {
+  // Go through all text areas and set their value.
+  const textAreas = document.getElementsByTagName('textarea');
+  for (let i = 0; i < textAreas.length; i++) {
+    textAreas[i].innerHTML = textAreas[i].value;
+  }
+
+  const bBox = workspace.getBlocksBoundingBox();
+  const x = bBox.x || bBox.left;
+  const y = bBox.y || bBox.top;
+  const width = bBox.width || bBox.right - x;
+  const height = bBox.height || bBox.bottom - y;
+
+  const blockCanvas = workspace.getCanvas();
+  const clone = blockCanvas.cloneNode(true);
+  clone.removeAttribute('transform');
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  svg.appendChild(clone);
+  svg.setAttribute('viewBox',
+      x + ' ' + y + ' ' + width + ' ' + height);
+
+  svg.setAttribute('class', 'blocklySvg ' +
+    (workspace.options.renderer || 'geras') + '-renderer ' +
+    (workspace.getTheme ? workspace.getTheme().name + '-theme' : ''));
+  svg.setAttribute('width', width);
+  svg.setAttribute('height', height);
+  svg.setAttribute('style', 'background-color: transparent');
+
+  const css = [].slice.call(document.head.querySelectorAll('style'))
+      .filter(function(el) {
+        return /\.blocklySvg/.test(el.innerText) ||
+        (el.id.indexOf('blockly-') === 0);
+      }).map(function(el) {
+        return el.innerText;
+      }).join('\n');
+  const style = document.createElement('style');
+  style.innerHTML = css + '\n' + customCss;
+  svg.insertBefore(style, svg.firstChild);
+
+  let svgAsXML = (new XMLSerializer).serializeToString(svg);
+  svgAsXML = svgAsXML.replace(/&nbsp/g, '&#160');
+  const data = 'data:image/svg+xml,' + encodeURIComponent(svgAsXML);
+
+  svgToPng_(data, width, height, callback);
+}
+
+/**
+ * Download a screenshot of the blocks on a Blockly workspace.
+ * @param {!Blockly.WorkspaceSvg} workspace The Blockly workspace.
+ */
+export function downloadWorkspaceScreenshot(workspace) {
+  workspaceToSvg_(workspace, function(datauri) {
+    const a = document.createElement('a');
+    a.download = 'screenshot.png';
+    a.target = '_self';
+    a.href = datauri;
+    document.body.appendChild(a);
+    a.click();
+    a.parentNode.removeChild(a);
+  });
+}


### PR DESCRIPTION
Part of #245 

Remaining work: initialize on workspace so that it's in the context menu automatically, rather than needing to be added by the developer.

This is just a copy of the code in tests/playground/screenshot.js, with some es6-ification. I also alphabetized some exports in index.js.

I'm not sure the best way to test this.