### PR TITLE
Remove mutating while in flyout - plus minus

### DIFF
--- a/plugins/block-plus-minus/src/field_minus.js
+++ b/plugins/block-plus-minus/src/field_minus.js
@@ -37,6 +37,10 @@ function onClick_(minusField) {
   // TODO: This is a dupe of the mutator code, anyway to unify?
   const block = minusField.getSourceBlock();
 
+  if (block.isInFlyout) {
+    return;
+  }
+
   Blockly.Events.setGroup(true);
 
   const oldMutationDom = block.mutationToDom();

--- a/plugins/block-plus-minus/src/field_plus.js
+++ b/plugins/block-plus-minus/src/field_plus.js
@@ -37,6 +37,10 @@ function onClick_(plusField) {
   // TODO: This is a dupe of the mutator code, anyway to unify?
   const block = plusField.getSourceBlock();
 
+  if (block.isInFlyout) {
+    return;
+  }
+
   Blockly.Events.setGroup(true);
 
   const oldMutationDom = block.mutationToDom();


### PR DESCRIPTION
### Description

Removes the ability for the blocks to mutate while they are in the flyout. This was previously only possible with simple toolboxes, but now it is impossible.

### Testing

1) Modified the index.html file to not include categories.
2) Added a lists_create_with block.
3) Observed that neither the + nor - fields worked while the block was in the flyout.
4) Dragged the block to the workspace.
5) Observed how both fields worked.