### PR TITLE
Fix context menu bug in +/- blocks

### DIFF
--- a/plugins/block-plus-minus/src/procedures.js
+++ b/plugins/block-plus-minus/src/procedures.js
@@ -174,7 +174,7 @@ const procedureContextMenu = {
 
     // Add options to create getters for each parameter.
     const varModels = this.getVarModels();
-    for (let i = 0, model; (model = varModels[i]); i++) {
+    for (const model of varModels) {
       const text = Blockly.Msg['VARIABLES_SET_CREATE_GET']
           .replace('%1', model.name);
 
@@ -244,7 +244,7 @@ const procedureDefMutator = {
 
     const names = [];
     const ids = [];
-    for (let i = 0, childNode; (childNode = xmlElement.childNodes[i]); i++) {
+    for (const childNode of xmlElement.childNodes) {
       if (childNode.nodeName.toLowerCase() == 'arg') {
         names.push(childNode.getAttribute('name'));
         ids.push(childNode.getAttribute('varid') ||

--- a/plugins/block-plus-minus/test/procedures.mocha.js
+++ b/plugins/block-plus-minus/test/procedures.mocha.js
@@ -164,7 +164,8 @@ suite('Procedure blocks', function() {
        * @type {Array<SerializationTestCase>}
        */
       const testCases = [
-        {title: 'Empty XML definition',
+        {
+          title: 'Minimal definition',
           xml: '<block type="' + testSuite.defType + '"/>',
           expectedXml:
               '<block xmlns="https://developers.google.com/blockly/xml" ' +
@@ -176,7 +177,68 @@ suite('Procedure blocks', function() {
                 assertDefBlockStructure(block, testSuite.hasReturn);
               },
         },
-        {title: 'Empty XML caller',
+        {
+          title: 'Common definition',
+          xml:
+              '<block type="' + testSuite.defType + '">' +
+              '  <field name="NAME">do something</field>' +
+              '</block>',
+          expectedXml:
+              '<block xmlns="https://developers.google.com/blockly/xml" ' +
+              'type="' + testSuite.defType + '" id="1">\n' +
+              '  <field name="NAME">do something</field>\n' +
+              '</block>',
+          assertBlockStructure:
+              (block) => {
+                assertDefBlockStructure(block, testSuite.hasReturn);
+              },
+        },
+        {
+          title: 'With vars definition',
+          xml:
+              '<block type="' + testSuite.defType + '">\n' +
+              '  <mutation>\n' +
+              '    <arg name="x" varid="arg1"></arg>\n' +
+              '    <arg name="y" varid="arg2"></arg>\n' +
+              '  </mutation>\n' +
+              '  <field name="NAME">do something</field>\n' +
+              '</block>',
+          expectedXml:
+              '<block xmlns="https://developers.google.com/blockly/xml" ' +
+              'type="' + testSuite.defType + '" id="1">\n' +
+              '  <mutation>\n' +
+              '    <arg name="x" varid="arg1"></arg>\n' +
+              '    <arg name="y" varid="arg2"></arg>\n' +
+              '  </mutation>\n' +
+              '  <field name="NAME">do something</field>\n' +
+              '  <field name="1">x</field>\n' + // Because genUID is stubbed.
+              '  <field name="1">y</field>\n' +
+              '</block>',
+          assertBlockStructure:
+              (block) => {
+                assertDefBlockStructure(block, testSuite.hasReturn, ['x', 'y']);
+              },
+        },
+        {
+          title: 'No statements definition',
+          xml:
+              '<block type="procedures_defreturn">\n' +
+              '  <mutation statements="false"></mutation>\n' +
+              '  <field name="NAME">do something</field>\n' +
+              '</block>',
+          expectedXml:
+              '<block xmlns="https://developers.google.com/blockly/xml" ' +
+              'type="procedures_defreturn" id="1">\n' +
+              '  <mutation statements="false"></mutation>\n' +
+              '  <field name="NAME">do something</field>\n' +
+              '</block>',
+          assertBlockStructure:
+              (block) => {
+                assertDefBlockStructure(block, true, [], false);
+              },
+        },
+        {
+          title: 'Minimal caller',
           xml: '<block type="' + testSuite.callType + '"/>',
           expectedXml:
               '<block xmlns="https://developers.google.com/blockly/xml" ' +
@@ -189,6 +251,44 @@ suite('Procedure blocks', function() {
           assertBlockStructure:
               (block) => {
                 assertCallBlockStructure(block);
+              },
+        },
+        {
+          title: 'Common caller',
+          xml:
+              '<block type="' + testSuite.callType + '">\n' +
+              '  <mutation name="do something"/>\n' +
+              '</block>',
+          expectedXml:
+              '<block xmlns="https://developers.google.com/blockly/xml" ' +
+              'type="' + testSuite.callType + '" id="1">\n' +
+              '  <mutation name="do something"></mutation>\n' +
+              '</block>',
+          assertBlockStructure:
+              (block) => {
+                assertCallBlockStructure(block);
+              },
+        },
+        {
+          title: 'With vars caller',
+          xml:
+              '<block type="' + testSuite.callType + '">\n' +
+              '  <mutation name="do something">\n' +
+              '    <arg name="x"></arg>\n' +
+              '    <arg name="y"></arg>\n' +
+              '  </mutation>\n' +
+              '</block>',
+          expectedXml:
+              '<block xmlns="https://developers.google.com/blockly/xml" ' +
+              'type="' + testSuite.callType + '" id="1">\n' +
+              '  <mutation name="do something">\n' +
+              '    <arg name="x"></arg>\n' +
+              '    <arg name="y"></arg>\n' +
+              '  </mutation>\n' +
+              '</block>',
+          assertBlockStructure:
+              (block) => {
+                assertCallBlockStructure(block, ['x', 'y']);
               },
         },
       ];


### PR DESCRIPTION
### Description

Fixes the context menu bug brought to my attention by [this post](https://groups.google.com/g/blockly/c/KQS4cTwj4xo).

Also does some general cleanup related to types, conforming to the style guide, and removing TODOs.

[EDIT: Actually I'm going to move this to use for...of constructs]
[EDIT2: Done]

### Testing

1) Right clicked the block in the flyout. Observed how the only option was "help".
2) Dragged the block out, and right clicked it. Observed how there were no "Create 'get'" options.
3) Added two variables to the block, and right clicked it. Observed how there were two "Create 'get'" options.
4) Removed 1 variable from the block, and right clicked it. Observed how there was one "Create 'get'" option.
5) Removed the remaining variable from the block, and right clicked it. Observed how there were no "Create'get'" options.