### PR TITLE
Make the workspace start at the edge of the flyout

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousFlyout.js
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.js
@@ -239,6 +239,9 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
         if (this.toolboxPosition_ == Blockly.TOOLBOX_AT_LEFT) {
           x = targetWorkspaceMetrics.toolboxWidth;
         } else {
+          // TODO(https://github.com/google/blockly/issues/4396): Use a better
+          // API to adjust this value.
+          // This is the only line that changed from the original.
           x = targetWorkspaceMetrics.viewWidth;
         }
       } else {

--- a/plugins/continuous-toolbox/src/ContinuousToolbox.js
+++ b/plugins/continuous-toolbox/src/ContinuousToolbox.js
@@ -29,9 +29,11 @@ export class ContinuousToolbox extends Blockly.Toolbox {
     flyout.show(this.getInitialFlyoutContents_());
     flyout.recordScrollPositions();
 
-    // Replace workspace.getMetrics with a version that measures the flyout
+    // Replace workspace.getMetrics with a version that measures the flyout.
     // Ideally this would be set using the workspace options struct but that
     // is not currently possible.
+    // TODO(https://github.com/google/blockly/issues/4377): Replace via
+    // options struct when possible.
     this.workspace_.getMetrics =
         this.workspaceGetMetrics_.bind(this.workspace_);
   }
@@ -148,6 +150,7 @@ export class ContinuousToolbox extends Blockly.Toolbox {
    * Gets adjusted metrics for the workspace, accounting for the flyout width.
    * This will be set as the WorkspaceSvg's getMetrics function, as there
    * is currently no way to set this using the options struct.
+   * TODO(https://github.com/google/blockly/issues/4377): Replace via options.
    * @return {!Blockly.utils.Metrics} Contains size and position metrics of a
    *     top level workspace.
    * @private

--- a/plugins/continuous-toolbox/src/ContinuousToolbox.js
+++ b/plugins/continuous-toolbox/src/ContinuousToolbox.js
@@ -28,6 +28,12 @@ export class ContinuousToolbox extends Blockly.Toolbox {
     const flyout = this.getFlyout();
     flyout.show(this.getInitialFlyoutContents_());
     flyout.recordScrollPositions();
+
+    // Replace workspace.getMetrics with a version that measures the flyout
+    // Ideally this would be set using the workspace options struct but that
+    // is not currently possible.
+    this.workspace_.getMetrics =
+        this.workspaceGetMetrics_.bind(this.workspace_);
   }
 
   /** @override */
@@ -131,6 +137,79 @@ export class ContinuousToolbox extends Blockly.Toolbox {
       return flyout.getClientRect();
     }
     return super.getClientRect();
+  }
+
+  /**
+   * Gets adjusted metrics for the workspace, accounting for the flyout width.
+   * This will be set as the WorkspaceSvg's getMetrics function, as there
+   * is currently no way to set this using the options struct.
+   * @return {!Blockly.utils.Metrics} Contains size and position metrics of a
+   *     top level workspace.
+   * @private
+   * @this Blockly.WorkspaceSvg
+   */
+  workspaceGetMetrics_() {
+    const toolboxDimensions =
+      Blockly.WorkspaceSvg.getDimensionsPx_(this.toolbox_);
+    const flyoutDimensions =
+      Blockly.WorkspaceSvg.getDimensionsPx_(this.toolbox_.getFlyout());
+
+
+    // Contains height and width in CSS pixels.
+    // svgSize is equivalent to the size of the injectionDiv at this point.
+    const svgSize = Blockly.svgSize(this.getParentSvg());
+    const viewSize = {height: svgSize.height, width: svgSize.width};
+    if (this.toolbox_) {
+    // Note: Not actually supported at this time due to ContinunousToolbox
+    // only supporting a vertical flyout. But included for completeness.
+      if (this.toolboxPosition == Blockly.TOOLBOX_AT_TOP ||
+          this.toolboxPosition == Blockly.TOOLBOX_AT_BOTTOM) {
+        viewSize.height -= (toolboxDimensions.height + flyoutDimensions.height);
+      } else if (this.toolboxPosition == Blockly.TOOLBOX_AT_LEFT ||
+          this.toolboxPosition == Blockly.TOOLBOX_AT_RIGHT) {
+        viewSize.width -= (toolboxDimensions.width + flyoutDimensions.width);
+      }
+    }
+
+    // svgSize is now the space taken up by the Blockly workspace, not including
+    // the toolbox.
+    const contentDimensions =
+      Blockly.WorkspaceSvg.getContentDimensions_(this, viewSize);
+
+    let absoluteLeft = 0;
+    if (this.toolbox_ && this.toolboxPosition == Blockly.TOOLBOX_AT_LEFT) {
+      absoluteLeft = toolboxDimensions.width + flyoutDimensions.width;
+    }
+    let absoluteTop = 0;
+    if (this.toolbox_ && this.toolboxPosition == Blockly.TOOLBOX_AT_TOP) {
+      absoluteTop = toolboxDimensions.height + flyoutDimensions.height;
+    }
+
+    const metrics = {
+      contentHeight: contentDimensions.height,
+      contentWidth: contentDimensions.width,
+      contentTop: contentDimensions.top,
+      contentLeft: contentDimensions.left,
+
+      viewHeight: viewSize.height,
+      viewWidth: viewSize.width,
+      viewTop: -this.scrollY,
+      viewLeft: -this.scrollX,
+
+      absoluteTop: absoluteTop,
+      absoluteLeft: absoluteLeft,
+
+      svgHeight: svgSize.height,
+      svgWidth: svgSize.width,
+
+      toolboxWidth: toolboxDimensions.width,
+      toolboxHeight: toolboxDimensions.height,
+      toolboxPosition: this.toolboxPosition,
+
+      flyoutWidth: flyoutDimensions.width,
+      flyoutHeight: flyoutDimensions.height,
+    };
+    return metrics;
   }
 }
 

--- a/plugins/continuous-toolbox/src/ContinuousToolbox.js
+++ b/plugins/continuous-toolbox/src/ContinuousToolbox.js
@@ -151,7 +151,7 @@ export class ContinuousToolbox extends Blockly.Toolbox {
    * @return {!Blockly.utils.Metrics} Contains size and position metrics of a
    *     top level workspace.
    * @private
-   * @this Blockly.WorkspaceSvg
+   * @this {Blockly.WorkspaceSvg}
    */
   workspaceGetMetrics_() {
     const toolboxDimensions =

--- a/plugins/eslint-config/index.js
+++ b/plugins/eslint-config/index.js
@@ -43,6 +43,7 @@ module.exports = {
       tagNamePreference: {
         'returns': 'return',
       },
+      mode: 'closure',
     },
   },
 
@@ -82,12 +83,6 @@ module.exports = {
   overrides: [
     {
       files: ['**/*.mocha.js'],
-      settings: {
-        jsdoc: {
-          mode: 'closure',
-        },
-      },
-
       env: {
         mocha: true,
       },


### PR DESCRIPTION
Since the flyout is always open, we make the workspace start at the edge of the flyout instead of the edge of the toolbox. This prevents blocks from going under the always-open flyout (basically, there are the same edge cases there are for the existing toolbox like when the content is too wide, blocks can still be dragged partially under the flyout).

This required overriding two methods, a little heavyhanded for what we ultimately needed to change, but bugs have been or will be filed for improvements.