### PR TITLE
Pull in code to recycle blocks

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousFlyout.js
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.js
@@ -338,8 +338,8 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
 
   /**
    * Puts a previously created block into the recycle bin and moves it to the
-   * top or the workspace. Used during large workspace swaps to limit the number
-   * of new dom elements we need to create.
+   * top of the workspace. Used during large workspace swaps to limit the number
+   * of new DOM elements we need to create.
    * @param {!Blockly.BlockSvg} block The block to recycle.
    * @protected
    */

--- a/plugins/continuous-toolbox/src/ContinuousToolbox.js
+++ b/plugins/continuous-toolbox/src/ContinuousToolbox.js
@@ -69,6 +69,11 @@ export class ContinuousToolbox extends Blockly.Toolbox {
   }
 
   /** @override */
+  refreshSelection() {
+    this.getFlyout().show(this.getInitialFlyoutContents_());
+  }
+
+  /** @override */
   updateFlyout_(_oldItem, newItem) {
     if (newItem) {
       const target = this.getFlyout()


### PR DESCRIPTION
Summary:

- `clearOldBlocks_` gets called at the beginning of `flyout.show()`. This will add any blocks that can be recycled to the `this.recycledBlocks_` list.

- We use the `recycledBlocks_` list in `createBlock_` to bypass calling `domToBlock` if the block has been recycled. This is the expensive call that we are trying to avoid if possible.
- We empty the `recycledBlocks_` after we have used it.

Note: What makes a block recyclable is probably an application based decision, so this should be something that can be easily changed.