### PR TITLE
Add spaghetti dev tool action

### DIFF
--- a/plugins/dev-tools/src/addGUIControls.js
+++ b/plugins/dev-tools/src/addGUIControls.js
@@ -14,6 +14,7 @@ import * as Blockly from 'blockly/core';
 import {DebugRenderer} from './debugRenderer';
 import {HashState} from './playground/hash_state';
 import {populateRandom} from './populateRandom';
+import {spaghetti} from './spaghetti';
 import toolboxCategories from './toolboxCategories';
 import toolboxSimple from './toolboxSimple';
 
@@ -700,6 +701,9 @@ function addActions(gui, workspace) {
   // Stress Test.
   gui.addAction('Random Blocks', (workspace) => {
     populateRandom(workspace, 100);
+  }, 'Stress Test');
+  gui.addAction('Spaghetti!', (workspace) => {
+    spaghetti(workspace, 8);
   }, 'Stress Test');
 
   // Accessibility actions.

--- a/plugins/dev-tools/src/index.js
+++ b/plugins/dev-tools/src/index.js
@@ -10,6 +10,7 @@ import * as testHelpers from './test_helpers.mocha';
 import {DebugRenderer} from './debugRenderer';
 import {generateFieldTestBlocks} from './generateFieldTestBlocks';
 import {populateRandom} from './populateRandom';
+import {spaghetti} from './spaghetti';
 import {downloadWorkspaceScreenshot} from './screenshot';
 
 let addGUIControls;
@@ -29,6 +30,7 @@ export {
   downloadWorkspaceScreenshot,
   generateFieldTestBlocks,
   populateRandom,
+  spaghetti,
   testHelpers,
   toolboxCategories,
   toolboxSimple,

--- a/plugins/dev-tools/src/spaghetti.js
+++ b/plugins/dev-tools/src/spaghetti.js
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Helper for populating the workspace with nested if-statement
+ * blocks, for testing.
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+import Blockly from 'blockly/core';
+
+const spaghettiXml = [
+  '  <block type="controls_if">',
+  '    <value name="IF0">',
+  '      <block type="logic_compare">',
+  '        <field name="OP">EQ</field>',
+  '        <value name="A">',
+  '          <block type="math_arithmetic">',
+  '            <field name="OP">MULTIPLY</field>',
+  '            <value name="A">',
+  '              <block type="math_number">',
+  '                <field name="NUM">6</field>',
+  '              </block>',
+  '            </value>',
+  '            <value name="B">',
+  '              <block type="math_number">',
+  '                <field name="NUM">7</field>',
+  '              </block>',
+  '            </value>',
+  '          </block>',
+  '        </value>',
+  '        <value name="B">',
+  '          <block type="math_number">',
+  '            <field name="NUM">42</field>',
+  '          </block>',
+  '        </value>',
+  '      </block>',
+  '    </value>',
+  '    <statement name="DO0"></statement>',
+  '    <next></next>',
+  '  </block>'].join('\n');
+
+/**
+ * Populate the workspace with nested if-statement blocks, for testing.
+ * @param {Blockly.Workspace} workspace The workspace to populate.
+ * @param {number} depth How many layers of nesting to create.
+ */
+export function spaghetti(workspace, depth) {
+  let xml = spaghettiXml;
+  for (let i = 0; i < depth; i++) {
+    xml = xml.replace(/(<(statement|next)( name="DO0")?>)<\//g,
+        '$1' + spaghettiXml + '</');
+  }
+  xml = '<xml xmlns="https://developers.google.com/blockly/xml">' + xml +
+      '</xml>';
+  const dom = Blockly.Xml.textToDom(xml);
+  console.time('Spaghetti domToWorkspace');
+  Blockly.Xml.domToWorkspace(dom, workspace);
+  console.timeEnd('Spaghetti domToWorkspace');
+}


### PR DESCRIPTION
Similar to spaghetti in the Blockly playground, add an action that populates the workspace with a nested set of if-statement blocks.

Add the action to the playground by default (under the Stress Test category).