### PR TITLE
update create-package to use semver and correct license string

### DIFF
--- a/plugins/dev-create/bin/create.js
+++ b/plugins/dev-create/bin/create.js
@@ -114,7 +114,7 @@ const gitPluginPath =
 
 const packageJson = {
   name: pluginPackageName,
-  version: `0.${new Date().toISOString().slice(0, 10).replace(/-/g, '')}.0`,
+  version: `0.0.0`,
   description: templateJson.description || `A Blockly ${pluginType}.`,
   scripts: templateJson.scripts || {
     'build': 'blockly-scripts build',
@@ -142,7 +142,7 @@ const packageJson = {
     'url': `${gitURL}.git`,
     'directory': gitPluginPath,
   } : {},
-  license: 'Apache 2.0',
+  license: 'Apache-2.0',
   directories: {
     'dist': 'dist',
     'src': 'src',


### PR DESCRIPTION
Previously, set the default version to use the date, now sets to 0.0.0. Previously set the license to 'Apache 2.0' which causes npm to complain, should be 'Apache-2.0'

Tested via `node ../dev-create/bin/create test --type plugin` and manually inspected the resulting test package; it had the correct values for both version and license