### PR TITLE
Fix regex for creating expected date value for tests.

### DIFF
--- a/plugins/field-date/test/field_date_test.mocha.js
+++ b/plugins/field-date/test/field_date_test.mocha.js
@@ -42,7 +42,7 @@ suite('FieldDate', function() {
   // Cannot use toISOString() because it returns in UTC.
   const defaultFieldValue = new Date().toLocaleDateString()
       .replace(/(\d+)\/(\d+)\/(\d+)/, "$3-$1-$2")
-      .replace(/-(\d-)|-(\d)$/, '-0$1');
+      .replace(/-(\d)(?!\d)/g, '-0$1');
   const assertFieldDefault = function(field) {
     assertFieldValue(field, defaultFieldValue);
   };


### PR DESCRIPTION
Fix regex for creating expected default value for FieldDate tests.

Previously the regex expression didn't take into account that the match would consume the `-` character at the end of the match causing it to behave incorrectly for case like: `'2020-1-1'` (and only match the first single digit and create string `'2020-01-1'`). By using negative lookahead `(?!)` the `-` at the end of the match is not captured. Also the previous expression did not work correctly for `'2020-10-1'` and would replace incorrectly (creating string `'2020-10-0'`).

This should fix Travis failures for FieldDate for #376