### PR TITLE
use throw for handling errors

### DIFF
--- a/examples/blockly-node/index.js
+++ b/examples/blockly-node/index.js
@@ -45,5 +45,5 @@ try {
   console.log(code);
 }
 catch (e) {
-  console.log(e);
+  throw new Error("An error occured")
 }


### PR DESCRIPTION
I used the throw statement to provide a proper way of showing errors rather than just logging them into the console.