### PR TITLE
Add type unification - project static

### DIFF
--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -227,12 +227,14 @@ export class TypeHierarchy {
     }
     return types.reduce((accumulator, currType) => {
       const nearestCommonParentsMap = this.nearestCommonParents_.get(currType);
-      // Note: flatMap() doesn't work on Node 10. See #431.
+      // Note: neither flatMap() nor flat() work on Node 10. See #431.
       return accumulator
           .map((type) => {
             return nearestCommonParentsMap.get(type);
           })
-          .flat()
+          .reduce((flat, toFlatten) => {
+            return [...flat, ...toFlatten];
+          }, [])
           .filter((type, i, array) => {
             return array.indexOf(type) == i;
           });

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -227,10 +227,12 @@ export class TypeHierarchy {
     }
     return types.reduce((accumulator, currType) => {
       const nearestCommonParentsMap = this.nearestCommonParents_.get(currType);
+      // Note: flatMap() doesn't work on Node 10. See #431.
       return accumulator
-          .flatMap((type) => {
+          .map((type) => {
             return nearestCommonParentsMap.get(type);
           })
+          .flat()
           .filter((type, i, array) => {
             return array.indexOf(type) == i;
           });

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -27,7 +27,21 @@ export class TypeHierarchy {
      */
     this.types_ = new Map();
 
-    this.init_(hierarchyDef);
+    /**
+     * Map of type names to maps of type names to sets of type names that are
+     * the least common ancestors of the two types. You can think of it like
+     * a two-dimensional array where both axes contain all of the type names.
+     *
+     * A least common ancestor of two types u and v is defined as:
+     * A super type of both u and v that has no descendant which is also an
+     * ancestor of both u and v.
+     * @type {!Map<!Map<Set<string>>>}
+     * @private
+     */
+    this.leastCommonAncestors_ = new Map();
+
+    this.initTypes_(hierarchyDef);
+    this.initLeastCommonAncestors_();
   }
 
   /**
@@ -35,7 +49,7 @@ export class TypeHierarchy {
    * @param {!Object} hierarchyDef The definition of the type hierarchy.
    * @private
    */
-  init_(hierarchyDef) {
+  initTypes_(hierarchyDef) {
     // NOTE: This does not do anything to stop a developer from creating a
     // cyclic type hierarchy (eg Dog <: Mammal <: Dog). They are expected to
     // not do that.
@@ -43,6 +57,62 @@ export class TypeHierarchy {
       const lowerCaseName = typeName.toLowerCase();
       this.types_.set(lowerCaseName,
           new TypeDef(lowerCaseName, hierarchyDef[typeName]));
+    }
+    for (const [typeName, type] of this.types_) {
+      type.forEachSuper((superName) => {
+        const superType = this.types_.get(superName);
+        if (!superType) {
+          throw Error('The type ' + typeName + ' says it fulfills the type ' +
+              superName + ', but that type is not defined');
+        }
+        superType.addSub(typeName);
+      });
+    }
+  }
+
+  /**
+   * Initializes the leastCommonAncestors_ graph so the least common ancestors
+   * of two types can be accessed in constant time.
+   *
+   * Implements the pre-processing algorithm defined in:
+   * Czumaj, Artur, Miroslaw Kowaluk and and Andrzej Lingas. "Faster algorithms
+   * for finding lowest common ancestors in directed acyclic graphs."
+   * Theoretical Computer Science, 380.1-2 (2007): 37-46.
+   *https://bit.ly/2SrCRs5
+   *
+   * Operates in O(nm) where n is the number of nodes and m is the number of
+   * edges.
+   * @private
+   */
+  initLeastCommonAncestors_() {
+    // Maps each type to a set of all of the descendants of that type.
+    const descendantsMap = new Map();
+    let unvisitedTypes = new Set(this.types_.keys());
+
+    while (unvisitedTypes.size) {
+      for (const [typeName, type] of this.types_) {
+        const unvisitedSubs = type.subs().filter(
+            unvisitedTypes.has, unvisitedTypes);
+        if (!unvisitedSubs.length) {
+          const descendants = new Set([typeName]);
+          type.forEachSub((subName) => {
+            descendantsMap.get(subName).forEach(descendants.add, descendants);
+          });
+          descendantsMap.set(typeName, descendants);
+          unvisitedTypes.delete(typeName);
+        }
+      }
+    }
+
+    unvisitedTypes = new Set(this.types_.keys());
+    while(unvisitedTypes.size) {
+      for (const [typeName, type] of this.types_) {
+        const unvisitedSupers = type.supers().filter(
+            unvisitedTypes.has, unvisitedTypes);
+        if (!unvisitedSupers.length) {
+
+        }
+      }
     }
   }
 
@@ -70,12 +140,12 @@ export class TypeHierarchy {
 
   /**
    * Returns true if the types are identical, or if the first type fulfills the
-   * second type (directly or via one of its super types), as specified in the
+   * second type (directly or via one of its supertypes), as specified in the
    * type hierarchy definition. False otherwise.
-   * @param {string} subName The name of the possible sub type.
-   * @param {string} superName The name of the possible super type.
+   * @param {string} subName The name of the possible subtype.
+   * @param {string} superName The name of the possible supertype.
    * @return {boolean} True if the types are identical, or if the first type
-   *     fulfills the second type (directly or via its super types) as specified
+   *     fulfills the second type (directly or via its supertypes) as specified
    *     in the type hierarchy definition. False otherwise.
    */
   typeFulfillsType(subName, superName) {
@@ -91,6 +161,18 @@ export class TypeHierarchy {
     return subType.someSuper(
         (name) => this.typeFulfillsType(name, caselessSup), this);
   }
+
+  /**
+   * Finds the nearest common parent of the two type names.
+   * @param {string} type1 The first type to try to find the nearest common
+   *     parent of.
+   * @param {string} type2 The second type to try to find the nearest common
+   *     parent of.
+   * @private
+   */
+  findNearestCommonParent_(type1, type2) {
+
+  }
 }
 
 /**
@@ -99,7 +181,7 @@ export class TypeHierarchy {
 class TypeDef {
   /**
    * Constructs a TypeDef with the given name. Uses the given info for further
-   * initialization (eg defining super types).
+   * initialization (eg defining supertypes).
    * @param {string} name The name of the type.
    * @param {!Object} info The info about the type.
    */
@@ -107,16 +189,23 @@ class TypeDef {
     /**
      * The name of this type.
      * @type {string}
-     * @private
+     * @public
      */
-    this.name_ = name;
+    this.name = name;
 
     /**
-     * The names of the super types of this type.
+     * The caseless names of the direct supertypes of this type.
      * @type {!Array<string>}
      * @private
      */
     this.fulfills_ = [];
+
+    /**
+     * The caseless names of the direct subtypes of this type.
+     * @type {!Array<string>}
+     * @private
+     */
+    this.fulfillsThis_ = [];
 
     this.init_(info);
   }
@@ -133,10 +222,37 @@ class TypeDef {
   }
 
   /**
-   * Returns true if this type has a direct super type with the given name.
+   * Adds the given type to the list of direct subtypes of this type.
+   * @param {string} subType The name of the type to add to the list of subtypes
+   *     of this type.
+   */
+  addSub(subType) {
+    this.fulfillsThis_.push(subType.toLowerCase());
+  }
+
+  /**
+   * Returns a new set of all types that are direct supertypes of this type.
+   * @return {!Array<string>} A new set of all types that are direct supertypes
+   *     of this type.
+   */
+  supers() {
+    return [...this.fulfills_];
+  }
+
+  /**
+   * Returns true if this type has any supertypes. False otherwise.
+   * @return {boolean} True if this type has any supertypes. False otherwise.
+   */
+  hasSupers() {
+    return !!this.fulfills_.length;
+  }
+
+  /**
+   * Returns true if this type has a direct supertype with the given name.
    * False otherwise.
-   * @param {string} superName The name of the possible direct super type.
-   * @return {boolean} True if this type has a direct super type with the given
+   * @param {string} superName The caseless name of the possible direct super
+   *     type.
+   * @return {boolean} True if this type has a direct supertype with the given
    *     name. False otherwise.
    */
   hasDirectSuper(superName) {
@@ -145,14 +261,77 @@ class TypeDef {
 
   /**
    * Returns true if the given function returns a truthy value for at least one
-   * super type of this type. False otherwise.
+   * supertype of this type. False otherwise.
    * @param {function(string, number=, !Array=):boolean} callback A function
-   *     used to test each super type.
+   *     used to test each supertype.
    * @param {!Object=} thisArg A value to use as `this` when executing callback.
    * @return {boolean} True if the given function returns a truthy value for
-   *     at least one super type of this type. False otherwise.
+   *     at least one supertype of this type. False otherwise.
    */
   someSuper(callback, thisArg) {
     return this.fulfills_.some(callback, thisArg);
+  }
+
+  /**
+   * Executes the provided function once for each direct supertype of this
+   * type.
+   * @param {function(string)} callback The function to execute on each direct
+   *     supertype of this type.
+   * @param {!Object=} thisArg Value to use as `this` when executing callback.
+   */
+  forEachSuper(callback, thisArg) {
+    this.fulfills_.forEach(callback, thisArg);
+  }
+
+  /**
+   * Returns a new set of all types that are direct subtypes of this type.
+   * @return {!Array<string>} A new set of all types that are direct subtypes of
+   *     this type.
+   */
+  subs() {
+    return [...this.fulfillsThis_];
+  }
+
+  /**
+   * Returns true if this type has any subtypes. False otherwise.
+   * @return {boolean} True if this type has any subtypes. False otherwise.
+   */
+  hasSubs() {
+    return !!this.fulfillsThis_.length;
+  }
+
+  /**
+   * Returns true if this type has a direct subtype with the given name. False
+   * otherwise.
+   * @param {string} subName The caseless name of the possible direct subtype.
+   * @return {boolean} True if this type has a direct subtype with the given
+   *     name. False otherwise.
+   */
+  hasDirectSub(subName) {
+    return this.fulfillsThis_.includes(subName);
+  }
+
+  /**
+   * Returns true if the given function returns a truthy value for at least one
+   * subtype of this type. False otherwise.
+   * @param {function(string, number=, !Array=):boolean} callback A function
+   *     used to test each subtype.
+   * @param {!Object=} thisArg A value to use as `this` when executing callback.
+   * @return {boolean} True if the given function returns a truthy value for
+   *     at least one subtype of this type. False otherwise.
+   */
+  someSub(callback, thisArg) {
+    return this.fulfillsThis_.some(callback, thisArg);
+  }
+
+  /**
+   * Executes the provided function once for each direct subtype of this
+   * type.
+   * @param {function(string)} callback The function to execute on each direct
+   *     subtype of this type.
+   * @param {!Object=} thisArg Value to use as `this` when executing callback.
+   */
+  forEachSub(callback, thisArg) {
+    this.fulfillsThis_.forEach(callback, thisArg);
   }
 }

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -181,5 +181,481 @@ suite('TypeHierarchy', function() {
     });
   });
 
-  suite('')
+  suite('nearestCommonParents', function() {
+    suite('Variable Arguments', function() {
+      test('No args', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+        });
+        const union = hierarchy.getNearestCommonParents();
+        chai.assert.isArray(union);
+        chai.assert.isEmpty(union);
+      });
+
+      test('One arg', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+        });
+        const union = hierarchy.getNearestCommonParents('typeA');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+    });
+
+    suite('Simple tree unions', function() {
+      test('Unify self', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+        });
+        const union = hierarchy.getNearestCommonParents('typeA', 'typeA');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+
+      test('Unify parent', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {
+            'fulfills': ['typeA'],
+          },
+        });
+        const union = hierarchy.getNearestCommonParents('typeB', 'typeA');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+
+      test('Unify parsib', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {
+            'fulfills': ['typeA'],
+          },
+          'typeC': {
+            'fulfills': ['typeA'],
+          },
+          'typeD': {
+            'fulfills': ['typeB'],
+          },
+        });
+        const union = hierarchy.getNearestCommonParents('typeD', 'typeC');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+
+      test('Unify grandparent', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {
+            'fulfills': ['typeA'],
+          },
+          'typeC': {
+            'fulfills': ['typeB'],
+          },
+        });
+        const union = hierarchy.getNearestCommonParents('typeC', 'typeA');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+
+      test('Unify grandparsib', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {
+            'fulfills': ['typeA'],
+          },
+          'typeC': {
+            'fulfills': ['typeA'],
+          },
+          'typeD': {
+            'fulfills': ['typeB'],
+          },
+          'typeE': {
+            'fulfills': ['typeD'],
+          },
+        });
+        const union = hierarchy.getNearestCommonParents('typeE', 'typeC');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+
+      test('Unify sibling', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {
+            'fulfills': ['typeA'],
+          },
+          'typeC': {
+            'fulfills': ['typeA'],
+          },
+        });
+        const union = hierarchy.getNearestCommonParents('typeB', 'typeC');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+
+      test('Unify cousin', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {
+            'fulfills': ['typeA'],
+          },
+          'typeC': {
+            'fulfills': ['typeA'],
+          },
+          'typeD': {
+            'fulfills': ['typeB'],
+          },
+          'typeE': {
+            'fulfills': ['typeC'],
+          },
+        });
+        const union = hierarchy.getNearestCommonParents('typeD', 'typeE');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+
+      test('Unify second cousin', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {
+            'fulfills': ['typeA'],
+          },
+          'typeC': {
+            'fulfills': ['typeA'],
+          },
+          'typeD': {
+            'fulfills': ['typeB'],
+          },
+          'typeE': {
+            'fulfills': ['typeC'],
+          },
+          'typeF': {
+            'fulfills': ['typeD'],
+          },
+          'typeG': {
+            'fulfills': ['typeE'],
+          },
+        });
+        const union = hierarchy.getNearestCommonParents('typeF', 'typeG');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+
+      test('Unify first cousin once removed', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {
+            'fulfills': ['typeA'],
+          },
+          'typeC': {
+            'fulfills': ['typeA'],
+          },
+          'typeD': {
+            'fulfills': ['typeB'],
+          },
+          'typeE': {
+            'fulfills': ['typeC'],
+          },
+          'typeF': {
+            'fulfills': ['typeD'],
+          },
+          'typeG': {
+            'fulfills': ['typeE'],
+          },
+        });
+        const union = hierarchy.getNearestCommonParents('typeD', 'typeG');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+
+      test('Unify child', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {
+            'fulfills': ['typeA'],
+          },
+        });
+        const union = hierarchy.getNearestCommonParents('typeA', 'typeB');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+
+      test('Unify nibling', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {
+            'fulfills': ['typeA'],
+          },
+          'typeC': {
+            'fulfills': ['typeA'],
+          },
+          'typeD': {
+            'fulfills': ['typeB'],
+          },
+        });
+        const union = hierarchy.getNearestCommonParents('typeC', 'typeD');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+
+      test('Unify grandnibling', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {
+            'fulfills': ['typeA'],
+          },
+          'typeC': {
+            'fulfills': ['typeA'],
+          },
+          'typeD': {
+            'fulfills': ['typeB'],
+          },
+          'typeE': {
+            'fulfills': ['typeD'],
+          },
+        });
+        const union = hierarchy.getNearestCommonParents('typeC', 'typeE');
+        chai.assert.deepEqual(union, ['typea']);
+      });
+
+      test('Unify unrelated', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {},
+        });
+        const union = hierarchy.getNearestCommonParents('typeA', 'typeB');
+        chai.assert.isArray(union);
+        chai.assert.isEmpty(union);
+      });
+    });
+
+    /* All of these tests use the following graph. Children are below their
+     * parents, except in the case of W and V. In that case there is an arrow
+     * to indicate that V is a child of W.
+     *
+     *  .------U----.
+     *  |       \   |
+     *  |  W---->V  |
+     *  |  |\    |  |
+     *  |  | \   |  |
+     *  \  |  Z  |  Q
+     *   \ | / \ | /
+     *    \|/   \|/
+     *     X     Y
+     */
+    suite('Harder graph unions', function() {
+      const hierarchy = new TypeHierarchy({
+        'typeU': {},
+        'typeW': {},
+        'typeQ': {
+          'fulfills': ['typeU'],
+        },
+        'typeV': {
+          'fulfills': ['typeU', 'typeW'],
+        },
+        'typeZ': {
+          'fulfills': ['typeW'],
+        },
+        'typeX': {
+          'fulfills': ['typeU', 'typeW', 'typeZ'],
+        },
+        'typeY': {
+          'fulfills': ['typeZ', 'typeV', 'typeQ'],
+        },
+      });
+
+      test('X and Y', function() {
+        const union = hierarchy.getNearestCommonParents('typeX', 'typeY');
+        chai.assert.deepEqual(union, ['typez', 'typeu']);
+      });
+
+      test('X, Y and Z', function() {
+        const union = hierarchy.getNearestCommonParents(
+            'typeX', 'typeY', 'typeZ');
+        chai.assert.deepEqual(union, ['typez']);
+      });
+
+      test('X, Y and W', function() {
+        const union = hierarchy.getNearestCommonParents(
+            'typeX', 'typeY', 'typeW');
+        chai.assert.deepEqual(union, ['typew']);
+      });
+
+      test('X, Y and V', function() {
+        const union = hierarchy.getNearestCommonParents(
+            'typeX', 'typeY', 'typeV');
+        chai.assert.deepEqual(union, ['typew', 'typeu']);
+      });
+
+      test('U and W', function() {
+        const union = hierarchy.getNearestCommonParents('typeU', 'typeW');
+        chai.assert.isArray(union);
+        chai.assert.isEmpty(union);
+      });
+    });
+
+    suite('Multiparent unions', function() {
+      suite('Two parents, two children', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {},
+          'typeC': {
+            'fulfills': ['typeA', 'typeB'],
+          },
+          'typeD': {
+            'fulfills': ['typeA', 'typeB'],
+          },
+        });
+
+        test('C and D', function() {
+          const union = hierarchy.getNearestCommonParents('typeC', 'typeD');
+          chai.assert.deepEqual(union, ['typea', 'typeb']);
+        });
+
+        test('C, D and A', function() {
+          const union = hierarchy.getNearestCommonParents(
+              'typeC', 'typeD', 'typeA');
+          chai.assert.deepEqual(union, ['typea']);
+        });
+
+        test('A and B', function() {
+          const union = hierarchy.getNearestCommonParents('typeA', 'typeB');
+          chai.assert.isArray(union);
+          chai.assert.isEmpty(union);
+        });
+      });
+
+      suite('Three parents, three children', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {},
+          'typeC': {},
+          'typeD': {
+            'fulfills': ['typeA', 'typeB'],
+          },
+          'typeE': {
+            'fulfills': ['typeA', 'typeB', 'typeC'],
+          },
+          'typeF': {
+            'fulfills': ['typeB', 'typeC'],
+          },
+        });
+
+        test('D and E', function() {
+          const union = hierarchy.getNearestCommonParents('typeD', 'typeE');
+          chai.assert.deepEqual(union, ['typea', 'typeb']);
+        });
+
+        test('E and F', function() {
+          const union = hierarchy.getNearestCommonParents('typeE', 'typeF');
+          chai.assert.deepEqual(union, ['typeb', 'typec']);
+        });
+
+        test('D and F', function() {
+          const union = hierarchy.getNearestCommonParents('typeD', 'typeF');
+          chai.assert.deepEqual(union, ['typeb']);
+        });
+
+        test('D, E and F', function() {
+          const union = hierarchy.getNearestCommonParents(
+              'typeD', 'typeE', 'typeF');
+          chai.assert.deepEqual(union, ['typeb']);
+        });
+
+        test('D, E and A', function() {
+          const union = hierarchy.getNearestCommonParents(
+              'typeD', 'typeE', 'typeA');
+          chai.assert.deepEqual(union, ['typea']);
+        });
+
+        test('D, E, F and B', function() {
+          const union = hierarchy.getNearestCommonParents(
+              'typeD', 'typeE', 'typeF', 'typeB');
+          chai.assert.deepEqual(union, ['typeb']);
+        });
+
+        test('D, E and C', function() {
+          const union = hierarchy.getNearestCommonParents(
+              'typeD', 'typeE', 'typeC');
+          chai.assert.isArray(union);
+          chai.assert.isEmpty(union);
+        });
+      });
+
+      suite('Two layers', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {},
+          'typeC': {},
+          'typeD': {
+            'fulfills': ['typeA', 'typeB'],
+          },
+          'typeE': {
+            'fulfills': ['typeA', 'typeB', 'typeC'],
+          },
+          'typeF': {
+            'fulfills': ['typeB', 'typeC'],
+          },
+          'typeG': {
+            'fulfills': ['typeD', 'typeE'],
+          },
+          'typeH': {
+            'fulfills': ['typeD', 'typeE'],
+          },
+        });
+
+        test('G and H', function() {
+          const union = hierarchy.getNearestCommonParents('typeG', 'typeH');
+          chai.assert.deepEqual(union, ['typed', 'typee']);
+        });
+
+        test('G, H and F', function() {
+          const union = hierarchy.getNearestCommonParents(
+              'typeG', 'typeH', 'typeF');
+          chai.assert.deepEqual(union, ['typeb', 'typec']);
+        });
+      });
+
+      suite('Three layers', function() {
+        const hierarchy = new TypeHierarchy({
+          'typeA': {},
+          'typeB': {},
+          'typeC': {},
+          'typeD': {},
+          'typeE': {
+            'fulfills': ['typeA', 'typeB'],
+          },
+          'typeF': {
+            'fulfills': ['typeA', 'typeB', 'typeC'],
+          },
+          'typeG': {
+            'fulfills': ['typeB', 'typeC', 'typeD'],
+          },
+          'typeH': {
+            'fulfills': ['typeC', 'typeD'],
+          },
+          'typeI': {
+            'fulfills': ['typeE', 'typeF'],
+          },
+          'typeJ': {
+            'fulfills': ['typeE', 'typeF', 'typeG'],
+          },
+          'typeK': {
+            'fulfills': ['typeF', 'typeG'],
+          },
+          'typeL': {
+            'fulfills': ['typeI', 'typeJ'],
+          },
+          'typeM': {
+            'fulfills': ['typeI', 'typeJ'],
+          },
+        });
+
+        test('L and M', function() {
+          const union = hierarchy.getNearestCommonParents('typeL', 'typeM');
+          chai.assert.deepEqual(union, ['typei', 'typej']);
+        });
+
+        test('L, M and K', function() {
+          const union = hierarchy.getNearestCommonParents(
+              'typeL', 'typeM', 'typeK');
+          chai.assert.deepEqual(union, ['typef', 'typeg']);
+        });
+
+        test('L, M, K and H', function() {
+          const union = hierarchy.getNearestCommonParents(
+              'typeL', 'typeM', 'typeK', 'typeH');
+          chai.assert.deepEqual(union, ['typec', 'typed']);
+        });
+      });
+    });
+  });
 });

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -180,4 +180,6 @@ suite('TypeHierarchy', function() {
       chai.assert.isTrue(hierarchy.typeFulfillsType('typea', 'typeB'));
     });
   });
+
+  suite('')
 });

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -13,6 +13,19 @@ const chai = require('chai');
 const {TypeHierarchy} = require('../src/type_hierarchy');
 
 suite('TypeHierarchy', function() {
+  test('Super not defined', function() {
+    chai.assert.throws(
+        function() {
+          new TypeHierarchy({
+            'typeA': {
+              'fulfills': ['typeB'],
+            },
+          });
+        },
+        'The type typea says it fulfills the type typeb, but that type is not' +
+        ' defined');
+  });
+
   suite('typeExists', function() {
     test('Simple', function() {
       const hierarchy = new TypeHierarchy({
@@ -35,16 +48,6 @@ suite('TypeHierarchy', function() {
       });
       chai.assert.isFalse(hierarchy.typeExists(' typeA '),
           'Expected TypeHierarchy to respect padding.');
-    });
-
-    test('Super but not defined', function() {
-      const hierarchy = new TypeHierarchy({
-        'typeA': {
-          'fulfills': ['typeB'],
-        },
-      });
-      chai.assert.isFalse(hierarchy.typeExists('typeB'),
-          'Expected only top-level types to exist.');
     });
   });
 


### PR DESCRIPTION
### Description

Adds the `getNearestCommonParents` function to the type hierarchy. This function finds the nearest common super type of two or more types. This will allow me to add functionality for treating a generic multi-input block with multiple child blocks that share a common super type as that super type. For example, the below "Select Random" block is treated as a "Mammal" because its two child blocks have that supertype in common:
![TypeUnification](https://user-images.githubusercontent.com/25440652/97929767-b81c0300-1d1e-11eb-8e32-6b3e475e6b34.gif)

To achieve this I had to add a pre-processing algorithm to the type hierarchy. The pre-processing runs in O(v*e) where v is the number of vertices in the graph and e is the number of edges. Note that this is longer than the O(v+e) time of the hierarchy validation, so we might want to consider doing validation by default, instead of requiring developers to call it separately.

I included a citation for the original research paper where I found the pre-processing algorithm in the source code, but I also created a [blog post](http://bekawestberg.me/blog/lowest-common-ancestor/) about it which I think explains the algorithm a bit more clearly. Or I hope it does anyway hehe.

Also note: this does **not** have anything to do with union types (eg (bool or string)). At the moment I'm not planning to implement any support for union types specifically.

### Testing
36 unit tests for the `getNearestCommonParents` function covering:
* All the different ways I could think of that types could be related (parents, parsibs, cousins, niblings, etc).
* Tests that require the logic to eliminate duplicates or common parents that are not the *nearest* common parent (see Harder graph unions).
* Tests where there are multiple equally near common parents (see Multiparent unions).