### PR TITLE
Add test blocks back in

### DIFF
--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -293,8 +293,7 @@ export function createPlayground(container, createWorkspace,
       toolboxes: config.toolboxes || {
         'categories': toolboxCategories,
         'simple': toolboxSimple,
-        // TODO (#210): Enable this once the test toolbox has stabalized.
-        // 'test blocks': toolboxTestBlocks,
+        'test blocks': toolboxTestBlocks,
       },
     });
 


### PR DESCRIPTION
Found this while looking through the code. #210 has been closed so this should be uncommented. I'm a bit confused how test blocks are working in the advanced playground. 