### PR TITLE
initial collapse button for advanced playground

### DIFF
--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -80,7 +80,7 @@ let PlaygroundAPI;
  */
 export function createPlayground(container, createWorkspace,
     defaultOptions, config = {}, vsEditorPath) {
-  const {blocklyDiv, monacoDiv, guiContainer, tabButtons, tabsDiv} =
+  const {blocklyDiv, minimizeButton, monacoDiv, guiContainer, playgroundDiv, tabButtons, tabsDiv} =
     renderPlayground(container);
 
   // Load the code editor.
@@ -302,6 +302,19 @@ export function createPlayground(container, createWorkspace,
     guiElement.style.position = 'relative';
     guiElement.style.minWidth = '100%';
     guiContainer.appendChild(guiElement);
+
+    // Create minimize button
+    minimizeButton.addEventListener('click', (e) => {
+      if (playgroundDiv.style.display === 'none') {
+        playgroundDiv.style.display = 'flex';
+        minimizeButton.textContent = 'Collapse';
+      } else {
+        playgroundDiv.style.display = 'none';
+        minimizeButton.textContent = 'Expand';
+      }
+
+      Blockly.svgResize(workspace);
+    });
 
     // Playground API.
 

--- a/plugins/dev-tools/src/playground/ui.js
+++ b/plugins/dev-tools/src/playground/ui.js
@@ -15,8 +15,10 @@
  * @param {HTMLElement} container The container to render the playground in.
  * @return {{
  *     blocklyDiv: HTMLElement,
+ *     minimizeButton: HTMLElement,
  *     monacoDiv: HTMLElement,
  *     guiContainer: HTMLElement,
+ *     playgroundDiv: HTMLElement,
  *     tabsDiv: HTMLElement,
  *     tabButtons: HTMLElement,
  * }} An object with the various playground components.
@@ -42,6 +44,19 @@ export function renderPlayground(container) {
   blocklyArea.appendChild(blocklyDiv);
 
   // Playground area.
+
+  // Minimize button
+  const minimizeButton = document.createElement('div');
+  minimizeButton.style.width = '18px';
+  minimizeButton.style.background = 'black';
+  minimizeButton.style.color = 'white';
+  minimizeButton.style.font = `12px 'Lucida Grande', sans-serif`;
+  minimizeButton.style.writingMode = 'vertical-lr';
+  minimizeButton.style.textOrientation = 'mixed';
+  minimizeButton.style.textAlign = 'center';
+  minimizeButton.textContent = 'Collapse';
+  container.appendChild(minimizeButton);
+
 
   const playgroundDiv = document.createElement('div');
   playgroundDiv.style.flex = '1 1 1';
@@ -112,8 +127,10 @@ export function renderPlayground(container) {
 
   return {
     blocklyDiv,
+    minimizeButton,
     monacoDiv: editorContainer,
     guiContainer,
+    playgroundDiv,
     tabsDiv,
     tabButtons,
   };


### PR DESCRIPTION
Adds a collapse/expand button to hide the config section of the advanced playground (the entire right hand div). Blockly will automatically resize itself when pressed.

It could be prettier, and right now the state isn't saved, but it's nice for demos and stuff to be able to hide it easily. Definitely open to style changes now (or can be done in a follow up pr if you have specific ideas)