### PR TITLE
Add more info on gh-pages for each package

### DIFF
--- a/gh-pages/_layouts/plugin_index.html
+++ b/gh-pages/_layouts/plugin_index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>{{ page.dir | remove: "/plugins/" | remove: "/test/" }}</title>
+  <title>{{ page.packageName | append: ' demo' }}</title>
   <link rel="stylesheet" href="{{ 'css/slate.css' | relative_url }}" />
   <link rel="stylesheet" href="{{ 'css/custom.css' | relative_url }}" />
 
@@ -11,10 +11,11 @@
 
 <body>
   <nav>
-    <span class="pluginName">{{ "Plugin: " | append: page.dir | remove: "/plugins/" | remove: "/test/" }}</span>
+    <span class="pluginName">{{ page.packageName | append: ': ' | append: page.description }}</span>
     <a href="../README" class="button1">View readme</a>
     <a href="{{ 'https://github.com/google/blockly-samples/blob/master/'
       | append: page.dir | remove: '/test/' | append: '/src' }}" class="button1">View code</a>
+    <a href="{{ 'https://www.npmjs.com/package/' | append: page.packageName }}" class="button1">View on npm</a>
     <a href="/blockly-samples/index.html" class="button1">Back to index</a>
   </nav>
   <section>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,57 +103,67 @@ function publishDryRun(done) {
   return publish(true)(done);
 }
 
-function preparePlugin(pluginDir) {
+/**
+ * Build the front matter string for a plugin's demo and readme pages based on the contents
+ * of the plugin's package.json.
+ * @param {string} pluginDir The subdirectory (inside plugins/) for this plugin.
+ * @return {string} The front matter string, including leading and following dashes.
+ */
+function buildFrontMatter(pluginDir) {
+  const appDirectory = fs.realpathSync(process.cwd());
+  const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
 
-  return gulp
-    .src([
-      pluginDir + '/test/index.html',
-      pluginDir + '/README.md'
-    ], { base: './plugins/' })
-    // Add front matter tags to index and readme pages for jekyll processing.
-    .pipe(header('---\n---\n'))
-    .pipe(gulp.src([
-      pluginDir + '/build/test_bundle.js',
-    ], { base: './plugins/' }))
-    .pipe(gulp.dest('./gh-pages/plugins/'));
-}
+  const packageJson = require(resolveApp('./plugins/' + pluginDir + '/package.json'));
+  console.log(`Preparing plugin for ${packageJson.name}`);
 
-
-
-function getFolders(dir) {
-  return fs.readdirSync(dir)
-    .filter(function (file) {
-      return fs.statSync(path.join(dir, file)).isDirectory();
-    });
-}
-
-function preparePlugins() {
-  const pluginsDir = 'plugins';
-  const promises = [];
-  var folders = getFolders(pluginsDir);
-  var tasks = folders.map(function(folder) {
-    return preparePlugin(folder);
-  });
-
-  return merge(tasks);
+  let frontMatter = '---\n' +
+    // Escape the package name: @ is not a valid character in Jekyll's YAML.
+    'packageName: "' + packageJson.name + '"\n' +
+    'description: "' + packageJson.description + '"\n' +
+    '---\n';
+  return frontMatter;
 }
 
 /**
- * Prepare gh-pages for deployment.  Copy over the relevant files from each of
- * the plugins and move them under gh-pages.
+ * Copy over the test page (index.html and bundled js) and the readme for
+ * this plugin. Add variables as needed for Jekyll.
+ * The resulting code lives in gh-pages/plugins/<pluginName>
+ * @param {string} pluginDir The subdirectory (inside plugins/) for this plugin.
  */
-function prepareToDeployToGhPages() {
+function preparePlugin(pluginDir) {
   return gulp
     .src([
-      './plugins/*/test/index.html',
-      './plugins/*/README.md'
-    ], { base: './plugins/' })
-    // Add front matter tags to index and readme pages for jekyll processing.
-    .pipe(header('---\n---\n'))
+      './plugins/' + pluginDir + '/test/index.html',
+      './plugins/' + pluginDir + '/README.md'
+    ], { base: './plugins/', allowEmpty: true })
+    // Add front matter tags to index and readme pages for Jekyll processing.
+    .pipe(header(buildFrontMatter(pluginDir)))
     .pipe(gulp.src([
-      './plugins/*/build/test_bundle.js',
-    ], { base: './plugins/' }))
+      './plugins/' + pluginDir + '/build/test_bundle.js',
+    ], { base: './plugins/', allowEmpty: true }))
     .pipe(gulp.dest('./gh-pages/plugins/'));
+}
+
+function getFolders(dir) {
+  return
+}
+
+/**
+ * Prepare plugins for deployment to gh-pages.
+ *
+ * For each plugin, copy relevant files to the gh-pages directory.
+ */
+function prepareToDeployPlugins(done) {
+  const dir = './plugins';
+  var folders = fs.readdirSync(dir)
+    .filter(function (file) {
+      return fs.statSync(path.join(dir, file)).isDirectory();
+    });
+  return gulp.parallel(folders.map(function(folder) {
+    return function () {
+      return preparePlugin(folder);
+    }
+  }))(done);
 }
 
 /**
@@ -193,7 +203,7 @@ module.exports = {
   checkLicenses: checkLicenses,
   deploy: deployToGhPagesOrigin,
   deployUpstream: deployToGhPagesUpstream,
-  predeploy: prepareToDeployToGhPages,
+  predeploy: prepareToDeployPlugins,
   publish: publishRelease,
-  publishDryRun: publishDryRun,
+  publishDryRun: publishDryRun
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,14 +33,14 @@ function checkLicenses() {
   // Check root package.json.
   promises.push(checker.checkLocalDirectory('.'));
   fs.readdirSync(pluginsDir)
-    .filter((file) => {
-      return fs.statSync(path.join(pluginsDir, file)).isDirectory();
-    })
-    .forEach((plugin) => {
-      const pluginDir = path.join(pluginsDir, plugin);
-      // Check each plugin package.json.
-      promises.push(checker.checkLocalDirectory(pluginDir));
-    });
+      .filter((file) => {
+        return fs.statSync(path.join(pluginsDir, file)).isDirectory();
+      })
+      .forEach((plugin) => {
+        const pluginDir = path.join(pluginsDir, plugin);
+        // Check each plugin package.json.
+        promises.push(checker.checkLocalDirectory(pluginDir));
+      });
   return Promise.all(promises);
 }
 
@@ -55,8 +55,8 @@ function publish(dryRun) {
     // Login to npm.
     console.log('Logging in to npm.');
     execSync(
-      `npm login --registry https://wombat-dressing-room.appspot.com`,
-      { stdio: 'inherit' });
+        `npm login --registry https://wombat-dressing-room.appspot.com`,
+        {stdio: 'inherit'});
 
     const releaseDir = 'dist';
     // Delete the release directory if it exists.
@@ -69,17 +69,17 @@ function publish(dryRun) {
     console.log(`Checking out a fresh copy of blockly-samples under\
  ${path.resolve(releaseDir)}`);
     execSync(
-      `git clone https://github.com/google/blockly-samples ${releaseDir}`,
-      { stdio: 'pipe' });
+        `git clone https://github.com/google/blockly-samples ${releaseDir}`,
+        {stdio: 'pipe'});
 
     // Run npm install.
     console.log('Running npm install.');
-    execSync(`npm install`, { cwd: releaseDir, stdio: 'inherit' });
+    execSync(`npm install`, {cwd: releaseDir, stdio: 'inherit'});
 
     // Run npm publish.
     execSync(
-      `npm run publish:${dryRun ? 'check' : '_internal'}`,
-      { cwd: releaseDir, stdio: 'inherit' });
+        `npm run publish:${dryRun ? 'check' : '_internal'}`,
+        {cwd: releaseDir, stdio: 'inherit'});
 
     done();
   };
@@ -135,17 +135,13 @@ function preparePlugin(pluginDir) {
     .src([
       './plugins/' + pluginDir + '/test/index.html',
       './plugins/' + pluginDir + '/README.md'
-    ], { base: './plugins/', allowEmpty: true })
+    ], {base: './plugins/', allowEmpty: true})
     // Add front matter tags to index and readme pages for Jekyll processing.
     .pipe(header(buildFrontMatter(pluginDir)))
     .pipe(gulp.src([
       './plugins/' + pluginDir + '/build/test_bundle.js',
-    ], { base: './plugins/', allowEmpty: true }))
+    ], {base: './plugins/', allowEmpty: true}))
     .pipe(gulp.dest('./gh-pages/plugins/'));
-}
-
-function getFolders(dir) {
-  return
 }
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,11 +116,12 @@ function buildFrontMatter(pluginDir) {
   const packageJson = require(resolveApp('./plugins/' + pluginDir + '/package.json'));
   console.log(`Preparing plugin for ${packageJson.name}`);
 
-  let frontMatter = '---\n' +
-    // Escape the package name: @ is not a valid character in Jekyll's YAML.
-    'packageName: "' + packageJson.name + '"\n' +
-    'description: "' + packageJson.description + '"\n' +
-    '---\n';
+  // Escape the package name: @ is not a valid character in Jekyll's YAML.
+  let frontMatter = `---
+packageName: "${packageJson.name}"
+description: "${packageJson.description}"
+---
+`;
   return frontMatter;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13686399/97381945-6c350e00-1887-11eb-986b-9d777d9afe1b.png)

Changes here:
- Get package name and description from package.json
- Use package name + " demo" as page title
- Add package description at top of page.
- Remove "plugin: " from top of page
- Add link to package on npm