### PR TITLE
Un-skip invalid string test cases for field-date

### DIFF
--- a/plugins/field-date/package-lock.json
+++ b/plugins/field-date/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/field-date",
-	"version": "4.1.1",
+	"version": "4.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1571,9 +1571,9 @@
 			"dev": true
 		},
 		"abab": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
-			"integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
 			"dev": true
 		},
 		"accepts": {
@@ -2024,9 +2024,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
 			"dev": true
 		},
 		"babel-eslint": {
@@ -2201,9 +2201,9 @@
 			}
 		},
 		"blockly": {
-			"version": "3.20200402.1",
-			"resolved": "https://registry.npmjs.org/blockly/-/blockly-3.20200402.1.tgz",
-			"integrity": "sha512-3caKdRgwD7EtiSfHYS82nRG0gb8/82AYUHUd3hQFypUAe1nJT8+gkM5SRLkwzEeYJcmRZraiYEpYaG2U603vcw==",
+			"version": "3.20200924.1",
+			"resolved": "https://registry.npmjs.org/blockly/-/blockly-3.20200924.1.tgz",
+			"integrity": "sha512-Uv1UBMfyQJ0Q2uko5JZoxZwpZ8zgtb8Tj0+Yp5aVDwHrB8Aj1KSmb4SnepwbJYAOGZLKkPMcJBApayyJMgtUwg==",
 			"dev": true,
 			"requires": {
 				"jsdom": "^15.2.1"
@@ -3629,9 +3629,9 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-			"integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+			"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
 			"dev": true,
 			"requires": {
 				"esprima": "^4.0.1",
@@ -5493,13 +5493,27 @@
 			"dev": true
 		},
 		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.5.5",
+				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.12.5",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+					"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				}
 			}
 		},
 		"has": {
@@ -8525,21 +8539,21 @@
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-			"integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+			"integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.15"
+				"lodash": "^4.17.19"
 			}
 		},
 		"request-promise-native": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
-			"integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+			"integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
 			"dev": true,
 			"requires": {
-				"request-promise-core": "1.1.3",
+				"request-promise-core": "1.1.4",
 				"stealthy-require": "^1.1.1",
 				"tough-cookie": "^2.3.3"
 			},
@@ -11135,9 +11149,9 @@
 			}
 		},
 		"ws": {
-			"version": "7.2.5",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
-			"integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+			"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
 			"dev": true
 		},
 		"xml-name-validator": {

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blockly/field-date",
-    "version": "4.1.1",
+    "version": "4.1.2",
     "description": "A Blockly date picker field that uses the Google Closure date picker.",
     "scripts": {
         "build": "gulp build",
@@ -39,7 +39,7 @@
     "devDependencies": {
         "@blockly/dev-scripts": "^1.1.0",
         "@blockly/dev-tools": "^2.0.1",
-        "blockly": "^3.20200402.1",
+        "blockly": "^3.20200924.1",
         "google-closure-compiler": "^20200224.0.0",
         "google-closure-library": "^20200224.0.0",
         "gulp": "^4.0.2",
@@ -47,7 +47,7 @@
         "gulp-umd": "^2.0.0"
     },
     "peerDependencies": {
-        "blockly": ">=3.20191014.4"
+        "blockly": ">=3.20200924.1"
     },
     "publishConfig": {
         "access": "public",

--- a/plugins/field-date/src/field_date.js
+++ b/plugins/field-date/src/field_date.js
@@ -55,6 +55,14 @@ Blockly.FieldDate.fromJson = function(options) {
 };
 
 /**
+ * The default value for this field.
+ * @type {*}
+ * @protected
+ */
+Blockly.FieldDate.prototype.DEFAULT_VALUE =
+    new Date().toISOString().substring(0, 10);
+
+/**
  * Serializable fields are saved by the XML renderer, non-serializable fields
  * are not. Editable fields should also be serializable.
  * @type {boolean}

--- a/plugins/field-date/src/field_date.js
+++ b/plugins/field-date/src/field_date.js
@@ -38,8 +38,16 @@ goog.require('goog.ui.DatePicker');
  * @constructor
  */
 Blockly.FieldDate = function(opt_value, opt_validator) {
-  Blockly.FieldDate.superClass_.constructor.call(this,
-      opt_value || new goog.date.Date().toIsoString(true), opt_validator);
+  /**
+   * The default value for this field (current date).
+   * @type {*}
+   * @protected
+   */
+  Blockly.FieldDate.prototype.DEFAULT_VALUE =
+      new goog.date.Date().toIsoString(true);
+
+  Blockly.FieldDate.superClass_.constructor.call(this, opt_value,
+      opt_validator);
 };
 Blockly.utils.object.inherits(Blockly.FieldDate, Blockly.Field);
 
@@ -53,14 +61,6 @@ Blockly.utils.object.inherits(Blockly.FieldDate, Blockly.Field);
 Blockly.FieldDate.fromJson = function(options) {
   return new Blockly.FieldDate(options['date']);
 };
-
-/**
- * The default value for this field.
- * @type {*}
- * @protected
- */
-Blockly.FieldDate.prototype.DEFAULT_VALUE =
-    new Date().toISOString().substring(0, 10);
 
 /**
  * Serializable fields are saved by the XML renderer, non-serializable fields

--- a/plugins/field-date/test/field_date_test.mocha.js
+++ b/plugins/field-date/test/field_date_test.mocha.js
@@ -52,12 +52,6 @@ suite('FieldDate', function() {
     assertFieldValue(field, testCase.value);
   };
 
-  // TODO(https://github.com/google/blockly/issues/3903): Re-enable test cases
-  //  after fixing.
-  invalidValueTestCases[3].skip = true;
-  invalidValueTestCases[4].skip = true;
-  invalidValueTestCases[5].skip = true;
-
   runConstructorSuiteTests(
       FieldDate, validValueTestCases, invalidValueTestCases,
       validTestCaseAssertField, assertFieldDefault);
@@ -65,12 +59,6 @@ suite('FieldDate', function() {
   runFromJsonSuiteTests(
       FieldDate, validValueTestCases, invalidValueTestCases,
       validTestCaseAssertField, assertFieldDefault);
-
-  // TODO(https://github.com/google/blockly/issues/3903): Remove skip=false
-  //  after removing skip=true.
-  invalidValueTestCases[3].skip = false;
-  invalidValueTestCases[4].skip = false;
-  invalidValueTestCases[5].skip = false;
 
   suite('setValue', function() {
     suite('Empty -> New Value', function() {

--- a/plugins/field-date/test/field_date_test.mocha.js
+++ b/plugins/field-date/test/field_date_test.mocha.js
@@ -38,7 +38,11 @@ suite('FieldDate', function() {
   };
   invalidValueTestCases.forEach(addArgsAndJson);
   validValueTestCases.forEach(addArgsAndJson);
-  const defaultFieldValue = new Date().toISOString().substring(0, 10);
+  // Construct ISO string using current timezone.
+  // Cannot use toISOString() because it returns in UTC.
+  const defaultFieldValue = new Date().toLocaleDateString()
+      .replace(/(\d+)\/(\d+)\/(\d+)/, "$3-$1-$2")
+      .replace(/-(\d-)|-(\d)$/, '-0$1');
   const assertFieldDefault = function(field) {
     assertFieldValue(field, defaultFieldValue);
   };


### PR DESCRIPTION
- Sets default value for FieldDate on `DEFAULT_VALUE` property
- Update logic in tests for expected default value (which previously had issues when run locally on machine with non-UTC time zone)
- Un-skips invalid string test cases for `FieldDate`
- Updates `Blockly` version dependency
- Bumps version of `FieldDate`