### PR TITLE
Update workspace search test page to use the dev tools playground

### DIFF
--- a/plugins/workspace-search/test/index.html
+++ b/plugins/workspace-search/test/index.html
@@ -3,80 +3,9 @@
 <head>
   <meta charset="utf-8">
   <title>Workspace Search Playground</title>
-
-  <style>
-    html, body {
-      height: 100%;
-    }
-    body {
-      background-color: #fff;
-      font-family: sans-serif;
-    }
-    h1 {
-      font-weight: normal;
-      font-size: 140%;
-    }
-
-    #octaweb {
-      width: 100%;
-    }
-    #octaweb th {
-      padding-top: 1em;
-      width: 50%;
-    }
-    #octaweb td {
-      width: 50%;
-    }
-    #octaweb td >div {
-      height: 480px;
-      width: 100%;
-    }
-  </style>
 </head>
 <body>
-  <h1>Blockly Workspace Search Playground</h1>
-
-  <form id="options">
-    <select name="toolbox" onchange="document.forms.options.submit()">
-      <option value="categories">Categories</option>
-      <option value="simple">Simple</option>
-    </select>
-  </form>
-
-  <table id="octaweb">
-    <tr>
-      <th>LTR, Vertical, Start</th>
-      <th>RTL, Vertical, Start</th>
-    </tr>
-    <tr>
-      <td><div id="blocklyDivVertStartLTR"></div></td>
-      <td><div id="blocklyDivVertStartRTL"></div></td>
-    </tr>
-    <tr>
-      <th>LTR, Vertical, End</th>
-      <th>RTL, Vertical, End</th>
-    </tr>
-    <tr>
-      <td><div id="blocklyDivVertEndLTR"></div></td>
-      <td><div id="blocklyDivVertEndRTL"></div></td>
-    </tr>
-    <tr>
-      <th>LTR, Horizontal, Start</th>
-      <th>RTL, Horizontal, Start</th>
-    </tr>
-    <tr>
-      <td><div id="blocklyDivHorizontalStartLTR"></div></td>
-      <td><div id="blocklyDivHorizontalStartRTL"></div></td>
-    </tr>
-    <tr>
-      <th>LTR, Horizontal, End</th>
-      <th>RTL, Horizontal, End</th>
-    </tr>
-    <tr>
-      <td><div id="blocklyDivHorizontalEndLTR"></div></td>
-      <td><div id="blocklyDivHorizontalEndRTL"></div></td>
-    </tr>
-  </table>
+    <div id="root"></div>
 
   <script src="../build/test_bundle.js"></script>
 </body>

--- a/plugins/workspace-search/test/index.js
+++ b/plugins/workspace-search/test/index.js
@@ -11,68 +11,28 @@
 
 import * as Blockly from 'blockly';
 import {WorkspaceSearch} from '../src/index.js';
-import {toolboxCategories, toolboxSimple} from '@blockly/dev-tools';
-
-const options = {
-  comments: true,
-  collapse: true,
-  disable: true,
-  maxBlocks: Infinity,
-  oneBasedIndex: true,
-  readOnly: false,
-  scrollbars: true,
-  trashcan: true,
-  zoom: {
-    controls: true,
-    wheel: false,
-    maxScale: 4,
-    minScale: 0.25,
-    scaleSpeed: 1.1,
-  },
-};
+import {toolboxCategories, createPlayground} from '@blockly/dev-tools';
 
 /**
- * Test page startup, setup Blockly instances.
+ * Create a workspace.
+ * @param {HTMLElement} blocklyDiv The blockly container div.
+ * @param {!Blockly.BlocklyOptions} options The Blockly options.
+ * @return {!Blockly.WorkspaceSvg} The created workspace.
  */
-function start() {
-  const match = location.search.match(/toolbox=([^&]+)/);
-  const toolbox = match && match[1] == 'simple' ?
-      toolboxSimple : toolboxCategories;
-  startBlocklyInstance('VertStartLTR', false, false, 'start', toolbox, true);
-  startBlocklyInstance('VertStartRTL', true, false, 'start', toolbox);
+function createWorkspace(blocklyDiv, options) {
+  const workspace = Blockly.inject(blocklyDiv, options);
 
-  startBlocklyInstance('VertEndLTR', false, false, 'end', toolbox);
-  startBlocklyInstance('VertEndRTL', true, false, 'end', toolbox);
-
-  startBlocklyInstance('HorizontalStartLTR', false, true, 'start', toolbox);
-  startBlocklyInstance('HorizontalStartRTL', true, true, 'start', toolbox);
-
-  startBlocklyInstance('HorizontalEndLTR', false, true, 'end', toolbox);
-  startBlocklyInstance('HorizontalEndRTL', true, true, 'end', toolbox);
-}
-
-/**
- * Inject a Blockly instance.
- * @param {string} suffix Id suffix to use.
- * @param {boolean} rtl RTL option.
- * @param {boolean} horizontalLayout Horizontal layout option.
- * @param {string} position Toolbox position option.
- * @param {string} toolbox Toolbox value.
- * @param {boolean=} optOpenSearch Optional, whether or not to open the
- *     workspace search box.
- */
-function startBlocklyInstance(suffix, rtl, horizontalLayout, position, toolbox,
-    optOpenSearch) {
-  options.rtl = rtl;
-  options.toolbox = toolbox;
-  options.horizontalLayout = horizontalLayout;
-  options.toolboxPosition = position;
-  const ws = Blockly.inject('blocklyDiv' + suffix, options);
-  const workspaceSearch = new WorkspaceSearch(ws);
+  const workspaceSearch = new WorkspaceSearch(workspace);
   workspaceSearch.init();
-  if (optOpenSearch) {
-    workspaceSearch.open();
-  }
+  workspaceSearch.open();
+  return workspace;
 }
 
-document.addEventListener('DOMContentLoaded', start);
+document.addEventListener('DOMContentLoaded', function() {
+  const defaultOptions = {
+    toolbox: toolboxCategories,
+  };
+  createPlayground(document.getElementById('root'), createWorkspace,
+      defaultOptions);
+});
+


### PR DESCRIPTION
As with the typed variable playground, this is a simplification that also makes it look better on gh-pages, and I will need to deploy upstream after merging.