### PR TITLE
Use getFlyout instead of private property

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousToolbox.js
+++ b/plugins/continuous-toolbox/src/ContinuousToolbox.js
@@ -126,8 +126,9 @@ export class ContinuousToolbox extends Blockly.Toolbox {
   /** @override */
   getClientRect() {
     // If the flyout never closes, it should be the deletable area.
-    if (this.flyout_ && !this.flyout_.autoClose) {
-      return this.flyout_.getClientRect();
+    const flyout = this.getFlyout();
+    if (flyout && !flyout.autoClose) {
+      return flyout.getClientRect();
     }
     return super.getClientRect();
   }


### PR DESCRIPTION
this.flyout_ is private but getFlyout() is not.