### PR TITLE
Add basic subtype support to project static

### DIFF
--- a/plugins/nominal-connection-checker/README.md
+++ b/plugins/nominal-connection-checker/README.md
@@ -22,20 +22,20 @@ npm install blockly-plugin-nominal --save
 
 ## Usage
 
-<!--
-  - TODO: Update usage.
-  -->
 ```js
 import * as Blockly from 'blockly';
-import {NominalConnectionChecker} from 'nominal-connection-checker';
+import {pluginInfo as NominalConnectionCheckerPluginInfo} from '@blockly/plugin-nominal-connection-checker';
 
 // Inject Blockly.
 const workspace = Blockly.inject('blocklyDiv', {
   toolbox: toolboxCategories,
+  plugins: {
+      ...NominalConnectionCheckerPluginInfo,
+    },
 });
 
 // Initialize plugin.
-workspace.connectionChecker = new NominalConnectionChecker(hierarchyDef);
+workspace.connectionChecker.init(hierarchyDef);
 ```
 
 ## API

--- a/plugins/nominal-connection-checker/package-lock.json
+++ b/plugins/nominal-connection-checker/package-lock.json
@@ -1057,9 +1057,9 @@
       }
     },
     "@blockly/dev-scripts": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-scripts/-/dev-scripts-1.0.3.tgz",
-      "integrity": "sha512-Vg9Vao3jSEMT8yuWB42jc1BCDnIMTYUBCfkk/8+u/JYMkn/sAsVDZW5PF102zDtGbcilaDFyd/1Teoeiei+OYQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-scripts/-/dev-scripts-1.1.0.tgz",
+      "integrity": "sha512-YzwD5Zm1kJ1ukgfHqydwlkhtboROIU27cbarDHqlH/M9fhTF6/n5DVWIYtfofbe/j1ENGgUZ9hNOQvskq7/Yog==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
@@ -1187,9 +1187,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
-      "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==",
+      "version": "14.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.1.tgz",
+      "integrity": "sha512-aYNbO+FZ/3KGeQCEkNhHFRIzBOUgc7QvcVNKXbfnhDkSfwUv91JsQQa10rDgKSTSLkXZ1UIyPe4FJJNVgw1xWQ==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -2122,15 +2122,15 @@
       }
     },
     "browserslist": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.1.tgz",
-      "integrity": "sha512-zyBTIHydW37pnb63c7fHFXUG6EcqWOqoMdDx6cdyaDFriZ20EoVxcE95S54N+heRqY8m8IUgB5zYta/gCwSaaA==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.2.tgz",
+      "integrity": "sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001124",
-        "electron-to-chromium": "^1.3.562",
+        "caniuse-lite": "^1.0.30001125",
+        "electron-to-chromium": "^1.3.564",
         "escalade": "^3.0.2",
-        "node-releases": "^1.1.60"
+        "node-releases": "^1.1.61"
       }
     },
     "buffer": {
@@ -2238,9 +2238,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001124",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
-      "integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==",
+      "version": "1.0.30001125",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001125.tgz",
+      "integrity": "sha512-9f+r7BW8Qli917mU3j0fUaTweT3f3vnX/Lcs+1C73V+RADmFme+Ih0Br8vONQi3X0lseOe6ZHfsZLCA8MSjxUA==",
       "dev": true
     },
     "caseless": {
@@ -3114,9 +3114,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.564",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.564.tgz",
-      "integrity": "sha512-fNaYN3EtKQWLQsrKXui8mzcryJXuA0LbCLoizeX6oayG2emBaS5MauKjCPAvc29NEY4FpLHIUWiP+Y0Bfrs5dg==",
+      "version": "1.3.566",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.566.tgz",
+      "integrity": "sha512-V0fANdGN7waOE0tvCDhjf1vqPRevG3eo0asYm42c4t1qmZSunlnUuWQDxglUi9wDpbKQlGIttMJ+2DYpRwvYRA==",
       "dev": true
     },
     "elliptic": {
@@ -3202,9 +3202,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "version": "1.18.0-next.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+      "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -3212,8 +3212,9 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
         "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "is-negative-zero": "^2.0.0",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
         "string.prototype.trimend": "^1.0.1",
@@ -4759,9 +4760,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.1.tgz",
+      "integrity": "sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg==",
       "dev": true
     },
     "is-data-descriptor": {
@@ -4835,6 +4836,12 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+      "dev": true
     },
     "is-number": {
       "version": "3.0.0",
@@ -5536,6 +5543,18 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
+        "object.assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+          "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+          }
+        },
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -5741,9 +5760,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.60",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
-      "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
+      "version": "1.1.61",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
+      "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
       "dev": true
     },
     "normalize-path": {
@@ -5830,6 +5849,27 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "object-keys": {
@@ -5848,15 +5888,15 @@
       }
     },
     "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.0",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -5867,6 +5907,27 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "object.pick": {
@@ -6466,6 +6527,27 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "regexpp": {
@@ -7534,6 +7616,27 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "string.prototype.trimstart": {
@@ -7544,6 +7647,27 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "string_decoder": {

--- a/plugins/nominal-connection-checker/package.json
+++ b/plugins/nominal-connection-checker/package.json
@@ -8,7 +8,8 @@
     "lint": "blockly-scripts lint",
     "postinstall": "blockly-scripts postinstall",
     "prepublishOnly": "npm run clean && npm run build",
-    "start": "blockly-scripts start"
+    "start": "blockly-scripts start",
+    "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
   "module": "./src/index.js",
@@ -42,7 +43,8 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.0.3",
     "@blockly/dev-tools": "^1.1.3",
-    "blockly": "git://github.com/google/blockly.git#develop"
+    "blockly": "git://github.com/google/blockly.git#develop",
+    "chai": "^4.2.0"
   },
   "peerDependencies": {
     "blockly": ">=3"

--- a/plugins/nominal-connection-checker/src/index.js
+++ b/plugins/nominal-connection-checker/src/index.js
@@ -4,32 +4,109 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// TODO: Edit plugin overview.
 /**
- * @fileoverview Plugin overview.
+ * @fileoverview A Blockly plugin that allows you to create more advanced
+ * connection checks.
  */
 
-// TODO: Rename plugin and edit plugin description.
+import * as Blockly from 'blockly/core';
+import {TypeHierarchy} from './type_hierarchy';
+
+// TODO: Fix the version of Blockly being required in package.json.
+
 /**
- * Plugin description.
+ * A connection checker that is targeted at helping Blockly model languages with
+ * complex nominal typing systems, like C++, Java, or Rust.
+ * @implements {Blockly.IConnectionChecker}
  */
-export class Plugin {
+export class NominalConnectionChecker extends Blockly.ConnectionChecker {
   /**
-   * Constructor for ...
-   * @param {!Blockly.WorkspaceSvg} workspace The workspace that the plugin will
-   *     be added to.
+   * Constructs the connection checker.
    */
-  constructor(workspace) {
+  constructor() {
+    super();
+
     /**
-     * The workspace.
-     * @type {!Blockly.WorkspaceSvg}
-     * @protected
+     * The type hierarchy used by this connection checker. Defines which types
+     * are subtypes of which other types.
+     * @type {?TypeHierarchy}
+     * @private
      */
-    this.workspace_ = workspace;
+    this.typeHierarchy_ = null;
   }
 
   /**
-   * Initialize.
+   * Initializes the connection checker with the given hierarchy def.
+   * @param {!Object} hierarchyDef The definition of our type hierarchy.
+   * TODO: Add some sort of JSON schema for the hierarchy.
    */
-  init() { }
+  init(hierarchyDef) {
+    this.typeHierarchy_ = new TypeHierarchy(hierarchyDef);
+  }
+
+  /**
+   * @override
+   */
+  doTypeChecks(a, b) {
+    const {superior, inferior} = this.getSupAndSubConnections_(a, b);
+    const supCheck = superior.getCheck();
+    const subCheck = inferior.getCheck();
+    const typeHierarchy = this.getTypeHierarchy_();
+
+    return supCheck.some((supType) => {
+      return subCheck.some((subType) => {
+        return typeHierarchy.typeIsSuperOfType(supType, subType);
+      });
+    });
+  }
+
+  /**
+   * Returns the type hierarchy if this connection checker has been initialized.
+   * Otherwise throws an error.
+   * @return {!TypeHierarchy} The type hierarchy of this connection checker.
+   * @throws {Error}
+   * @private
+   */
+  getTypeHierarchy_() {
+    if (!this.typeHierarchy_) {
+      throw Error('The connection checker has not been initialized.');
+    }
+    return /** @type{!TypeHierarchy} */ (this.typeHierarchy_);
+  }
+
+  /**
+   * Returns an object which has the two given connections correctly assigned
+   * to either 'superior' or 'inferior' depending on which is superior and
+   * which is inferior.
+   * @param {!Blockly.Connection} a The first connection.
+   * @param {!Blockly.Connection} b The second connection.
+   * @return {{superior: !Blockly.Connection, inferior: !Blockly.Connection}} An
+   *     object containing the connections, which are now correctly assigned to
+   *     either 'superior' or 'inferior'.
+   * @private
+   */
+  getSupAndSubConnections_(a, b) {
+    if (a.isSuperior()) {
+      return {
+        superior: a,
+        inferior: b,
+      };
+    } else {
+      return {
+        superior: b,
+        inferior: a,
+      };
+    }
+  }
 }
+
+export const registrationType = Blockly.registry.Type.CONNECTION_CHECKER;
+export const registrationName = 'NominalConnectionChecker';
+
+// Register the checker so that it can be used by name.
+Blockly.registry.register(
+    registrationType, registrationName, NominalConnectionChecker);
+
+export const pluginInfo = {
+  [registrationType]: registrationName,
+};

--- a/plugins/nominal-connection-checker/src/index.js
+++ b/plugins/nominal-connection-checker/src/index.js
@@ -73,13 +73,13 @@ export class NominalConnectionChecker extends Blockly.ConnectionChecker {
 
   /**
    * Returns an object which has the two given connections correctly assigned
-   * to either 'superior' or 'inferior' depending on which is superior and
-   * which is inferior.
+   * to either 'parent' or 'child' depending on which is the parent connection
+   * and which is the child connection.
    * @param {!Blockly.Connection} a The first connection.
    * @param {!Blockly.Connection} b The second connection.
    * @return {{parent: !Blockly.Connection, child: !Blockly.Connection}} An
    *     object containing the connections, which are now correctly assigned to
-   *     either 'superior' or 'inferior'.
+   *     either 'parent' or 'child'.
    * @private
    */
   getParentAndChildConnections_(a, b) {

--- a/plugins/nominal-connection-checker/src/index.js
+++ b/plugins/nominal-connection-checker/src/index.js
@@ -48,13 +48,13 @@ export class NominalConnectionChecker extends Blockly.ConnectionChecker {
    * @override
    */
   doTypeChecks(a, b) {
-    const {superior, inferior} = this.getSupAndSubConnections_(a, b);
+    const {parent, child} = this.getParentAndChildConnections_(a, b);
     // Checks should only contain a single type.
-    const supType = superior.getCheck()[0];
-    const subType = inferior.getCheck()[0];
+    const parentType = parent.getCheck()[0];
+    const childType = child.getCheck()[0];
     const typeHierarchy = this.getTypeHierarchy_();
 
-    return typeHierarchy.typeIsSuperOfType(supType, subType);
+    return typeHierarchy.typeFulfillsType(childType, parentType);
   }
 
   /**
@@ -77,21 +77,21 @@ export class NominalConnectionChecker extends Blockly.ConnectionChecker {
    * which is inferior.
    * @param {!Blockly.Connection} a The first connection.
    * @param {!Blockly.Connection} b The second connection.
-   * @return {{superior: !Blockly.Connection, inferior: !Blockly.Connection}} An
+   * @return {{parent: !Blockly.Connection, child: !Blockly.Connection}} An
    *     object containing the connections, which are now correctly assigned to
    *     either 'superior' or 'inferior'.
    * @private
    */
-  getSupAndSubConnections_(a, b) {
+  getParentAndChildConnections_(a, b) {
     if (a.isSuperior()) {
       return {
-        superior: a,
-        inferior: b,
+        parent: a,
+        child: b,
       };
     } else {
       return {
-        superior: b,
-        inferior: a,
+        parent: b,
+        child: a,
       };
     }
   }

--- a/plugins/nominal-connection-checker/src/index.js
+++ b/plugins/nominal-connection-checker/src/index.js
@@ -49,15 +49,12 @@ export class NominalConnectionChecker extends Blockly.ConnectionChecker {
    */
   doTypeChecks(a, b) {
     const {superior, inferior} = this.getSupAndSubConnections_(a, b);
-    const supCheck = superior.getCheck();
-    const subCheck = inferior.getCheck();
+    // Checks should only contain a single type.
+    const supType = superior.getCheck()[0];
+    const subType = inferior.getCheck()[0];
     const typeHierarchy = this.getTypeHierarchy_();
 
-    return supCheck.some((supType) => {
-      return subCheck.some((subType) => {
-        return typeHierarchy.typeIsSuperOfType(supType, subType);
-      });
-    });
+    return typeHierarchy.typeIsSuperOfType(supType, subType);
   }
 
   /**

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -39,9 +39,10 @@ export class TypeHierarchy {
     // NOTE: This does not do anything to stop a developer from creating a
     // cyclic type hierarchy (eg Dog <: Mammal <: Dog). They are expected to
     // not do that.
-    const typeNames = Object.keys(hierarchyDef);
-    for (let i = 0, typeName; (typeName = typeNames[i]); i++) {
-      this.types_[typeName] = new TypeDef(typeName, hierarchyDef[typeName]);
+    for (const typeName of Object.keys(hierarchyDef)) {
+      const lowerCaseName = typeName.toLowerCase();
+      this.types_[lowerCaseName] = new TypeDef(
+          lowerCaseName, hierarchyDef[typeName]);
     }
   }
 
@@ -53,7 +54,7 @@ export class TypeHierarchy {
    * otherwise.
    */
   typeExists(name) {
-    return !!this.types_[name];
+    return !!this.types_[name.toLowerCase()];
   }
 
   /**
@@ -64,7 +65,7 @@ export class TypeHierarchy {
    *     otherwise.
    */
   typeIsExactlyType(name1, name2) {
-    return name1 == name2;
+    return name1.toLowerCase() == name2.toLowerCase();
   }
 
   /**
@@ -78,15 +79,17 @@ export class TypeHierarchy {
    *     in the type hierarchy definition. False otherwise.
    */
   typeFulfillsType(subName, superName) {
-    if (this.typeIsExactlyType(subName, superName)) {
+    const caselessSub = subName.toLowerCase();
+    const caselessSup = superName.toLowerCase();
+    if (this.typeIsExactlyType(caselessSub, caselessSup)) {
       return true;
     }
-    const subType = this.types_[subName];
-    if (subType.hasDirectSuper(superName)) {
+    const subType = this.types_[caselessSub];
+    if (subType.hasDirectSuper(caselessSup)) {
       return true;
     }
     return subType.someSuper(
-        (name) => this.typeFulfillsType(name, superName), this);
+        (name) => this.typeFulfillsType(name, caselessSup), this);
   }
 }
 
@@ -126,7 +129,7 @@ class TypeDef {
   init_(info) {
     if (info.fulfills && info.fulfills.length) {
       // Shallow copy should be fine since it just holds strings.
-      this.fulfills_ = info.fulfills.slice();
+      this.fulfills_ = info.fulfills.map((val) => val.toLowerCase());
     }
   }
 

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -1,0 +1,167 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Defines the TypeHierarchy and all of its private helper
+ * prototypes.
+ */
+'use strict';
+
+/**
+ * Defines a type hierarchy. Used for doing operations like telling if one type
+ * is a subtype of another type.
+ */
+export class TypeHierarchy {
+  /**
+   * Constructs the TypeHierarchy, initializing it with the given hierarchyDef.
+   * @param {!Object} hierarchyDef The definition of the type hierarchy.
+   */
+  constructor(hierarchyDef) {
+    /**
+     * Map of type names to TypeDefs.
+     * @type {!Object<!string, !TypeDef>}
+     * @private
+     */
+    this.types_ = Object.create(null);
+
+    this.init_(hierarchyDef);
+  }
+
+  /**
+   * Initializes the TypeHierarchy's types_.
+   * @param {!Object} hierarchyDef The definition of the type hierarchy.
+   * @private
+   */
+  init_(hierarchyDef) {
+    // NOTE: This does not do anything to stop a developer from creating a
+    // cyclic type hierarchy (eg Dog <: Mammal <: Dog). They are expected to
+    // not do that.
+    const typeNames = Object.keys(hierarchyDef);
+    for (let i = 0, typeName; (typeName = typeNames[i]); i++) {
+      this.types_[typeName] = new TypeDef(typeName, hierarchyDef[typeName]);
+    }
+  }
+
+  /**
+   * Returns true if the given type name exists in the hierarchy. False
+   * otherwise.
+   * @param {string} name The name of the type.
+   * @return {boolean} True if the given type exists in the hierarchy. False
+   * otherwise.
+   */
+  typeExists(name) {
+    return !!this.types_[name];
+  }
+
+  /**
+   * Returns true if the types are exactly the same type. False otherwise.
+   * @param {string} name1 The name of the first type.
+   * @param {string} name2 The name of the second type.
+   * @return {boolean} True if the types are exactly the same type. False
+   *     otherwise.
+   */
+  typeIsExactlyType(name1, name2) {
+    return name1 == name2;
+  }
+
+  /**
+   * Returns true if the first type is a super type of the second type. False
+   * otherwise.
+   * @param {string} superName The name of the possible super type.
+   * @param {string} subName The name of the possible sub type.
+   * @return {boolean} True if the first type is a super type of the second
+   *     type. False otherwise.
+   */
+  typeIsSuperOfType(superName, subName) {
+    if (this.typeIsExactlyType(superName, subName)) {
+      return true;
+    }
+    const subType = this.types_[subName];
+    if (subType.hasDirectSuper(superName)) {
+      return true;
+    }
+    return subType.someSuper(function(name) {
+      return this.typeIsSuperOfType(superName, name);
+    }, this);
+  }
+
+  /**
+   * Returns true if the first type is a subt type of the second type. False
+   * otherwise.
+   * @param {string} subName The name of the possible sub type.
+   * @param {string} superName The name of the possible super type.
+   * @return {boolean} True if the first type is a sub type of the second type.
+   *     False otherwise.
+   */
+  typeIsSubOfType(subName, superName) {
+    return this.typeIsSuperOfType(superName, subName);
+  }
+}
+
+/**
+ * Represents a type.
+ */
+class TypeDef {
+  /**
+   * Constructs a TypeDef with the given name. Uses the given info for further
+   * initialization (eg defining super types).
+   * @param {!string} name The name of the type.
+   * @param {!Object} info The info about the type.
+   */
+  constructor(name, info) {
+    /**
+     * The name of this type.
+     * @type {string}
+     * @private
+     */
+    this.name_ = name;
+
+    /**
+     * The names of the super types of this type.
+     * @type {!Array<string>}
+     * @private
+     */
+    this.fulfills_ = [];
+
+    this.init_(info);
+  }
+
+  /**
+   * Initializes the TypeDef's data.
+   * @param {!Object} info The info about the type.
+   * @private
+   */
+  init_(info) {
+    if (info.fulfills && info.fulfills.length) {
+      // Shallow copy should be fine since it just holds strings.
+      this.fulfills_ = info.fulfills.slice();
+    }
+  }
+
+  /**
+   * Returns true if this type has a direct super type with the given name.
+   * False otherwise.
+   * @param {string} superName The name of the possible direct super type.
+   * @return {boolean} True if this type has a direct super type with the given
+   *     name. False otherwise.
+   */
+  hasDirectSuper(superName) {
+    return this.fulfills_.includes(superName);
+  }
+
+  /**
+   * Returns true if the given function returns a truthy value for at least one
+   * super type of this type. False otherwise.
+   * @param {function(string, number=, !Array=):boolean} callback A function
+   *     used to test each super type.
+   * @param {!Object=} thisArg A value to use as `this` when executing callback.
+   * @return {boolean} True if the given function returns a truthy value for
+   *     at least one super type of this type. False otherwise.
+   */
+  someSuper(callback, thisArg) {
+    return this.fulfills_.some(callback, thisArg);
+  }
+}

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -22,10 +22,10 @@ export class TypeHierarchy {
   constructor(hierarchyDef) {
     /**
      * Map of type names to TypeDefs.
-     * @type {!Object<!string, !TypeDef>}
+     * @type {!Map<string, !TypeDef>}
      * @private
      */
-    this.types_ = Object.create(null);
+    this.types_ = new Map();
 
     this.init_(hierarchyDef);
   }
@@ -41,8 +41,8 @@ export class TypeHierarchy {
     // not do that.
     for (const typeName of Object.keys(hierarchyDef)) {
       const lowerCaseName = typeName.toLowerCase();
-      this.types_[lowerCaseName] = new TypeDef(
-          lowerCaseName, hierarchyDef[typeName]);
+      this.types_.set(lowerCaseName,
+          new TypeDef(lowerCaseName, hierarchyDef[typeName]));
     }
   }
 
@@ -54,7 +54,7 @@ export class TypeHierarchy {
    * otherwise.
    */
   typeExists(name) {
-    return !!this.types_[name.toLowerCase()];
+    return this.types_.has(name.toLowerCase());
   }
 
   /**
@@ -84,7 +84,7 @@ export class TypeHierarchy {
     if (this.typeIsExactlyType(caselessSub, caselessSup)) {
       return true;
     }
-    const subType = this.types_[caselessSub];
+    const subType = this.types_.get(caselessSub);
     if (subType.hasDirectSuper(caselessSup)) {
       return true;
     }

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -68,36 +68,25 @@ export class TypeHierarchy {
   }
 
   /**
-   * Returns true if the first type is a super type of the second type. False
-   * otherwise.
-   * @param {string} superName The name of the possible super type.
+   * Returns true if the types are identical, or if the first type fulfills the
+   * second type (directly or via one of its super types), as specified in the
+   * type hierarchy definition. False otherwise.
    * @param {string} subName The name of the possible sub type.
-   * @return {boolean} True if the first type is a super type of the second
-   *     type. False otherwise.
+   * @param {string} superName The name of the possible super type.
+   * @return {boolean} True if the types are identical, or if the first type
+   *     fulfills the second type (directly or via its super types) as specified
+   *     in the type hierarchy definition. False otherwise.
    */
-  typeIsSuperOfType(superName, subName) {
-    if (this.typeIsExactlyType(superName, subName)) {
+  typeFulfillsType(subName, superName) {
+    if (this.typeIsExactlyType(subName, superName)) {
       return true;
     }
     const subType = this.types_[subName];
     if (subType.hasDirectSuper(superName)) {
       return true;
     }
-    return subType.someSuper(function(name) {
-      return this.typeIsSuperOfType(superName, name);
-    }, this);
-  }
-
-  /**
-   * Returns true if the first type is a subt type of the second type. False
-   * otherwise.
-   * @param {string} subName The name of the possible sub type.
-   * @param {string} superName The name of the possible super type.
-   * @return {boolean} True if the first type is a sub type of the second type.
-   *     False otherwise.
-   */
-  typeIsSubOfType(subName, superName) {
-    return this.typeIsSuperOfType(superName, subName);
+    return subType.someSuper(
+        (name) => this.typeFulfillsType(name, superName), this);
   }
 }
 

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -100,7 +100,7 @@ class TypeDef {
   /**
    * Constructs a TypeDef with the given name. Uses the given info for further
    * initialization (eg defining super types).
-   * @param {!string} name The name of the type.
+   * @param {string} name The name of the type.
    * @param {!Object} info The info about the type.
    */
   constructor(name, info) {
@@ -128,7 +128,6 @@ class TypeDef {
    */
   init_(info) {
     if (info.fulfills && info.fulfills.length) {
-      // Shallow copy should be fine since it just holds strings.
       this.fulfills_ = info.fulfills.map((val) => val.toLowerCase());
     }
   }

--- a/plugins/nominal-connection-checker/test/.mocharc.js
+++ b/plugins/nominal-connection-checker/test/.mocharc.js
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict';
+
+module.exports = {
+  ui: 'tdd',
+};

--- a/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
@@ -168,14 +168,14 @@ suite('NominalConnectionChecker', function() {
       const dogOut = this.getBlockOutput('static_dog');
       dogOut.setCheck(['Random', 'Dog']);
       const trainDogIn = this.getBlockInput('static_train_dog');
-      chai.assert.isTrue(this.checker.doTypeChecks(dogOut, trainDogIn));
+      chai.assert.isFalse(this.checker.doTypeChecks(dogOut, trainDogIn));
     });
 
     test('Multiple input checks', function() {
       const dogOut = this.getBlockOutput('static_dog');
       const trainDogIn = this.getBlockInput('static_train_dog');
       trainDogIn.setCheck(['Random', 'Dog']);
-      chai.assert.isTrue(this.checker.doTypeChecks(dogOut, trainDogIn));
+      chai.assert.isFalse(this.checker.doTypeChecks(dogOut, trainDogIn));
     });
 
     test('Unrelated types', function() {

--- a/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Unit tests for NominalConnectionChecker.
+ */
+
+const chai = require('chai');
+const Blockly = require('blockly/node');
+
+const {pluginInfo} = require('../src/index.js');
+
+suite('NominalConnectionChecker', function() {
+  setup(function() {
+    Blockly.defineBlocksWithJsonArray([
+      {
+        'type': 'static_animal',
+        'message0': 'Animal',
+        'output': ['Animal'],
+        'style': 'math_blocks',
+      },
+      {
+        'type': 'static_mammal',
+        'message0': 'Mammal',
+        'output': ['Mammal'],
+        'style': 'math_blocks',
+      },
+      {
+        'type': 'static_dog',
+        'message0': 'Dog',
+        'output': ['Dog'],
+        'style': 'math_blocks',
+      },
+      {
+        'type': 'static_bat',
+        'message0': 'Bat',
+        'output': ['Bat'],
+        'style': 'math_blocks',
+      },
+      {
+        'type': 'static_weigh_animal',
+        'message0': 'Weigh Animal %1',
+        'args0': [
+          {
+            'type': 'input_value',
+            'name': 'INPUT',
+            'check': 'Animal',
+          },
+        ],
+        'style': 'math_blocks',
+      },
+      {
+        'type': 'static_milk_mammal',
+        'message0': 'Milk Mammal %1',
+        'args0': [
+          {
+            'type': 'input_value',
+            'name': 'INPUT',
+            'check': 'Mammal',
+          },
+        ],
+        'style': 'math_blocks',
+      },
+      {
+        'type': 'static_train_dog',
+        'message0': 'Train Dog %1',
+        'args0': [
+          {
+            'type': 'input_value',
+            'name': 'INPUT',
+            'check': 'Dog',
+          },
+        ],
+        'style': 'math_blocks',
+      },
+      {
+        'type': 'static_launch_flying',
+        'message0': 'Launch Flying Animal %1',
+        'args0': [
+          {
+            'type': 'input_value',
+            'name': 'INPUT',
+            'check': 'FlyingAnimal',
+          },
+        ],
+        'style': 'math_blocks',
+      },
+    ]);
+
+    const hierarchyDef = {
+      // Random is a type disconnected from the rest of the hierarchy.
+      'Random': { },
+      'Animal': { },
+      'FlyingAnimal': {
+        'fulfills': ['Animal'],
+      },
+      'Mammal': {
+        'fulfills': ['Animal'],
+      },
+      'Dog': {
+        'fulfills': ['Mammal'],
+      },
+      'Bat': {
+        'fulfills': ['FlyingAnimal', 'Mammal'],
+      },
+    };
+
+    const options = {
+      plugins: {
+        ...pluginInfo,
+      },
+    };
+
+    this.workspace = new Blockly.Workspace(options);
+    this.workspace.connectionChecker.init(hierarchyDef);
+    this.checker = this.workspace.connectionChecker;
+
+    this.getBlockOutput = function(blockType) {
+      return this.workspace.newBlock(blockType).outputConnection;
+    };
+    this.getBlockInput = function(blockType) {
+      return this.workspace.newBlock(blockType).getInput('INPUT').connection;
+    };
+  });
+
+  teardown(function() {
+    delete Blockly.Blocks['static_animal'];
+    delete Blockly.Blocks['static_mammal'];
+    delete Blockly.Blocks['static_dog'];
+    delete Blockly.Blocks['static_bat'];
+    delete Blockly.Blocks['static_weigh_animal'];
+    delete Blockly.Blocks['static_milk_mammal'];
+    delete Blockly.Blocks['static_train_dog'];
+    delete Blockly.Blocks['static_launch_flying'];
+  });
+
+  suite('Simple subtyping', function() {
+    test('Exact types', function() {
+      const dogOut = this.getBlockOutput('static_dog');
+      const trainDogIn = this.getBlockInput('static_train_dog');
+      chai.assert.isTrue(this.checker.doTypeChecks(dogOut, trainDogIn));
+    });
+
+    test('Simple super', function() {
+      const dogOut = this.getBlockOutput('static_dog');
+      const milkMammalIn = this.getBlockInput('static_milk_mammal');
+      chai.assert.isTrue(this.checker.doTypeChecks(dogOut, milkMammalIn));
+    });
+
+    test('Multiple supers', function() {
+      const batOut = this.getBlockOutput('static_bat');
+      const milkMammalIn = this.getBlockInput('static_milk_mammal');
+      const launchFlyingIn = this.getBlockInput('static_launch_flying');
+      chai.assert.isTrue(this.checker.doTypeChecks(batOut, milkMammalIn));
+      chai.assert.isTrue(this.checker.doTypeChecks(batOut, launchFlyingIn));
+    });
+
+    test('Deep supers', function() {
+      const dogOut = this.getBlockOutput('static_dog');
+      const weighAnimalIn = this.getBlockInput('static_weigh_animal');
+      chai.assert.isTrue(this.checker.doTypeChecks(dogOut, weighAnimalIn));
+    });
+
+    test('Multiple output checks', function() {
+      const dogOut = this.getBlockOutput('static_dog');
+      dogOut.setCheck(['Random', 'Dog']);
+      const trainDogIn = this.getBlockInput('static_train_dog');
+      chai.assert.isTrue(this.checker.doTypeChecks(dogOut, trainDogIn));
+    });
+
+    test('Multiple input checks', function() {
+      const dogOut = this.getBlockOutput('static_dog');
+      const trainDogIn = this.getBlockInput('static_train_dog');
+      trainDogIn.setCheck(['Random', 'Dog']);
+      chai.assert.isTrue(this.checker.doTypeChecks(dogOut, trainDogIn));
+    });
+
+    test('Unrelated types', function() {
+      const batOut = this.getBlockOutput('static_bat');
+      const trainDogIn = this.getBlockInput('static_train_dog');
+      chai.assert.isFalse(this.checker.doTypeChecks(batOut, trainDogIn));
+    });
+
+    test('Backwards types', function() {
+      const mammalOut = this.getBlockOutput('static_mammal');
+      const trainDogIn = this.getBlockInput('static_train_dog');
+      chai.assert.isFalse(this.checker.doTypeChecks(mammalOut, trainDogIn));
+    });
+  });
+});

--- a/plugins/nominal-connection-checker/test/index.js
+++ b/plugins/nominal-connection-checker/test/index.js
@@ -13,7 +13,7 @@ import {addCodeEditor} from '@blockly/dev-tools/src/playground/monaco';
 import {LocalStorageState} from '@blockly/dev-tools/src/playground/state';
 import {renderPlayground, renderCodeTab} from
   '@blockly/dev-tools/src/playground/ui.js';
-import {Plugin} from '../src/index';
+import {pluginInfo as NominalConnectionCheckerPluginInfo} from '../src/index';
 
 /**
  * @typedef {{
@@ -40,6 +40,9 @@ function createWorkspace(blocklyDiv, typeHierarchy, blocks) {
     });
   });
   const options = {
+    plugins: {
+      ...NominalConnectionCheckerPluginInfo,
+    },
     toolbox: {
       'kind': Blockly.utils.toolbox.FLYOUT_TOOLBOX_KIND,
       'contents': toolboxContents,
@@ -55,10 +58,7 @@ function createWorkspace(blocklyDiv, typeHierarchy, blocks) {
   };
 
   const workspace = Blockly.inject(blocklyDiv, options);
-
-  // TODO: Initialize your plugin here.
-  const plugin = new Plugin(workspace);
-  plugin.init();
+  workspace.connectionChecker.init(typeHierarchy);
 
   return workspace;
 }

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -130,20 +130,14 @@ suite('TypeHierarchy', function() {
       chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
     });
 
-    test('Super not defined', function() {
-      const hierarchy = new TypeHierarchy({
-        'A': {
-          'fulfills': ['B'],
-        },
-      });
-      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
-    });
-
     test('Multiple supers', function() {
       const hierarchy = new TypeHierarchy({
         'A': {
           'fulfills': ['B', 'C', 'D'],
         },
+        'B': { },
+        'C': { },
+        'D': { },
       });
       chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
       chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'C'));

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -1,0 +1,247 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Unit tests for TypeHierarchy.
+ */
+
+const chai = require('chai');
+
+const {TypeHierarchy} = require('../src/type_hierarchy');
+
+suite('TypeHierarchy', function() {
+  suite('typeExists', function() {
+    test('Simple', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': { },
+      });
+      chai.assert.isTrue(hierarchy.typeExists('A'));
+    });
+
+    test('Case', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': { },
+      });
+      chai.assert.isFalse(hierarchy.typeExists('a'),
+          'Expected TypeHierarchy to be case-sensitive.');
+    });
+
+    test('Padding', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': { },
+      });
+      chai.assert.isFalse(hierarchy.typeExists(' A '),
+          'Expected TypeHierarchy to respect padding.');
+    });
+
+    test('Super but not defined', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': ['B'],
+        },
+      });
+      chai.assert.isFalse(hierarchy.typeExists('B'),
+          'Expected only top-level types to exist.');
+    });
+  });
+
+  suite('typeIsExactlyType', function() {
+    test('Simple', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': { },
+      });
+      chai.assert.isTrue(hierarchy.typeIsExactlyType('A', 'A'));
+    });
+
+    test('Case', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': { },
+      });
+      chai.assert.isFalse(hierarchy.typeIsExactlyType('A', 'a'),
+          'Expected TypeHierarchy to be case-sensitive.');
+    });
+
+    test('Padding', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': { },
+      });
+      chai.assert.isFalse(hierarchy.typeIsExactlyType('A', ' A '),
+          'Expected TypeHierarchy to respect padding.');
+    });
+
+    test('Super', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': ['B'],
+        },
+        'B': { },
+      });
+      chai.assert.isFalse(hierarchy.typeIsExactlyType('A', 'B'));
+    });
+
+    test('Sub', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': { },
+        'B': {
+          'fulfills': ['A'],
+        },
+      });
+      chai.assert.isFalse(hierarchy.typeIsExactlyType('A', 'B'));
+    });
+  });
+
+  suite('typeIsSuperOfType', function() {
+    test('Empty fulfills', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': [],
+        },
+      });
+      chai.assert.isFalse(hierarchy.typeIsSuperOfType('B', 'A'));
+    });
+
+    test('Undefined fulfills', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': { },
+      });
+      chai.assert.isFalse(hierarchy.typeIsSuperOfType('B', 'A'));
+    });
+
+    test('Super defined first', function() {
+      const hierarchy = new TypeHierarchy({
+        'B': { },
+        'A': {
+          'fulfills': ['B'],
+        },
+      });
+      chai.assert.isTrue(hierarchy.typeIsSuperOfType('B', 'A'));
+    });
+
+    test('Super defined second', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': ['B'],
+        },
+        'B': { },
+      });
+      chai.assert.isTrue(hierarchy.typeIsSuperOfType('B', 'A'));
+    });
+
+    test('Super not defined', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': ['B'],
+        },
+      });
+      chai.assert.isTrue(hierarchy.typeIsSuperOfType('B', 'A'));
+    });
+
+    test('Multiple supers', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': ['B', 'C', 'D'],
+        },
+      });
+      chai.assert.isTrue(hierarchy.typeIsSuperOfType('B', 'A'));
+      chai.assert.isTrue(hierarchy.typeIsSuperOfType('C', 'A'));
+      chai.assert.isTrue(hierarchy.typeIsSuperOfType('D', 'A'));
+    });
+
+    test('Deep super', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': ['B'],
+        },
+        'B': {
+          'fulfills': ['C'],
+        },
+        'C': {
+          'fulfills': ['D'],
+        },
+        'D': { },
+      });
+      chai.assert.isTrue(hierarchy.typeIsSuperOfType('B', 'A'));
+      chai.assert.isTrue(hierarchy.typeIsSuperOfType('C', 'A'));
+      chai.assert.isTrue(hierarchy.typeIsSuperOfType('D', 'A'));
+    });
+  });
+
+  suite('typeIsSubOfType', function() {
+    test('Empty fulfills', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': [],
+        },
+      });
+      chai.assert.isFalse(hierarchy.typeIsSubOfType('A', 'B'));
+    });
+
+    test('Undefined fulfills', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': { },
+      });
+      chai.assert.isFalse(hierarchy.typeIsSubOfType('A', 'B'));
+    });
+
+    test('Super defined first', function() {
+      const hierarchy = new TypeHierarchy({
+        'B': { },
+        'A': {
+          'fulfills': ['B'],
+        },
+      });
+      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'B'));
+    });
+
+    test('Super defined second', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': ['B'],
+        },
+        'B': { },
+      });
+      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'B'));
+    });
+
+    test('Super not defined', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': ['B'],
+        },
+      });
+      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'B'));
+    });
+
+    test('Multiple supers', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': ['B', 'C', 'D'],
+        },
+      });
+      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'B'));
+      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'C'));
+      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'D'));
+    });
+
+    test('Deep super', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': ['B'],
+        },
+        'B': {
+          'fulfills': ['C'],
+        },
+        'C': {
+          'fulfills': ['D'],
+        },
+        'D': { },
+      });
+      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'B'));
+      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'C'));
+      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'D'));
+    });
+  });
+});

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -93,21 +93,21 @@ suite('TypeHierarchy', function() {
     });
   });
 
-  suite('typeIsSuperOfType', function() {
+  suite('typeFulfillsType', function() {
     test('Empty fulfills', function() {
       const hierarchy = new TypeHierarchy({
         'A': {
           'fulfills': [],
         },
       });
-      chai.assert.isFalse(hierarchy.typeIsSuperOfType('B', 'A'));
+      chai.assert.isFalse(hierarchy.typeFulfillsType('A', 'B'));
     });
 
     test('Undefined fulfills', function() {
       const hierarchy = new TypeHierarchy({
         'A': { },
       });
-      chai.assert.isFalse(hierarchy.typeIsSuperOfType('B', 'A'));
+      chai.assert.isFalse(hierarchy.typeFulfillsType('A', 'B'));
     });
 
     test('Super defined first', function() {
@@ -117,7 +117,7 @@ suite('TypeHierarchy', function() {
           'fulfills': ['B'],
         },
       });
-      chai.assert.isTrue(hierarchy.typeIsSuperOfType('B', 'A'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
     });
 
     test('Super defined second', function() {
@@ -127,7 +127,7 @@ suite('TypeHierarchy', function() {
         },
         'B': { },
       });
-      chai.assert.isTrue(hierarchy.typeIsSuperOfType('B', 'A'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
     });
 
     test('Super not defined', function() {
@@ -136,7 +136,7 @@ suite('TypeHierarchy', function() {
           'fulfills': ['B'],
         },
       });
-      chai.assert.isTrue(hierarchy.typeIsSuperOfType('B', 'A'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
     });
 
     test('Multiple supers', function() {
@@ -145,9 +145,9 @@ suite('TypeHierarchy', function() {
           'fulfills': ['B', 'C', 'D'],
         },
       });
-      chai.assert.isTrue(hierarchy.typeIsSuperOfType('B', 'A'));
-      chai.assert.isTrue(hierarchy.typeIsSuperOfType('C', 'A'));
-      chai.assert.isTrue(hierarchy.typeIsSuperOfType('D', 'A'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'C'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'D'));
     });
 
     test('Deep super', function() {
@@ -163,85 +163,9 @@ suite('TypeHierarchy', function() {
         },
         'D': { },
       });
-      chai.assert.isTrue(hierarchy.typeIsSuperOfType('B', 'A'));
-      chai.assert.isTrue(hierarchy.typeIsSuperOfType('C', 'A'));
-      chai.assert.isTrue(hierarchy.typeIsSuperOfType('D', 'A'));
-    });
-  });
-
-  suite('typeIsSubOfType', function() {
-    test('Empty fulfills', function() {
-      const hierarchy = new TypeHierarchy({
-        'A': {
-          'fulfills': [],
-        },
-      });
-      chai.assert.isFalse(hierarchy.typeIsSubOfType('A', 'B'));
-    });
-
-    test('Undefined fulfills', function() {
-      const hierarchy = new TypeHierarchy({
-        'A': { },
-      });
-      chai.assert.isFalse(hierarchy.typeIsSubOfType('A', 'B'));
-    });
-
-    test('Super defined first', function() {
-      const hierarchy = new TypeHierarchy({
-        'B': { },
-        'A': {
-          'fulfills': ['B'],
-        },
-      });
-      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'B'));
-    });
-
-    test('Super defined second', function() {
-      const hierarchy = new TypeHierarchy({
-        'A': {
-          'fulfills': ['B'],
-        },
-        'B': { },
-      });
-      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'B'));
-    });
-
-    test('Super not defined', function() {
-      const hierarchy = new TypeHierarchy({
-        'A': {
-          'fulfills': ['B'],
-        },
-      });
-      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'B'));
-    });
-
-    test('Multiple supers', function() {
-      const hierarchy = new TypeHierarchy({
-        'A': {
-          'fulfills': ['B', 'C', 'D'],
-        },
-      });
-      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'B'));
-      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'C'));
-      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'D'));
-    });
-
-    test('Deep super', function() {
-      const hierarchy = new TypeHierarchy({
-        'A': {
-          'fulfills': ['B'],
-        },
-        'B': {
-          'fulfills': ['C'],
-        },
-        'C': {
-          'fulfills': ['D'],
-        },
-        'D': { },
-      });
-      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'B'));
-      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'C'));
-      chai.assert.isTrue(hierarchy.typeIsSubOfType('A', 'D'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'C'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'D'));
     });
   });
 });

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -25,8 +25,8 @@ suite('TypeHierarchy', function() {
       const hierarchy = new TypeHierarchy({
         'A': { },
       });
-      chai.assert.isFalse(hierarchy.typeExists('a'),
-          'Expected TypeHierarchy to be case-sensitive.');
+      chai.assert.isTrue(hierarchy.typeExists('a'),
+          'Expected TypeHierarchy to be case-insensitive.');
     });
 
     test('Padding', function() {
@@ -60,8 +60,10 @@ suite('TypeHierarchy', function() {
       const hierarchy = new TypeHierarchy({
         'A': { },
       });
-      chai.assert.isFalse(hierarchy.typeIsExactlyType('A', 'a'),
-          'Expected TypeHierarchy to be case-sensitive.');
+      chai.assert.isTrue(hierarchy.typeIsExactlyType('A', 'a'),
+          'Expected TypeHierarchy to be case-insensitive.');
+      chai.assert.isTrue(hierarchy.typeIsExactlyType('a', 'A'),
+          'Expected TypeHierarchy to be case-insensitive.');
     });
 
     test('Padding', function() {
@@ -160,6 +162,19 @@ suite('TypeHierarchy', function() {
       chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
       chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'C'));
       chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'D'));
+    });
+
+    test('Case', function() {
+      const hierarchy = new TypeHierarchy({
+        'A': {
+          'fulfills': ['B'],
+        },
+        'b': { },
+      });
+      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'b'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('a', 'b'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('a', 'B'));
     });
   });
 });

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -16,34 +16,34 @@ suite('TypeHierarchy', function() {
   suite('typeExists', function() {
     test('Simple', function() {
       const hierarchy = new TypeHierarchy({
-        'A': { },
+        'typeA': { },
       });
-      chai.assert.isTrue(hierarchy.typeExists('A'));
+      chai.assert.isTrue(hierarchy.typeExists('typeA'));
     });
 
     test('Case', function() {
       const hierarchy = new TypeHierarchy({
-        'A': { },
+        'typeA': { },
       });
-      chai.assert.isTrue(hierarchy.typeExists('a'),
+      chai.assert.isTrue(hierarchy.typeExists('typea'),
           'Expected TypeHierarchy to be case-insensitive.');
     });
 
     test('Padding', function() {
       const hierarchy = new TypeHierarchy({
-        'A': { },
+        'typeA': { },
       });
-      chai.assert.isFalse(hierarchy.typeExists(' A '),
+      chai.assert.isFalse(hierarchy.typeExists(' typeA '),
           'Expected TypeHierarchy to respect padding.');
     });
 
     test('Super but not defined', function() {
       const hierarchy = new TypeHierarchy({
-        'A': {
-          'fulfills': ['B'],
+        'typeA': {
+          'fulfills': ['typeB'],
         },
       });
-      chai.assert.isFalse(hierarchy.typeExists('B'),
+      chai.assert.isFalse(hierarchy.typeExists('typeB'),
           'Expected only top-level types to exist.');
     });
   });
@@ -53,73 +53,73 @@ suite('TypeHierarchy', function() {
       const hierarchy = new TypeHierarchy({
         'A': { },
       });
-      chai.assert.isTrue(hierarchy.typeIsExactlyType('A', 'A'));
+      chai.assert.isTrue(hierarchy.typeIsExactlyType('typeA', 'typeA'));
     });
 
     test('Case', function() {
       const hierarchy = new TypeHierarchy({
-        'A': { },
+        'typeA': { },
       });
-      chai.assert.isTrue(hierarchy.typeIsExactlyType('A', 'a'),
+      chai.assert.isTrue(hierarchy.typeIsExactlyType('typeA', 'typea'),
           'Expected TypeHierarchy to be case-insensitive.');
-      chai.assert.isTrue(hierarchy.typeIsExactlyType('a', 'A'),
+      chai.assert.isTrue(hierarchy.typeIsExactlyType('typea', 'typeA'),
           'Expected TypeHierarchy to be case-insensitive.');
     });
 
     test('Padding', function() {
       const hierarchy = new TypeHierarchy({
-        'A': { },
+        'typeA': { },
       });
-      chai.assert.isFalse(hierarchy.typeIsExactlyType('A', ' A '),
+      chai.assert.isFalse(hierarchy.typeIsExactlyType('typeA', ' typeA '),
           'Expected TypeHierarchy to respect padding.');
     });
 
     test('Super', function() {
       const hierarchy = new TypeHierarchy({
-        'A': {
-          'fulfills': ['B'],
+        'typeA': {
+          'fulfills': ['typeB'],
         },
-        'B': { },
+        'typeB': { },
       });
-      chai.assert.isFalse(hierarchy.typeIsExactlyType('A', 'B'));
+      chai.assert.isFalse(hierarchy.typeIsExactlyType('typeA', 'typeB'));
     });
 
     test('Sub', function() {
       const hierarchy = new TypeHierarchy({
-        'A': { },
-        'B': {
-          'fulfills': ['A'],
+        'typeA': { },
+        'typeB': {
+          'fulfills': ['typeA'],
         },
       });
-      chai.assert.isFalse(hierarchy.typeIsExactlyType('A', 'B'));
+      chai.assert.isFalse(hierarchy.typeIsExactlyType('typeA', 'typeB'));
     });
   });
 
   suite('typeFulfillsType', function() {
     test('Empty fulfills', function() {
       const hierarchy = new TypeHierarchy({
-        'A': {
+        'typeA': {
           'fulfills': [],
         },
       });
-      chai.assert.isFalse(hierarchy.typeFulfillsType('A', 'B'));
+      chai.assert.isFalse(hierarchy.typeFulfillsType('typeA', 'typeB'));
     });
 
     test('Undefined fulfills', function() {
       const hierarchy = new TypeHierarchy({
-        'A': { },
+        'typeA': { },
       });
-      chai.assert.isFalse(hierarchy.typeFulfillsType('A', 'B'));
+      chai.assert.isFalse(hierarchy.typeFulfillsType('typeA', 'typeB'));
     });
 
     test('Super defined first', function() {
       const hierarchy = new TypeHierarchy({
-        'B': { },
-        'A': {
-          'fulfills': ['B'],
+        'typeB': { },
+        'typeA': {
+          'fulfills': ['typeB'],
         },
       });
-      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeB'));
     });
 
     test('Super defined second', function() {
@@ -134,47 +134,47 @@ suite('TypeHierarchy', function() {
 
     test('Multiple supers', function() {
       const hierarchy = new TypeHierarchy({
-        'A': {
-          'fulfills': ['B', 'C', 'D'],
+        'typeA': {
+          'fulfills': ['typeB', 'typeC', 'typeD'],
         },
-        'B': { },
-        'C': { },
-        'D': { },
+        'typeB': { },
+        'typeC': { },
+        'typeD': { },
       });
-      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'C'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'D'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeB'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeC'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeD'));
     });
 
     test('Deep super', function() {
       const hierarchy = new TypeHierarchy({
-        'A': {
-          'fulfills': ['B'],
+        'typeA': {
+          'fulfills': ['typeB'],
         },
-        'B': {
-          'fulfills': ['C'],
+        'typeB': {
+          'fulfills': ['typeC'],
         },
-        'C': {
-          'fulfills': ['D'],
+        'typeC': {
+          'fulfills': ['typeD'],
         },
-        'D': { },
+        'typeD': { },
       });
-      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'C'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'D'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeB'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeC'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeD'));
     });
 
     test('Case', function() {
       const hierarchy = new TypeHierarchy({
-        'A': {
-          'fulfills': ['B'],
+        'typeA': {
+          'fulfills': ['typeB'],
         },
-        'b': { },
+        'typeb': { },
       });
-      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'b'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('a', 'b'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('a', 'B'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeb'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeB'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('typea', 'typeb'));
+      chai.assert.isTrue(hierarchy.typeFulfillsType('typea', 'typeB'));
     });
   });
 });


### PR DESCRIPTION
### Description

Adds basic subtyping support to project static. This has no parameterized types or generic types, just a very simple TypeHierarchy.

### Hierarchy def validation

Currently the TypeHierarchy doesn't do any validation on the hierarchyDef it gets passed, which means that it is possible to define circular dependencies.

I haven't added validation yet because I'm worried that it is going to become really expensive once the type system gets more complex. (Eg, making sure that the parameter variance of parameters is compatible with their super types.) If in most cases devs will be defining valid hierarchies, it doesn't seem worth it to me atm.

I'm wondering if maybe it would be nice to add a validation function devs could run while they're constructing their hierarchy? That way they can test it if they want, but it's not required on start-up.

Or maybe it is just better to always validate. I would love your opinions on this :D

### Testing

Manually tested using the playground.
Wrote unit tests for all of the public functions on the TypeHierarchy.
Wrote unit tests for the connection checker to cover basic subtyping.

---

[Edit: I removed support for multiple checks on connections because that doesn't really makes sense when we go to bind generic type names to explicit types. Anything you can do with multiple type checks you should be able to do with single type checks by defining (via the type hierarchy) that both types fulfill a common super type.]