### PR TITLE
Fix issue with conflicting param names

### DIFF
--- a/plugins/block-plus-minus/src/procedures.js
+++ b/plugins/block-plus-minus/src/procedures.js
@@ -476,6 +476,7 @@ const procedureDefMutator = {
       }
     });
     this.varIdsToDelete_.length = 0;
+    this.preEditVarModel_ = null;
   },
 };
 

--- a/plugins/block-plus-minus/src/procedures.js
+++ b/plugins/block-plus-minus/src/procedures.js
@@ -396,11 +396,10 @@ const procedureDefMutator = {
     const caselessName = newName.toLowerCase();
 
     /**
-     * Returns true if the given argDatum is the argDatum associated with this
-     * field, or has a different caseless name than the argDatum associated
-     * with this field. False otherwise.
+     * Returns true if the given argDatum is associated with this field, or has
+     * a different caseless name than the argDatum associated with this field.
      * @param {{model: Blockly.VariableModel, argId:string}} argDatum The
-     *     argDatum we want to make sure is different from the argDatum
+     *     argDatum we want to make sure does not conflict with the argDatum
      *     associated with this field.
      * @return {boolean} True if the given datum does not conflict with the
      *     datum associated with this field.


### PR DESCRIPTION
### Description

While fixing #404 (hah) I discovered some bugs with parameter name conflicts.

If the new name became empty, callers would not be updated:
![EmptyName](https://user-images.githubusercontent.com/25440652/96057256-62e68300-0e3d-11eb-90f3-3bf75295bf3f.gif)

If the new name became conflicting, callers would not be updated:
![ConflictingNames](https://user-images.githubusercontent.com/25440652/96057267-667a0a00-0e3d-11eb-950a-2601a71f7964.gif)

This PR fixes those issues. It also reorganizes the validator a little bit because it was very messy.

### Testing
1. Tested that empty names update callers.
![EmptyNameFixed](https://user-images.githubusercontent.com/25440652/96057825-a42b6280-0e3e-11eb-93d1-c3014393722a.gif)

2. Tested that conflicting names update callers.
![ConflictingNamesFixed](https://user-images.githubusercontent.com/25440652/96057827-a5f52600-0e3e-11eb-997c-e0bcdc07b9d8.gif)

1. Tested that creating an empty name without update callers works fine.
![EmptyNoErrors](https://user-images.githubusercontent.com/25440652/96057727-75ad8780-0e3e-11eb-8ef6-e4f8b5b16306.gif)

2. Tested that creating a naming conflict without updating callers works fine.
![ConflictingNamesNoErrors](https://user-images.githubusercontent.com/25440652/96057748-7cd49580-0e3e-11eb-877b-514ea64be17a.gif)
