### PR TITLE
Add type hierarchy validation - project static

### DIFF
--- a/plugins/nominal-connection-checker/package-lock.json
+++ b/plugins/nominal-connection-checker/package-lock.json
@@ -5105,9 +5105,9 @@
       }
     },
     "just-extend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
       "dev": true
     },
     "killable": {

--- a/plugins/nominal-connection-checker/package.json
+++ b/plugins/nominal-connection-checker/package.json
@@ -44,7 +44,8 @@
     "@blockly/dev-scripts": "^1.0.3",
     "@blockly/dev-tools": "^1.1.3",
     "blockly": "git://github.com/google/blockly.git#develop",
-    "chai": "^4.2.0"
+    "chai": "^4.2.0",
+    "sinon": "^9.0.3"
   },
   "peerDependencies": {
     "blockly": ">=3"

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Defines functions for validation a type hierarchy definition.
+ */
+'use strict';
+
+/**
+ * Validates the given hierarchy definition. Does checks for duplicate types,
+ * circular dependencies, etc. Errors are logged to the console (not thrown).
+ * @param {!Object} hierarchyDef The definition of the type hierarchy.
+ */
+export function validateHierarchy(hierarchyDef) {
+  if (!hierarchyDef ||
+      typeof hierarchyDef != 'object' ||
+      Array.isArray(hierarchyDef)) {
+    console.error('The hierarchy definition should be an object.');
+    return;
+  }
+
+  checkConflictingTypes(hierarchyDef);
+}
+
+/**
+ * Checks the hierarchyDef for conflicting types.
+ * @param {!Object} hierarchyDef The definition of the type hierarchy.
+ */
+function checkConflictingTypes(hierarchyDef) {
+  const conflictMsg = 'The type name \'%s\' conflicts with the type name(s) %s';
+
+  // Map of caseless names to cased names.
+  const definedTypes = new Map();
+  // Map of original names to arrays of conflicting names.
+  const conflictingTypes = new Map();
+
+  for (const type of Object.keys(hierarchyDef)) {
+    const caselessType = type.toLowerCase();
+    if (definedTypes.has(caselessType)) {
+      const originalType = definedTypes.get(caselessType);
+      if (!conflictingTypes.has(originalType)) {
+        conflictingTypes.set(originalType, [type]);
+      } else {
+        conflictingTypes.get(originalType).push(type);
+      }
+    } else {
+      definedTypes.set(caselessType, type);
+    }
+  }
+
+  for (const [type, conflicts] of conflictingTypes) {
+    console.error(conflictMsg, type, conflicts);
+  }
+}

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -97,25 +97,6 @@ function checkSupersDefined(hierarchyDef) {
  */
 function checkCircularDependencies(hierarchyDef) {
   /**
-   * Logs an informative error about a cyclic dependency.
-   * @param {!Array<string>} cycleArray An array of all the types that have been
-   *     visited since our entry node.
-   */
-  function logCycle(cycleArray) {
-    const lastType = cycleArray[cycleArray.length - 1].toLowerCase();
-    const index = cycleArray.findIndex((elem) =>
-      elem.toLowerCase() == lastType);
-    const firstType = cycleArray[index];
-
-    let errorMsg = `The type ${firstType} creates a circular dependency: `;
-    errorMsg += firstType;
-    for (let i = index + 1; i < cycleArray.length; i++) {
-      errorMsg += ' fulfills ' + cycleArray[i];
-    }
-    console.error(errorMsg);
-  }
-
-  /**
    * Searches cycles in the type hierarchy recursively.
    * @param {string} typeName The name of the current type being examined.
    * @param {!Set<string>} currentTraversalSet The set of all of the type types
@@ -133,7 +114,7 @@ function checkCircularDependencies(hierarchyDef) {
     visitedTypes.add(caselessName);
     if (currentTraversalSet.has(caselessName)) {
       currentTraversal.push(typeName);
-      logCycle(currentTraversal);
+      logCircularDependency(currentTraversal);
       currentTraversal.pop();
       return;
     }
@@ -165,4 +146,22 @@ function checkCircularDependencies(hierarchyDef) {
       searchForCyclesRec(type, new Set(), []);
     }
   }
+}
+
+/**
+ * Logs an informative error about a cyclic dependency.
+ * @param {!Array<string>} cycleArray An array of all the types that have been
+ *     visited since our entry node.
+ */
+function logCircularDependency(cycleArray) {
+  const lastType = cycleArray[cycleArray.length - 1].toLowerCase();
+  const index = cycleArray.findIndex((elem) => elem.toLowerCase() == lastType);
+  const firstType = cycleArray[index];
+
+  let errorMsg = `The type ${firstType} creates a circular dependency: `;
+  errorMsg += firstType;
+  for (let i = index + 1; i < cycleArray.length; i++) {
+    errorMsg += ' fulfills ' + cycleArray[i];
+  }
+  console.error(errorMsg);
 }

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -23,6 +23,7 @@ export function validateHierarchy(hierarchyDef) {
   }
 
   checkConflictingTypes(hierarchyDef);
+  checkSupersDefined(hierarchyDef);
 }
 
 /**
@@ -53,5 +54,32 @@ function checkConflictingTypes(hierarchyDef) {
 
   for (const [type, conflicts] of conflictingTypes) {
     console.error(conflictMsg, type, conflicts);
+  }
+}
+
+/**
+ * Checks the hierarchy def for any super types (eg 'fulfills': ['type]) which
+ * are not defined as top-level types.
+ * @param {!Object} hierarchyDef The definition of the type hierarchy.
+ */
+function checkSupersDefined(hierarchyDef) {
+  const errorMsg = 'The type %s says it fulfills the type %s, but that type' +
+      ' is not defined';
+
+  const types = new Set();
+  const keys = Object.keys(hierarchyDef);
+  for (const type of keys) {
+    types.add(type.toLowerCase());
+  }
+  for (const type of keys) {
+    const typeInfo = hierarchyDef[type];
+    if (!typeInfo.fulfills) {
+      continue;
+    }
+    for (const superType of typeInfo.fulfills) {
+      if (!types.has(superType.toLowerCase())) {
+        console.error(errorMsg, type, superType);
+      }
+    }
   }
 }

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * @fileoverview Defines functions for validation a type hierarchy definition.
+ * @fileoverview Defines functions for validating a type hierarchy definition.
  */
 'use strict';
 

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Unit tests for validation of a type hierarchy definition.
+ */
+
+const chai = require('chai');
+const sinon = require('sinon');
+
+const {validateHierarchy} = require('../src/hierarchy_validation.js');
+
+suite('Hierarchy Validation', function() {
+  setup(function() {
+    this.errorStub = sinon.stub(console, 'error');
+  });
+
+  teardown(function() {
+    this.errorStub.restore();
+  });
+
+  suite('Correct type', function() {
+    test('Object', function() {
+      validateHierarchy({});
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+
+    test('Undefined', function() {
+      validateHierarchy();
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(
+          'The hierarchy definition should be an object.'));
+    });
+
+    test('Array', function() {
+      validateHierarchy([]);
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(
+          'The hierarchy definition should be an object.'));
+    });
+  });
+
+  suite('Conflicts', function() {
+    setup(function() {
+      this.conflictMsg =
+          'The type name \'%s\' conflicts with the type name(s) %s';
+    });
+
+    test('No conflicts', function() {
+      validateHierarchy({
+        'typeA': { },
+        'typeB': { },
+        'typeC': { },
+      });
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+
+    test('Type conflicts once', function() {
+      validateHierarchy({
+        'typeA': { },
+        'TypeA': { },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(
+          this.conflictMsg, 'typeA', ['TypeA']));
+    });
+
+    test('Type conflicts multiple', function() {
+      validateHierarchy({
+        'typeA': { },
+        'TypeA': { },
+        'Typea': { },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(
+          this.conflictMsg, 'typeA', ['TypeA', 'Typea']));
+    });
+
+    test('Multiple conflicts', function() {
+      validateHierarchy({
+        'typeA': { },
+        'TypeA': { },
+        'typeB': { },
+        'TypeB': { },
+      });
+      chai.assert.isTrue(this.errorStub.calledTwice);
+      chai.assert.isTrue(this.errorStub.calledWith(
+          this.conflictMsg, 'typeA', ['TypeA']));
+      chai.assert.isTrue(this.errorStub.calledWith(
+          this.conflictMsg, 'typeB', ['TypeB']));
+    });
+  });
+});

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -93,4 +93,52 @@ suite('Hierarchy Validation', function() {
           this.conflictMsg, 'typeB', ['TypeB']));
     });
   });
+
+  suite('Defined supers', function() {
+    setup(function() {
+      this.errorMsg = 'The type %s says it fulfills the type %s, but that' +
+          ' type is not defined';
+    });
+
+    test('Defined before', function() {
+      validateHierarchy({
+        'typeB': { },
+        'typeA': {
+          'fulfills': ['typeB'],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+
+    test('Defined after', function() {
+      validateHierarchy({
+        'typeA': {
+          'fulfills': ['typeB'],
+        },
+        'typeB': { },
+      });
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+
+    test('Not defined', function() {
+      validateHierarchy({
+        'typeA': {
+          'fulfills': ['typeB'],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(
+          this.errorMsg, 'typeA', 'typeB'));
+    });
+
+    test('Case', function() {
+      validateHierarchy({
+        'typeB': { },
+        'typeA': {
+          'fulfills': ['TypeB'],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+  });
 });


### PR DESCRIPTION
### Description

Adds an exported function `validateHierarchy` that takes in an object an validates it. This function logs an informative error to the console using `console.error` whenever it encounters a problem with the hierarchy definition. I chose to use `console.error` rather than `throw` so that I could log multiple errors.

#### Checks
Validation currently runs three checks:
* **Conflicting types.**
  For example the following hierarchy definition:
  ```json
  {
    "typeA": { },
    "TYPEA": { }
  }
  ```
  would throw an error because the type hierarchy is caseless, which causes typeA and TYPEA to conflict.
* **Undefined supers.**
  For example the following hierarchy definition:
  ```json
  {
    "typeA": {
      "fulfills": ["typeB"]
    }
  }
  ```
  would log an error, because the super type typeB is not defined in the type hierarchy.
* **Circular dependencies.**
  For example the following hierarchy definition:
  ```json
  {
    "typeA": {
      "fulfills": ["typeB"]
    },
    "typeB": {
      "fullfills": ["typeA"]
    }
  }
  ```
  would log an error, because typeA fulfills typeB fulfills typeA, which doesn't make sense.

More checks will be added as project static becomes more complex.

### Testing

I added unit tests for all the different kinds of errors :D