### PR TITLE
Rename publish:release to publish:_internal for clarity

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,8 +23,8 @@ const rimraf = require('rimraf');
  */
 function checkLicenses() {
   const checker = new jsgl.LicenseChecker({
-      // dev: true,
-      // verbose: false,
+    // dev: true,
+    // verbose: false,
   });
   checker.setDefaultHandlers();
   const pluginsDir = 'plugins';
@@ -77,7 +77,7 @@ function publish(dryRun) {
 
     // Run npm publish.
     execSync(
-        `npm run publish:${dryRun ? 'check' : 'release'}`,
+        `npm run publish:${dryRun ? 'check' : '_internal'}`,
         {cwd: releaseDir, stdio: 'inherit'});
 
     done();
@@ -111,7 +111,7 @@ function prepareToDeployToGhPages() {
       .src([
         './plugins/*/test/index.html',
         './plugins/*/build/test_bundle.js'],
-          {base: './plugins/'})
+      {base: './plugins/'})
       .pipe(gulp.dest('./gh-pages/plugins/'));
 }
 

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
         "lint": "lerna run lint",
         "postinstall": "npm run boot",
         "test": "lerna run test",
+        "publish": "gulp publish",
         "publish:check": "lerna changed",
-        "publish:release": "lerna publish",
         "publish:dryrun": "gulp publishDryRun",
-        "publish": "gulp publish"
+        "publish:_internal": "lerna publish"
     },
     "devDependencies": {
         "@blockly/eslint-config": "^2.0.0",


### PR DESCRIPTION
`npm run publish` is what we should call when we release. 
Internally the publish scripts checks out a clean version of blockly-samples in a temporary directory and calls `npm run publish:_internal` when it has prepared the repo for release.