### PR TITLE
Set a dynamic generator as the current tab if it is active

### DIFF
--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -346,6 +346,8 @@ export function createPlayground(container, createWorkspace,
           (ws) => generator.workspaceToCode(ws), true);
       if (activeTab === label) {
         // Set the new generator as the current tab if it is currently active.
+        // This occurs when a dynamically added generator is active and the page
+        // is reloaded.
         setActiveTab(tabs[label]);
       }
     };

--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -202,7 +202,9 @@ export function createPlayground(container, createWorkspace,
           }
         }
 
-        currentGenerate();
+        if (currentGenerate) {
+          currentGenerate();
+        }
 
         let code = '';
         try {
@@ -265,9 +267,12 @@ export function createPlayground(container, createWorkspace,
     });
 
     // Set the initial tab as active.
-    let currentTab = tabs[playgroundState.get('activeTab')];
+    const activeTab = playgroundState.get('activeTab');
+    let currentTab = tabs[activeTab];
     let currentGenerate;
-    setActiveTab(currentTab);
+    if (currentTab) {
+      setActiveTab(currentTab);
+    }
 
     // Load the GUI controls.
     const gui = addGUIControls((options) => {
@@ -339,6 +344,10 @@ export function createPlayground(container, createWorkspace,
       }
       tabs[label] = registerGenerator(label, language || 'javascript',
           (ws) => generator.workspaceToCode(ws), true);
+      if (activeTab === label) {
+        // Set the new generator as the current tab if it is currently active.
+        setActiveTab(tabs[label]);
+      }
     };
 
     const playground = {


### PR DESCRIPTION
For generators added through `addGenerators` after the playground is loaded we aren't able to set them as active until they are added.

This adds a check once a generator is added to see if it's active, if so, it sets it as the current tab.