### PR TITLE
Flesh out priority queue map interface - project static

### DIFF
--- a/plugins/nominal-connection-checker/src/priority_queue_map.js
+++ b/plugins/nominal-connection-checker/src/priority_queue_map.js
@@ -72,7 +72,7 @@ export class PriorityQueueMap {
    *     the given key.
    */
   getAllValues(key) {
-    const bindings = this.getAllBindings();
+    const bindings = this.getAllBindings(key);
     return bindings && bindings.map((binding) => binding.value);
   }
 
@@ -110,12 +110,12 @@ export class PriorityQueueMap {
    * a matching priority.
    * @param {*} key The key to unbind the value from.
    * @param {*} value The value to unbind from the key.
-   * @param {number=} opt_priority The priority of the binding.
+   * @param {number=} priority The priority of the binding.
    * @return {boolean} True if the binding existed, false otherwise.
    */
-  unbind(key, value, opt_priority) {
+  unbind(key, value, priority = undefined) {
     return this.unbindMatching(
-        key, this.createSimpleMatcher_(value, opt_priority));
+        key, this.createSimpleMatcher_(value, priority));
   }
 
   /**
@@ -124,17 +124,16 @@ export class PriorityQueueMap {
    * matching priority.
    * @param {*} key The key to remove bindings from.
    * @param {*} value The value to unbind from the key.
-   * @param {number=} opt_priority The priority of the bindings.
+   * @param {number=} priority The priority of the bindings.
    */
-  unbindAll(key, value, opt_priority) {
+  unbindAll(key, value, priority = undefined) {
     this.unbindAllMatching(
-        key, this.createSimpleMatcher_(value, opt_priority));
+        key, this.createSimpleMatcher_(value, priority));
   }
 
   /**
-   * Removes the first binding associated with the given key that has the given
-   * priority, and that will make the matcher return true from the key's
-   * priority queue of values.
+   * Removes the first binding associated with the given key that  will make the
+   * matcher return true from the key's priority queue of values.
    * @param {*} key The key to unbind a value from.
    * @param {function(*, number):boolean} matcher The callback function used to
    *     test each binding. Takes in the binding's value and priority.
@@ -157,7 +156,7 @@ export class PriorityQueueMap {
   /**
    * Removes all bindings associate with the given key that make the matcher
    * return true.
-   * @param {string} key The key to remove bindings from.
+   * @param {*} key The key to remove bindings from.
    * @param {function(*, number):boolean} matcher The callback function used to
    *     test each element.
    */
@@ -168,19 +167,30 @@ export class PriorityQueueMap {
   }
 
   /**
+   * Returns true if the PriorityQueueMap contains any bindings for the given
+   * key. False otherwise.
+   * @param {*} key The key to search for.
+   * @return {boolean} True if the PriorityQueueMap contains any bindings for
+   *     the given key. False otherwise.
+   */
+  has(key) {
+    return !!this.getAllBindings(key);
+  }
+
+  /**
    * Returns true if the key's priority queue contains the given value. If a
    * priority is provided this will only return true if the value also has the
    * given priority.
    * @param {*} key The key we want to examine the values of.
    * @param {*} value The value to search for.
-   * @param {number=} opt_priority The priority the value should have.
+   * @param {number=} priority The priority the value should have.
    * @return {boolean} True if key's priority queue contains the given value,
    *     and in the case that a priority is provided the priority matches. False
    *     otherwise.
    */
-  has(key, value, opt_priority) {
-    return this.hasMatching(
-        key, this.createSimpleMatcher_(value, opt_priority));
+  hasValue(key, value, priority = undefined) {
+    return this.hasMatchingValue(
+        key, this.createSimpleMatcher_(value, priority));
   }
 
   /**
@@ -192,7 +202,7 @@ export class PriorityQueueMap {
    * @return {boolean} True if there is at least one binding associated with the
    *     given key that will make the the matcher return true. False otherwise.
    */
-  hasMatching(key, matcher) {
+  hasMatchingValue(key, matcher) {
     const bindings = this.getAllBindings(key);
     if (!bindings) {
       return false;
@@ -205,7 +215,7 @@ export class PriorityQueueMap {
   /**
    * Returns an array of all bindings that pass the test implemented by the
    * matcher function.
-   * @param {string} key The key to filter the bindings of.
+   * @param {*} key The key to filter the bindings of.
    * @param {function(*, number):boolean} matcher The callback function used to
    *     test each element.
    * @return {!Array<!Binding>} An array of matching bindings. If no bindings
@@ -227,12 +237,12 @@ export class PriorityQueueMap {
   /**
    * Executes the callback once for each binding on each key. Order is not
    * guaranteed.
-   * @param {function(string, *, number)} callback The callback to execute on
+   * @param {function(*, *, number)} callback The callback to execute on
    *     each binding of each key. Takes in the key, and the value, and the
    *     priority of the binding.
    */
   forEach(callback) {
-    this.map_.forEach((key, bindings) => {
+    this.map_.forEach((bindings, key) => {
       bindings.forEach((binding) => {
         callback(key, binding.value, binding.priority);
       });
@@ -242,7 +252,7 @@ export class PriorityQueueMap {
   /**
    * Executes the callback once for each binding associated with the given key.
    * Order is not guaranteed.
-   * @param {string} key The key to enumerate over the bindings of.
+   * @param {*} key The key to enumerate over the bindings of.
    * @param {function(*, number)} callback The callback to execute on each
    *     binding associated with the given key. Tkaes in the value and the
    *     priority of the binding.
@@ -262,14 +272,14 @@ export class PriorityQueueMap {
    * priority is also provided it only returns true if the priority matches as
    * well.
    * @param {*} value The value to match.
-   * @param {number} opt_priority The priority to match.
+   * @param {number=} priority The priority to match.
    * @return {function(*, number): boolean} A simple matcher function.
    * @private
    */
-  createSimpleMatcher_(value, opt_priority) {
-    return (val, priority) => {
-      return (opt_priority === undefined || priority === opt_priority) &&
-          val === value;
+  createSimpleMatcher_(value, priority) {
+    return (elemValue, elemPriority) => {
+      return (priority === undefined || elemPriority === priority) &&
+          elemValue === value;
     };
   }
 }

--- a/plugins/nominal-connection-checker/src/priority_queue_map.js
+++ b/plugins/nominal-connection-checker/src/priority_queue_map.js
@@ -137,15 +137,16 @@ export class PriorityQueueMap {
    * @param {*} key The key to unbind a value from.
    * @param {function(*, number):boolean} matcher The callback function used to
    *     test each binding. Takes in the binding's value and priority.
+   * @param {!Object=} thisArg The value to use as `this` inside the matcher.
    * @return {boolean} True if a matching binding existed, false otherwise.
    */
-  unbindMatching(key, matcher) {
+  unbindMatching(key, matcher, thisArg = undefined) {
     const bindings = this.getAllBindings(key);
     if (!bindings) {
       return false;
     }
     const index = bindings.findIndex((binding) => {
-      return matcher(binding.value, binding.priority);
+      return matcher.call(thisArg, binding.value, binding.priority);
     });
     if (index != -1) {
       bindings.splice(index, 1);
@@ -159,10 +160,11 @@ export class PriorityQueueMap {
    * @param {*} key The key to remove bindings from.
    * @param {function(*, number):boolean} matcher The callback function used to
    *     test each element.
+   * @param {!Object=} thisArg The value to use as `this` inside the matcher.
    */
-  unbindAllMatching(key, matcher) {
-    if (this.unbindMatching(key, matcher)) {
-      this.unbindAllMatching(key, matcher);
+  unbindAllMatching(key, matcher, thisArg = undefined) {
+    if (this.unbindMatching(key, matcher, thisArg)) {
+      this.unbindAllMatching(key, matcher, thisArg);
     }
   }
 
@@ -199,16 +201,17 @@ export class PriorityQueueMap {
    * @param {*} key The key we want to examine the bindings of.
    * @param {function(*, number):boolean} matcher The callback function used to
    *     test each element.
+   * @param {!Object=} thisArg The value to use as `this` inside the matcher.
    * @return {boolean} True if there is at least one binding associated with the
    *     given key that will make the the matcher return true. False otherwise.
    */
-  hasMatchingValue(key, matcher) {
+  hasMatchingValue(key, matcher, thisArg = undefined) {
     const bindings = this.getAllBindings(key);
     if (!bindings) {
       return false;
     }
     return bindings.some((binding) => {
-      return matcher(binding.value, binding.priority);
+      return matcher.call(thisArg, binding.value, binding.priority);
     });
   }
 
@@ -218,15 +221,16 @@ export class PriorityQueueMap {
    * @param {*} key The key to filter the bindings of.
    * @param {function(*, number):boolean} matcher The callback function used to
    *     test each element.
+   * @param {!Object=} thisArg The value to use as `this` inside the matcher.
    * @return {!Array<!Binding>} An array of matching bindings. If no bindings
    *     match an empty array will be returned.
    */
-  filter(key, matcher) {
+  filter(key, matcher, thisArg = undefined) {
     const array = [];
     const bindings = this.getAllBindings(key);
     if (bindings) {
       bindings.forEach((binding) => {
-        if (matcher(binding.value, binding.priority)) {
+        if (matcher.call(thisArg, binding.value, binding.priority)) {
           array.push(binding);
         }
       });
@@ -240,11 +244,12 @@ export class PriorityQueueMap {
    * @param {function(*, *, number)} callback The callback to execute on
    *     each binding of each key. Takes in the key, and the value, and the
    *     priority of the binding.
+   * @param {!Object=} thisArg The value to use as `this` inside the matcher.
    */
-  forEach(callback) {
+  forEach(callback, thisArg = undefined) {
     this.map_.forEach((bindings, key) => {
       bindings.forEach((binding) => {
-        callback(key, binding.value, binding.priority);
+        callback.call(thisArg, key, binding.value, binding.priority);
       });
     });
   }
@@ -256,14 +261,15 @@ export class PriorityQueueMap {
    * @param {function(*, number)} callback The callback to execute on each
    *     binding associated with the given key. Tkaes in the value and the
    *     priority of the binding.
+   * @param {!Object=} thisArg The value to use as `this` inside the matcher.
    */
-  forEachBinding(key, callback) {
+  forEachBinding(key, callback, thisArg = undefined) {
     const bindings = this.getAllBindings(key);
     if (!bindings) {
       return;
     }
     bindings.forEach((binding) => {
-      callback(binding.value, binding.priority);
+      callback.call(thisArg, binding.value, binding.priority);
     });
   }
 

--- a/plugins/nominal-connection-checker/src/priority_queue_map.js
+++ b/plugins/nominal-connection-checker/src/priority_queue_map.js
@@ -65,6 +65,30 @@ export class PriorityQueueMap {
   }
 
   /**
+   * Returns all values associated with the given key, or undefined if the key
+   * is not bound. Order is not guaranteed.
+   * @param {*} key The key to return the values of.
+   * @return {undefined|!Array<*>} An array of all of the values associated with
+   *     the given key.
+   */
+  getAllValues(key) {
+    const bindings = this.getAllBindings();
+    return bindings && bindings.map((binding) => binding.value);
+  }
+
+  /**
+   * Returns all Bindings associated with the given key, or undefined if the
+   * key is not bound.
+   * @param {*} key The key to return the bindings of.
+   * @return {undefined|!Array<!Binding>} An array of all of the bindings
+   *     associated with the given key.
+   */
+  getAllBindings(key) {
+    const bindings = this.map_.get(key);
+    return (!bindings || !bindings.length) ? undefined : bindings;
+  }
+
+  /**
    * Adds the given value with the associated priority to the key's priority
    * queue of values.
    * @param {*} key The key to bind the value to.
@@ -81,22 +105,172 @@ export class PriorityQueueMap {
   }
 
   /**
-   * Removes the given value with the associated priority from the key's
-   * priority queue of values.
+   * Removes the first instance of the given value from the key's priority queue
+   * of values. If a priority is provided a value will only be removed if it has
+   * a matching priority.
    * @param {*} key The key to unbind the value from.
    * @param {*} value The value to unbind from the key.
-   * @param {number} priority The priority of the binding.
+   * @param {number=} opt_priority The priority of the binding.
+   * @return {boolean} True if the binding existed, false otherwise.
    */
-  unbind(key, value, priority) {
-    const bindings = this.map_.get(key);
+  unbind(key, value, opt_priority) {
+    return this.unbindMatching(
+        key, this.createSimpleMatcher_(value, opt_priority));
+  }
+
+  /**
+   * Removes all instances of the given value from the key's priority queue of
+   * values. If a priority is provided a value will only be removed if it has a
+   * matching priority.
+   * @param {*} key The key to remove bindings from.
+   * @param {*} value The value to unbind from the key.
+   * @param {number=} opt_priority The priority of the bindings.
+   */
+  unbindAll(key, value, opt_priority) {
+    this.unbindAllMatching(
+        key, this.createSimpleMatcher_(value, opt_priority));
+  }
+
+  /**
+   * Removes the first binding associated with the given key that has the given
+   * priority, and that will make the matcher return true from the key's
+   * priority queue of values.
+   * @param {*} key The key to unbind a value from.
+   * @param {function(*, number):boolean} matcher The callback function used to
+   *     test each binding. Takes in the binding's value and priority.
+   * @return {boolean} True if a matching binding existed, false otherwise.
+   */
+  unbindMatching(key, matcher) {
+    const bindings = this.getAllBindings(key);
     if (!bindings) {
-      return;
+      return false;
     }
-    const index = bindings.findIndex((binding) =>
-      binding.value === value && binding.priority === priority);
+    const index = bindings.findIndex((binding) => {
+      return matcher(binding.value, binding.priority);
+    });
     if (index != -1) {
       bindings.splice(index, 1);
     }
+    return index != -1;
+  }
+
+  /**
+   * Removes all bindings associate with the given key that make the matcher
+   * return true.
+   * @param {string} key The key to remove bindings from.
+   * @param {function(*, number):boolean} matcher The callback function used to
+   *     test each element.
+   */
+  unbindAllMatching(key, matcher) {
+    if (this.unbindMatching(key, matcher)) {
+      this.unbindAllMatching(key, matcher);
+    }
+  }
+
+  /**
+   * Returns true if the key's priority queue contains the given value. If a
+   * priority is provided this will only return true if the value also has the
+   * given priority.
+   * @param {*} key The key we want to examine the values of.
+   * @param {*} value The value to search for.
+   * @param {number=} opt_priority The priority the value should have.
+   * @return {boolean} True if key's priority queue contains the given value,
+   *     and in the case that a priority is provided the priority matches. False
+   *     otherwise.
+   */
+  has(key, value, opt_priority) {
+    return this.hasMatching(
+        key, this.createSimpleMatcher_(value, opt_priority));
+  }
+
+  /**
+   * Returns true if there is at least one binding associated with the given key
+   * that will make the matcher return true.
+   * @param {*} key The key we want to examine the bindings of.
+   * @param {function(*, number):boolean} matcher The callback function used to
+   *     test each element.
+   * @return {boolean} True if there is at least one binding associated with the
+   *     given key that will make the the matcher return true. False otherwise.
+   */
+  hasMatching(key, matcher) {
+    const bindings = this.getAllBindings(key);
+    if (!bindings) {
+      return false;
+    }
+    return bindings.some((binding) => {
+      return matcher(binding.value, binding.priority);
+    });
+  }
+
+  /**
+   * Returns an array of all bindings that pass the test implemented by the
+   * matcher function.
+   * @param {string} key The key to filter the bindings of.
+   * @param {function(*, number):boolean} matcher The callback function used to
+   *     test each element.
+   * @return {!Array<!Binding>} An array of matching bindings. If no bindings
+   *     match an empty array will be returned.
+   */
+  filter(key, matcher) {
+    const array = [];
+    const bindings = this.getAllBindings(key);
+    if (bindings) {
+      bindings.forEach((binding) => {
+        if (matcher(binding.value, binding.priority)) {
+          array.push(binding);
+        }
+      });
+    }
+    return array;
+  }
+
+  /**
+   * Executes the callback once for each binding on each key. Order is not
+   * guaranteed.
+   * @param {function(string, *, number)} callback The callback to execute on
+   *     each binding of each key. Takes in the key, and the value, and the
+   *     priority of the binding.
+   */
+  forEach(callback) {
+    this.map_.forEach((key, bindings) => {
+      bindings.forEach((binding) => {
+        callback(key, binding.value, binding.priority);
+      });
+    });
+  }
+
+  /**
+   * Executes the callback once for each binding associated with the given key.
+   * Order is not guaranteed.
+   * @param {string} key The key to enumerate over the bindings of.
+   * @param {function(*, number)} callback The callback to execute on each
+   *     binding associated with the given key. Tkaes in the value and the
+   *     priority of the binding.
+   */
+  forEachBinding(key, callback) {
+    const bindings = this.getAllBindings(key);
+    if (!bindings) {
+      return;
+    }
+    bindings.forEach((binding) => {
+      callback(binding.value, binding.priority);
+    });
+  }
+
+  /**
+   * Returns a basic matcher that returns true if the values match. If a
+   * priority is also provided it only returns true if the priority matches as
+   * well.
+   * @param {*} value The value to match.
+   * @param {number} opt_priority The priority to match.
+   * @return {function(*, number): boolean} A simple matcher function.
+   * @private
+   */
+  createSimpleMatcher_(value, opt_priority) {
+    return (val, priority) => {
+      return (opt_priority === undefined || priority === opt_priority) &&
+          val === value;
+    };
   }
 }
 

--- a/plugins/nominal-connection-checker/test/priority_queue_map_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/priority_queue_map_test.mocha.js
@@ -345,6 +345,14 @@ suite('PriorityQueueMap', function() {
           'test', (value, priority) => value.objKey == 'value');
       this.assertBindings('test', {value: 'test1', priority: 10});
     });
+
+    test('this', function() {
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      const thisArg = {};
+      this.priorityQueueMap.unbindMatching('test', function(value, priority) {
+        chai.assert.equal(this, thisArg);
+      }, thisArg);
+    });
   });
 
   suite('unbindAllMatching', function() {
@@ -381,6 +389,14 @@ suite('PriorityQueueMap', function() {
       this.priorityQueueMap.unbindAllMatching(
           'test', (value, priority) => value.objKey == 'value');
       this.assertBindings('test', {value: 'test1', priority: 10});
+    });
+
+    test('this', function() {
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      const thisArg = {};
+      this.priorityQueueMap.unbindAllMatching('test', function(value, priority) {
+        chai.assert.equal(this, thisArg);
+      }, thisArg);
     });
   });
 
@@ -488,6 +504,14 @@ ${priority !== undefined ? priority : 'any'}}.`);
       chai.assert.isTrue(this.priorityQueueMap.hasMatchingValue(
           'test', (value, priority) => value.objKey == 'value'));
     });
+
+    test('this', function() {
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      const thisArg = {};
+      this.priorityQueueMap.hasMatchingValue('test', function(value, priority) {
+        chai.assert.equal(this, thisArg);
+      }, thisArg);
+    });
   });
 
   suite('filter', function() {
@@ -522,6 +546,14 @@ ${priority !== undefined ? priority : 'any'}}.`);
       this.priorityQueueMap.bind('test', {objKey: 'value'}, 20);
       this.assertFilter('test', (value, priority) => value.objKey == 'value',
           {value: {objKey: 'value'}, priority: 20});
+    });
+
+    test('this', function() {
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      const thisArg = {};
+      this.priorityQueueMap.filter('test', function(value, priority) {
+        chai.assert.equal(this, thisArg);
+      }, thisArg);
     });
   });
 
@@ -558,6 +590,14 @@ ${priority !== undefined ? priority : 'any'}}.`);
       this.priorityQueueMap.forEach(spy);
       chai.assert.isTrue(spy.notCalled);
     });
+
+    test('this', function() {
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      const thisArg = {};
+      this.priorityQueueMap.forEach(function(value, priority) {
+        chai.assert.equal(this, thisArg);
+      }, thisArg);
+    });
   });
 
   suite('forEachBinding', function() {
@@ -592,6 +632,14 @@ ${priority !== undefined ? priority : 'any'}}.`);
       const spy = sinon.spy();
       this.priorityQueueMap.forEachBinding('test', spy);
       chai.assert.isTrue(spy.notCalled);
+    });
+
+    test('this', function() {
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      const thisArg = {};
+      this.priorityQueueMap.forEachBinding('test', function(value, priority) {
+        chai.assert.equal(this, thisArg);
+      }, thisArg);
     });
   });
 

--- a/plugins/nominal-connection-checker/test/priority_queue_map_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/priority_queue_map_test.mocha.js
@@ -109,6 +109,16 @@ suite('PriorityQueueMap', function() {
       this.priorityQueueMap.bind('test', 'test3', 30);
       this.assertAllValues('test', 'test1', 'test2', 'test3');
     });
+
+    test('Bad key', function() {
+      chai.assert.isUndefined(this.priorityQueueMap.getAllValues('test'));
+    });
+
+    test('No values', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.priorityQueueMap.unbind('test', 'test', 0);
+      chai.assert.isUndefined(this.priorityQueueMap.getAllValues('test'));
+    });
   });
 
   suite('getAllBindings', function() {
@@ -137,6 +147,16 @@ suite('PriorityQueueMap', function() {
           {value: 'test1', priority: 10},
           {value: 'test2', priority: 20},
           {value: 'test3', priority: 30});
+    });
+
+    test('Bad key', function() {
+      chai.assert.isUndefined(this.priorityQueueMap.getAllBindings('test'));
+    });
+
+    test('No values', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.priorityQueueMap.unbind('test', 'test', 0);
+      chai.assert.isUndefined(this.priorityQueueMap.getAllBindings('test'));
     });
   });
 

--- a/plugins/nominal-connection-checker/test/priority_queue_map_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/priority_queue_map_test.mocha.js
@@ -9,6 +9,7 @@
  */
 
 const chai = require('chai');
+const sinon = require('sinon');
 
 const {PriorityQueueMap} = require('../src/priority_queue_map.js');
 
@@ -48,6 +49,12 @@ suite('PriorityQueueMap', function() {
       this.priorityQueueMap.unbind('test', 'test', 0);
       chai.assert.isUndefined(this.priorityQueueMap.getValues('test'));
     });
+
+    test('Different Priorities', function() {
+      this.priorityQueueMap.bind('test', 'test', 10);
+      this.priorityQueueMap.bind('test', 'test2', 0);
+      this.assertValues('test', 'test');
+    });
   });
 
   suite('getBindings', function() {
@@ -72,6 +79,64 @@ suite('PriorityQueueMap', function() {
       this.priorityQueueMap.bind('test', 'test', 0);
       this.priorityQueueMap.unbind('test', 'test', 0);
       chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
+    });
+
+    test('Different priorities', function() {
+      this.priorityQueueMap.bind('test', 'test', 10);
+      this.priorityQueueMap.bind('test', 'test2', 0);
+      this.assertBindings('test',
+          {value: 'test', priority: 10});
+    });
+  });
+
+  suite('getAllValues', function() {
+    setup(function() {
+      this.assertAllValues = function(key, ...values) {
+        chai.assert.deepEqual(this.priorityQueueMap.getAllValues(key), values);
+      };
+    });
+
+    test('Same priorities', function() {
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      this.priorityQueueMap.bind('test', 'test2', 0);
+      this.priorityQueueMap.bind('test', 'test3', 0);
+      this.assertAllValues('test', 'test1', 'test2', 'test3');
+    });
+
+    test('Different priorities', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', 'test2', 20);
+      this.priorityQueueMap.bind('test', 'test3', 30);
+      this.assertAllValues('test', 'test1', 'test2', 'test3');
+    });
+  });
+
+  suite('getAllBindings', function() {
+    setup(function() {
+      this.assertAllBindings = function(key, ...bindings) {
+        chai.assert.deepEqual(
+            this.priorityQueueMap.getAllBindings(key), bindings);
+      };
+    });
+
+    test('Same priorities', function() {
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      this.priorityQueueMap.bind('test', 'test2', 0);
+      this.priorityQueueMap.bind('test', 'test3', 0);
+      this.assertAllBindings('test',
+          {value: 'test1', priority: 0},
+          {value: 'test2', priority: 0},
+          {value: 'test3', priority: 0});
+    });
+
+    test('Different priorities', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', 'test2', 20);
+      this.priorityQueueMap.bind('test', 'test3', 30);
+      this.assertAllBindings('test',
+          {value: 'test1', priority: 10},
+          {value: 'test2', priority: 20},
+          {value: 'test3', priority: 30});
     });
   });
 
@@ -147,6 +212,17 @@ suite('PriorityQueueMap', function() {
       chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
     });
 
+    test('No bindings', function() {
+      this.priorityQueueMap.unbind('test', 'test', 0);
+      chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
+    });
+
+    test('Priority not provided', function() {
+      this.priorityQueueMap.bind('test', 'test', 10);
+      this.priorityQueueMap.unbind('test', 'test');
+      chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
+    });
+
     test('Stringified value', function() {
       this.priorityQueueMap.bind('test', 1, 0);
       this.priorityQueueMap.unbind('test', '1', 0);
@@ -166,6 +242,13 @@ suite('PriorityQueueMap', function() {
       chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
     });
 
+    test('Same object, priority not provided', function() {
+      const value = {test: 'test'};
+      this.priorityQueueMap.bind('test', value, 0);
+      this.priorityQueueMap.unbind('test', value);
+      chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
+    });
+
     test('Different priority', function() {
       this.priorityQueueMap.bind('test', 'test', 0);
       this.priorityQueueMap.unbind('test', 'test', 10);
@@ -176,6 +259,319 @@ suite('PriorityQueueMap', function() {
       this.priorityQueueMap.bind('test', 'test', 0);
       this.priorityQueueMap.unbind('test', 'test', '0');
       this.assertBindings('test', {value: 'test', priority: 0});
+    });
+  });
+
+  suite('unbindAll', function() {
+    test('Same priorities, provided', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.unbindAll('test', 'test1', 10);
+      chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
+    });
+
+    test('Same priorities, not provided', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.unbindAll('test', 'test1');
+      chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
+    });
+
+    test('Different priorities, provided', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      this.priorityQueueMap.unbindAll('test', 'test1', 10);
+      this.assertBindings('test', {value: 'test1', priority: 0});
+    });
+
+    test('Different priorities, not provided', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      this.priorityQueueMap.unbindAll('test', 'test1');
+      chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
+    });
+  });
+
+  suite('unbindMatching', function() {
+    test('Simple', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.unbindMatching('test', () => true);
+      chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
+    });
+
+    test('With priority X', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', 'test2', 20);
+      this.priorityQueueMap.bind('test', 'test3', 30);
+      this.priorityQueueMap.unbindMatching(
+          'test', (value, priority) => priority == 30);
+      this.assertBindings('test', {value: 'test2', priority: 20});
+    });
+
+    test('With falsey value', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', false, 20);
+      this.priorityQueueMap.unbindMatching(
+          'test', (value, priority) => !value);
+      this.assertBindings('test', {value: 'test1', priority: 10});
+    });
+
+    test('Similar object', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', {objKey: 'value', test: 'stuff'}, 20);
+      this.priorityQueueMap.unbindMatching(
+          'test', (value, priority) => value.objKey == 'value');
+      this.assertBindings('test', {value: 'test1', priority: 10});
+    });
+  });
+
+  suite('unbindAllMatching', function() {
+    test('Simple', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.unbindAllMatching('test', () => true);
+      chai.assert.isUndefined(this.priorityQueueMap.getBindings('test'));
+    });
+
+    test('All with priority X', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', 'test2', 20);
+      this.priorityQueueMap.bind('test', 'test3', 30);
+      this.priorityQueueMap.bind('test', 'test4', 30);
+      this.priorityQueueMap.unbindAllMatching(
+          'test', (value, priority) => priority == 30);
+      this.assertBindings('test', {value: 'test2', priority: 20});
+    });
+
+    test('All with falsey value', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', false, 20);
+      this.priorityQueueMap.bind('test', 0, 30);
+      this.priorityQueueMap.unbindAllMatching(
+          'test', (value, priority) => !value);
+      this.assertBindings('test', {value: 'test1', priority: 10});
+    });
+
+    test('All similar objects', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', {objKey: 'value', test: 'stuff'}, 20);
+      this.priorityQueueMap.bind('test', {objKey: 'value', stuff: 'test'}, 30);
+      this.priorityQueueMap.unbindAllMatching(
+          'test', (value, priority) => value.objKey == 'value');
+      this.assertBindings('test', {value: 'test1', priority: 10});
+    });
+  });
+
+  suite('has', function() {
+    test('Does have', function() {
+      this.priorityQueueMap.bind('test', 'test', 10);
+      chai.assert.isTrue(
+          this.priorityQueueMap.has('test'),
+          `Expected the priority queue map to have the key 'test'`);
+    });
+
+    test(`Doesn't have`, function() {
+      chai.assert.isFalse(
+          this.priorityQueueMap.has('test'),
+          `Expected the priority queue map to not have the key 'test'`);
+    });
+  });
+
+  suite('hasValue', function() {
+    setup(function() {
+      this.assertHasValue = function(key, value, priority = undefined) {
+        chai.assert.isTrue(
+            this.priorityQueueMap.hasValue(key, value, priority),
+            `Expected the priority queue map to have the binding {key: ${key},
+value: ${value}, priority: ${priority !== undefined ? priority : 'any'}}.`);
+      };
+
+      this.assertNotHasValue = function(key, value, priority = undefined) {
+        chai.assert.isFalse(
+            this.priorityQueueMap.hasValue(key, value, priority),
+            `Expected the priority queue map to not have the binding
+{key: ${key}, value: ${value}, priority:
+${priority !== undefined ? priority : 'any'}}.`);
+      };
+    });
+
+    test('Simple', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.assertHasValue('test', 'test', 0);
+    });
+
+    test('No bindings', function() {
+      this.assertNotHasValue('test', 'test', 0);
+    });
+
+    test('Priority not provided', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.assertHasValue('test', 'test');
+    });
+
+    test('Stringified value', function() {
+      this.priorityQueueMap.bind('test', 1, 0);
+      this.assertNotHasValue('test', '1', 0);
+    });
+
+    test('Similar object value', function() {
+      this.priorityQueueMap.bind('test', {test: 'test'}, 0);
+      this.assertNotHasValue('test', {test: 'test'}, 0);
+    });
+
+    test('Same object value', function() {
+      const value = {test: 'test'};
+      this.priorityQueueMap.bind('test', value, 0);
+      this.assertHasValue('test', value, 0);
+    });
+
+    test('Same object, priority not provided', function() {
+      const value = {test: 'test'};
+      this.priorityQueueMap.bind('test', value, 0);
+      this.assertHasValue('test', value);
+    });
+
+    test('Different priority', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.assertNotHasValue('test', 'test', 10);
+    });
+
+    test('Stringified priority', function() {
+      this.priorityQueueMap.bind('test', 'test', 0);
+      this.assertNotHasValue('test', 'test', '0');
+    });
+  });
+
+  suite('hasMatchingValue', function() {
+    test('Simple', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      chai.assert.isTrue(this.priorityQueueMap.hasMatchingValue(
+          'test', () => true));
+    });
+
+    test('With priority X', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      chai.assert.isTrue(this.priorityQueueMap.hasMatchingValue(
+          'test', (value, priority) => priority == 10));
+    });
+
+    test('Falsey value', function() {
+      this.priorityQueueMap.bind('test', false, 10);
+      chai.assert.isTrue(this.priorityQueueMap.hasMatchingValue(
+          'test', (value, priority) => !value));
+    });
+
+    test('Similar object', function() {
+      this.priorityQueueMap.bind('test', {objKey: 'value'}, 10);
+      chai.assert.isTrue(this.priorityQueueMap.hasMatchingValue(
+          'test', (value, priority) => value.objKey == 'value'));
+    });
+  });
+
+  suite('filter', function() {
+    setup(function() {
+      this.assertFilter = function(key, filterFn, ...values) {
+        chai.assert.deepEqual(
+            this.priorityQueueMap.filter(key, filterFn), values);
+      };
+    });
+
+    test('Simple', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.assertFilter('test', () => true, {value: 'test1', priority: 10});
+    });
+
+    test('With priority X', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', 'test2', 20);
+      this.assertFilter('test', (value, priority) => priority == 10,
+          {value: 'test1', priority: 10});
+    });
+
+    test('Falsey value', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', false, 20);
+      this.assertFilter('test', (value, priority) => !value,
+          {value: false, priority: 20});
+    });
+
+    test('Similar objects', function() {
+      this.priorityQueueMap.bind('test', 'test1', 10);
+      this.priorityQueueMap.bind('test', {objKey: 'value'}, 20);
+      this.assertFilter('test', (value, priority) => value.objKey == 'value',
+          {value: {objKey: 'value'}, priority: 20});
+    });
+  });
+
+  suite('forEach', function() {
+    test('Simple', function() {
+      this.priorityQueueMap.bind('test1', 'test1', 0);
+      this.priorityQueueMap.bind('test2', 'test2', 10);
+      this.priorityQueueMap.bind('test3', 'test3', 20);
+      const spy = sinon.spy();
+      this.priorityQueueMap.forEach(spy);
+
+      chai.assert.isTrue(spy.calledThrice, 'Expected 3 callbacks');
+      chai.assert.isTrue(
+          spy.calledWith('test1', 'test1', 0),
+          `Expected callback to be called with 'test1', 'test1', and 0`);
+      chai.assert.isTrue(
+          spy.calledWith('test2', 'test2', 10),
+          `Expected callback to be called with 'test2', 'test2', and 10`);
+      chai.assert.isTrue(
+          spy.calledWith('test3', 'test3', 20),
+          `Expected callback to be called with 'test3', 'test3', and 20`);
+    });
+
+    test('No keys', function() {
+      const spy = sinon.spy();
+      this.priorityQueueMap.forEach(spy);
+      chai.assert.isTrue(spy.notCalled);
+    });
+
+    test('No bindings', function() {
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      this.priorityQueueMap.unbind('test', 'test1', 0);
+      const spy = sinon.spy();
+      this.priorityQueueMap.forEach(spy);
+      chai.assert.isTrue(spy.notCalled);
+    });
+  });
+
+  suite('forEachBinding', function() {
+    test('Simple', function() {
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      this.priorityQueueMap.bind('test', 'test2', 10);
+      this.priorityQueueMap.bind('test', 'test3', 20);
+      const spy = sinon.spy();
+      this.priorityQueueMap.forEachBinding('test', spy);
+
+      chai.assert.isTrue(spy.calledThrice, 'Expected 3 callbacks');
+      chai.assert.isTrue(
+          spy.calledWith('test1', 0),
+          `Expected callback to be called with  'test1', and 0`);
+      chai.assert.isTrue(
+          spy.calledWith('test2', 10),
+          `Expected callback to be called with 'test2', and 10`);
+      chai.assert.isTrue(
+          spy.calledWith('test3', 20),
+          `Expected callback to be called with 'test3', and 20`);
+    });
+
+    test('Bad key', function() {
+      const spy = sinon.spy();
+      this.priorityQueueMap.forEachBinding('test', spy);
+      chai.assert.isTrue(spy.notCalled);
+    });
+
+    test('No bindings', function() {
+      this.priorityQueueMap.bind('test', 'test1', 0);
+      this.priorityQueueMap.unbind('test', 'test1', 0);
+      const spy = sinon.spy();
+      this.priorityQueueMap.forEachBinding('test', spy);
+      chai.assert.isTrue(spy.notCalled);
     });
   });
 


### PR DESCRIPTION
### Description

Fleshes out the priority queue map interface so that it will (hopefully) be really robust, and not require changes in the future.

I think it's a good idea to do a "batch edit" like this because making modifications to lower-level interfaces while working on higher-level problems makes you more likely to create bugs in the lower-level interfaces.

Specifically this adds:
* getAllValues and getAllBindings
* unbindAll, unbindMatching, unbindAllMatching
* has, hasValue, hasMatchingValue
* filter
* forEach, forEachBinding

So it basically adds a robust set of has() and delete() equivalents, and adds some stream processing functions I think are important for all data structures.

It also makes some minor changes to existing functions.

### Testing

Each new function was given a suite of unit tests to document the behavior.