### PR TITLE
Make the flyout part of the deletable area

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousToolbox.js
+++ b/plugins/continuous-toolbox/src/ContinuousToolbox.js
@@ -63,6 +63,15 @@ export class ContinuousToolbox extends Blockly.Toolbox {
       this.flyout_.stepScrollAnimation();
     }
   }
+
+  /** @override */
+  getClientRect() {
+    // If the flyout never closes, it should be in the deletable area.
+    if (this.flyout_ && !this.flyout_.autoClose) {
+      return this.flyout_.getClientRect();
+    }
+    return super.getClientRect();
+  }
 }
 
 Blockly.Css.register([

--- a/plugins/continuous-toolbox/src/ContinuousToolbox.js
+++ b/plugins/continuous-toolbox/src/ContinuousToolbox.js
@@ -66,7 +66,7 @@ export class ContinuousToolbox extends Blockly.Toolbox {
 
   /** @override */
   getClientRect() {
-    // If the flyout never closes, it should be in the deletable area.
+    // If the flyout never closes, it should be the deletable area.
     if (this.flyout_ && !this.flyout_.autoClose) {
       return this.flyout_.getClientRect();
     }


### PR DESCRIPTION
When dragging a block out of the flyout, you now have to drag it sufficiently out of the flyout area to drop it onto the workspace. This is done if autoClose = false, or in other words if the flyout will still be open while you're dragging. Otherwise, the normal toolbox rules apply.