### PR TITLE
Add hierarchy validation checks for generic names - project static

### DIFF
--- a/plugins/nominal-connection-checker/src/generic_map.js
+++ b/plugins/nominal-connection-checker/src/generic_map.js
@@ -85,6 +85,7 @@ export class GenericMap {
    *     type is not bound.
    */
   getExplicitType(blockId, genericType) {
+    genericType = genericType.toLowerCase();
     const priorityMap = this.dependenciesMap_.get(blockId);
     if (!priorityMap) {
       return undefined;
@@ -160,6 +161,8 @@ export class GenericMap {
    *     bindings ovveride lower priority bindings.
    */
   bindTypeToExplicit(blockId, genericType, explicitType, priority) {
+    genericType = genericType.toLowerCase();
+    explicitType = explicitType.toLowerCase();
     let queueMap = this.dependenciesMap_.get(blockId);
     if (!queueMap) {
       queueMap = new PriorityQueueMap();
@@ -220,6 +223,8 @@ export class GenericMap {
    * @param {number} priority The priority of the binding to remove.
    */
   unbindTypeFromExplicit(blockId, genericType, explicitType, priority) {
+    genericType = genericType.toLowerCase();
+    explicitType = explicitType.toLowerCase();
     if (this.dependenciesMap_.has(blockId)) {
       this.dependenciesMap_.get(blockId).unbind(
           genericType, explicitType, priority);

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -25,6 +25,7 @@ export function validateHierarchy(hierarchyDef) {
   checkConflictingTypes(hierarchyDef);
   checkSupersDefined(hierarchyDef);
   checkCircularDependencies(hierarchyDef);
+  checkGenerics(hierarchyDef);
 }
 
 /**
@@ -164,4 +165,20 @@ function logCircularDependency(cycleArray) {
     errorMsg += ' fulfills ' + cycleArray[i];
   }
   console.error(errorMsg);
+}
+
+/**
+ * Checks for any type names that also fulfill the properties of being generic
+ * type names. Eg 'A', 'a', '*', '1', etc.
+ * @param {!Object} hierarchyDef The definition of the type hierarchy.
+ */
+function checkGenerics(hierarchyDef) {
+  const error = 'The type %s will act like a generic type if used as a ' +
+      'connection check, because it is a single character.';
+
+  for (const type of Object.keys(hierarchyDef)) {
+    if (typeof type == 'string' && type.length == 1) {
+      console.error(error, type);
+    }
+  }
 }

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -179,7 +179,7 @@ function checkGenerics(hierarchyDef) {
       'connection check, because it is a single character.';
 
   for (const type of Object.keys(hierarchyDef)) {
-    if (typeof type == 'string' && type.length == 1) {
+    if (isGeneric(type)) {
       console.error(error, type);
     }
   }

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -9,6 +9,8 @@
  */
 'use strict';
 
+import {isGeneric} from './utils';
+
 /**
  * Validates the given hierarchy definition. Does checks for duplicate types,
  * circular dependencies, etc. Errors are logged to the console (not thrown).

--- a/plugins/nominal-connection-checker/src/index.js
+++ b/plugins/nominal-connection-checker/src/index.js
@@ -216,6 +216,7 @@ export class NominalConnectionChecker extends Blockly.ConnectionChecker {
    */
   isGeneric_(connection) {
     const check = this.getCheck_(connection);
+    // If you ever update this, be sure to update hierarchy_validation.js too.
     return typeof check == 'string' && check.length == 1;
   }
 

--- a/plugins/nominal-connection-checker/src/utils.js
+++ b/plugins/nominal-connection-checker/src/utils.js
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/**
+ * @fileoverview A file defining helper functions useful in multiple modules.
+ */
+
+/**
+ * Returns the type name (which could be generic) associated with the
+ * connection.
+ * @param {!Blockly.Connection} connection The connection to find the check of.
+ * @return {string} The caseless type name associated with the connection, or
+ *     the null string if the connection has no type.
+ */
+export function getCheck(connection) {
+  const check = connection.getCheck()[0];
+  if (!check || typeof check != 'string') {
+    return '';
+  }
+  return check.toLowerCase();
+}
+
+
+/**
+ * Returns true if type is generic. False otherwise.
+ * @param {string} type The type to check for generic-ness.
+ * @return {boolean} True if the type is generic. False otherwise.
+ * @private
+ */
+export function isGeneric(type) {
+  return type.length == 1;
+}
+
+/**
+ * Returns true if type is explicit. False otherwise.
+ * @param {string} type The type to check for explicit-ness.
+ * @return {boolean} True if the type is explicit. False otherwise.
+ * @private
+ */
+export function isExplicit(type) {
+  return type.length > 1;
+}
+
+/**
+ * Returns true if the connection has a generic connection check. False
+ * otherwise.
+ * @param {!Blockly.Connection} connection The connection to check for
+ *     generic-ness.
+ * @return {boolean} True if the connection has a generic connection check.
+ *     False otherwise.
+ * @private
+ */
+export function isGenericConnection(connection) {
+  return isGeneric(getCheck(connection));
+}
+
+/**
+ * Returns true if the connection has an explicit connection check. False
+ * otherwise.
+ * @param {!Blockly.Connection} connection The connection check to check for
+ *     explicit-ness.
+ * @return {boolean} True if the connection has an explicit connection check.
+ *     False otherwise.
+ * @private
+ */
+export function isExplicitConnection(connection) {
+  return isExplicit(getCheck(connection));
+}

--- a/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/connection_checker_test.mocha.js
@@ -234,7 +234,7 @@ suite('NominalConnectionChecker', function() {
 
     test('Multiple output checks', function() {
       const [dogOut] = this.getBlockOutput('static_dog');
-      dogOut.setCheck(['Random', 'Dog']);
+      dogOut.setCheck(['Random', 'dog']);
       const [trainDogIn] = this.getBlockInput('static_train_dog');
       this.assertCannotConnect(dogOut, trainDogIn);
     });
@@ -242,7 +242,7 @@ suite('NominalConnectionChecker', function() {
     test('Multiple input checks', function() {
       const [dogOut] = this.getBlockOutput('static_dog');
       const [trainDogIn] = this.getBlockInput('static_train_dog');
-      trainDogIn.setCheck(['Random', 'Dog']);
+      trainDogIn.setCheck(['Random', 'dog']);
       this.assertCannotConnect(dogOut, trainDogIn);
     });
 
@@ -259,47 +259,6 @@ suite('NominalConnectionChecker', function() {
     });
   });
 
-  suite('isGeneric_', function() {
-    setup(function() {
-      this.assertGeneric = function(check, boolVal) {
-        const mockConn = {
-          getCheck: function() {
-            return [check];
-          },
-        };
-        chai.assert.equal(this.checker.isGeneric_(mockConn), boolVal);
-      };
-    });
-
-    test('"a"', function() {
-      this.assertGeneric('a', true);
-    });
-
-    test('"A"', function() {
-      this.assertGeneric('A', true);
-    });
-
-    test('"*"', function() {
-      this.assertGeneric('*', true);
-    });
-
-    test('"1"', function() {
-      this.assertGeneric('1', true);
-    });
-
-    test('1', function() {
-      this.assertGeneric(1, false);
-    });
-
-    test('"LongCheck"', function() {
-      this.assertGeneric('LongCheck', false);
-    });
-
-    test('"\uD83D\uDE00" (emoji)', function() {
-      this.assertGeneric('\uD83D\uDE00', false);
-    });
-  });
-
   suite('Simple generics', function() {
     // Both explicit is the other suite.
 
@@ -312,14 +271,14 @@ suite('NominalConnectionChecker', function() {
     test('Parent explicit, child bound sub', function() {
       const [milkMammalIn] = this.getBlockInput('static_milk_mammal');
       const [identityOut, id] = this.getBlockOutput('static_identity');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'dog', INPUT_PRIORITY);
       this.assertCanConnect(milkMammalIn, identityOut);
     });
 
     test('Parent explicit, child bound super', function() {
       const [trainDogIn] = this.getBlockInput('static_train_dog');
       const [identityOut, id] = this.getBlockOutput('static_identity');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Mammal', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'mammal', INPUT_PRIORITY);
       this.assertCannotConnect(trainDogIn, identityOut);
     });
 
@@ -338,44 +297,44 @@ suite('NominalConnectionChecker', function() {
     test('Parent unbound, child bound', function() {
       const [identityIn] = this.getBlockInput('static_identity');
       const [identityOut, id] = this.getBlockOutput('static_identity');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'dog', INPUT_PRIORITY);
       this.assertCanConnect(identityIn, identityOut);
     });
 
     test('Parent bound, child explicit sub', function() {
       const [identityIn, id] = this.getBlockInput('static_identity');
       const [dogOut] = this.getBlockOutput('static_dog');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Mammal', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'mammal', OUTPUT_PRIORITY);
       this.assertCanConnect(identityIn, dogOut);
     });
 
     test('Parent bound, child explicit super', function() {
       const [identityIn, id] = this.getBlockInput('static_identity');
       const [mammalOut] = this.getBlockOutput('static_mammal');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'dog', OUTPUT_PRIORITY);
       this.assertCannotConnect(identityIn, mammalOut);
     });
 
     test('Parent bound, child unbound', function() {
       const [identityIn, id] = this.getBlockInput('static_identity');
       const [identityOut] = this.getBlockOutput('static_identity');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'dog', OUTPUT_PRIORITY);
       this.assertCanConnect(identityIn, identityOut);
     });
 
     test('Parent bound, child bound sub', function() {
       const [identityIn, inId] = this.getBlockInput('static_identity');
       const [identityOut, outId] = this.getBlockOutput('static_identity');
-      this.genericMap.bindTypeToExplicit(inId, 'T', 'Mammal', OUTPUT_PRIORITY);
-      this.genericMap.bindTypeToExplicit(outId, 'T', 'Dog', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(inId, 'T', 'mammal', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(outId, 'T', 'dog', INPUT_PRIORITY);
       this.assertCanConnect(identityIn, identityOut);
     });
 
     test('Parent bound, child bound super', function() {
       const [identityIn, inId] = this.getBlockInput('static_identity');
       const [identityOut, outId] = this.getBlockOutput('static_identity');
-      this.genericMap.bindTypeToExplicit(inId, 'T', 'Dog', OUTPUT_PRIORITY);
-      this.genericMap.bindTypeToExplicit(outId, 'T', 'Mammal', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(inId, 'T', 'dog', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(outId, 'T', 'mammal', INPUT_PRIORITY);
       this.assertCannotConnect(identityIn, identityOut);
     });
 
@@ -383,9 +342,9 @@ suite('NominalConnectionChecker', function() {
       const [selectRandomIn, id] = this.getBlockInput('static_select_random');
       const [dogOut] = this.getBlockOutput('static_dog');
       const [batOut] = this.getBlockOutput('static_bat');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Mammal', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'mammal', OUTPUT_PRIORITY);
       this.assertCanConnect(selectRandomIn, dogOut);
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'dog', INPUT_PRIORITY);
       // Expect the output binding to get priority.
       this.assertCanConnect(selectRandomIn, batOut);
     });
@@ -395,7 +354,7 @@ suite('NominalConnectionChecker', function() {
       const [dogOut] = this.getBlockOutput('static_dog');
       const [batOut] = this.getBlockOutput('static_bat');
       this.assertCanConnect(selectRandomIn, dogOut);
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'dog', INPUT_PRIORITY);
 
       // TODO: Pick functionality.
       this.assertCanConnect(selectRandomIn, batOut);
@@ -405,16 +364,16 @@ suite('NominalConnectionChecker', function() {
     test('Parent explicit, child bound multiple explicit sub', function() {
       const [milkMammalIn] = this.getBlockInput('static_milk_mammal');
       const [selectRandomOut, id] = this.getBlockOutput('static_select_random');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Bat', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'dog', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'bat', INPUT_PRIORITY);
       this.assertCanConnect(milkMammalIn, selectRandomOut);
     });
 
     test('Parent explicit, child bound multiple explicit some sub', function() {
       const [launchFlyingIn] = this.getBlockInput('static_launch_flying');
       const [selectRandomOut, id] = this.getBlockOutput('static_select_random');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Bat', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'dog', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'bat', INPUT_PRIORITY);
       this.assertCannotConnect(launchFlyingIn, selectRandomOut);
     });
   });
@@ -464,7 +423,7 @@ suite('NominalConnectionChecker', function() {
       trainDogIn.connect(identityOut);
       this.clock.tick(1);
       this.assertNoBinding(trainDogIn);
-      this.assertHasBinding(identityOut, 'Dog');
+      this.assertHasBinding(identityOut, 'dog');
 
       trainDogIn.disconnect();
       this.clock.tick(1);
@@ -475,17 +434,17 @@ suite('NominalConnectionChecker', function() {
     test('Parent explicit, child bound', function() {
       const [milkMammalIn] = this.getBlockInput('static_milk_mammal');
       const [identityOut, id] = this.getBlockOutput('static_identity');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'dog', INPUT_PRIORITY);
 
       milkMammalIn.connect(identityOut);
       this.clock.tick(1);
       this.assertNoBinding(milkMammalIn);
-      this.assertHasBinding(identityOut, 'Mammal');
+      this.assertHasBinding(identityOut, 'mammal');
 
       milkMammalIn.disconnect();
       this.clock.tick();
       this.assertNoBinding(milkMammalIn);
-      this.assertHasBinding(identityOut, 'Dog');
+      this.assertHasBinding(identityOut, 'dog');
     });
 
     test('Parent unbound, child explicit', function() {
@@ -494,7 +453,7 @@ suite('NominalConnectionChecker', function() {
 
       identityIn.connect(dogOut);
       this.clock.tick(1);
-      this.assertHasBinding(identityIn, 'Dog');
+      this.assertHasBinding(identityIn, 'dog');
       this.assertNoBinding(dogOut);
 
       identityIn.disconnect();
@@ -521,66 +480,66 @@ suite('NominalConnectionChecker', function() {
     test('Parent unbound, child bound', function() {
       const [identityIn] = this.getBlockInput('static_identity');
       const [identityOut, id] = this.getBlockOutput('static_identity');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'dog', INPUT_PRIORITY);
 
       identityIn.connect(identityOut);
       this.clock.tick(1);
-      this.assertHasBinding(identityIn, 'Dog');
-      this.assertHasBinding(identityOut, 'Dog');
+      this.assertHasBinding(identityIn, 'dog');
+      this.assertHasBinding(identityOut, 'dog');
 
       identityIn.disconnect();
       this.clock.tick(1);
       this.assertNoBinding(identityIn);
-      this.assertHasBinding(identityOut, 'Dog');
+      this.assertHasBinding(identityOut, 'dog');
     });
 
     test('Parent bound, child explicit', function() {
       const [identityIn, id] = this.getBlockInput('static_identity');
       const [dogOut] = this.getBlockOutput('static_dog');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Mammal', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'mammal', OUTPUT_PRIORITY);
 
       identityIn.connect(dogOut);
       this.clock.tick(1);
-      this.assertHasBinding(identityIn, 'Mammal');
+      this.assertHasBinding(identityIn, 'mammal');
       this.assertNoBinding(dogOut);
 
       identityIn.disconnect();
       this.clock.tick(1);
-      this.assertHasBinding(identityIn, 'Mammal');
+      this.assertHasBinding(identityIn, 'mammal');
       this.assertNoBinding(dogOut);
     });
 
     test('Parent bound, child unbound', function() {
       const [identityIn, id] = this.getBlockInput('static_identity');
       const [identityOut] = this.getBlockOutput('static_identity');
-      this.genericMap.bindTypeToExplicit(id, 'T', 'Dog', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(id, 'T', 'dog', OUTPUT_PRIORITY);
 
       identityIn.connect(identityOut);
       this.clock.tick(1);
-      this.assertHasBinding(identityIn, 'Dog');
-      this.assertHasBinding(identityOut, 'Dog');
+      this.assertHasBinding(identityIn, 'dog');
+      this.assertHasBinding(identityOut, 'dog');
 
       identityIn.disconnect();
       this.clock.tick(1);
-      this.assertHasBinding(identityIn, 'Dog');
+      this.assertHasBinding(identityIn, 'dog');
       this.assertNoBinding(identityOut);
     });
 
     test('Parent bound, child bound', function() {
       const [identityIn, inId] = this.getBlockInput('static_identity');
       const [identityOut, outId] = this.getBlockOutput('static_identity');
-      this.genericMap.bindTypeToExplicit(inId, 'T', 'Mammal', OUTPUT_PRIORITY);
-      this.genericMap.bindTypeToExplicit(outId, 'T', 'Dog', INPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(inId, 'T', 'mammal', OUTPUT_PRIORITY);
+      this.genericMap.bindTypeToExplicit(outId, 'T', 'dog', INPUT_PRIORITY);
 
       identityIn.connect(identityOut);
       this.clock.tick(1);
-      this.assertHasBinding(identityIn, 'Mammal');
-      this.assertHasBinding(identityOut, 'Mammal');
+      this.assertHasBinding(identityIn, 'mammal');
+      this.assertHasBinding(identityOut, 'mammal');
 
       identityIn.disconnect();
       this.clock.tick(1);
-      this.assertHasBinding(identityIn, 'Mammal');
-      this.assertHasBinding(identityOut, 'Dog');
+      this.assertHasBinding(identityIn, 'mammal');
+      this.assertHasBinding(identityOut, 'dog');
     });
 
     test('Parent explicit, child bound -> disconnect child\'s child',
@@ -593,19 +552,19 @@ suite('NominalConnectionChecker', function() {
 
           identityIn.connect(dogOut);
           this.clock.tick(1);
-          this.assertHasBinding(identityIn, 'Dog');
+          this.assertHasBinding(identityIn, 'dog');
           this.assertNoBinding(dogOut);
 
           milkMammalIn.connect(identityOut);
           this.clock.tick(1);
           this.assertNoBinding(milkMammalIn);
-          this.assertHasBinding(identityIn, 'Mammal');
+          this.assertHasBinding(identityIn, 'mammal');
           this.assertNoBinding(dogOut);
 
           identityIn.disconnect();
           this.clock.tick();
           this.assertNoBinding(milkMammalIn);
-          this.assertHasBinding(identityIn, 'Mammal');
+          this.assertHasBinding(identityIn, 'mammal');
           this.assertNoBinding(dogOut);
         });
 
@@ -620,19 +579,19 @@ suite('NominalConnectionChecker', function() {
           milkMammalIn.connect(identityOut);
           this.clock.tick(1);
           this.assertNoBinding(milkMammalIn);
-          this.assertHasBinding(identityIn, 'Mammal');
+          this.assertHasBinding(identityIn, 'mammal');
 
           identityIn.connect(dogOut);
           this.clock.tick(1);
           this.assertNoBinding(milkMammalIn);
-          this.assertHasBinding(identityIn, 'Mammal');
+          this.assertHasBinding(identityIn, 'mammal');
           this.assertNoBinding(dogOut);
 
 
           milkMammalIn.disconnect();
           this.clock.tick(1);
           this.assertNoBinding(milkMammalIn);
-          this.assertHasBinding(identityIn, 'Dog');
+          this.assertHasBinding(identityIn, 'dog');
           this.assertNoBinding(dogOut);
         });
 
@@ -650,8 +609,8 @@ suite('NominalConnectionChecker', function() {
       bIn.connect(cOut);
       this.clock.tick(1);
       this.assertNoBinding(cOut);
-      this.assertHasBinding(bIn, 'Dog');
-      this.assertHasBinding(aIn, 'Dog');
+      this.assertHasBinding(bIn, 'dog');
+      this.assertHasBinding(aIn, 'dog');
 
       bIn.disconnect(cOut);
       this.clock.tick(1);
@@ -669,18 +628,18 @@ suite('NominalConnectionChecker', function() {
       aIn.connect(bOut);
       this.clock.tick(1);
       this.assertNoBinding(aIn);
-      this.assertHasBinding(bOut, 'Dog');
+      this.assertHasBinding(bOut, 'dog');
 
       bIn.connect(cOut);
       this.clock.tick(1);
       this.assertNoBinding(aIn);
-      this.assertHasBinding(bIn, 'Dog');
-      this.assertHasBinding(cOut, 'Dog');
+      this.assertHasBinding(bIn, 'dog');
+      this.assertHasBinding(cOut, 'dog');
 
       bIn.disconnect();
       this.clock.tick(1);
       this.assertNoBinding(aIn);
-      this.assertHasBinding(bIn, 'Dog');
+      this.assertHasBinding(bIn, 'dog');
       this.assertNoBinding(cOut);
 
       aIn.disconnect();
@@ -699,18 +658,18 @@ suite('NominalConnectionChecker', function() {
       cOut.connect(bIn);
       this.clock.tick(1);
       this.assertNoBinding(cOut);
-      this.assertHasBinding(bIn, 'Dog');
+      this.assertHasBinding(bIn, 'dog');
 
       bOut.connect(aIn);
       this.clock.tick(1);
       this.assertNoBinding(cOut);
-      this.assertHasBinding(bOut, 'Dog');
-      this.assertHasBinding(aIn, 'Dog');
+      this.assertHasBinding(bOut, 'dog');
+      this.assertHasBinding(aIn, 'dog');
 
       bOut.disconnect();
       this.clock.tick(1);
       this.assertNoBinding(cOut);
-      this.assertHasBinding(bOut, 'Dog');
+      this.assertHasBinding(bOut, 'dog');
       this.assertNoBinding(aIn);
 
       cOut.disconnect();
@@ -734,8 +693,8 @@ suite('NominalConnectionChecker', function() {
       bOut.connect(aIn);
       this.clock.tick(1);
       this.assertNoBinding(aIn);
-      this.assertHasBinding(bOut, 'Dog');
-      this.assertHasBinding(cOut, 'Dog');
+      this.assertHasBinding(bOut, 'dog');
+      this.assertHasBinding(cOut, 'dog');
 
       bOut.disconnect();
       this.clock.tick(1);
@@ -754,18 +713,18 @@ suite('NominalConnectionChecker', function() {
       selectRandomIn1.connect(dogOut1);
       this.clock.tick(1);
       this.assertNoBinding(dogOut1);
-      this.assertHasBinding(selectRandomIn1, 'Dog');
+      this.assertHasBinding(selectRandomIn1, 'dog');
 
       selectRandomIn2.connect(dogOut2);
       this.clock.tick(1);
       this.assertNoBinding(dogOut1);
       this.assertNoBinding(dogOut2);
-      this.assertHasBinding(selectRandomIn1, 'Dog');
+      this.assertHasBinding(selectRandomIn1, 'dog');
 
       selectRandomIn1.disconnect();
       this.clock.tick(1);
       this.assertNoBinding(dogOut2);
-      this.assertHasBinding(selectRandomIn1, 'Dog');
+      this.assertHasBinding(selectRandomIn1, 'dog');
 
       selectRandomIn2.disconnect();
       this.clock.tick(1);
@@ -786,18 +745,18 @@ suite('NominalConnectionChecker', function() {
           selectRandomIn1.connect(dogOut);
           this.clock.tick(1);
           this.assertNoBinding(dogOut);
-          this.assertHasBinding(selectRandomIn1, 'Dog');
+          this.assertHasBinding(selectRandomIn1, 'dog');
 
           selectRandomIn2.connect(batOut);
           this.clock.tick(1);
           this.assertNoBinding(dogOut);
           this.assertNoBinding(batOut);
-          this.assertHasBinding(selectRandomIn1, 'Mammal');
+          this.assertHasBinding(selectRandomIn1, 'mammal');
 
           selectRandomIn1.disconnect();
           this.clock.tick(1);
           this.assertNoBinding(batOut);
-          this.assertHasBinding(selectRandomIn1, 'Bat');
+          this.assertHasBinding(selectRandomIn1, 'bat');
 
           selectRandomIn2.disconnect();
           this.clock.tick(1);
@@ -816,18 +775,18 @@ suite('NominalConnectionChecker', function() {
           selectRandomIn1.connect(dogOut);
           this.clock.tick(1);
           this.assertNoBinding(dogOut);
-          this.assertHasBinding(selectRandomIn1, 'Dog');
+          this.assertHasBinding(selectRandomIn1, 'dog');
 
           selectRandomIn2.connect(mammalOut);
           this.clock.tick(1);
           this.assertNoBinding(dogOut);
           this.assertNoBinding(mammalOut);
-          this.assertHasBinding(selectRandomIn1, 'Mammal');
+          this.assertHasBinding(selectRandomIn1, 'mammal');
 
           selectRandomIn1.disconnect();
           this.clock.tick(1);
           this.assertNoBinding(mammalOut);
-          this.assertHasBinding(selectRandomIn1, 'Mammal');
+          this.assertHasBinding(selectRandomIn1, 'mammal');
 
           selectRandomIn2.disconnect();
           this.clock.tick(1);
@@ -846,18 +805,18 @@ suite('NominalConnectionChecker', function() {
           selectRandomIn1.connect(dogOut);
           this.clock.tick(1);
           this.assertNoBinding(dogOut);
-          this.assertHasBinding(selectRandomIn1, 'Dog');
+          this.assertHasBinding(selectRandomIn1, 'dog');
 
           selectRandomIn2.connect(reptileOut);
           this.clock.tick(1);
           this.assertNoBinding(dogOut);
           this.assertNoBinding(reptileOut);
-          this.assertHasBinding(selectRandomIn1, 'Animal');
+          this.assertHasBinding(selectRandomIn1, 'animal');
 
           selectRandomIn1.disconnect();
           this.clock.tick(1);
           this.assertNoBinding(reptileOut);
-          this.assertHasBinding(selectRandomIn1, 'Reptile');
+          this.assertHasBinding(selectRandomIn1, 'reptile');
 
           selectRandomIn2.disconnect();
           this.clock.tick(1);

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -44,10 +44,8 @@ suite('Hierarchy Validation', function() {
   });
 
   suite('Conflicts', function() {
-    setup(function() {
-      this.conflictMsg =
-          'The type name \'%s\' conflicts with the type name(s) %s';
-    });
+    const conflictMsg =
+        'The type name \'%s\' conflicts with the type name(s) %s';
 
     test('No conflicts', function() {
       validateHierarchy({
@@ -65,7 +63,7 @@ suite('Hierarchy Validation', function() {
       });
       chai.assert.isTrue(this.errorStub.calledOnce);
       chai.assert.isTrue(this.errorStub.calledWith(
-          this.conflictMsg, 'typeA', ['TypeA']));
+          conflictMsg, 'typeA', ['TypeA']));
     });
 
     test('Type conflicts multiple', function() {
@@ -76,7 +74,7 @@ suite('Hierarchy Validation', function() {
       });
       chai.assert.isTrue(this.errorStub.calledOnce);
       chai.assert.isTrue(this.errorStub.calledWith(
-          this.conflictMsg, 'typeA', ['TypeA', 'Typea']));
+          conflictMsg, 'typeA', ['TypeA', 'Typea']));
     });
 
     test('Multiple conflicts', function() {
@@ -88,17 +86,15 @@ suite('Hierarchy Validation', function() {
       });
       chai.assert.isTrue(this.errorStub.calledTwice);
       chai.assert.isTrue(this.errorStub.calledWith(
-          this.conflictMsg, 'typeA', ['TypeA']));
+          conflictMsg, 'typeA', ['TypeA']));
       chai.assert.isTrue(this.errorStub.calledWith(
-          this.conflictMsg, 'typeB', ['TypeB']));
+          conflictMsg, 'typeB', ['TypeB']));
     });
   });
 
   suite('Defined supers', function() {
-    setup(function() {
-      this.errorMsg = 'The type %s says it fulfills the type %s, but that' +
-          ' type is not defined';
-    });
+    const errorMsg = 'The type %s says it fulfills the type %s, but that' +
+        ' type is not defined';
 
     test('Defined before', function() {
       validateHierarchy({
@@ -127,8 +123,7 @@ suite('Hierarchy Validation', function() {
         },
       });
       chai.assert.isTrue(this.errorStub.calledOnce);
-      chai.assert.isTrue(this.errorStub.calledWith(
-          this.errorMsg, 'typeA', 'typeB'));
+      chai.assert.isTrue(this.errorStub.calledWith(errorMsg, 'typeA', 'typeB'));
     });
 
     test('Case', function() {
@@ -293,6 +288,50 @@ suite('Hierarchy Validation', function() {
       chai.assert.isTrue(this.errorStub.calledWith(
           'The type typeA creates a circular dependency: ' +
           'typeA fulfills TypeA'));
+    });
+  });
+
+  suite('Generics', function() {
+    const errorMsg = 'The type %s will act like a generic type if used as a ' +
+        'connection check, because it is a single character.';
+
+    test('"valid"', function() {
+      validateHierarchy({
+        'valid': { },
+      });
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+
+    test('"a"', function() {
+      validateHierarchy({
+        'a': { },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(errorMsg, 'a'));
+    });
+
+    test('"A"', function() {
+      validateHierarchy({
+        'A': { },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(errorMsg, 'A'));
+    });
+
+    test('"*"', function() {
+      validateHierarchy({
+        '*': { },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(errorMsg, '*'));
+    });
+
+    test('"1"', function() {
+      validateHierarchy({
+        '1': { },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(errorMsg, '1'));
     });
   });
 });

--- a/plugins/nominal-connection-checker/test/utils_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/utils_test.mocha.js
@@ -1,0 +1,226 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Unit tests for utils.
+ */
+
+const chai = require('chai');
+
+const {getCheck, isGeneric, isExplicit,
+  isGenericConnection, isExplicitConnection} = require('../src/utils');
+
+suite('Utils tests', function() {
+  /**
+   * Creates a mock connection with a getCheck function that returns the given
+   * check.
+   * @param {!Array} check The check the mock connection should have.
+   * @return {{getCheck: function():!Array}} The new mock connection.
+   */
+  function createMockConnection(check) {
+    return {
+      getCheck: function() {
+        return check;
+      },
+    };
+  }
+
+  suite('getCheck', function() {
+    test('Empty', function() {
+      const mock = createMockConnection([]);
+      chai.assert.equal(getCheck(mock), '');
+    });
+
+    test('"a"', function() {
+      const mock = createMockConnection(['a']);
+      chai.assert.isTrue(isGenericConnection(mock));
+      chai.assert.equal(getCheck(mock), 'a');
+    });
+
+    test('"A"', function() {
+      const mock = createMockConnection(['A']);
+      chai.assert.equal(getCheck(mock), 'a');
+    });
+
+    test('"*"', function() {
+      const mock = createMockConnection(['*']);
+      chai.assert.equal(getCheck(mock), '*');
+    });
+
+    test('"1"', function() {
+      const mock = createMockConnection(['1']);
+      chai.assert.equal(getCheck(mock), '1');
+    });
+
+    test('1', function() {
+      const mock = createMockConnection([1]);
+      chai.assert.equal(getCheck(mock), '');
+    });
+
+    test('"LongCheck"', function() {
+      const mock = createMockConnection(['LongCheck']);
+      chai.assert.equal(getCheck(mock), 'longcheck');
+    });
+
+    test('"\uD83D\uDE00" (emoji)', function() {
+      const mock = createMockConnection(['\uD83D\uDE00']);
+      chai.assert.isFalse(isGenericConnection(mock));
+      chai.assert.equal(getCheck(mock), '\uD83D\uDE00');
+    });
+
+    test('Nested', function() {
+      const mock = createMockConnection([['a']]);
+      chai.assert.equal(getCheck(mock), '');
+    });
+  });
+
+  suite('isGeneric', function() {
+    test('"a"', function() {
+      chai.assert.isTrue(isGeneric('a'));
+    });
+
+    test('"A"', function() {
+      chai.assert.isTrue(isGeneric('A'));
+    });
+
+    test('"*"', function() {
+      chai.assert.isTrue(isGeneric('*'));
+    });
+
+    test('"1"', function() {
+      chai.assert.isTrue(isGeneric('1'));
+    });
+
+    test('"LongCheck"', function() {
+      chai.assert.isFalse(isGeneric('LongCheck'));
+    });
+
+    test('"\uD83D\uDE00" (emoji)', function() {
+      chai.assert.isFalse(isGeneric('\uD83D\uDE00'));
+    });
+  });
+
+  suite('isExplicit', function() {
+    test('"a"', function() {
+      chai.assert.isFalse(isExplicit('a'));
+    });
+
+    test('"A"', function() {
+      chai.assert.isFalse(isExplicit('A'));
+    });
+
+    test('"*"', function() {
+      chai.assert.isFalse(isExplicit('*'));
+    });
+
+    test('"1"', function() {
+      chai.assert.isFalse(isExplicit('1'));
+    });
+
+    test('"LongCheck"', function() {
+      chai.assert.isTrue(isExplicit('LongCheck'));
+    });
+
+    test('"\uD83D\uDE00" (emoji)', function() {
+      chai.assert.isTrue(isExplicit('\uD83D\uDE00'));
+    });
+  });
+
+  suite('isGenericConnection', function() {
+    test('Empty', function() {
+      const mock = createMockConnection([]);
+      chai.assert.isFalse(isGenericConnection(mock));
+    });
+
+    test('"a"', function() {
+      const mock = createMockConnection(['a']);
+      chai.assert.isTrue(isGenericConnection(mock));
+    });
+
+    test('"A"', function() {
+      const mock = createMockConnection(['A']);
+      chai.assert.isTrue(isGenericConnection(mock));
+    });
+
+    test('"*"', function() {
+      const mock = createMockConnection(['*']);
+      chai.assert.isTrue(isGenericConnection(mock));
+    });
+
+    test('"1"', function() {
+      const mock = createMockConnection(['1']);
+      chai.assert.isTrue(isGenericConnection(mock));
+    });
+
+    test('1', function() {
+      const mock = createMockConnection([1]);
+      chai.assert.isFalse(isGenericConnection(mock));
+    });
+
+    test('"LongCheck"', function() {
+      const mock = createMockConnection(['LongCheck']);
+      chai.assert.isFalse(isGenericConnection(mock));
+    });
+
+    test('"\uD83D\uDE00" (emoji)', function() {
+      const mock = createMockConnection(['\uD83D\uDE00']);
+      chai.assert.isFalse(isGenericConnection(mock));
+    });
+
+    test('Nested', function() {
+      const mock = createMockConnection([['a']]);
+      chai.assert.isFalse(isGenericConnection(mock));
+    });
+  });
+
+  suite('isExplicitConnection', function() {
+    test('Empty', function() {
+      const mock = createMockConnection([]);
+      chai.assert.isFalse(isExplicitConnection(mock));
+    });
+
+    test('"a"', function() {
+      const mock = createMockConnection(['a']);
+      chai.assert.isFalse(isExplicitConnection(mock));
+    });
+
+    test('"A"', function() {
+      const mock = createMockConnection(['A']);
+      chai.assert.isFalse(isExplicitConnection(mock));
+    });
+
+    test('"*"', function() {
+      const mock = createMockConnection(['*']);
+      chai.assert.isFalse(isExplicitConnection(mock));
+    });
+
+    test('"1"', function() {
+      const mock = createMockConnection(['1']);
+      chai.assert.isFalse(isExplicitConnection(mock));
+    });
+
+    test('1', function() {
+      const mock = createMockConnection([1]);
+      chai.assert.isFalse(isExplicitConnection(mock));
+    });
+
+    test('"LongCheck"', function() {
+      const mock = createMockConnection(['LongCheck']);
+      chai.assert.isTrue(isExplicitConnection(mock));
+    });
+
+    test('"\uD83D\uDE00" (emoji)', function() {
+      const mock = createMockConnection(['\uD83D\uDE00']);
+      chai.assert.isTrue(isExplicitConnection(mock));
+    });
+
+    test('Nested', function() {
+      const mock = createMockConnection([['a']]);
+      chai.assert.isFalse(isExplicitConnection(mock));
+    });
+  });
+});
+


### PR DESCRIPTION
### Description

Adds a check that informs the developer if the type hierarchy includes a type that would act like a generic type. Eg if we had a hierarchy like the following:
```json
{
  "a": { }
}
```
The validator would log an error to the console saying "The type a will act like a generic type if used as a connection check, because it is a single character."

### Testing

Added tests to make sure that errors are properly logged if a hierarchy definition containing generic types is passed.