### PR TITLE
Add support custom create function for field creation tests

### DIFF
--- a/plugins/dev-tools/src/block_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/block_test_helpers.mocha.js
@@ -38,8 +38,8 @@ CodeGenerationTestCase.prototype.expectedInnerOrder = undefined;
 CodeGenerationTestCase.prototype.useWorkspaceToCode = false;
 /**
  * A function that creates the block for the test.
- * @param {Blockly.Workspace} workspace The workspace context for this test.
- * @return {Blockly.Block}
+ * @param {!Blockly.Workspace} workspace The workspace context for this test.
+ * @return {!Blockly.Block}
  */
 CodeGenerationTestCase.prototype.createBlock = undefined;
 
@@ -74,15 +74,15 @@ SerializationTestCase.prototype.expectedXml = '';
 /**
  * A function that asserts tests has the expected structure after converting to
  *    block from given xml.
- * @param {Blockly.Block} block The block to check.
+ * @param {!Blockly.Block} block The block to check.
  */
 SerializationTestCase.prototype.assertBlockStructure = undefined;
 
 /**
  * Returns mocha test callback for code generation based on provided
  *    generator.
- * @param {Blockly.Generator} generator The generator to use in test.
- * @return {function(CodeGenerationTestCase):Function} Function that
+ * @param {!Blockly.Generator} generator The generator to use in test.
+ * @return {function(!CodeGenerationTestCase):!Function} Function that
  *    returns mocha test callback based on test case.
  * @private
  */
@@ -115,13 +115,13 @@ const createCodeGenerationTestFn_ = (generator) => {
 
 /**
  * Runs blockToCode test suites.
- * @param {Array<CodeGenerationTestSuite>} testSuites The test suites to run.
+ * @param {!Array<!CodeGenerationTestSuite>} testSuites The test suites to run.
  */
 export const runCodeGenerationTestSuites = (testSuites) => {
   /**
    * Creates function used to generate mocha test callback.
-   * @param {CodeGenerationTestSuite} suiteInfo The test suite information.
-   * @return {function(CodeGenerationTestCase):Function} Function that
+   * @param {!CodeGenerationTestSuite} suiteInfo The test suite information.
+   * @return {function(!CodeGenerationTestCase):!Function} Function that
    *    creates mocha test callback.
    */
   const createTestFn = (suiteInfo) => {
@@ -133,13 +133,13 @@ export const runCodeGenerationTestSuites = (testSuites) => {
 
 /**
  * Runs serialization test suite.
- * @param {Array<SerializationTestCase>} testCases The test cases to run.
+ * @param {!Array<!SerializationTestCase>} testCases The test cases to run.
  */
 export const runSerializationTestSuite = (testCases) => {
   /**
    * Creates test callback for xmlToBlock test.
-   * @param {SerializationTestCase} testCase The test case information.
-   * @return {Function} The test callback.
+   * @param {!SerializationTestCase} testCase The test case information.
+   * @return {!Function} The test callback.
    */
   const createXmlToBlockTestCallback = (testCase) => {
     return function() {
@@ -150,8 +150,8 @@ export const runSerializationTestSuite = (testCases) => {
   };
   /**
    * Creates test callback for xml round trip test.
-   * @param {SerializationTestCase} testCase The test case information.
-   * @return {Function} The test callback.
+   * @param {!SerializationTestCase} testCase The test case information.
+   * @return {!Function} The test callback.
    */
   const createXmlRoundTripTestCallback = (testCase) => {
     return function() {

--- a/plugins/dev-tools/src/common_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/common_test_helpers.mocha.js
@@ -45,19 +45,19 @@ TestSuite.prototype.skip = false;
  */
 TestSuite.prototype.only = false;
 /**
- * @type {Array<T>} The associated test cases.
+ * @type {!Array<T>} The associated test cases.
  */
 TestSuite.prototype.testCases = [];
 
 /**
  * Runs provided test cases.
  * @template {TestCase} T
- * @param {Array<T>} testCases The test cases to run.
+ * @param {!Array<T>} testCases The test cases to run.
  * @param {function(T):Function} createTestCallback Creates test
  *    callback using given test case.
  */
 export function runTestCases(testCases, createTestCallback) {
-  testCases.forEach(/** @type {TestCase} */(testCase) => {
+  testCases.forEach(/** @type {!TestCase} */(testCase) => {
     let testCall = (testCase.skip ? test.skip : test);
     testCall = (testCase.only ? test.only : testCall);
     testCall(testCase.title, createTestCallback(testCase));
@@ -67,13 +67,13 @@ export function runTestCases(testCases, createTestCallback) {
 /**
  * Runs provided test suite.
  * @template {TestCase} T
- * @param {Array<TestSuite<T>>} testSuites The test suites to run.
- * @param {function(TestSuite<T>):(function(T):Function)
+ * @param {Array<!TestSuite<T>>} testSuites The test suites to run.
+ * @param {function(!TestSuite<T>):(function(T):!Function)
  *    } createTestCaseCallback Creates test case callback using given test
  *    suite.
  */
 export function runTestSuites(testSuites, createTestCaseCallback) {
-  testSuites.forEach(/** @type {TestSuite} */(testSuite) => {
+  testSuites.forEach(/** @type {!TestSuite} */(testSuite) => {
     let suiteCall = (testSuite.skip ? suite.skip : suite);
     suiteCall = (testSuite.only ? suite.only : suiteCall);
     suiteCall(testSuite.title, function() {

--- a/plugins/dev-tools/src/field_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/field_test_helpers.mocha.js
@@ -28,7 +28,7 @@ FieldValueTestCase.prototype.expectedValue = undefined;
  */
 FieldValueTestCase.prototype.expectedText = undefined;
 /**
- * @type {RegExp|string|undefined} Optional error message matcher if test case
+ * @type {!RegExp|string|undefined} Optional error message matcher if test case
  *    is expected to throw.
  */
 FieldValueTestCase.prototype.errMsgMatcher = undefined;
@@ -51,7 +51,7 @@ FieldCreationTestCase.prototype.json = undefined;
 
 /**
  * Assert a field's value is the same as the expected value.
- * @param {Blockly.Field} field The field.
+ * @param {!Blockly.Field} field The field.
  * @param {*} expectedValue The expected value.
  * @param {string=} expectedText The expected text.
  */
@@ -68,10 +68,10 @@ export function assertFieldValue(field, expectedValue,
 
 /**
  * Runs provided creation test cases.
- * @param {Array<FieldCreationTestCase>} testCases The test cases to run.
- * @param {function(Blockly.Field, FieldCreationTestCase)} assertion The
+ * @param {!Array<!FieldCreationTestCase>} testCases The test cases to run.
+ * @param {function(!Blockly.Field, !FieldCreationTestCase)} assertion The
  *    assertion to use.
- * @param {function(new:Blockly.Field,FieldCreationTestCase):Blockly.Field
+ * @param {function(new:Blockly.Field,!FieldCreationTestCase):Blockly.Field
  *    } creation A function that returns an instance of the field based on the
  *    provided test case.
  * @private
@@ -93,8 +93,8 @@ function runCreationTests_(testCases, assertion, creation) {
 
 /**
  * Runs provided creation test cases.
- * @param {Array<FieldCreationTestCase>} testCases The test cases to run.
- * @param {function(new:Blockly.Field,FieldCreationTestCase):Blockly.Field
+ * @param {!Array<!FieldCreationTestCase>} testCases The test cases to run.
+ * @param {function(new:Blockly.Field,!FieldCreationTestCase):Blockly.Field
  *    } creation A function that returns an instance of the field based on the
  *    provided test case.
  * @private
@@ -102,8 +102,8 @@ function runCreationTests_(testCases, assertion, creation) {
 function runCreationTestsAssertThrows_(testCases, creation) {
   /**
    * Creates test callback for creation test.
-   * @param {FieldCreationTestCase} testCase The test case to use.
-   * @return {Function} The test callback.
+   * @param {!FieldCreationTestCase} testCase The test case to use.
+   * @return {!Function} The test callback.
    */
   const createTestFn = (testCase) => {
     return function() {
@@ -119,17 +119,17 @@ function runCreationTestsAssertThrows_(testCases, creation) {
  * Runs suite of tests for constructor for the specified field.
  * @param {function(new:Blockly.Field, *=)} TestedField The class of the field
  *    being tested.
- * @param {Array<FieldCreationTestCase>} validValueTestCases Test cases with
+ * @param {Array<!FieldCreationTestCase>} validValueTestCases Test cases with
  *    valid values for given field.
- * @param {Array<FieldCreationTestCase>} invalidValueTestCases Test cases with
+ * @param {Array<!FieldCreationTestCase>} invalidValueTestCases Test cases with
  *    invalid values for given field.
- * @param {function(Blockly.Field, FieldCreationTestCase)
+ * @param {function(!Blockly.Field, !FieldCreationTestCase)
  *    } validRunAssertField Asserts that field has expected values.
- * @param {function(Blockly.Field)=} assertFieldDefault Asserts that field has
+ * @param {function(!Blockly.Field)=} assertFieldDefault Asserts that field has
  *    default values. If undefined, tests will check that field throws when
  *    invalid value is passed rather than asserting default.
- * @param {function(FieldCreationTestCase=)=} customCreateWithJs Custom creation
- *    function to use in tests.
+ * @param {function(!FieldCreationTestCase=)=} customCreateWithJs Custom
+ *    creation function to use in tests.
  */
 export function runConstructorSuiteTests(TestedField, validValueTestCases,
     invalidValueTestCases, validRunAssertField, assertFieldDefault,
@@ -152,8 +152,8 @@ export function runConstructorSuiteTests(TestedField, validValueTestCases,
 
     /**
      * Creates a field using its constructor and the provided test case.
-     * @param {FieldCreationTestCase} testCase The test case information.
-     * @return {Blockly.Field} The instantiated field.
+     * @param {!FieldCreationTestCase} testCase The test case information.
+     * @return {!Blockly.Field} The instantiated field.
      */
     const createWithJs = function(testCase) {
       return customCreateWithJs ? customCreateWithJs.call(this, testCase) :
@@ -173,16 +173,16 @@ export function runConstructorSuiteTests(TestedField, validValueTestCases,
  * Runs suite of tests for fromJson creation of specified field.
  * @param {function(new:Blockly.Field, *=)} TestedField The class of the field
  *    being tested.
- * @param {Array<FieldCreationTestCase>} validValueTestCases Test cases with
+ * @param {!Array<!FieldCreationTestCase>} validValueTestCases Test cases with
  *    valid values for given field.
- * @param {Array<FieldCreationTestCase>} invalidValueTestCases Test cases with
+ * @param {!Array<!FieldCreationTestCase>} invalidValueTestCases Test cases with
  *    invalid values for given field.
- * @param {function(Blockly.Field, FieldValueTestCase)
+ * @param {function(!Blockly.Field, !FieldValueTestCase)
  *    } validRunAssertField Asserts that field has expected values.
- * @param {function(Blockly.Field)=} assertFieldDefault Asserts that field has
+ * @param {function(!Blockly.Field)=} assertFieldDefault Asserts that field has
  *    default values. If undefined, tests will check that field throws when
  *    invalid value is passed rather than asserting default.
- * @param {function(FieldCreationTestCase=)=} customCreateWithJson Custom
+ * @param {function(!FieldCreationTestCase=)=} customCreateWithJson Custom
  *    creation function to use in tests.
  */
 export function runFromJsonSuiteTests(TestedField, validValueTestCases,
@@ -206,8 +206,8 @@ export function runFromJsonSuiteTests(TestedField, validValueTestCases,
 
     /**
      * Creates a field using fromJson and the provided test case.
-     * @param {FieldCreationTestCase} testCase The test case information.
-     * @return {Blockly.Field} The instantiated field.
+     * @param {!FieldCreationTestCase} testCase The test case information.
+     * @return {!Blockly.Field} The instantiated field.
      */
     const createWithJson = function(testCase) {
       return customCreateWithJson ? customCreateWithJson.call(this, testCase) :
@@ -225,9 +225,9 @@ export function runFromJsonSuiteTests(TestedField, validValueTestCases,
 
 /**
  * Runs tests for setValue calls.
- * @param {Array<FieldValueTestCase>} validValueTestCases Test cases with
+ * @param {!Array<!FieldValueTestCase>} validValueTestCases Test cases with
  *    valid values.
- * @param {Array<FieldValueTestCase>} invalidValueTestCases Test cases with
+ * @param {!Array<!FieldValueTestCase>} invalidValueTestCases Test cases with
  *    invalid values.
  * @param {*} invalidRunExpectedValue Expected value for field after invalid
  *    call to setValue.
@@ -238,8 +238,8 @@ export function runSetValueTests(validValueTestCases, invalidValueTestCases,
     invalidRunExpectedValue, invalidRunExpectedText) {
   /**
    * Creates test callback for invalid setValue test.
-   * @param {FieldValueTestCase} testCase The test case information.
-   * @return {Function} The test callback.
+   * @param {!FieldValueTestCase} testCase The test case information.
+   * @return {!Function} The test callback.
    */
   const createInvalidSetValueTestCallback = (testCase) => {
     return function() {
@@ -250,8 +250,8 @@ export function runSetValueTests(validValueTestCases, invalidValueTestCases,
   };
   /**
    * Creates test callback for valid setValue test.
-   * @param {FieldValueTestCase} testCase The test case information.
-   * @return {Function} The test callback.
+   * @param {!FieldValueTestCase} testCase The test case information.
+   * @return {!Function} The test callback.
    */
   const createValidSetValueTestCallback = (testCase) => {
     return function() {

--- a/plugins/dev-tools/src/field_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/field_test_helpers.mocha.js
@@ -84,7 +84,7 @@ function runCreationTests_(testCases, assertion, creation) {
    */
   const createTestFn = (testCase) => {
     return function() {
-      const field = creation(testCase);
+      const field = creation.call(this, testCase);
       assertion(field, testCase);
     };
   };
@@ -108,7 +108,7 @@ function runCreationTestsAssertThrows_(testCases, creation) {
   const createTestFn = (testCase) => {
     return function() {
       assert.throws(function() {
-        creation(testCase);
+        creation.call(this, testCase);
       }, testCase.errMsgMatcher);
     };
   };
@@ -128,19 +128,24 @@ function runCreationTestsAssertThrows_(testCases, creation) {
  * @param {function(Blockly.Field)=} assertFieldDefault Asserts that field has
  *    default values. If undefined, tests will check that field throws when
  *    invalid value is passed rather than asserting default.
+ * @param {function(FieldCreationTestCase=)=} customCreateWithJs Custom creation
+ *    function to use in tests.
  */
 export function runConstructorSuiteTests(TestedField, validValueTestCases,
-    invalidValueTestCases, validRunAssertField, assertFieldDefault) {
+    invalidValueTestCases, validRunAssertField, assertFieldDefault,
+    customCreateWithJs) {
   suite('Constructor', function() {
     if (assertFieldDefault) {
       test('Empty', function() {
-        const field = new TestedField();
+        const field = customCreateWithJs ? customCreateWithJs.call(this) :
+            new TestedField();
         assertFieldDefault(field);
       });
     } else {
       test('Empty', function() {
         assert.throws(function() {
-          new TestedField();
+          customCreateWithJs ? customCreateWithJs.call(this) :
+              new TestedField();
         });
       });
     }
@@ -150,16 +155,17 @@ export function runConstructorSuiteTests(TestedField, validValueTestCases,
      * @param {FieldCreationTestCase} testCase The test case information.
      * @return {Blockly.Field} The instantiated field.
      */
-    const createWithJS = function(testCase) {
-      return new TestedField(...testCase.args);
+    const createWithJs = function(testCase) {
+      return customCreateWithJs ? customCreateWithJs.call(this, testCase) :
+          new TestedField(...testCase.args);
     };
     if (assertFieldDefault) {
       runCreationTests_(
-          invalidValueTestCases, assertFieldDefault, createWithJS);
+          invalidValueTestCases, assertFieldDefault, createWithJs);
     } else {
-      runCreationTestsAssertThrows_(invalidValueTestCases, createWithJS);
+      runCreationTestsAssertThrows_(invalidValueTestCases, createWithJs);
     }
-    runCreationTests_(validValueTestCases, validRunAssertField, createWithJS);
+    runCreationTests_(validValueTestCases, validRunAssertField, createWithJs);
   });
 }
 
@@ -176,19 +182,24 @@ export function runConstructorSuiteTests(TestedField, validValueTestCases,
  * @param {function(Blockly.Field)=} assertFieldDefault Asserts that field has
  *    default values. If undefined, tests will check that field throws when
  *    invalid value is passed rather than asserting default.
+ * @param {function(FieldCreationTestCase=)=} customCreateWithJson Custom
+ *    creation function to use in tests.
  */
 export function runFromJsonSuiteTests(TestedField, validValueTestCases,
-    invalidValueTestCases, validRunAssertField, assertFieldDefault) {
+    invalidValueTestCases, validRunAssertField, assertFieldDefault,
+    customCreateWithJson) {
   suite('fromJson', function() {
     if (assertFieldDefault) {
       test('Empty', function() {
-        const field = TestedField.fromJson({});
+        const field = customCreateWithJson ? customCreateWithJson.call(this) :
+            TestedField.fromJson({});
         assertFieldDefault(field);
       });
     } else {
       test('Empty', function() {
         assert.throws(function() {
-          TestedField.fromJson({});
+          customCreateWithJson ? customCreateWithJson.call(this) :
+              TestedField.fromJson({});
         });
       });
     }
@@ -199,7 +210,8 @@ export function runFromJsonSuiteTests(TestedField, validValueTestCases,
      * @return {Blockly.Field} The instantiated field.
      */
     const createWithJson = function(testCase) {
-      return TestedField.fromJson(testCase.json);
+      return customCreateWithJson ? customCreateWithJson.call(this, testCase) :
+          TestedField.fromJson(testCase.json);
     };
     if (assertFieldDefault) {
       runCreationTests_(


### PR DESCRIPTION
Allows for passing in custom logic for instantiating fields for creation tests (constructor and fromJson). Also added `call`s  to bind `this` context so that custom creation function can have access to `this` of mocha test (and can access properties like `this.workspace`).
Changes needed for https://github.com/google/blockly/pull/4417.