### PR TITLE
Editable field date

### DIFF
--- a/plugins/field-date/src/field_date.js
+++ b/plugins/field-date/src/field_date.js
@@ -34,10 +34,11 @@ goog.require('goog.ui.DatePicker');
  * @param {Function=} opt_validator A function that is called to validate
  *    changes to the field's value. Takes in a date string & returns a
  *    validated date string ('YYYY-MM-DD' format), or null to abort the change.
+ * @param {?(boolean|string)=} opt_textEdit Whether to enable text editor.
  * @extends {Blockly.Field}
  * @constructor
  */
-Blockly.FieldDate = function(opt_value, opt_validator) {
+Blockly.FieldDate = function(opt_value, opt_validator, opt_textEdit = false) {
   /**
    * The default value for this field (current date).
    * @type {*}
@@ -48,6 +49,13 @@ Blockly.FieldDate = function(opt_value, opt_validator) {
 
   Blockly.FieldDate.superClass_.constructor.call(this, opt_value,
       opt_validator);
+
+  /**
+   * Whether text editing is enabled on this field.
+   * @type {boolean}
+   * @private
+   */
+  this.textEditEnabled_ = opt_textEdit == true || opt_textEdit == 'true';
 };
 Blockly.utils.object.inherits(Blockly.FieldDate, Blockly.FieldTextInput);
 
@@ -59,7 +67,7 @@ Blockly.utils.object.inherits(Blockly.FieldDate, Blockly.FieldTextInput);
  * @nocollapse
  */
 Blockly.FieldDate.fromJson = function(options) {
-  return new Blockly.FieldDate(options['date']);
+  return new Blockly.FieldDate(options['date'], undefined, options['textEdit']);
 };
 
 /**
@@ -176,12 +184,14 @@ Blockly.FieldDate.prototype.updateEditor_ = function() {
  * @override
  */
 Blockly.FieldDate.prototype.showEditor_ = function(opt_e, _opt_quietInput) {
-  // Mobile browsers have issues with in-line textareas (focus & keyboards).
-  const noFocus =
-      Blockly.utils.userAgent.MOBILE ||
-      Blockly.utils.userAgent.ANDROID ||
-      Blockly.utils.userAgent.IPAD;
-  Blockly.FieldDate.superClass_.showEditor_.call(this, opt_e, noFocus);
+  if (this.textEditEnabled_) {
+    // Mobile browsers have issues with in-line textareas (focus & keyboards).
+    const noFocus =
+        Blockly.utils.userAgent.MOBILE ||
+        Blockly.utils.userAgent.ANDROID ||
+        Blockly.utils.userAgent.IPAD;
+    Blockly.FieldDate.superClass_.showEditor_.call(this, opt_e, noFocus);
+  }
   // Build the DOM.
   this.showDropdown_();
 };

--- a/plugins/field-date/src/field_date.js
+++ b/plugins/field-date/src/field_date.js
@@ -49,7 +49,7 @@ Blockly.FieldDate = function(opt_value, opt_validator) {
   Blockly.FieldDate.superClass_.constructor.call(this, opt_value,
       opt_validator);
 };
-Blockly.utils.object.inherits(Blockly.FieldDate, Blockly.Field);
+Blockly.utils.object.inherits(Blockly.FieldDate, Blockly.FieldTextInput);
 
 /**
  * Construct a FieldDate from a JSON arg object.
@@ -167,10 +167,22 @@ Blockly.FieldDate.prototype.updateEditor_ = function() {
 };
 
 /**
- * Create and show the date field's editor.
- * @private
+ * Show the inline free-text editor on top of the text along with the date
+ *    editor.
+ * @param {Event=} opt_e Optional mouse event that triggered the field to
+ *     open, or undefined if triggered programmatically.
+ * @param {boolean=} _opt_quietInput Quiet input.
+ * @protected
+ * @override
  */
-Blockly.FieldDate.prototype.showEditor_ = function() {
+Blockly.FieldDate.prototype.showEditor_ = function(opt_e, _opt_quietInput) {
+  // Mobile browsers have issues with in-line textareas (focus & keyboards).
+  const noFocus =
+      Blockly.utils.userAgent.MOBILE ||
+      Blockly.utils.userAgent.ANDROID ||
+      Blockly.utils.userAgent.IPAD;
+  Blockly.FieldDate.superClass_.showEditor_.call(this, opt_e, noFocus);
+  // Build the DOM.
   this.picker_ = this.dropdownCreate_();
   this.picker_.render(Blockly.DropDownDiv.getContentDiv());
   Blockly.utils.dom.addClass(this.picker_.getElement(), 'blocklyDatePicker');
@@ -231,7 +243,7 @@ Blockly.FieldDate.prototype.dropdownDispose_ = function() {
  */
 Blockly.FieldDate.prototype.onDateSelected_ = function(event) {
   var date = event.date ? event.date.toIsoString(true) : '';
-  this.setValue(date);
+  this.setEditorValue_(date);
   Blockly.DropDownDiv.hideIfOwner(this);
 };
 

--- a/plugins/field-date/src/field_date.js
+++ b/plugins/field-date/src/field_date.js
@@ -176,7 +176,7 @@ Blockly.FieldDate.prototype.updateEditor_ = function() {
 
 /**
  * Shows the inline free-text editor on top of the text along with the date
- *    editor.
+ * editor.
  * @param {Event=} opt_e Optional mouse event that triggered the field to
  *     open, or undefined if triggered programmatically.
  * @param {boolean=} _opt_quietInput Quiet input.

--- a/plugins/field-date/src/field_date.js
+++ b/plugins/field-date/src/field_date.js
@@ -60,7 +60,7 @@ Blockly.FieldDate = function(opt_value, opt_validator, opt_textEdit = false) {
 Blockly.utils.object.inherits(Blockly.FieldDate, Blockly.FieldTextInput);
 
 /**
- * Construct a FieldDate from a JSON arg object.
+ * Constructs a FieldDate from a JSON arg object.
  * @param {!Object} options A JSON object with options (date).
  * @return {!Blockly.FieldDate} The new field instance.
  * @package
@@ -99,7 +99,7 @@ Blockly.FieldDate.prototype.DROPDOWN_BORDER_COLOUR = 'silver';
 Blockly.FieldDate.prototype.DROPDOWN_BACKGROUND_COLOUR = 'white';
 
 /**
- * Ensure that the input value is a valid date.
+ * Ensures that the input value is a valid date.
  * @param {*=} opt_newValue The input value.
  * @return {?string} A valid date, or null if invalid.
  * @protected
@@ -117,7 +117,7 @@ Blockly.FieldDate.prototype.doClassValidation_ = function(opt_newValue) {
 };
 
 /**
- * Render the field. If the picker is shown make sure it has the current
+ * Renders the field. If the picker is shown make sure it has the current
  * date selected.
  * @protected
  */
@@ -175,7 +175,7 @@ Blockly.FieldDate.prototype.updateEditor_ = function() {
 };
 
 /**
- * Show the inline free-text editor on top of the text along with the date
+ * Shows the inline free-text editor on top of the text along with the date
  *    editor.
  * @param {Event=} opt_e Optional mouse event that triggered the field to
  *     open, or undefined if triggered programmatically.
@@ -218,7 +218,7 @@ Blockly.FieldDate.prototype.showDropdown_ = function() {
 };
 
 /**
- * Create the date dropdown editor.
+ * Creates the date dropdown editor.
  * @return {!goog.ui.DatePicker} The newly created date picker.
  * @private
  */
@@ -249,7 +249,7 @@ Blockly.FieldDate.prototype.dropdownCreate_ = function() {
 };
 
 /**
- * Handle a click on the text input.
+ * Handles a click on the text input.
  * @param {!MouseEvent} e Mouse event.
  * @private
  */
@@ -260,7 +260,7 @@ Blockly.FieldDate.prototype.onClick_ = function(e) {
 };
 
 /**
- * Bind handlers for user input on the text input field's editor.
+ * Binds handlers for user input on the text input field's editor.
  * @param {!HTMLElement} htmlInput The htmlInput to which event
  *    handlers will be bound.
  * @protected
@@ -274,7 +274,7 @@ Blockly.FieldDate.prototype.bindInputEvents_ = function(htmlInput) {
 };
 
 /**
- * Unbind handlers for user input and workspace size changes.
+ * Unbinds handlers for user input and workspace size changes.
  * @private
  * @override
  */
@@ -287,7 +287,7 @@ Blockly.FieldDate.prototype.unbindInputEvents_ = function() {
 };
 
 /**
- * Dispose of references to DOM elements and events belonging
+ * Disposes of references to DOM elements and events belonging
  * to the date editor.
  * @private
  */
@@ -298,7 +298,7 @@ Blockly.FieldDate.prototype.dropdownDispose_ = function() {
 };
 
 /**
- * Handle a CHANGE event in the date picker.
+ * Handles a CHANGE event in the date picker.
  * @param {!Event} event The CHANGE event.
  * @private
  */
@@ -314,7 +314,7 @@ Blockly.FieldDate.prototype.onDateSelected_ = function(event) {
 };
 
 /**
- * Load the best language pack by scanning the Blockly.Msg object for a
+ * Loads the best language pack by scanning the Blockly.Msg object for a
  * language that matches the available languages in Closure.
  * @private
  */

--- a/plugins/field-date/test/field_date_test.mocha.js
+++ b/plugins/field-date/test/field_date_test.mocha.js
@@ -41,7 +41,7 @@ suite('FieldDate', function() {
   // Construct ISO string using current timezone.
   // Cannot use toISOString() because it returns in UTC.
   const defaultFieldValue = new Date().toLocaleDateString()
-      .replace(/(\d+)\/(\d+)\/(\d+)/, "$3-$1-$2")
+      .replace(/(\d+)\/(\d+)\/(\d+)/, '$3-$1-$2')
       .replace(/-(\d)(?!\d)/g, '-0$1');
   const assertFieldDefault = function(field) {
     assertFieldValue(field, defaultFieldValue);

--- a/plugins/field-date/test/index.js
+++ b/plugins/field-date/test/index.js
@@ -15,8 +15,17 @@ import '../dist/date_compressed';
 
 const toolbox = generateFieldTestBlocks('field_date', [
   {
+    'label': 'Simple',
     'args': {
       'date': '2020-02-20',
+      'textEdit': 'false',
+    },
+  },
+  {
+    'label': 'Text Edit',
+    'args': {
+      'date': '2020-02-20',
+      'textEdit': 'true',
     },
   },
 ]);


### PR DESCRIPTION
### Details
Fixes #343

Adding text edit functionality to field-date plugin.
- Changing base class of FieldDate from Field to FieldTextEdit
- Adding option in constructor for enable/disable of text edit
- Showing text editor based on whether text edit is enabled
- Adding logic to handle text editor/date picker interactions
  - Hide text editor when date is selected from picker
  - Show date picker on click of field (to allow for re-openining date picker after it was used)
  - Update date picker on valid change of text input

### Screenshots
![dc6f8d35-446c-4f14-9e8e-0699dcd0d66c](https://user-images.githubusercontent.com/6621618/95239487-e65dff80-07bf-11eb-8a0f-e626032b5baf.gif)

### Additional Information
While testing this field, found it was also affected by https://github.com/google/blockly/issues/4345.
