### PR TITLE
Add super basic generics - project static

### DIFF
--- a/plugins/nominal-connection-checker/package-lock.json
+++ b/plugins/nominal-connection-checker/package-lock.json
@@ -4,661 +4,542 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "^7.10.4"
-      }
-    },
-    "@babel/compat-data": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.11.0.tgz",
-      "integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.12.0",
-        "invariant": "^2.2.4",
-        "semver": "^5.5.0"
-      }
-    },
-    "@babel/core": {
-      "version": "7.11.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
-      "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.6",
-        "@babel/helper-module-transforms": "^7.11.0",
-        "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.11.5",
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.11.5",
-        "@babel/types": "^7.11.5",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.2",
-        "lodash": "^4.17.19",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
-      }
-    },
-    "@babel/generator": {
-      "version": "7.11.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-      "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.11.5",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      }
-    },
-    "@babel/helper-annotate-as-pure": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
-      "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
-      "integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-compilation-targets": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
-      "integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
-      "dev": true,
-      "requires": {
-        "@babel/compat-data": "^7.10.4",
-        "browserslist": "^4.12.0",
-        "invariant": "^2.2.4",
-        "levenary": "^1.1.1",
-        "semver": "^5.5.0"
-      }
-    },
-    "@babel/helper-create-class-features-plugin": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
-      "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-member-expression-to-functions": "^7.10.5",
-        "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.10.4"
-      }
-    },
-    "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
-      "integrity": "sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
-        "@babel/helper-regex": "^7.10.4",
-        "regexpu-core": "^4.7.0"
-      }
-    },
-    "@babel/helper-define-map": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
-      "integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/types": "^7.10.5",
-        "lodash": "^4.17.19"
-      }
-    },
-    "@babel/helper-explode-assignable-expression": {
-      "version": "7.11.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
-      "integrity": "sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
-      "integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-      "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.11.0"
-      }
-    },
-    "@babel/helper-module-imports": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-      "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-module-transforms": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-      "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.10.4",
-        "@babel/helper-simple-access": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.11.0",
-        "lodash": "^4.17.19"
-      }
-    },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-      "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-plugin-utils": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+    "abab": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
+      "integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==",
       "dev": true
     },
-    "@babel/helper-regex": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
-      "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.19"
-      }
-    },
-    "@babel/helper-remap-async-to-generator": {
-      "version": "7.11.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
-      "integrity": "sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
-        "@babel/helper-wrap-function": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-      "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.10.4",
-        "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-simple-access": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-      "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
-      "dev": true,
-      "requires": {
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
-      "integrity": "sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.11.0"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.11.0"
-      }
-    },
-    "@babel/helper-validator-identifier": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+    "acorn": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
       "dev": true
     },
-    "@babel/helper-wrap-function": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
-      "integrity": "sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==",
+    "acorn-globals": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+      "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helpers": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-      "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
-      "dev": true,
-      "requires": {
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
+        "acorn": "^6.0.1",
+        "acorn-walk": "^6.0.1"
       },
       "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
+        "acorn": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+          "dev": true
         }
       }
     },
-    "@babel/parser": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+    "acorn-walk": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
     },
-    "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
-      "integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
+    "ajv": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-remap-async-to-generator": "^7.10.4",
-        "@babel/plugin-syntax-async-generators": "^7.8.0"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
-    "@babel/plugin-proposal-class-properties": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
-      "integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "safer-buffer": "~2.1.0"
       }
     },
-    "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
-      "integrity": "sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==",
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+        "tweetnacl": "^0.14.3"
       }
     },
-    "@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.10.4.tgz",
-      "integrity": "sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==",
+    "blockly": {
+      "version": "git://github.com/google/blockly.git#29269957c7cae8bd39e18b594e76844a41f582be",
+      "from": "git://github.com/google/blockly.git#develop",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+        "jsdom": "^15.2.1"
       }
     },
-    "@babel/plugin-proposal-json-strings": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
-      "integrity": "sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==",
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-json-strings": "^7.8.0"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
-    "@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.11.0.tgz",
-      "integrity": "sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==",
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+        "delayed-stream": "~1.0.0"
       }
     },
-    "@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
-      "integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cssom": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+          "dev": true
+        }
       }
     },
-    "@babel/plugin-proposal-numeric-separator": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
-      "integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+        "assert-plus": "^1.0.0"
       }
     },
-    "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
-      "integrity": "sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==",
+    "data-urls": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+      "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-transform-parameters": "^7.10.4"
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.2.0",
+        "whatwg-url": "^7.0.0"
       }
     },
-    "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
-      "integrity": "sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==",
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+        "type-detect": "^4.0.0"
       }
     },
-    "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
-      "integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+        "webidl-conversions": "^4.0.2"
       }
     },
-    "@babel/plugin-proposal-private-methods": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz",
-      "integrity": "sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==",
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
-    "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
-      "integrity": "sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==",
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
-    "@babel/plugin-syntax-async-generators": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
-    "@babel/plugin-syntax-class-properties": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-      "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "assert-plus": "^1.0.0"
       }
     },
-    "@babel/plugin-syntax-dynamic-import": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
       }
     },
-    "@babel/plugin-syntax-export-namespace-from": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
+        "whatwg-encoding": "^1.0.1"
       }
     },
-    "@babel/plugin-syntax-json-strings": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
-    "@babel/plugin-syntax-logical-assignment-operators": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "@babel/plugin-syntax-nullish-coalescing-operator": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsdom": {
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
+      "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "abab": "^2.0.0",
+        "acorn": "^7.1.0",
+        "acorn-globals": "^4.3.2",
+        "array-equal": "^1.0.0",
+        "cssom": "^0.4.1",
+        "cssstyle": "^2.0.0",
+        "data-urls": "^1.1.0",
+        "domexception": "^1.0.1",
+        "escodegen": "^1.11.1",
+        "html-encoding-sniffer": "^1.0.2",
+        "nwsapi": "^2.2.0",
+        "parse5": "5.1.0",
+        "pn": "^1.1.0",
+        "request": "^2.88.0",
+        "request-promise-native": "^1.0.7",
+        "saxes": "^3.1.9",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^3.0.1",
+        "w3c-hr-time": "^1.0.1",
+        "w3c-xmlserializer": "^1.1.2",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^7.0.0",
+        "ws": "^7.0.0",
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+          "dev": true
+        }
       }
     },
-    "@babel/plugin-syntax-numeric-separator": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
-    "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
-    "@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
+        "mime-db": "1.44.0"
       }
     },
-    "@babel/plugin-syntax-optional-chaining": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      }
+    "nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "dev": true
     },
-    "@babel/plugin-syntax-top-level-await": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
-      "integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      }
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
-    "@babel/plugin-syntax-typescript": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.4.tgz",
-      "integrity": "sha512-oSAEz1YkBCAKr5Yiq8/BNtvSAPwkp/IyUnwZogd8p+F0RuYQQrLeRUzIQhueQTTBy/F+a40uS7OFKxnkRvmvFQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      }
-    },
-    "@babel/plugin-transform-arrow-functions": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
-      "integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      }
-    },
-    "@babel/plugin-transform-async-to-generator": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
-      "integrity": "sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-remap-async-to-generator": "^7.10.4"
-      }
-    },
-    "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
-      "integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      }
-    },
-    "@babel/plugin-transform-block-scoping": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz",
-      "integrity": "sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      }
-    },
-    "@babel/plugin-transform-classes": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
-      "integrity": "sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
-        "@babel/helper-define-map": "^7.10.4",
-        "@babel/helper-function-name": "^7.10.4",
-        "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.10.4",
-        "@babel/helper-split-export-declaration": "^7.10.4",
-        "globals": "^11.1.0"
-      }
-    },
-    "@babel/plugin-transform-computed-properties": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
-      "integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      }
-    },
-    "@babel/plugin-transform-destructuring": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
-      "integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      }
-    },
-    "@babel/plugin-transform-dotall-regex": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
-      "integrity": "sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==",
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.10.4",
@@ -8202,34 +8083,239 @@
         }
       }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+    "parse5": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
       "dev": true
     },
-    "utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.19"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "saxes": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+      "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.1.1"
+      }
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+      "dev": true,
+      "requires": {
+        "ip-regex": "^2.1.0",
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
-    },
-    "v8-compile-cache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
-      "dev": true
-    },
-    "vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {
@@ -8242,12 +8328,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
-    },
-    "vm-browserify": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
-      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
-      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -8269,567 +8349,10 @@
         "xml-name-validator": "^3.0.0"
       }
     },
-    "watchpack": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
-      "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
-      "dev": true,
-      "requires": {
-        "chokidar": "^3.4.1",
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.0"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "chokidar": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-          "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "anymatch": "~3.1.1",
-            "braces": "~3.0.2",
-            "fsevents": "~2.1.2",
-            "glob-parent": "~5.1.0",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.4.0"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true,
-          "optional": true
-        },
-        "readdirp": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "picomatch": "^2.2.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
-      }
-    },
-    "watchpack-chokidar2": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
-      "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "chokidar": "^2.1.8"
-      },
-      "dependencies": {
-        "anymatch": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
-          },
-          "dependencies": {
-            "normalize-path": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "remove-trailing-separator": "^1.0.1"
-              }
-            }
-          }
-        },
-        "binary-extensions": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-          "dev": true,
-          "optional": true
-        },
-        "chokidar": {
-          "version": "2.1.8",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.1",
-            "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.3",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^3.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.2.1",
-            "upath": "^1.1.1"
-          }
-        },
-        "fsevents": {
-          "version": "1.2.13",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "dev": true,
-          "optional": true
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "is-extglob": "^2.1.0"
-              }
-            }
-          }
-        },
-        "is-binary-path": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "binary-extensions": "^1.0.0"
-          }
-        },
-        "readdirp": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "micromatch": "^3.1.10",
-            "readable-stream": "^2.0.2"
-          }
-        }
-      }
-    },
-    "wbuf": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
-      "dev": true,
-      "requires": {
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "webpack": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
-      "integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-module-context": "1.9.0",
-        "@webassemblyjs/wasm-edit": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "acorn": "^6.4.1",
-        "ajv": "^6.10.2",
-        "ajv-keywords": "^3.4.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.3.0",
-        "eslint-scope": "^4.0.3",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.4.0",
-        "loader-utils": "^1.2.3",
-        "memory-fs": "^0.4.1",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.3",
-        "neo-async": "^2.6.1",
-        "node-libs-browser": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.7.4",
-        "webpack-sources": "^1.4.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
-          "dev": true
-        },
-        "eslint-scope": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        }
-      }
-    },
-    "webpack-cli": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.12.tgz",
-      "integrity": "sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.2",
-        "cross-spawn": "^6.0.5",
-        "enhanced-resolve": "^4.1.1",
-        "findup-sync": "^3.0.0",
-        "global-modules": "^2.0.0",
-        "import-local": "^2.0.0",
-        "interpret": "^1.4.0",
-        "loader-utils": "^1.4.0",
-        "supports-color": "^6.1.0",
-        "v8-compile-cache": "^2.1.1",
-        "yargs": "^13.3.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "webpack-dev-middleware": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
-      "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
-      "dev": true,
-      "requires": {
-        "memory-fs": "^0.4.1",
-        "mime": "^2.4.4",
-        "mkdirp": "^0.5.1",
-        "range-parser": "^1.2.1",
-        "webpack-log": "^2.0.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-          "dev": true
-        }
-      }
-    },
-    "webpack-dev-server": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz",
-      "integrity": "sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==",
-      "dev": true,
-      "requires": {
-        "ansi-html": "0.0.7",
-        "bonjour": "^3.5.0",
-        "chokidar": "^2.1.8",
-        "compression": "^1.7.4",
-        "connect-history-api-fallback": "^1.6.0",
-        "debug": "^4.1.1",
-        "del": "^4.1.1",
-        "express": "^4.17.1",
-        "html-entities": "^1.3.1",
-        "http-proxy-middleware": "0.19.1",
-        "import-local": "^2.0.0",
-        "internal-ip": "^4.3.0",
-        "ip": "^1.1.5",
-        "is-absolute-url": "^3.0.3",
-        "killable": "^1.0.1",
-        "loglevel": "^1.6.8",
-        "opn": "^5.5.0",
-        "p-retry": "^3.0.1",
-        "portfinder": "^1.0.26",
-        "schema-utils": "^1.0.0",
-        "selfsigned": "^1.10.7",
-        "semver": "^6.3.0",
-        "serve-index": "^1.9.1",
-        "sockjs": "0.3.20",
-        "sockjs-client": "1.4.0",
-        "spdy": "^4.0.2",
-        "strip-ansi": "^3.0.1",
-        "supports-color": "^6.1.0",
-        "url": "^0.11.0",
-        "webpack-dev-middleware": "^3.7.2",
-        "webpack-log": "^2.0.0",
-        "ws": "^6.2.1",
-        "yargs": "^13.3.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "anymatch": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-          "dev": true,
-          "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
-          },
-          "dependencies": {
-            "normalize-path": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-              "dev": true,
-              "requires": {
-                "remove-trailing-separator": "^1.0.1"
-              }
-            }
-          }
-        },
-        "binary-extensions": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-          "dev": true
-        },
-        "chokidar": {
-          "version": "2.1.8",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-          "dev": true,
-          "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.1",
-            "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.3",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^3.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.2.1",
-            "upath": "^1.1.1"
-          }
-        },
-        "fsevents": {
-          "version": "1.2.13",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "dev": true,
-          "optional": true
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^2.1.0"
-              }
-            }
-          }
-        },
-        "is-binary-path": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-          "dev": true,
-          "requires": {
-            "binary-extensions": "^1.0.0"
-          }
-        },
-        "readdirp": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "micromatch": "^3.1.10",
-            "readable-stream": "^2.0.2"
-          }
-        },
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "webpack-log": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
-      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "^3.0.0",
-        "uuid": "^3.3.2"
-      }
-    },
-    "webpack-sources": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-      "dev": true,
-      "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "websocket-driver": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-      "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-      "dev": true,
-      "requires": {
-        "websocket-extensions": ">=0.1.1"
-      }
-    },
-    "websocket-extensions": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
-      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
     "whatwg-encoding": {
@@ -8858,146 +8381,11 @@
         "webidl-conversions": "^4.0.2"
       }
     },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
-    },
-    "worker-farm": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
-      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
-      "dev": true,
-      "requires": {
-        "errno": "~0.1.7"
-      }
-    },
-    "worker-rpc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.1.1.tgz",
-      "integrity": "sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==",
-      "dev": true,
-      "requires": {
-        "microevent.ts": "~0.1.1"
-      }
-    },
-    "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "dependencies": {
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        }
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "write": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^0.5.1"
-      }
-    },
-    "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "dev": true,
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -9010,88 +8398,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
-    },
-    "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
-    },
-    "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-      "dev": true,
-      "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
-      },
-      "dependencies": {
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
-    "yargs-unparser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
-      "dev": true,
-      "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
-      }
     }
   }
 }

--- a/plugins/nominal-connection-checker/package.json
+++ b/plugins/nominal-connection-checker/package.json
@@ -61,5 +61,6 @@
     "defaults",
     "IE 11",
     "IE_Mob 11"
-  ]
+  ],
+  "dependencies": {}
 }

--- a/plugins/nominal-connection-checker/src/generic_map.js
+++ b/plugins/nominal-connection-checker/src/generic_map.js
@@ -36,8 +36,6 @@ export class GenericMap {
    *     to.
    */
   constructor(workspace) {
-    // TODO: Move to maps.
-
     /**
      * The workspace this GenericMap belongs to.
      * @type {!Blockly.Workspace}

--- a/plugins/nominal-connection-checker/src/generic_map.js
+++ b/plugins/nominal-connection-checker/src/generic_map.js
@@ -26,6 +26,18 @@ export const INPUT_PRIORITY = 100;
 export const OUTPUT_PRIORITY = 200;
 
 /**
+ * The minimum priority that can/should be passed to the GenericMap.
+ * @type {number}
+ */
+export const MIN_PRIORITY = 0;
+
+/**
+ * The maximum priority that can/should be passed to the GenericMap.
+ * @type {number}
+ */
+export const MAX_PRIORITY = Number.MAX_SAFE_INTEGER;
+
+/**
  * Defines a map where generic types can be bound to explicit types in
  * a given environment.
  */

--- a/plugins/nominal-connection-checker/src/generic_map.js
+++ b/plugins/nominal-connection-checker/src/generic_map.js
@@ -1,0 +1,239 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Defines the GenericMap.
+ */
+'use strict';
+
+import {PriorityQueueMap} from './priority_queue_map';
+
+/**
+ * The priority for binding an explicit type to a generic type based on an input
+ * of the block with the generic type.
+ * @type {number}
+ */
+export const INPUT_PRIORITY = 100;
+
+/**
+ * The priority for binding an explicit type to a generic type based on the
+ * output of the block with the generic type.
+ * @type {number}
+ */
+export const OUTPUT_PRIORITY = 200;
+
+/**
+ * Defines a map where generic types can be bound to explicit types in
+ * a given environment.
+ */
+export class GenericMap {
+  /**
+   * Constructs the GenericMap.
+   * @param {!Blockly.Workspace} workspace The workspace this GenericMap belongs
+   *     to.
+   */
+  constructor(workspace) {
+    // TODO: Move to maps.
+
+    /**
+     * The workspace this GenericMap belongs to.
+     * @type {!Blockly.Workspace}
+     * @private
+     */
+    this.workspace_ = workspace;
+
+    /**
+     * Map of block ids to PriorityQueMaps that define what the generic types
+     * of the block are bound to.
+     * @type {!Map<string, !PriorityQueueMap>}
+     * @private
+     */
+    this.dependenciesMap_ = new Map();
+
+    /**
+     * Map of block ids to objects that map generic type names to arrays of
+     * DependerInfo specifying what other blocks and generic types on those
+     * blocks depend on the generic type of the lookup block.
+     * @type {!Map<string, !Map<string, !Array<DependerInfo>>>}
+     * @private
+     */
+    this.dependersMap_ = new Map();
+  }
+
+  /**
+   * Returns the name of the explicit type bound to the generic type in the
+   * context of the given block, or undefined if the type is not bound.
+   * @param {string} blockId The block id that the generic type is
+   *     possibly bound in.
+   * @param {string} genericType The generic type to find the explicit binding
+   *     of.
+   * @return {undefined|string} The name of the explicit type bound to the
+   *     generic type in the context of the given block, or undefined if the
+   *     type is not bound.
+   */
+  getExplicitType(blockId, genericType) {
+    const priorityMap = this.dependenciesMap_.get(blockId);
+    if (!priorityMap) {
+      return undefined;
+    }
+    const types = priorityMap.getValues(genericType);
+    if (!types) {
+      return undefined;
+    }
+    // In the future we might add logic to figure out what the super type of all
+    // of the types is. But for now there should only be one type bound anyway.
+    return types[0];
+  }
+
+  /**
+   * Binds the given dependerType name to the dependencyType's explicit type in
+   * the context of the dependerId. Should only be called if the dependencyType
+   * is currently bound to an explicit type in the context of its block.
+   * Also associates info about the depender with the dependency so that
+   * dependers can be easily removed if the dependency block ever looses its
+   * explicit type.
+   * @param {string} dependerId The id of the block that is depending on the
+   *     dependency block.
+   * @param {string} dependerType The name of the generic type in the depender
+   *     block that we want to bind to the other type in the dependency block.
+   * @param {string} dependencyId The id of the block that the depender block
+   *     is depending on.
+   * @param {string} dependencyType The name of the generic type in the
+   *     dependency block that we want to bind the dependerType to.
+   * @param {number} priority The priority of the binding. Higher priority
+   *     bindings override lower priority bindings.
+   */
+  bindTypeToGeneric(
+      dependerId, dependerType, dependencyId, dependencyType, priority) {
+    if (!this.workspace_.getBlockById(dependerId)) {
+      throw Error(
+          'The depender id (' + dependerId + ') is not a valid block id');
+    }
+    if (!this.workspace_.getBlockById(dependencyId)) {
+      throw Error(
+          'The dependency id (' + dependencyId + ') is not a valid block id');
+    }
+
+    const explicitType = this.getExplicitType(dependencyId, dependencyType);
+    if (!explicitType) {
+      throw Error('The type ' + dependencyType + ' on block ' + dependencyId +
+          ' is not bound to an explicit type. The generic type must be bound' +
+          ' before another generic type can bind to it.');
+    }
+    this.bindTypeToExplicit(dependerId, dependerType, explicitType, priority);
+
+    let types = this.dependersMap_.get(dependencyId);
+    if (!types) {
+      types = new Map();
+      this.dependersMap_.set(dependencyId, types);
+    }
+    let dependers = types.get(dependencyType);
+    if (!dependers) {
+      dependers = [];
+      types.set(dependencyType, dependers);
+    }
+    dependers.push(new DependerInfo(dependerId, dependerType, dependencyType));
+  }
+
+  /**
+   * Binds the given genericType name to the explicitType name in the context
+   * of the blockId.
+   * @param {string} blockId The id of the block to bind the genericType within.
+   * @param {string} genericType The name of the generic type that we want to
+   *     bind to the explicit type.
+   * @param {string} explicitType The name of the explicit type we want to bind
+   *     the generic type to.
+   * @param {number} priority The priority of the binding. Higher priority
+   *     bindings ovveride lower priority bindings.
+   */
+  bindTypeToExplicit(blockId, genericType, explicitType, priority) {
+    let queueMap = this.dependenciesMap_.get(blockId);
+    if (!queueMap) {
+      queueMap = new PriorityQueueMap();
+      this.dependenciesMap_.set(blockId, queueMap);
+    }
+    queueMap.bind(genericType, explicitType, priority);
+
+    // TODO: Flow through all other connections if necessary.
+    //   Make sure to update them if we get a higher priority binding.
+  }
+
+  /**
+   * Unbinds the given dependerType name from the dependencyType's explicit type
+   * in the context of the dependerId.
+   * Also de-associates info about the depender from the dependency.
+   * @param {string} dependerId The id of the block that is depending on the
+   *     dependency block.
+   * @param {string} dependerType The name of the generic type in the depender
+   *     block that we want to unbind from the other type on in the dependency
+   *     block.
+   * @param {string} dependencyId The id of the block that the depender block
+   *     was depending on.
+   * @param {string} dependencyType The name of the generic type in the
+   *     dependency block that we want to unbind the dependerType from.
+   * @param {number} priority The priority of the binding to remove.
+   */
+  unbindTypeFromGeneric(
+      dependerId, dependerType, dependencyId, dependencyType, priority) {
+    const types = this.dependersMap_.get(dependencyId);
+    if (!types) {
+      return;
+    }
+    const dependers = types.get(dependencyType);
+    if (!dependers) {
+      return;
+    }
+    const index = dependers.findIndex((elem) => {
+      return elem.blockId == dependerId &&
+          elem.dependerType == dependerType &&
+          elem.dependencyType == dependencyType;
+    });
+    if (index != -1) {
+      const explicitType = this.getExplicitType(dependencyId, dependencyType);
+      this.unbindTypeFromExplicit(
+          dependerId, dependerType, explicitType, priority);
+      dependers.splice(index, 1);
+    }
+  }
+
+  /**
+   * Unbinds the given generic type name from the explicit type name in the
+   * context of the blockId.
+   * @param {string} blockId The the block to unbind the types in.
+   * @param {string} genericType The name of the generic type to unbind from the
+   *     explicit type.
+   * @param {string} explicitType The name of the explicit type to unbind from
+   *     the generic type.
+   * @param {number} priority The priority of the binding to remove.
+   */
+  unbindTypeFromExplicit(blockId, genericType, explicitType, priority) {
+    if (this.dependenciesMap_.has(blockId)) {
+      this.dependenciesMap_.get(blockId).unbind(
+          genericType, explicitType, priority);
+    }
+    // TODO: Flow through all other connections.
+  }
+}
+
+/**
+ * A class containing info about a depender. Used to tell the depender to stop
+ * depending on the block it is depending on.
+ */
+class DependerInfo {
+  /**
+   * Constructs a DependerInfo.
+   * @param {string} blockId The id of the depender block.
+   * @param {string} dependerType The type on the depender block that is
+   *     depending on a generic type on another block.
+   * @param {string} dependencyType The generic type on the other block that the
+   *     dependerType is depending on.
+   */
+  constructor(blockId, dependerType, dependencyType) {
+    this.blockId = blockId;
+    this.dependerType = dependerType;
+    this.dependencyType = dependencyType;
+  }
+}

--- a/plugins/nominal-connection-checker/src/index.js
+++ b/plugins/nominal-connection-checker/src/index.js
@@ -60,7 +60,6 @@ export class NominalConnectionChecker extends Blockly.ConnectionChecker {
    */
   init(hierarchyDef) {
     this.typeHierarchy_ = new TypeHierarchy(hierarchyDef);
-    // TODO: Check if we need to release this.
     this.workspace_.addChangeListener(this.onChangeListener_.bind(this));
   }
 

--- a/plugins/nominal-connection-checker/src/index.js
+++ b/plugins/nominal-connection-checker/src/index.js
@@ -217,8 +217,7 @@ export class NominalConnectionChecker extends Blockly.ConnectionChecker {
    */
   isGeneric_(connection) {
     const check = this.getCheck_(connection);
-    return check.length == 1 && check == check.toUpperCase() &&
-        check != check.toLowerCase();
+    return typeof check == 'string' && check.length == 1;
   }
 
   /**

--- a/plugins/nominal-connection-checker/src/index.js
+++ b/plugins/nominal-connection-checker/src/index.js
@@ -11,6 +11,7 @@
 
 import * as Blockly from 'blockly/core';
 import {TypeHierarchy} from './type_hierarchy';
+import {GenericMap, INPUT_PRIORITY, OUTPUT_PRIORITY} from './generic_map';
 
 // TODO: Fix the version of Blockly being required in package.json.
 
@@ -22,9 +23,18 @@ import {TypeHierarchy} from './type_hierarchy';
 export class NominalConnectionChecker extends Blockly.ConnectionChecker {
   /**
    * Constructs the connection checker.
+   * @param {!Blockly.Workspace} workspace The workspace this connection checker
+   *     belongs to.
    */
-  constructor() {
+  constructor(workspace) {
     super();
+
+    /**
+     * The workspace this connection checker belongs to.
+     * @type {!Blockly.Workspace}
+     * @private
+     */
+    this.workspace_ = workspace;
 
     /**
      * The type hierarchy used by this connection checker. Defines which types
@@ -33,6 +43,14 @@ export class NominalConnectionChecker extends Blockly.ConnectionChecker {
      * @private
      */
     this.typeHierarchy_ = null;
+
+    /**
+     * The generic map used by this connection checker. Used to bind generic
+     * types to explicit types within the context of blocks.
+     * @type {!GenericMap}
+     * @private
+     */
+    this.genericMap_ = new GenericMap(workspace);
   }
 
   /**
@@ -42,6 +60,8 @@ export class NominalConnectionChecker extends Blockly.ConnectionChecker {
    */
   init(hierarchyDef) {
     this.typeHierarchy_ = new TypeHierarchy(hierarchyDef);
+    // TODO: Check if we need to release this.
+    this.workspace_.addChangeListener(this.onChangeListener_.bind(this));
   }
 
   /**
@@ -49,12 +69,90 @@ export class NominalConnectionChecker extends Blockly.ConnectionChecker {
    */
   doTypeChecks(a, b) {
     const {parent, child} = this.getParentAndChildConnections_(a, b);
-    // Checks should only contain a single type.
-    const parentType = parent.getCheck()[0];
-    const childType = child.getCheck()[0];
+    const parentType = this.getExplicitType_(parent);
+    const childType = this.getExplicitType_(child);
     const typeHierarchy = this.getTypeHierarchy_();
 
+    if (!parentType || !childType) {
+      // At least one is an unbound generic.
+      return true;
+    }
     return typeHierarchy.typeFulfillsType(childType, parentType);
+  }
+
+  /**
+   * Listens to changes on the workspace, and handles things like binding and
+   * unbinding generic types to explicit types.
+   * @param {!Blockly.Event} e The current event.
+   * @private
+   */
+  onChangeListener_(e) {
+    if (e.type != Blockly.Events.BLOCK_MOVE) {
+      return;
+    }
+
+    const childBlock = this.workspace_.getBlockById(e.blockId);
+    const childCon = childBlock.outputConnection;
+    if (!childCon) {
+      // Ignore statement blocks for now;
+      return;
+    }
+
+    const genericMap = this.getGenericMap();
+    let parentBlock;
+    let parentCon;
+    let explicitFn;
+    let genericFn;
+    if (e.newParentId) {
+      parentBlock = this.workspace_.getBlockById(e.newParentId);
+      parentCon = parentBlock.getInput(e.newInputName).connection;
+      explicitFn = GenericMap.prototype.bindTypeToExplicit.bind(genericMap);
+      genericFn = GenericMap.prototype.bindTypeToGeneric.bind(genericMap);
+    } else if (e.oldParentId) {
+      parentBlock = this.workspace_.getBlockById(e.oldParentId);
+      parentCon = parentBlock.getInput(e.oldInputName).connection;
+      explicitFn = GenericMap.prototype.unbindTypeFromExplicit.bind(genericMap);
+      genericFn = GenericMap.prototype.unbindTypeFromGeneric.bind(genericMap);
+    } else {
+      return;
+    }
+
+    const childCheck = this.getCheck_(childCon);
+    const parentCheck = this.getCheck_(parentCon);
+    if (this.isExplicit_(parentCon)) {
+      if (this.isGeneric_(childCon)) {
+        explicitFn(childBlock.id, childCheck, parentCheck, OUTPUT_PRIORITY);
+      }
+    } else if (this.isExplicit_(childCon)) {
+      explicitFn(parentBlock.id, parentCheck, childCheck, INPUT_PRIORITY);
+    } else {
+      const parentIsBound = !!this.getBoundType_(parentCon);
+      const childIsBound = !!this.getBoundType_(childCon);
+      if (parentIsBound) {
+        genericFn(
+            childBlock.id,
+            childCheck,
+            parentBlock.id,
+            parentCheck,
+            OUTPUT_PRIORITY);
+      }
+      if (childIsBound) {
+        genericFn(
+            parentBlock.id,
+            parentCheck,
+            childBlock.id,
+            childCheck,
+            INPUT_PRIORITY);
+      }
+    }
+  }
+
+  /**
+   * Returns the GenericMap of this connection checker.
+   * @return {!GenericMap} The GenericMap of this connection checker.
+   */
+  getGenericMap() {
+    return this.genericMap_;
   }
 
   /**
@@ -94,6 +192,78 @@ export class NominalConnectionChecker extends Blockly.ConnectionChecker {
         child: a,
       };
     }
+  }
+
+  /**
+   * Returns the type name (which could be generic) associated with the
+   * connection.
+   * @param {!Blockly.Connection} connection The connection to find the check
+   *     of.
+   * @return {string} The type name associated with the connection.
+   * @private
+   */
+  getCheck_(connection) {
+    return connection.getCheck()[0];
+  }
+
+  /**
+   * Returns true if the connection has a generic connection check. False
+   * otherwise.
+   * @param {!Blockly.Connection} connection The connection to check for
+   *     generic-ness.
+   * @return {boolean} True if the connection has a generic connection check.
+   *     False otherwise.
+   * @private
+   */
+  isGeneric_(connection) {
+    const check = this.getCheck_(connection);
+    return check.length == 1 && check == check.toUpperCase() &&
+        check != check.toLowerCase();
+  }
+
+  /**
+   * Returns true if the connection has an explicit connection check. False
+   * otherwise.
+   * @param {!Blockly.Connection} connection The connection check to check for
+   *     explicit-ness.
+   * @return {boolean} True if the connection has an explicit connection check.
+   *     False otherwise.
+   * @private
+   */
+  isExplicit_(connection) {
+    return !this.isGeneric_(connection);
+  }
+
+  /**
+   * Returns the explicit type bound to the connection's connection check if one
+   * exists. This will return undefined if the connection's connection check is
+   * explicit, or if it is generic and not bound.
+   * @param {!Blockly.Connection} connection The connection to get the bound
+   *     type of.
+   * @return {undefined|string} The explicit type bound to the connection's
+   *     connection check if one exists.
+   * @private
+   */
+  getBoundType_(connection) {
+    return this.getGenericMap().getExplicitType(
+        connection.getSourceBlock().id, this.getCheck_(connection));
+  }
+
+  /**
+   * Returns the explicit type of the connection. If the connection's check is
+   * explicit, this just returns that. If the connection's check is generic it
+   * returns the type bound to its generic check, if it exists. If it does not
+   * exist this returns undefined.
+   * @param {!Blockly.Connection} connection The connection to get the explicit
+   *     type of.
+   * @return {undefined|string} The explicit type, if one exists.
+   * @private
+   */
+  getExplicitType_(connection) {
+    const typeName = this.getCheck_(connection);
+    return this.isExplicit_(connection) ? typeName :
+        this.getGenericMap().getExplicitType(
+            connection.getSourceBlock().id, typeName);
   }
 }
 

--- a/plugins/nominal-connection-checker/src/priority_que_map.js
+++ b/plugins/nominal-connection-checker/src/priority_que_map.js
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Defines the PriorityQueueMap and its helper prototypes.
+ */
+'use strict';
+
+/**
+ * A map where keys can be bound to multiple values, which are given a priority.
+ * When you get the value of a key it returns all of the values with the highest
+ * priority.
+ */
+export class PriorityQueueMap {
+  /**
+   * Constructs the PriorityQueueMap.
+   */
+  constructor() {
+    /**
+     * Maps the keys to an array of Bindings.
+     * @type {!Object<*, !Array<Binding>>}
+     * @private
+     */
+    this.map_ = Object.create(null);
+  }
+
+  /**
+   * Returns the highest priority values for the given key. Or undefined if the
+   * key is not bound.
+   * @param {*} key The key to find the value of.
+   * @return {undefined|!Array<*>} The highest priority values for the given
+   *     key. Or undefined if the key is not bound.
+   */
+  getValues(key) {
+    const bindings = this.getBindings(key);
+    return bindings && bindings.map((binding) => binding.value);
+  }
+
+  /**
+   * Returns the highest priority Bindings for the given key. Or undefined if
+   * the key is not bound.
+   * @param {*} key The key to find the binding of.
+   * @return {undefined|!Array<!Binding>} The highest priority Bindings for the
+   *     given key. Or undefined if the key is not bound.
+   */
+  getBindings(key) {
+    const bindings = this.map_[key];
+    if (!bindings) {
+      return undefined;
+    }
+    let highestBindings = [bindings[0]];
+    let highestPriority = bindings[0].priority;
+    for (let i = 1, binding; (binding = bindings[i]); i++) {
+      if (binding.priority > highestPriority) {
+        highestPriority = binding.priority;
+        highestBindings = [binding];
+      } else if (binding.priority == highestPriority) {
+        highestBindings.push(binding);
+      }
+    }
+    return highestBindings;
+  }
+
+  /**
+   * Adds the given value with the associated priority to the key's priority
+   * queue of values.
+   * @param {*} key The key to bind the value to.
+   * @param {*} value The value to bind to the key.
+   * @param {number} priority The priority of the binding.
+   */
+  bind(key, value, priority) {
+    if (!this.map_[key]) {
+      this.map_[key] = [];
+    }
+    this.map_[key].push(new Binding(value, priority));
+  }
+
+  /**
+   * Removes the given value with the associated priority from the key's
+   * priority queue of values.
+   * @param {*} key The key to unbind the value from.
+   * @param {*} value The value to unbind from the key.
+   * @param {number} priority The priority of the binding.
+   */
+  unBind(key, value, priority) {
+    const bindings = this.map_[key];
+    if (!bindings) {
+      return;
+    }
+    const index = bindings.findIndex((binding) =>
+      binding.value == value && binding.priority == priority);
+    bindings.splice(index, 1);
+  }
+}
+
+/**
+ * Represents a value with the given priority for use in the PriorityQueueMap.
+ */
+class Binding {
+  /**
+   * Constructs the binding object.
+   * @param {*} value The value of the binding.
+   * @param {number} priority The priority of the binding.
+   */
+  constructor(value, priority) {
+    this.value = value;
+    this.priority = priority;
+  }
+}

--- a/plugins/nominal-connection-checker/src/priority_queue_map.js
+++ b/plugins/nominal-connection-checker/src/priority_queue_map.js
@@ -21,10 +21,10 @@ export class PriorityQueueMap {
   constructor() {
     /**
      * Maps the keys to an array of Bindings.
-     * @type {!Object<*, !Array<Binding>>}
+     * @type {!Map<*, !Array<Binding>>}
      * @private
      */
-    this.map_ = Object.create(null);
+    this.map_ = new Map();
   }
 
   /**
@@ -47,7 +47,7 @@ export class PriorityQueueMap {
    *     given key. Or undefined if the key is not bound.
    */
   getBindings(key) {
-    const bindings = this.map_[key];
+    const bindings = this.map_.get(key);
     if (!bindings || !bindings.length) {
       return undefined;
     }
@@ -72,10 +72,12 @@ export class PriorityQueueMap {
    * @param {number} priority The priority of the binding.
    */
   bind(key, value, priority) {
-    if (!this.map_[key]) {
-      this.map_[key] = [];
+    let bindings = this.map_.get(key);
+    if (!bindings) {
+      bindings = [];
+      this.map_.set(key, bindings);
     }
-    this.map_[key].push(new Binding(value, priority));
+    bindings.push(new Binding(value, priority));
   }
 
   /**
@@ -86,7 +88,7 @@ export class PriorityQueueMap {
    * @param {number} priority The priority of the binding.
    */
   unbind(key, value, priority) {
-    const bindings = this.map_[key];
+    const bindings = this.map_.get(key);
     if (!bindings) {
       return;
     }

--- a/plugins/nominal-connection-checker/src/priority_queue_map.js
+++ b/plugins/nominal-connection-checker/src/priority_queue_map.js
@@ -85,14 +85,16 @@ export class PriorityQueueMap {
    * @param {*} value The value to unbind from the key.
    * @param {number} priority The priority of the binding.
    */
-  unBind(key, value, priority) {
+  unbind(key, value, priority) {
     const bindings = this.map_[key];
     if (!bindings) {
       return;
     }
     const index = bindings.findIndex((binding) =>
-      binding.value == value && binding.priority == priority);
-    bindings.splice(index, 1);
+      binding.value === value && binding.priority === priority);
+    if (index != -1) {
+      bindings.splice(index, 1);
+    }
   }
 }
 
@@ -106,6 +108,10 @@ class Binding {
    * @param {number} priority The priority of the binding.
    */
   constructor(value, priority) {
+    // We cannot allow stringified numbers because we do comparison tests.
+    if (isNaN(priority) || typeof priority != 'number') {
+      throw Error('A binding\'s priority must be a number.');
+    }
     this.value = value;
     this.priority = priority;
   }

--- a/plugins/nominal-connection-checker/src/priority_queue_map.js
+++ b/plugins/nominal-connection-checker/src/priority_queue_map.js
@@ -48,7 +48,7 @@ export class PriorityQueueMap {
    */
   getBindings(key) {
     const bindings = this.map_[key];
-    if (!bindings) {
+    if (!bindings || !bindings.length) {
       return undefined;
     }
     let highestBindings = [bindings[0]];

--- a/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
@@ -9,9 +9,11 @@
  */
 
 const chai = require('chai');
+const sinon = require('sinon');
 const Blockly = require('blockly/node');
 
 const {pluginInfo} = require('../src/index.js');
+const {INPUT_PRIORITY, OUTPUT_PRIORITY} = require('../src/generic_map.js');
 
 suite('NominalConnectionChecker', function() {
   setup(function() {
@@ -26,6 +28,12 @@ suite('NominalConnectionChecker', function() {
         'type': 'static_mammal',
         'message0': 'Mammal',
         'output': ['Mammal'],
+        'style': 'math_blocks',
+      },
+      {
+        'type': 'static_reptile',
+        'message0': 'Reptile',
+        'output': ['Reptile'],
         'style': 'math_blocks',
       },
       {
@@ -88,6 +96,42 @@ suite('NominalConnectionChecker', function() {
         ],
         'style': 'math_blocks',
       },
+      {
+        'type': 'static_identity',
+        'message0': 'Identity %1',
+        'args0': [
+          {
+            'type': 'input_value',
+            'name': 'INPUT',
+            'check': 'T',
+          },
+        ],
+        'output': ['T'],
+        'style': 'text_blocks',
+      },
+      {
+        'type': 'static_select_random',
+        'message0': 'Select Random %1 %2 %3',
+        'args0': [
+          {
+            'type': 'input_value',
+            'name': 'INPUT',
+            'check': 'T',
+          },
+          {
+            'type': 'input_value',
+            'name': 'INPUT2',
+            'check': 'T',
+          },
+          {
+            'type': 'input_value',
+            'name': 'INPUT3',
+            'check': 'T',
+          },
+        ],
+        'output': ['T'],
+        'style': 'text_blocks',
+      },
     ]);
 
     const hierarchyDef = {
@@ -98,6 +142,9 @@ suite('NominalConnectionChecker', function() {
         'fulfills': ['Animal'],
       },
       'Mammal': {
+        'fulfills': ['Animal'],
+      },
+      'Reptile': {
         'fulfills': ['Animal'],
       },
       'Dog': {
@@ -117,77 +164,664 @@ suite('NominalConnectionChecker', function() {
     this.workspace = new Blockly.Workspace(options);
     this.workspace.connectionChecker.init(hierarchyDef);
     this.checker = this.workspace.connectionChecker;
+    this.genericMap = this.checker.getGenericMap();
 
     this.getBlockOutput = function(blockType) {
-      return this.workspace.newBlock(blockType).outputConnection;
+      const block = this.workspace.newBlock(blockType);
+      return [
+        block.outputConnection,
+        block.id,
+        block,
+      ];
     };
     this.getBlockInput = function(blockType) {
-      return this.workspace.newBlock(blockType).getInput('INPUT').connection;
+      const block = this.workspace.newBlock(blockType);
+      return [
+        block.getInput('INPUT').connection,
+        block.id,
+        block,
+      ];
+    };
+
+    this.assertCanConnect = function(conn1, conn2) {
+      chai.assert.isTrue(this.checker.doTypeChecks(conn1, conn2));
+    };
+    this.assertCannotConnect = function(conn1, conn2) {
+      chai.assert.isFalse(this.checker.doTypeChecks(conn1, conn2));
     };
   });
 
   teardown(function() {
     delete Blockly.Blocks['static_animal'];
     delete Blockly.Blocks['static_mammal'];
+    delete Blockly.Blocks['static_reptile'];
     delete Blockly.Blocks['static_dog'];
     delete Blockly.Blocks['static_bat'];
     delete Blockly.Blocks['static_weigh_animal'];
     delete Blockly.Blocks['static_milk_mammal'];
     delete Blockly.Blocks['static_train_dog'];
     delete Blockly.Blocks['static_launch_flying'];
+    delete Blockly.Blocks['static_identity'];
+    delete Blockly.Blocks['static_select_random'];
   });
 
   suite('Simple subtyping', function() {
     test('Exact types', function() {
-      const dogOut = this.getBlockOutput('static_dog');
-      const trainDogIn = this.getBlockInput('static_train_dog');
-      chai.assert.isTrue(this.checker.doTypeChecks(dogOut, trainDogIn));
+      const [dogOut] = this.getBlockOutput('static_dog');
+      const [trainDogIn] = this.getBlockInput('static_train_dog');
+      this.assertCanConnect(dogOut, trainDogIn);
     });
 
     test('Simple super', function() {
-      const dogOut = this.getBlockOutput('static_dog');
-      const milkMammalIn = this.getBlockInput('static_milk_mammal');
-      chai.assert.isTrue(this.checker.doTypeChecks(dogOut, milkMammalIn));
+      const [dogOut] = this.getBlockOutput('static_dog');
+      const [milkMammalIn] = this.getBlockInput('static_milk_mammal');
+      this.assertCanConnect(dogOut, milkMammalIn);
     });
 
     test('Multiple supers', function() {
-      const batOut = this.getBlockOutput('static_bat');
-      const milkMammalIn = this.getBlockInput('static_milk_mammal');
-      const launchFlyingIn = this.getBlockInput('static_launch_flying');
-      chai.assert.isTrue(this.checker.doTypeChecks(batOut, milkMammalIn));
-      chai.assert.isTrue(this.checker.doTypeChecks(batOut, launchFlyingIn));
+      const [batOut] = this.getBlockOutput('static_bat');
+      const [milkMammalIn] = this.getBlockInput('static_milk_mammal');
+      const [launchFlyingIn] = this.getBlockInput('static_launch_flying');
+      this.assertCanConnect(batOut, milkMammalIn);
+      this.assertCanConnect(batOut, launchFlyingIn);
     });
 
     test('Deep supers', function() {
-      const dogOut = this.getBlockOutput('static_dog');
-      const weighAnimalIn = this.getBlockInput('static_weigh_animal');
-      chai.assert.isTrue(this.checker.doTypeChecks(dogOut, weighAnimalIn));
+      const [dogOut] = this.getBlockOutput('static_dog');
+      const [weighAnimalIn] = this.getBlockInput('static_weigh_animal');
+      this.assertCanConnect(dogOut, weighAnimalIn);
     });
 
     test('Multiple output checks', function() {
-      const dogOut = this.getBlockOutput('static_dog');
+      const [dogOut] = this.getBlockOutput('static_dog');
       dogOut.setCheck(['Random', 'Dog']);
-      const trainDogIn = this.getBlockInput('static_train_dog');
-      chai.assert.isFalse(this.checker.doTypeChecks(dogOut, trainDogIn));
+      const [trainDogIn] = this.getBlockInput('static_train_dog');
+      this.assertCannotConnect(dogOut, trainDogIn);
     });
 
     test('Multiple input checks', function() {
-      const dogOut = this.getBlockOutput('static_dog');
-      const trainDogIn = this.getBlockInput('static_train_dog');
+      const [dogOut] = this.getBlockOutput('static_dog');
+      const [trainDogIn] = this.getBlockInput('static_train_dog');
       trainDogIn.setCheck(['Random', 'Dog']);
-      chai.assert.isFalse(this.checker.doTypeChecks(dogOut, trainDogIn));
+      this.assertCannotConnect(dogOut, trainDogIn);
     });
 
     test('Unrelated types', function() {
-      const batOut = this.getBlockOutput('static_bat');
-      const trainDogIn = this.getBlockInput('static_train_dog');
-      chai.assert.isFalse(this.checker.doTypeChecks(batOut, trainDogIn));
+      const [batOut] = this.getBlockOutput('static_bat');
+      const [trainDogIn] = this.getBlockInput('static_train_dog');
+      this.assertCannotConnect(batOut, trainDogIn);
     });
 
     test('Backwards types', function() {
-      const mammalOut = this.getBlockOutput('static_mammal');
-      const trainDogIn = this.getBlockInput('static_train_dog');
-      chai.assert.isFalse(this.checker.doTypeChecks(mammalOut, trainDogIn));
+      const [mammalOut] = this.getBlockOutput('static_mammal');
+      const [trainDogIn] = this.getBlockInput('static_train_dog');
+      this.assertCannotConnect(mammalOut, trainDogIn);
     });
+  });
+
+  suite('Simple generics', function() {
+    // Both explicit is the other suite.
+
+    test('Parent explicit, child unbound', function() {
+      const [trainDogIn] = this.getBlockInput('static_train_dog');
+      const [identityOut] = this.getBlockOutput('static_identity');
+      this.assertCanConnect(trainDogIn, identityOut);
+    });
+
+    test('Parent explicit, child bound sub', function() {
+      const [milkMammalIn] = this.getBlockInput('static_milk_mammal');
+      const [identityOut, id] = this.getBlockOutput('static_identity');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+      this.assertCanConnect(milkMammalIn, identityOut);
+    });
+
+    test('Parent explicit, child bound super', function() {
+      const [trainDogIn] = this.getBlockInput('static_train_dog');
+      const [identityOut, id] = this.getBlockOutput('static_identity');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Mammal', INPUT_PRIORITY);
+      this.assertCannotConnect(trainDogIn, identityOut);
+    });
+
+    test('Parent unbound, child explicit', function() {
+      const [identityIn] = this.getBlockInput('static_identity');
+      const [dogOut] = this.getBlockOutput('static_dog');
+      this.assertCanConnect(identityIn, dogOut);
+    });
+
+    test('Parent unbound, child unbound', function() {
+      const [identityIn] = this.getBlockInput('static_identity');
+      const [identityOut] = this.getBlockOutput('static_identity');
+      this.assertCanConnect(identityIn, identityOut);
+    });
+
+    test('Parent unbound, child bound', function() {
+      const [identityIn] = this.getBlockInput('static_identity');
+      const [identityOut, id] = this.getBlockOutput('static_identity');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+      this.assertCanConnect(identityIn, identityOut);
+    });
+
+    test('Parent bound, child explicit sub', function() {
+      const [identityIn, id] = this.getBlockInput('static_identity');
+      const [dogOut] = this.getBlockOutput('static_dog');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Mammal', OUTPUT_PRIORITY);
+      this.assertCanConnect(identityIn, dogOut);
+    });
+
+    test('Parent bound, child explicit super', function() {
+      const [identityIn, id] = this.getBlockInput('static_identity');
+      const [mammalOut] = this.getBlockOutput('static_mammal');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', OUTPUT_PRIORITY);
+      this.assertCannotConnect(identityIn, mammalOut);
+    });
+
+    test('Parent bound, child unbound', function() {
+      const [identityIn, id] = this.getBlockInput('static_identity');
+      const [identityOut] = this.getBlockOutput('static_identity');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', OUTPUT_PRIORITY);
+      this.assertCanConnect(identityIn, identityOut);
+    });
+
+    test('Parent bound, child bound sub', function() {
+      const [identityIn, inId] = this.getBlockInput('static_identity');
+      const [identityOut, outId] = this.getBlockOutput('static_identity');
+      this.genericMap.bindTypeToExplicit(inId, 'T', 'Mammal', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(outId, 'T', 'Dog', INPUT_PRIORITY);
+      this.assertCanConnect(identityIn, identityOut);
+    });
+
+    test('Parent bound, child bound super', function() {
+      const [identityIn, inId] = this.getBlockInput('static_identity');
+      const [identityOut, outId] = this.getBlockOutput('static_identity');
+      this.genericMap.bindTypeToExplicit(inId, 'T', 'Dog', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(outId, 'T', 'Mammal', INPUT_PRIORITY);
+      this.assertCannotConnect(identityIn, identityOut);
+    });
+
+    test('Parent bound, multiple child explicit sub', function() {
+      const [selectRandomIn, id] = this.getBlockInput('static_select_random');
+      const [dogOut] = this.getBlockOutput('static_dog');
+      const [batOut] = this.getBlockOutput('static_bat');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Mammal', OUTPUT_PRIORITY);
+      this.assertCanConnect(selectRandomIn, dogOut);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+      // Expect the output binding to get priority.
+      this.assertCanConnect(selectRandomIn, batOut);
+    });
+
+    test.skip('Parent unbound, multiple child explicit sub', function() {
+      const [selectRandomIn, id] = this.getBlockInput('static_select_random');
+      const [dogOut] = this.getBlockOutput('static_dog');
+      const [batOut] = this.getBlockOutput('static_bat');
+      this.assertCanConnect(selectRandomIn, dogOut);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+
+      // TODO: Pick functionality.
+      this.assertCanConnect(selectRandomIn, batOut);
+      this.assertCannotConnect(selectRandomIn, batOut);
+    });
+
+    test('Parent explicit, child bound multiple explicit sub', function() {
+      const [milkMammalIn] = this.getBlockInput('static_milk_mammal');
+      const [selectRandomOut, id] = this.getBlockOutput('static_select_random');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Bat', INPUT_PRIORITY);
+      this.assertCanConnect(milkMammalIn, selectRandomOut);
+    });
+
+    test('Parent explicit, child bound multiple explicit some sub', function() {
+      const [launchFlyingIn] = this.getBlockInput('static_launch_flying');
+      const [selectRandomOut, id] = this.getBlockOutput('static_select_random');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Bat', INPUT_PRIORITY);
+      this.assertCannotConnect(launchFlyingIn, selectRandomOut);
+    });
+  });
+
+  // This suite checks that bindings get updated correctly. It doesn't have
+  // anything to do with compatibility.
+  suite('Binding: connect and disconnect', function() {
+    setup(function() {
+      this.clock = sinon.useFakeTimers();
+
+      this.assertNoBinding = function(conn) {
+        chai.assert.isUndefined(
+            this.genericMap.getExplicitType(
+                conn.getSourceBlock().id, conn.getCheck()[0]));
+      };
+      this.assertHasBinding = function(conn, binding) {
+        chai.assert.equal(
+            this.genericMap.getExplicitType(
+                conn.getSourceBlock().id, conn.getCheck()[0]),
+            binding);
+      };
+    });
+
+    teardown(function() {
+      this.clock.restore();
+    });
+
+    test('Parent explicit, child explicit', function() {
+      const [trainDogIn] = this.getBlockInput('static_train_dog');
+      const [dogOut] = this.getBlockOutput('static_dog');
+
+      trainDogIn.connect(dogOut);
+      this.clock.tick(1);
+      this.assertNoBinding(trainDogIn);
+      this.assertNoBinding(dogOut);
+
+      trainDogIn.disconnect();
+      this.clock.tick(1);
+      this.assertNoBinding(trainDogIn);
+      this.assertNoBinding(dogOut);
+    });
+
+    test('Parent explicit, child unbound', function() {
+      const [trainDogIn] = this.getBlockInput('static_train_dog');
+      const [identityOut] = this.getBlockOutput('static_identity');
+
+      trainDogIn.connect(identityOut);
+      this.clock.tick(1);
+      this.assertNoBinding(trainDogIn);
+      this.assertHasBinding(identityOut, 'Dog');
+
+      trainDogIn.disconnect();
+      this.clock.tick(1);
+      this.assertNoBinding(trainDogIn);
+      this.assertNoBinding(identityOut);
+    });
+
+    test('Parent explicit, child bound', function() {
+      const [milkMammalIn] = this.getBlockInput('static_milk_mammal');
+      const [identityOut, id] = this.getBlockOutput('static_identity');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+
+      milkMammalIn.connect(identityOut);
+      this.clock.tick(1);
+      this.assertNoBinding(milkMammalIn);
+      this.assertHasBinding(identityOut, 'Mammal');
+
+      milkMammalIn.disconnect();
+      this.clock.tick();
+      this.assertNoBinding(milkMammalIn);
+      this.assertHasBinding(identityOut, 'Dog');
+    });
+
+    test('Parent unbound, child explicit', function() {
+      const [identityIn] = this.getBlockInput('static_identity');
+      const [dogOut] = this.getBlockOutput('static_dog');
+
+      identityIn.connect(dogOut);
+      this.clock.tick(1);
+      this.assertHasBinding(identityIn, 'Dog');
+      this.assertNoBinding(dogOut);
+
+      identityIn.disconnect();
+      this.clock.tick(1);
+      this.assertNoBinding(identityIn);
+      this.assertNoBinding(dogOut);
+    });
+
+    test('Parent unbound, child unbound', function() {
+      const [identityIn] = this.getBlockInput('static_identity');
+      const [identityOut] = this.getBlockOutput('static_identity');
+
+      identityIn.connect(identityOut);
+      this.clock.tick(1);
+      this.assertNoBinding(identityIn);
+      this.assertNoBinding(identityOut);
+
+      identityIn.disconnect();
+      this.clock.tick(1);
+      this.assertNoBinding(identityIn);
+      this.assertNoBinding(identityOut);
+    });
+
+    test('Parent unbound, child bound', function() {
+      const [identityIn] = this.getBlockInput('static_identity');
+      const [identityOut, id] = this.getBlockOutput('static_identity');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+
+      identityIn.connect(identityOut);
+      this.clock.tick(1);
+      this.assertHasBinding(identityIn, 'Dog');
+      this.assertHasBinding(identityOut, 'Dog');
+
+      identityIn.disconnect();
+      this.clock.tick(1);
+      this.assertNoBinding(identityIn);
+      this.assertHasBinding(identityOut, 'Dog');
+    });
+
+    test('Parent bound, child explicit', function() {
+      const [identityIn, id] = this.getBlockInput('static_identity');
+      const [dogOut] = this.getBlockOutput('static_dog');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Mammal', OUTPUT_PRIORITY);
+
+      identityIn.connect(dogOut);
+      this.clock.tick(1);
+      this.assertHasBinding(identityIn, 'Mammal');
+      this.assertNoBinding(dogOut);
+
+      identityIn.disconnect();
+      this.clock.tick(1);
+      this.assertHasBinding(identityIn, 'Mammal');
+      this.assertNoBinding(dogOut);
+    });
+
+    test('Parent bound, child unbound', function() {
+      const [identityIn, id] = this.getBlockInput('static_identity');
+      const [identityOut] = this.getBlockOutput('static_identity');
+      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', OUTPUT_PRIORITY);
+
+      identityIn.connect(identityOut);
+      this.clock.tick(1);
+      this.assertHasBinding(identityIn, 'Dog');
+      this.assertHasBinding(identityOut, 'Dog');
+
+      identityIn.disconnect();
+      this.clock.tick(1);
+      this.assertHasBinding(identityIn, 'Dog');
+      this.assertNoBinding(identityOut);
+    });
+
+    test('Parent bound, child bound', function() {
+      const [identityIn, inId] = this.getBlockInput('static_identity');
+      const [identityOut, outId] = this.getBlockOutput('static_identity');
+      this.genericMap.bindTypeToExplicit(inId, 'T', 'Mammal', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(outId, 'T', 'Dog', INPUT_PRIORITY);
+
+      identityIn.connect(identityOut);
+      this.clock.tick(1);
+      this.assertHasBinding(identityIn, 'Mammal');
+      this.assertHasBinding(identityOut, 'Mammal');
+
+      identityIn.disconnect();
+      this.clock.tick(1);
+      this.assertHasBinding(identityIn, 'Mammal');
+      this.assertHasBinding(identityOut, 'Dog');
+    });
+
+    test('Parent explicit, child bound -> disconnect child\'s child',
+        function() {
+          const [milkMammalIn] = this.getBlockInput('static_milk_mammal');
+          const [identityOut, , identity] =
+              this.getBlockOutput('static_identity');
+          const identityIn = identity.getInput('INPUT').connection;
+          const [dogOut] = this.getBlockOutput('static_dog');
+
+          identityIn.connect(dogOut);
+          this.clock.tick(1);
+          this.assertHasBinding(identityIn, 'Dog');
+          this.assertNoBinding(dogOut);
+
+          milkMammalIn.connect(identityOut);
+          this.clock.tick(1);
+          this.assertNoBinding(milkMammalIn);
+          this.assertHasBinding(identityIn, 'Mammal');
+          this.assertNoBinding(dogOut);
+
+          identityIn.disconnect();
+          this.clock.tick();
+          this.assertNoBinding(milkMammalIn);
+          this.assertHasBinding(identityIn, 'Mammal');
+          this.assertNoBinding(dogOut);
+        });
+
+    test('Parent bound, child explicit -> disconnect parent\'s parent',
+        function() {
+          const [milkMammalIn] = this.getBlockInput('static_milk_mammal');
+          const [identityIn, , identity] =
+              this.getBlockInput('static_identity');
+          const identityOut = identity.outputConnection;
+          const [dogOut] = this.getBlockOutput('static_dog');
+
+          milkMammalIn.connect(identityOut);
+          this.clock.tick(1);
+          this.assertNoBinding(milkMammalIn);
+          this.assertHasBinding(identityIn, 'Mammal');
+
+          identityIn.connect(dogOut);
+          this.clock.tick(1);
+          this.assertNoBinding(milkMammalIn);
+          this.assertHasBinding(identityIn, 'Mammal');
+          this.assertNoBinding(dogOut);
+
+
+          milkMammalIn.disconnect();
+          this.clock.tick(1);
+          this.assertNoBinding(milkMammalIn);
+          this.assertHasBinding(identityIn, 'Dog');
+          this.assertNoBinding(dogOut);
+        });
+
+    test.skip('A unbound, B unbound, C explicit', function() {
+      const [aIn] = this.getBlockInput('static_identity');
+      const [bIn, , b] = this.getBlockInput('static_identity');
+      const bOut = b.outputConnection;
+      const [cOut] = this.getBlockOutput('static_dog');
+
+      aIn.connect(bOut);
+      this.clock.tick(1);
+      this.assertNoBinding(aIn);
+      this.assertNoBinding(bOut);
+
+      bIn.connect(cOut);
+      this.clock.tick(1);
+      this.assertNoBinding(cOut);
+      this.assertHasBinding(bIn, 'Dog');
+      this.assertHasBinding(aIn, 'Dog');
+
+      bIn.disconnect(cOut);
+      this.clock.tick(1);
+      this.assertNoBinding(aIn);
+      this.assertNoBinding(bIn);
+      this.assertNoBinding(cOut);
+    });
+
+    test('A explicit, B unbound, C unbound', function() {
+      const [aIn] = this.getBlockInput('static_train_dog');
+      const [bIn, , b] = this.getBlockInput('static_identity');
+      const bOut = b.outputConnection;
+      const [cOut] = this.getBlockOutput('static_identity');
+
+      aIn.connect(bOut);
+      this.clock.tick(1);
+      this.assertNoBinding(aIn);
+      this.assertHasBinding(bOut, 'Dog');
+
+      bIn.connect(cOut);
+      this.clock.tick(1);
+      this.assertNoBinding(aIn);
+      this.assertHasBinding(bIn, 'Dog');
+      this.assertHasBinding(cOut, 'Dog');
+
+      bIn.disconnect();
+      this.clock.tick(1);
+      this.assertNoBinding(aIn);
+      this.assertHasBinding(bIn, 'Dog');
+      this.assertNoBinding(cOut);
+
+      aIn.disconnect();
+      this.clock.tick(1);
+      this.assertNoBinding(aIn);
+      this.assertNoBinding(bOut);
+      this.assertNoBinding(cOut);
+    });
+
+    test('C explicit, B unbound, A unbound', function() {
+      const [aIn] = this.getBlockInput('static_identity');
+      const [bIn, , b] = this.getBlockInput('static_identity');
+      const bOut = b.outputConnection;
+      const [cOut] = this.getBlockOutput('static_dog');
+
+      cOut.connect(bIn);
+      this.clock.tick(1);
+      this.assertNoBinding(cOut);
+      this.assertHasBinding(bIn, 'Dog');
+
+      bOut.connect(aIn);
+      this.clock.tick(1);
+      this.assertNoBinding(cOut);
+      this.assertHasBinding(bOut, 'Dog');
+      this.assertHasBinding(aIn, 'Dog');
+
+      bOut.disconnect();
+      this.clock.tick(1);
+      this.assertNoBinding(cOut);
+      this.assertHasBinding(bOut, 'Dog');
+      this.assertNoBinding(aIn);
+
+      cOut.disconnect();
+      this.clock.tick(1);
+      this.assertNoBinding(cOut);
+      this.assertNoBinding(bIn);
+      this.assertNoBinding(aIn);
+    });
+
+    test.skip('C unbound, B unbound, A explicit', function() {
+      const [aIn] = this.getBlockInput('static_train_dog');
+      const [bIn, , b] = this.getBlockInput('static_identity');
+      const bOut = b.outputConnection;
+      const [cOut] = this.getBlockOutput('static_identity');
+
+      cOut.connect(bIn);
+      this.clock.tick(1);
+      this.assertNoBinding(cOut);
+      this.assertNoBinding(bIn);
+
+      bOut.connect(aIn);
+      this.clock.tick(1);
+      this.assertNoBinding(aIn);
+      this.assertHasBinding(bOut, 'Dog');
+      this.assertHasBinding(cOut, 'Dog');
+
+      bOut.disconnect();
+      this.clock.tick(1);
+      this.assertNoBinding(aIn);
+      this.assertNoBinding(cOut);
+      this.assertNoBinding(bIn);
+    });
+
+    test('Parent unbound, multiple child explicit sub same', function() {
+      const [selectRandomIn1, , selectRandom] =
+          this.getBlockInput('static_select_random');
+      const selectRandomIn2 = selectRandom.getInput('INPUT2').connection;
+      const [dogOut1] = this.getBlockOutput('static_dog');
+      const [dogOut2] = this.getBlockOutput('static_dog');
+
+      selectRandomIn1.connect(dogOut1);
+      this.clock.tick(1);
+      this.assertNoBinding(dogOut1);
+      this.assertHasBinding(selectRandomIn1, 'Dog');
+
+      selectRandomIn2.connect(dogOut2);
+      this.clock.tick(1);
+      this.assertNoBinding(dogOut1);
+      this.assertNoBinding(dogOut2);
+      this.assertHasBinding(selectRandomIn1, 'Dog');
+
+      selectRandomIn1.disconnect();
+      this.clock.tick(1);
+      this.assertNoBinding(dogOut2);
+      this.assertHasBinding(selectRandomIn1, 'Dog');
+
+      selectRandomIn2.disconnect();
+      this.clock.tick(1);
+      this.assertNoBinding(dogOut2);
+      this.assertNoBinding(selectRandomIn2);
+    });
+
+    // The following tests are for if we decide to implement Proposal 2.
+    // https://docs.google.com/document/d/1QKYkmWjkle1JWCi3O8jXr8-7Toazh1pW_4EaVVgB_OI/edit#heading=h.z2m9hs1ghrwp
+    test.skip('Parent unbound, multiple child explicit sub different',
+        function() {
+          const [selectRandomIn1, , selectRandom] =
+              this.getBlockInput('static_select_random');
+          const selectRandomIn2 = selectRandom.getInput('INPUT2').connection;
+          const [dogOut] = this.getBlockOutput('static_dog');
+          const [batOut] = this.getBlockOutput('static_bat');
+
+          selectRandomIn1.connect(dogOut);
+          this.clock.tick(1);
+          this.assertNoBinding(dogOut);
+          this.assertHasBinding(selectRandomIn1, 'Dog');
+
+          selectRandomIn2.connect(batOut);
+          this.clock.tick(1);
+          this.assertNoBinding(dogOut);
+          this.assertNoBinding(batOut);
+          this.assertHasBinding(selectRandomIn1, 'Mammal');
+
+          selectRandomIn1.disconnect();
+          this.clock.tick(1);
+          this.assertNoBinding(batOut);
+          this.assertHasBinding(selectRandomIn1, 'Bat');
+
+          selectRandomIn2.disconnect();
+          this.clock.tick(1);
+          this.assertNoBinding(batOut);
+          this.assertNoBinding(selectRandomIn2);
+        });
+
+    test.skip('Parent unbound, multiple child explicit sub mixed levels',
+        function() {
+          const [selectRandomIn1, , selectRandom] =
+              this.getBlockInput('static_select_random');
+          const selectRandomIn2 = selectRandom.getInput('INPUT2').connection;
+          const [dogOut] = this.getBlockOutput('static_dog');
+          const [mammalOut] = this.getBlockOutput('static_mammal');
+
+          selectRandomIn1.connect(dogOut);
+          this.clock.tick(1);
+          this.assertNoBinding(dogOut);
+          this.assertHasBinding(selectRandomIn1, 'Dog');
+
+          selectRandomIn2.connect(mammalOut);
+          this.clock.tick(1);
+          this.assertNoBinding(dogOut);
+          this.assertNoBinding(mammalOut);
+          this.assertHasBinding(selectRandomIn1, 'Mammal');
+
+          selectRandomIn1.disconnect();
+          this.clock.tick(1);
+          this.assertNoBinding(mammalOut);
+          this.assertHasBinding(selectRandomIn1, 'Mammal');
+
+          selectRandomIn2.disconnect();
+          this.clock.tick(1);
+          this.assertNoBinding(mammalOut);
+          this.assertNoBinding(selectRandomIn2);
+        });
+
+    test.skip('Parent unbound, multiple child explicit sub mixed levels 2',
+        function() {
+          const [selectRandomIn1, , selectRandom] =
+              this.getBlockInput('static_select_random');
+          const selectRandomIn2 = selectRandom.getInput('INPUT2').connection;
+          const [dogOut] = this.getBlockOutput('static_dog');
+          const [reptileOut] = this.getBlockOutput('static_reptile');
+
+          selectRandomIn1.connect(dogOut);
+          this.clock.tick(1);
+          this.assertNoBinding(dogOut);
+          this.assertHasBinding(selectRandomIn1, 'Dog');
+
+          selectRandomIn2.connect(reptileOut);
+          this.clock.tick(1);
+          this.assertNoBinding(dogOut);
+          this.assertNoBinding(reptileOut);
+          this.assertHasBinding(selectRandomIn1, 'Animal');
+
+          selectRandomIn1.disconnect();
+          this.clock.tick(1);
+          this.assertNoBinding(reptileOut);
+          this.assertHasBinding(selectRandomIn1, 'Reptile');
+
+          selectRandomIn2.disconnect();
+          this.clock.tick(1);
+          this.assertNoBinding(reptileOut);
+          this.assertNoBinding(selectRandomIn2);
+        });
   });
 });

--- a/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
@@ -259,6 +259,47 @@ suite('NominalConnectionChecker', function() {
     });
   });
 
+  suite('isGeneric_', function() {
+    setup(function() {
+      this.assertGeneric = function(check, boolVal) {
+        const mockConn = {
+          getCheck: function() {
+            return [check];
+          },
+        };
+        chai.assert.equal(this.checker.isGeneric_(mockConn), boolVal);
+      };
+    });
+
+    test('"a"', function() {
+      this.assertGeneric('a', true);
+    });
+
+    test('"A"', function() {
+      this.assertGeneric('A', true);
+    });
+
+    test('"*"', function() {
+      this.assertGeneric('*', true);
+    });
+
+    test('"1"', function() {
+      this.assertGeneric('1', true);
+    });
+
+    test('1', function() {
+      this.assertGeneric(1, false);
+    });
+
+    test('"LongCheck"', function() {
+      this.assertGeneric('LongCheck', false);
+    });
+
+    test('"\uD83D\uDE00" (emoji)', function() {
+      this.assertGeneric('\uD83D\uDE00', false);
+    });
+  });
+
   suite('Simple generics', function() {
     // Both explicit is the other suite.
 

--- a/plugins/nominal-connection-checker/test/generic_map_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/generic_map_test.mocha.js
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Unit tests for GenericMap
+ */
+
+const chai = require('chai');
+const Blockly = require('blockly/node');
+
+const {pluginInfo} = require('../src/index.js');
+const {GenericMap, INPUT_PRIORITY, OUTPUT_PRIORITY} =
+    require('../src/generic_map.js');
+
+suite('GenericMap', function() {
+  setup(function() {
+    Blockly.defineBlocksWithJsonArray([
+      {
+        'type': 'static_identity',
+        'message0': 'Identity %1',
+        'args0': [
+          {
+            'type': 'input_value',
+            'name': 'INPUT',
+            'check': 'T',
+          },
+        ],
+        'output': ['T'],
+        'style': 'text_blocks',
+      },
+    ]);
+
+    const options = {
+      plugins: {
+        ...pluginInfo,
+      },
+    };
+
+    this.workspace = new Blockly.Workspace(options);
+    this.genericMap = new GenericMap(this.workspace);
+    this.dependerBlock = this.workspace.newBlock('static_identity');
+    this.dependerId = this.dependerBlock.id;
+    this.dependencyBlock = this.workspace.newBlock('static_identity');
+    this.dependencyId = this.dependencyBlock.id;
+
+    this.assertHasType = function(type) {
+      chai.assert.equal(
+          this.genericMap.getExplicitType(this.dependencyId, 'T'),
+          type);
+    };
+
+    this.bindType = function(type, priority) {
+      this.genericMap.bindTypeToExplicit(
+          this.dependencyId, 'T', type, priority);
+    };
+
+    this.unbindType = function(type, priority) {
+      this.genericMap.unbindTypeFromExplicit(
+          this.dependencyId, 'T', type, priority);
+    };
+  });
+
+  teardown(function() {
+    delete Blockly.Blocks['static_identity'];
+  });
+
+  suite('Priority', function() {
+    test('Input then output', function() {
+      this.bindType('test', INPUT_PRIORITY);
+      this.assertHasType('test');
+      this.bindType('test2', OUTPUT_PRIORITY);
+      this.assertHasType('test2');
+
+      this.unbindType('test2', OUTPUT_PRIORITY);
+      this.assertHasType('test');
+    });
+
+    test('Output then input', function() {
+      this.bindType('test', OUTPUT_PRIORITY);
+      this.assertHasType('test');
+      this.bindType('test2', INPUT_PRIORITY);
+      this.assertHasType('test');
+
+      this.unbindType('test2', INPUT_PRIORITY);
+      this.assertHasType('test');
+    });
+
+    test('Less than input', function() {
+      this.bindType('test', 99);
+      this.assertHasType('test');
+      this.bindType('test2', INPUT_PRIORITY);
+      this.assertHasType('test2');
+
+      this.unbindType('test2', INPUT_PRIORITY);
+      this.assertHasType('test');
+    });
+
+    test('Between input and output', function() {
+      this.bindType('test', INPUT_PRIORITY);
+      this.assertHasType('test');
+      this.bindType('test2', 150);
+      this.assertHasType('test2');
+      this.bindType('test3', OUTPUT_PRIORITY);
+      this.assertHasType('test3');
+
+      this.unbindType('test3', OUTPUT_PRIORITY);
+      this.assertHasType('test2');
+      this.unbindType('test2', 150);
+      this.assertHasType('test');
+    });
+
+    test('More than output', function() {
+      this.bindType('test', OUTPUT_PRIORITY);
+      this.assertHasType('test');
+      this.bindType('test2', 201);
+      this.assertHasType('test2');
+
+      this.unbindType('test2', 201);
+      this.assertHasType('test');
+    });
+  });
+
+  suite('bindToGeneric', function() {
+    test('Simple', function() {
+      this.bindType('test', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToGeneric(
+          this.dependerId, 'T', this.dependencyId, 'T', OUTPUT_PRIORITY);
+      chai.assert.equal(
+          this.genericMap.getExplicitType(this.dependerId, 'T'),
+          'test');
+    });
+
+    test('Depender block doesn\'t exist', function() {
+      chai.assert.throws(() => {
+        this.genericMap.bindTypeToGeneric(
+            'cats', 'T', this.dependencyId, 'T', OUTPUT_PRIORITY);
+      }, 'The depender id (cats) is not a valid block id');
+    });
+
+    test('Dependency block doesn\'t exist', function() {
+      chai.assert.throws(() => {
+        this.genericMap.bindTypeToGeneric(
+            this.dependerId, 'T', 'cats', 'T', OUTPUT_PRIORITY);
+      }, 'The dependency id (cats) is not a valid block id');
+    });
+
+    test('Dependency type isn\'t bound', function() {
+      chai.assert.throws(() => {
+        this.genericMap.bindTypeToGeneric(
+            this.dependerId, 'T', this.dependencyId, 'T', OUTPUT_PRIORITY);
+      }, /The type T on block .+ is not bound to an explicit type./);
+    });
+  });
+
+  suite('unbindFromGeneric', function() {
+    setup(function() {
+      this.bindGeneric = function(dependencyId, dependencyType) {
+        this.genericMap.bindTypeToGeneric(
+            this.dependerId,
+            'T',
+            dependencyId,
+            dependencyType,
+            OUTPUT_PRIORITY);
+      };
+
+      this.unbindGeneric = function(dependencyId, dependencyType) {
+        this.genericMap.unbindTypeFromGeneric(
+            this.dependerId,
+            'T',
+            dependencyId,
+            dependencyType,
+            OUTPUT_PRIORITY);
+      };
+
+      this.assertHasType = function(type) {
+        chai.assert.equal(
+            this.genericMap.getExplicitType(this.dependerId, type));
+      };
+    });
+
+    test('Simple', function() {
+      this.bindType('test', OUTPUT_PRIORITY);
+      this.bindGeneric(this.dependencyId, 'T');
+      this.unbindGeneric(this.dependencyId, 'T');
+      chai.assert.isUndefined(
+          this.genericMap.getExplicitType(this.dependerId, 'T'));
+    });
+
+    test('Dependency block has no dependers', function() {
+      this.bindType('test', OUTPUT_PRIORITY);
+      this.bindGeneric(this.dependencyId, 'T');
+      this.unbindGeneric('cats', 'T');
+      this.assertHasType('test');
+    });
+
+    test('Dependency type has no dependers', function() {
+      this.bindType('test', OUTPUT_PRIORITY);
+      this.bindGeneric(this.dependencyId, 'T');
+      this.unbindGeneric(this.dependencyId, 'G');
+      this.assertHasType('test');
+    });
+
+    test('Depender block is not bound', function() {
+      chai.assert.doesNotThrow(() => {
+        this.unbindGeneric(this.dependencyId, 'T');
+      });
+    });
+
+    test('Depender type is not bound', function() {
+      this.bindType('test', OUTPUT_PRIORITY);
+      this.bindGeneric(this.dependencyId, 'T');
+      chai.assert.doesNotThrow(() => {
+        this.genericMap.unbindTypeFromGeneric(
+            this.dependerId, 'G', this.dependencyId, 'T', OUTPUT_PRIORITY);
+      });
+    });
+  });
+});
+

--- a/plugins/nominal-connection-checker/test/priority_queue_map_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/priority_queue_map_test.mocha.js
@@ -1,0 +1,219 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Unit tests for PriorityQueueMap.
+ */
+
+const chai = require('chai');
+
+const {PriorityQueueMap} = require('../src/priority_queue_map.js');
+
+suite('PriorityQueueMap', function() {
+  setup(function() {
+    this.priorityQueueMap = new PriorityQueueMap();
+
+    this.assertBindings = function(key, ...bindings) {
+      chai.assert.deepEqual(this.priorityQueueMap.getBindings(key), bindings);
+    };
+  });
+
+  suite('getValues', function() {
+    setup(function() {
+      this.assertValues = function(key, ...values) {
+        chai.assert.deepEqual(this.priorityQueueMap.getValues(key), values);
+      };
+    });
+
+    test('Single value', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.assertValues('test', 'test');
+    });
+
+    test('Multiple values', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.priorityQueueMap.bind('test', 'test2', 0);
+      this.assertValues('test', 'test', 'test2');
+    });
+  });
+
+  suite('getBindings', function() {
+    test('Single binding', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.assertBindings('test', {value: 'test', priority: 0});
+    });
+
+    test('Multiple bindings', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.priorityQueueMap.bind('test', 'test2', 0);
+      this.assertBindings('test',
+          {value: 'test', priority: 0},
+          {value: 'test2', priority: 0});
+    });
+  });
+
+  suite('bind', function() {
+    setup(function() {
+      this.assertThrows = function(fn) {
+        chai.assert.throws(
+            fn.bind(this),
+            'A binding\'s priority must be a number.');
+      };
+    });
+
+    test('Simple', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.assertBindings('test', {value: 'test', priority: 0});
+    });
+
+    test('Undefined key', function() {
+      this.priorityQueueMap.bind(undefined, 'test', 0);
+      this.assertBindings(undefined, {value: 'test', priority: 0});
+    });
+
+    test('Null key', function() {
+      this.priorityQueueMap.bind(null, 'test', 0);
+      this.assertBindings(null, {value: 'test', priority: 0});
+    });
+
+    test('NaN key', function() {
+      this.priorityQueueMap.bind(NaN, 'test', 0);
+      this.assertBindings(NaN, {value: 'test', priority: 0});
+    });
+
+    test('Object key', function() {
+      this.priorityQueueMap.bind({test: 'test'}, 'test', 0);
+      this.assertBindings({test: 'test'}, {value: 'test', priority: 0});
+    });
+
+    test('Undefined value', function() {
+      this.priorityQueueMap.bind('test', undefined, 0);
+      this.assertBindings('test', {value: undefined, priority: 0});
+    });
+
+    test('Null value', function() {
+      this.priorityQueueMap.bind('test', null, 0);
+      this.assertBindings('test', {value: null, priority: 0});
+    });
+
+    test('Undefined priority', function() {
+      this.assertThrows(() => {
+        this.priorityQueueMap.bind('test', 'test', undefined);
+      });
+    });
+
+    test('Null priority', function() {
+      this.assertThrows(() => {
+        this.priorityQueueMap.bind('test', 'test', null);
+      });
+    });
+
+    test('NaN priority', function() {
+      this.assertThrows(() => {
+        this.priorityQueueMap.bind('test', 'test', NaN);
+      });
+    });
+
+    test('Stringified number priority', function() {
+      // We cannot allow stringified numbers because we do comparison tests.
+      this.assertThrows(() => {
+        this.priorityQueueMap.bind('test', 'test', '1');
+      });
+    });
+  });
+
+  suite('unbind', function() {
+    test('Simple', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.priorityQueueMap.unbind('test', 'test', 0);
+      chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
+    });
+
+    test('Stringified value', function() {
+      this.priorityQueueMap.bind('test', 1, 0);
+      this.priorityQueueMap.unbind('test', '1', 0);
+      this.assertBindings('test', {value: 1, priority: 0});
+    });
+
+    test('Similar object value', function() {
+      this.priorityQueueMap.bind('test', {test: 'test'}, 0);
+      this.priorityQueueMap.unbind('test', {test: 'test'}, 0);
+      this.assertBindings('test', {value: {test: 'test'}, priority: 0});
+    });
+
+    test('Same object value', function() {
+      const value = {test: 'test'};
+      this.priorityQueueMap.bind('test', value, 0);
+      this.priorityQueueMap.unbind('test', value, 0);
+      chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
+    });
+
+    test('Different priority', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.priorityQueueMap.unbind('test', 'test', 10);
+      this.assertBindings('test', {value: 'test', priority: 0});
+    });
+
+    test('Stringified priority', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.priorityQueueMap.unbind('test', 'test', '0');
+      this.assertBindings('test', {value: 'test', priority: 0});
+    });
+  });
+
+  suite('Priority', function() {
+    test('Single', function() {
+      this.priorityQueueMap.bind('test', 'test', 1);
+      this.assertBindings('test', {value: 'test', priority: 1});
+    });
+
+    test('Multiple', function() {
+      this.priorityQueueMap.bind('test', 'test', 1);
+      this.priorityQueueMap.bind('test', 'test2', 1);
+      this.priorityQueueMap.bind('test', 'test3', 1);
+      this.assertBindings('test',
+          {value: 'test', priority: 1},
+          {value: 'test2', priority: 1},
+          {value: 'test3', priority: 1});
+    });
+
+    test('Increasing', function() {
+      this.priorityQueueMap.bind('test', 'test', 1);
+      this.priorityQueueMap.bind('test', 'test2', 2);
+      this.priorityQueueMap.bind('test', 'test3', 3);
+      this.priorityQueueMap.bind('test', 'test4', 3);
+      this.assertBindings('test',
+          {value: 'test3', priority: 3},
+          {value: 'test4', priority: 3});
+    });
+
+    test('Decreasing', function() {
+      this.priorityQueueMap.bind('test', 'test', 3);
+      this.priorityQueueMap.bind('test', 'test2', 3);
+      this.priorityQueueMap.bind('test', 'test3', 2);
+      this.priorityQueueMap.bind('test', 'test4', 1);
+      this.assertBindings('test',
+          {value: 'test', priority: 3},
+          {value: 'test2', priority: 3});
+    });
+
+    test('Negatives', function() {
+      this.priorityQueueMap.bind('test', 'test', -2);
+      this.priorityQueueMap.bind('test', 'test2', -2);
+      this.priorityQueueMap.bind('test', 'test3', -1);
+      this.priorityQueueMap.bind('test', 'test4', 0);
+      this.assertBindings('test', {value: 'test4', priority: 0});
+    });
+
+    test('Floats', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.priorityQueueMap.bind('test', 'test2', 0.0001);
+      this.priorityQueueMap.bind('test', 'test3', 0.2);
+      this.priorityQueueMap.bind('test', 'test4', -0.3);
+      this.assertBindings('test', {value: 'test3', priority: 0.2});
+    });
+  });
+});

--- a/plugins/nominal-connection-checker/test/priority_queue_map_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/priority_queue_map_test.mocha.js
@@ -84,11 +84,6 @@ suite('PriorityQueueMap', function() {
       this.assertBindings(NaN, {value: 'test', priority: 0});
     });
 
-    test('Object key', function() {
-      this.priorityQueueMap.bind({test: 'test'}, 'test', 0);
-      this.assertBindings({test: 'test'}, {value: 'test', priority: 0});
-    });
-
     test('Undefined value', function() {
       this.priorityQueueMap.bind('test', undefined, 0);
       this.assertBindings('test', {value: undefined, priority: 0});

--- a/plugins/nominal-connection-checker/test/priority_queue_map_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/priority_queue_map_test.mocha.js
@@ -38,6 +38,16 @@ suite('PriorityQueueMap', function() {
       this.priorityQueueMap.bind('test', 'test2', 0);
       this.assertValues('test', 'test', 'test2');
     });
+
+    test('Bad key', function() {
+      chai.assert.isUndefined(this.priorityQueueMap.getValues('test'));
+    });
+
+    test('No values', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.priorityQueueMap.unbind('test', 'test', 0);
+      chai.assert.isUndefined(this.priorityQueueMap.getValues('test'));
+    });
   });
 
   suite('getBindings', function() {
@@ -52,6 +62,16 @@ suite('PriorityQueueMap', function() {
       this.assertBindings('test',
           {value: 'test', priority: 0},
           {value: 'test2', priority: 0});
+    });
+
+    test('Bad key', function() {
+      chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
+    });
+
+    test('No values', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.priorityQueueMap.unbind('test', 'test', 0);
+      chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
     });
   });
 


### PR DESCRIPTION
### Preface

This is a bit of a weird PR because it's mostly puzzle pieces that will hopefully come together later. But I'll do my best to explain where my brain is going.

Also, I know this PR description is super long, and I still don't think I did a good job explaining. So if there's anything that's unclear or anything I can do to make it more clear please tell me.

### Basic Idea

Let's start with a simple example of generics. Below there is a generic Identity block with a connection check T on its input and output. After we connect the Dog block to the Identity block we want the T check to start acting like a Dog check.
![ConnectDog](https://user-images.githubusercontent.com/25440652/93945815-7eea7f00-fcec-11ea-9917-c88845c63fd6.gif)

Now say we connect annother Identity block to the first Identity block. We now want that block's T check to /also/ start acting like a Dog check.
![ConnectIdentity](https://user-images.githubusercontent.com/25440652/93945822-83169c80-fcec-11ea-930b-bf577d745097.gif)

There are two ways we could implement this.
  1) Whenever we connect a connection with a generic check to another connection, we create a "pointer" to the connection check of the other connection. Then when we go to get the explicit type of the generic check, we do a recursive lookup to see if it is bound to an explicit type anywhere.
  So if we were to connect these two Identity blocks their T types would be bound to eachother.
  ![IdentityBlocks](https://user-images.githubusercontent.com/25440652/94073562-8a04e400-fdac-11ea-838c-f717f1b62138.png)

  2) We only "bind" a generic check to another check if the other check is an explicit type, or has an explicit type associated with it.
  So if were were to connect these two Identity blocks their T types would /not/ be bound to eachother.
  ![IdentityBlocks](https://user-images.githubusercontent.com/25440652/94073562-8a04e400-fdac-11ea-838c-f717f1b62138.png)
  But if we added a Dog block to the second one, then our bindings would update to look like this:
  ![IdentityWithDog](https://user-images.githubusercontent.com/25440652/94074077-68f0c300-fdad-11ea-908a-5ea842cc5c0a.png)


I decide to go with option 2. The logic will be more complicated, but I believe it will be more efficient.

#### Efficiency

For example, say we implement option 1 and then I build the following set of blocks:

Each time I connect an Identity block, the growing blob of blocks would need to recursively check every connected block to see if it is bound to an explicit anywhere.
![ConnectBlob](https://user-images.githubusercontent.com/25440652/93945948-d852ae00-fcec-11ea-8ae3-2334ece68314.gif)

Whereas option 2 wouldn't require any of that, because none of the blocks are bound yet. It would only require a recursive update if/when I were to eventually connect an explicit type.
![AddDogToBlob](https://user-images.githubusercontent.com/25440652/93945953-db4d9e80-fcec-11ea-93ad-8cb35b2a217b.gif)

#### Complicated logic

To implement option 2 we need to do different things after two connections connect, depending on the "kinds" of the connections.

So currently a connection check can have three different "kinds"
A) It can be explicit, eg Dog - **E**
B) It can be generic, and not currently bound to an explicit type - **GU**
C) It can be generic, and bound to an explicit type eg Dog - **GB**

Note that we **do** want to bind already bound generics (**GB**s) to **E**s and other **GB**s. The reasoning for this is explained below in the PriorityQueueMap section.

| Parent | Child | Action |
|----------|---------|----------|
|E|E|Bind neither|
|E|GU|Bind child to parent|
|E|GB|Bind child to parent|
|GU|E|Bind parent to child|
|GU|GU|Bind neither|
|GU|GB|Bind parent to child|
|GB|E|Bind parent to child|
|GB|GU|Bind child to parent|
|GB|GB|Bind both to each other|

This is what the logic [here](https://github.com/google/blockly-samples/pull/376/files#diff-150b7d992bf47b4060c87ae4d301ee6cR122) is meant to do.

We also need to do similar unbinding when the two blocks disconnect, except it's more complicated, because once an unbound connection is connected, it becomes bound.

| Parent | Child | Action |
|----------|---------|----------|
|E|E|Unbind Neither|
|~~E~~|~~GU~~|------|
|E|GB|Unbind child from parent|
|~~GU~~|~~E~~|------|
|GU|GU|Unbind neither|
|~~GU~~|~~GB~~|------|
|GB|E|Unbind parent from child|
|~~GB~~|~~GU~~|------|
|GB|GB|Unbind both to each other|

Luckily the unbinding logic pretty much works even though connections that were previously GUs are now GBs (since they've been bound by connecting). We just have to make sure that the GenericMap (see below) fails graceful if we try to delete a binding and the binding doesn't exist.

#### Current logic limitiations

Note that currently the logic doesn't handle updating the checks that are dependent on a block when a block updates.

So if you connect the explicit block first, and then continue connecting generic blocks all of the bindings "flow through" the connections.
![CorrectFlow](https://user-images.githubusercontent.com/25440652/93946437-21573200-fcee-11ea-9818-22acec52ea80.gif)

But if you connect the generic blocks together first, and then connect the explicit block, that's not handled yet.
![BadFlow](https://user-images.githubusercontent.com/25440652/93946441-24eab900-fcee-11ea-8903-ae5fb0cdb547.gif)

### Puzzle Pieces

#### PriorityQueueMap

This is a new data structure I created that works sort of like a map, except that keys are mapped to priority queues of values. So a key can be bound to multiple values, but it's actual value(s) is the value with the highest priority.

This new data structure is used to bind generic type names to their explicit type names, within the context of a block. It will probably also be used for generic type constraints, once I get there.

The reason we cannot implement type binding using a simple map is twofold:
1) We want outside devs to be able to override type bindings using fields or other UI they create (hence the priority).
2) We want to be able to bind generic types to multiple explicit types so that they can easily adapt to changing connections.

For example right now the generic type (T) of the Select Random block is unbound:
![Unbound](https://user-images.githubusercontent.com/25440652/93728466-ef6e9000-fb74-11ea-99d5-14c08daea407.png)

Now it should be bound to Dog:
![Dog](https://user-images.githubusercontent.com/25440652/93728470-f3021700-fb74-11ea-80b5-20e68a224688.png)

Now Mammal:
![Mammal1](https://user-images.githubusercontent.com/25440652/93728474-f4cbda80-fb74-11ea-9c1c-f1dcd5bf4d19.png)
![Mammal2](https://user-images.githubusercontent.com/25440652/93728479-f6959e00-fb74-11ea-9f79-643c7176faa8.png)
![Mammal3](https://user-images.githubusercontent.com/25440652/93728548-407e8400-fb75-11ea-99d0-765849dde26e.png)

And now Cat:
![Cat](https://user-images.githubusercontent.com/25440652/93728553-45433800-fb75-11ea-8601-541babdc6de2.png)

Allowing a type to have multiple bindings feels to me like the best way to handle any binding being removed at any time, and forcing the generic type to act like one of its other types.

#### Generic Map

The NominalConnectionChecker decides when to bind and unbind types, but the GenericMap handles the consequences of that decision (basically).

The generic map has two things it keeps track of.
1) For a given generic type on a given block, what explicit type is it currently bound to?
2) For a given generic type on a given block, what generic types on other blocks are dependent on the explicit type of this type?

(1) is useful for finding the explicit type of a generic type so that we can perform connection checks. (2) is useful for unbinding types. It will also allow us to have bindings “flow” through dependent types, once I add that.

### Problems related to blockly APIs

So currently all of the binding is handled through event listeners, which causes two problems:
1) Generic checks don't act bound until we wait 1 ms for the event delay.
2) Generic checks don't get bound when loading from XML

Adding a way for a connection checker to get a callback immediately after connect & disconnect would solve both problems, but that's really only useful if you want to implement generics.

If we decide to stick with the events system I'll probably end up adding a Promises system to fix (1) and hooking into the FinishedLoading event for (2)
