### PR TITLE
Add workspace event console logger to dev tools

### DIFF
--- a/plugins/dev-tools/src/addGUIControls.js
+++ b/plugins/dev-tools/src/addGUIControls.js
@@ -14,6 +14,7 @@ import * as Blockly from 'blockly/core';
 import {DebugRenderer} from './debugRenderer';
 import {HashState} from './playground/hash_state';
 import {populateRandom} from './populateRandom';
+import {enableLogger, disableLogger} from './logger';
 import toolboxCategories from './toolboxCategories';
 import toolboxSimple from './toolboxSimple';
 
@@ -701,6 +702,15 @@ function addActions(gui, workspace) {
   gui.addAction('Random Blocks', (workspace) => {
     populateRandom(workspace, 100);
   }, 'Stress Test');
+
+  // Logging.
+  gui.addCheckboxAction('Log Events', function(workspace, value) {
+    if (value) {
+      enableLogger(workspace);
+    } else {
+      disableLogger(workspace);
+    }
+  }, 'Logging');
 
   // Accessibility actions.
   gui.addCheckboxAction('Keyboard Nav', (_workspace, value) => {

--- a/plugins/dev-tools/src/index.js
+++ b/plugins/dev-tools/src/index.js
@@ -10,6 +10,7 @@ import * as testHelpers from './test_helpers.mocha';
 import {DebugRenderer} from './debugRenderer';
 import {generateFieldTestBlocks} from './generateFieldTestBlocks';
 import {populateRandom} from './populateRandom';
+import * as logger from './logger';
 import {downloadWorkspaceScreenshot} from './screenshot';
 
 let addGUIControls;
@@ -29,6 +30,7 @@ export {
   downloadWorkspaceScreenshot,
   generateFieldTestBlocks,
   populateRandom,
+  logger,
   testHelpers,
   toolboxCategories,
   toolboxSimple,

--- a/plugins/dev-tools/src/logger.js
+++ b/plugins/dev-tools/src/logger.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview A workspace console logger.
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+
+
+/**
+ * Enable console logging of workspace events.
+ * @param {!Blockly.Workspace} workspace The Blockly workspace.
+ */
+export function enableLogger(workspace) {
+  workspace.addChangeListener(log);
+}
+
+/**
+ * Disable console logging of workspace events.
+ * @param {!Blockly.Workspace} workspace The Blockly workspace.
+ */
+export function disableLogger(workspace) {
+  workspace.removeChangeListener(log);
+}
+
+/**
+ * Log a Blockly event directory to the console.
+ * @param {!Blockly.Events.Abstract} e The Blockly event.
+ */
+function log(e) {
+  console.log(e);
+}

--- a/plugins/dev-tools/src/logger.js
+++ b/plugins/dev-tools/src/logger.js
@@ -11,7 +11,7 @@
 
 
 /**
- * Enable console logging of workspace events.
+ * Enables console logging of workspace events.
  * @param {!Blockly.Workspace} workspace The Blockly workspace.
  */
 export function enableLogger(workspace) {
@@ -19,7 +19,7 @@ export function enableLogger(workspace) {
 }
 
 /**
- * Disable console logging of workspace events.
+ * Disables console logging of workspace events.
  * @param {!Blockly.Workspace} workspace The Blockly workspace.
  */
 export function disableLogger(workspace) {
@@ -27,7 +27,7 @@ export function disableLogger(workspace) {
 }
 
 /**
- * Log a Blockly event directory to the console.
+ * Logs a Blockly event directory to the console.
  * @param {!Blockly.Events.Abstract} e The Blockly event.
  */
 function log(e) {


### PR DESCRIPTION
Fixes https://github.com/google/blockly-samples/issues/296

Adds a workspace event console logger to the dev tools. Added as a checkbox action, checked for enabled, unchecked for disabled.

Similar behaviour to the console logger in the Blockly playground.