### PR TITLE
Update the toolbox definition

### DIFF
--- a/plugins/dev-tools/src/testblocks/index.js
+++ b/plugins/dev-tools/src/testblocks/index.js
@@ -24,15 +24,17 @@ import {category as styleCategory, onInit as initStyle} from './style';
 /**
  * The Test blocks toolbox.
  */
-export const toolbox = [
-  alignCategory,
-  basicCategory,
-  connectionsCategory,
-  dragCategory,
-  fieldsCategory,
-  mutatorsCategory,
-  styleCategory,
-];
+export const toolbox = {
+  "contents": [
+    alignCategory,
+    basicCategory,
+    connectionsCategory,
+    dragCategory,
+    fieldsCategory,
+    mutatorsCategory,
+    styleCategory,
+  ]
+};
 
 /**
  * Initialize this toolbox.

--- a/plugins/dev-tools/src/testblocks/index.js
+++ b/plugins/dev-tools/src/testblocks/index.js
@@ -25,7 +25,7 @@ import {category as styleCategory, onInit as initStyle} from './style';
  * The Test blocks toolbox.
  */
 export const toolbox = {
-  "contents": [
+  'contents': [
     alignCategory,
     basicCategory,
     connectionsCategory,


### PR DESCRIPTION
Update the toolbox definition for test blocks to work with the September 2020 release of blockly. Since dev tools is snapped to a certain version pushing this should not cause a problem. 