### PR TITLE
Es6-ify the pitch field

### DIFF
--- a/examples/keyboard-accessibility/src/field_pitch.js
+++ b/examples/keyboard-accessibility/src/field_pitch.js
@@ -11,207 +11,235 @@
  */
 'use strict';
 
-goog.provide('CustomFields.FieldPitch');
-
-goog.require('Blockly.FieldTextInput');
-goog.require('Blockly.utils.math');
-goog.require('Blockly.utils.object');
-
-var CustomFields = CustomFields || {};
+import Blockly from 'blockly/core';
 
 /**
- * Class for an editable pitch field.
- * @param {string} text The initial content of the field.
- * @extends {Blockly.FieldTextInput}
- * @constructor
+ * Pitch field from Blockly Games music.
  */
-CustomFields.FieldPitch = function (text) {
-  CustomFields.FieldPitch.superClass_.constructor.call(this, text);
-};
-Blockly.utils.object.inherits(CustomFields.FieldPitch, Blockly.FieldTextInput);
+export class FieldPitch extends Blockly.FieldTextInput {
+  /**
+   * Class for an editable pitch field.
+   * @param {string} text The initial content of the field.
+   * @extends {Blockly.FieldTextInput}
+   * @constructor
+   */
+  constructor(text) {
+    super(text);
+  }
 
-/**
- * Construct a FieldPitch from a JSON arg object.
- * @param {!Object} options A JSON object with options (pitch).
- * @return {!CustomFields.FieldPitch} The new field instance.
- * @package
- * @nocollapse
- */
-CustomFields.FieldPitch.fromJson = function (options) {
-  return new CustomFields.FieldPitch(options['pitch']);
-};
+  /**
+   * Construct a FieldPitch from a JSON arg object.
+   * @param {!Object} options A JSON object with options (pitch).
+   * @return {!FieldPitch} The new field instance.
+   * @package
+   * @nocollapse
+   */
+  static fromJson(options) {
+    return new FieldPitch(options['pitch']);
+  }
+
+  /**
+   * Show the inline free-text editor on top of the text and the note picker.
+   * @private
+   */
+  showEditor_() {
+    super.showEditor_();
+
+    const div = Blockly.WidgetDiv.DIV;
+    if (!div.firstChild) {
+      // Mobile interface uses Blockly.prompt.
+      return;
+    }
+    // Build the DOM.
+    const editor = this.dropdownCreate_();
+    Blockly.DropDownDiv.getContentDiv().appendChild(editor);
+
+    Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(),
+        this.sourceBlock_.style.colourTertiary);
+
+    Blockly.DropDownDiv.showPositionedByField(
+        this, this.dropdownDispose_.bind(this));
+
+    // The note picker is different from other fields in that it updates on
+    // mousemove even if it's not in the middle of a drag.  In future we may
+    // change this behaviour.  For now, using bindEvent_ instead of
+    // bindEventWithChecks_ allows it to work without a mousedown/touchstart.
+    this.clickWrapper_ =
+      Blockly.bindEvent_(this.imageElement_, 'click', this,
+          this.hide_);
+    this.moveWrapper_ =
+      Blockly.bindEvent_(this.imageElement_, 'mousemove', this,
+          this.onMouseMove);
+
+    this.updateGraph_();
+  }
+
+  /**
+   * Create the pitch editor.
+   * @return {!Element} The newly created pitch picker.
+   * @private
+   */
+  dropdownCreate_() {
+    this.imageElement_ = document.createElement('div');
+    this.imageElement_.id = 'notePicker';
+
+    return this.imageElement_;
+  }
+
+  /**
+   * Dispose of events belonging to the pitch editor.
+   * @private
+   */
+  dropdownDispose_() {
+    Blockly.unbindEvent_(this.clickWrapper_);
+    Blockly.unbindEvent_(this.moveWrapper_);
+  }
+
+  /**
+   * Hide the editor.
+   * @private
+   */
+  hide_() {
+    Blockly.WidgetDiv.hide();
+    Blockly.DropDownDiv.hideWithoutAnimation();
+  }
+
+  /**
+   * Set the note to match the mouse's position.
+   * @param {!Event} e Mouse move event.
+   */
+  onMouseMove(e) {
+    const bBox = this.imageElement_.getBoundingClientRect();
+    const dy = e.clientY - bBox.top;
+    const note = Blockly.utils.math.clamp(Math.round(13.5 - dy / 7.5), 0, 12);
+    this.imageElement_.style.backgroundPosition = (-note * 37) + 'px 0';
+    this.setEditorValue_(note);
+  }
+
+  /**
+   * Convert the machine-readable value (0-12) to human-readable text (C3-A4).
+   * @param {number|string} value The provided value.
+   * @return {string|undefined} The respective note, or undefined if invalid.
+   */
+  valueToNote(value) {
+    return FieldPitch.NOTES[Number(value)];
+  }
+
+  /**
+   * Convert the human-readable text (C3-A4) to machine-readable value (0-12).
+   * @param {string} text The provided note.
+   * @return {number|undefined} The respective value, or undefined if invalid.
+   */
+  noteToValue(text) {
+    const normalizedText = text.trim().toUpperCase();
+    const i = FieldPitch.NOTES.indexOf(normalizedText);
+    return i > -1 ? i : undefined;
+  }
+
+  /**
+   * Get the text to be displayed on the field node.
+   * @return {?string} The HTML value if we're editing, otherwise null. Null
+   *   means the super class will handle it, likely a string cast of value.
+   * @protected
+   */
+  getText_() {
+    if (this.isBeingEdited_) {
+      return super.getText_();
+    }
+    return this.valueToNote(this.getValue()) || null;
+  }
+
+  /**
+   * Transform the provided value into a text to show in the HTML input.
+   * @param {*} value The value stored in this field.
+   * @return {string} The text to show on the HTML input.
+   */
+  getEditorText_(value) {
+    return this.valueToNote(value);
+  }
+
+  /**
+   * Transform the text received from the HTML input (note) into a value
+   * to store in this field.
+   * @param {string} text Text received from the HTML input.
+   * @return {*} The value to store.
+   */
+  getValueFromEditorText_(text) {
+    return this.noteToValue(text);
+  }
+
+  /**
+   * Updates the graph when the field rerenders.
+   * @private
+   * @override
+   */
+  render_() {
+    super.render_();
+    this.updateGraph_();
+  }
+
+  /**
+   * Redraw the note picker with the current note.
+   * @private
+   */
+  updateGraph_() {
+    if (!this.imageElement_) {
+      return;
+    }
+    const i = this.getValue();
+    this.imageElement_.style.backgroundPosition = (-i * 37) + 'px 0';
+  }
+
+  /**
+   * Ensure that only a valid value may be entered.
+   * @param {*} opt_newValue The input value.
+   * @return {*} A valid value, or null if invalid.
+   */
+  doClassValidation_(opt_newValue) {
+    if (opt_newValue === null || opt_newValue === undefined) {
+      return null;
+    }
+    const note = this.valueToNote(opt_newValue);
+    if (note) {
+      return opt_newValue;
+    }
+    return null;
+  }
+}
 
 /**
  * All notes available for the picker.
  */
-CustomFields.FieldPitch.NOTES = 'C3 D3 E3 F3 G3 A3 B3 C4 D4 E4 F4 G4 A4'.split(/ /);
+FieldPitch.NOTES = 'C3 D3 E3 F3 G3 A3 B3 C4 D4 E4 F4 G4 A4'.split(/ /);
 
-/**
- * Show the inline free-text editor on top of the text and the note picker.
- * @private
- */
-CustomFields.FieldPitch.prototype.showEditor_ = function () {
-  CustomFields.FieldPitch.superClass_.showEditor_.call(this);
 
-  var div = Blockly.WidgetDiv.DIV;
-  if (!div.firstChild) {
-    // Mobile interface uses Blockly.prompt.
-    return;
-  }
-  // Build the DOM.
-  var editor = this.dropdownCreate_();
-  Blockly.DropDownDiv.getContentDiv().appendChild(editor);
+Blockly.fieldRegistry.register('field_pitch', FieldPitch);
 
-  Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(),
-    this.sourceBlock_.style.colourTertiary);
 
-  Blockly.DropDownDiv.showPositionedByField(
-    this, this.dropdownDispose_.bind(this));
+/* eslint-disable quotes */
+Blockly.defineBlocksWithJsonArray([
+  {
+    "type": "pitch_test",
+    "message0": 'pitch test: %1',
+    "args0": [
+      {
+        "type": "field_pitch",
+        "name": "PITCH",
+      },
+    ],
+    "output": null,
+    "colour": 160,
+  },
+]);
 
-  // The note picker is different from other fields in that it updates on
-  // mousemove even if it's not in the middle of a drag.  In future we may
-  // change this behaviour.  For now, using bindEvent_ instead of
-  // bindEventWithChecks_ allows it to work without a mousedown/touchstart.
-  this.clickWrapper_ =
-    Blockly.bindEvent_(this.imageElement_, 'click', this,
-      this.hide_);
-  this.moveWrapper_ =
-    Blockly.bindEvent_(this.imageElement_, 'mousemove', this,
-      this.onMouseMove);
-
-  this.updateGraph_();
+export const toolboxPitch = {
+  "kind": "flyoutToolbox",
+  "contents": [
+    {
+      "kind": "block",
+      "type": "pitch_test",
+    },
+  ],
 };
 
-/**
- * Create the pitch editor.
- * @return {!Element} The newly created pitch picker.
- * @private
- */
-CustomFields.FieldPitch.prototype.dropdownCreate_ = function () {
-  this.imageElement_ = document.createElement('div');
-  this.imageElement_.id = 'notePicker';
-
-  return this.imageElement_;
-};
-
-/**
- * Dispose of events belonging to the pitch editor.
- * @private
- */
-CustomFields.FieldPitch.prototype.dropdownDispose_ = function () {
-  Blockly.unbindEvent_(this.clickWrapper_);
-  Blockly.unbindEvent_(this.moveWrapper_);
-};
-
-/**
- * Hide the editor.
- * @private
- */
-CustomFields.FieldPitch.prototype.hide_ = function () {
-  Blockly.WidgetDiv.hide();
-  Blockly.DropDownDiv.hideWithoutAnimation();
-};
-
-/**
- * Set the note to match the mouse's position.
- * @param {!Event} e Mouse move event.
- */
-CustomFields.FieldPitch.prototype.onMouseMove = function (e) {
-  var bBox = this.imageElement_.getBoundingClientRect();
-  var dy = e.clientY - bBox.top;
-  var note = Blockly.utils.math.clamp(Math.round(13.5 - dy / 7.5), 0, 12);
-  this.imageElement_.style.backgroundPosition = (-note * 37) + 'px 0';
-  this.setEditorValue_(note);
-};
-
-/**
- * Convert the machine-readable value (0-12) to human-readable text (C3-A4).
- * @param {number|string} value The provided value.
- * @return {string|undefined} The respective note, or undefined if invalid.
- */
-CustomFields.FieldPitch.prototype.valueToNote = function (value) {
-  return CustomFields.FieldPitch.NOTES[Number(value)];
-};
-
-/**
- * Convert the human-readable text (C3-A4) to machine-readable value (0-12).
- * @param {string} text The provided note.
- * @return {number|undefined} The respective value, or undefined if invalid.
- */
-CustomFields.FieldPitch.prototype.noteToValue = function (text) {
-  var normalizedText = text.trim().toUpperCase();
-  var i = CustomFields.FieldPitch.NOTES.indexOf(normalizedText);
-  return i > -1 ? i : undefined;
-};
-
-/**
- * Get the text to be displayed on the field node.
- * @return {?string} The HTML value if we're editing, otherwise null. Null means
- *   the super class will handle it, likely a string cast of value.
- * @protected
- */
-CustomFields.FieldPitch.prototype.getText_ = function () {
-  if (this.isBeingEdited_) {
-    return CustomFields.FieldPitch.superClass_.getText_.call(this);
-  }
-  return this.valueToNote(this.getValue()) || null;
-};
-
-/**
- * Transform the provided value into a text to show in the HTML input.
- * @param {*} value The value stored in this field.
- * @return {string} The text to show on the HTML input.
- */
-CustomFields.FieldPitch.prototype.getEditorText_ = function (value) {
-  return this.valueToNote(value);
-};
-
-/**
- * Transform the text received from the HTML input (note) into a value
- * to store in this field.
- * @param {string} text Text received from the HTML input.
- * @return {*} The value to store.
- */
-CustomFields.FieldPitch.prototype.getValueFromEditorText_ = function (text) {
-  return this.noteToValue(text);
-};
-
-/**
- * Updates the graph when the field rerenders.
- * @private
- * @override
- */
-CustomFields.FieldPitch.prototype.render_ = function () {
-  CustomFields.FieldPitch.superClass_.render_.call(this);
-  this.updateGraph_();
-};
-
-/**
- * Redraw the note picker with the current note.
- * @private
- */
-CustomFields.FieldPitch.prototype.updateGraph_ = function () {
-  if (!this.imageElement_) {
-    return;
-  }
-  var i = this.getValue();
-  this.imageElement_.style.backgroundPosition = (-i * 37) + 'px 0';
-};
-
-/**
- * Ensure that only a valid value may be entered.
- * @param {*} opt_newValue The input value.
- * @return {*} A valid value, or null if invalid.
- */
-CustomFields.FieldPitch.prototype.doClassValidation_ = function (opt_newValue) {
-  if (opt_newValue === null || opt_newValue === undefined) {
-    return null;
-  }
-  var note = this.valueToNote(opt_newValue);
-  if (note) {
-    return opt_newValue;
-  }
-  return null;
-};
-
-Blockly.fieldRegistry.register('field_pitch', CustomFields.FieldPitch);
+/* eslint-enable quotes */

--- a/examples/keyboard-accessibility/test/index.js
+++ b/examples/keyboard-accessibility/test/index.js
@@ -9,9 +9,10 @@
  */
 
 import * as Blockly from 'blockly';
-import {toolboxCategories, createPlayground} from '@blockly/dev-tools';
+import {createPlayground} from '@blockly/dev-tools';
 import {speaker} from '../src/speaker';
 import {notePlayer} from '../src/note_player';
+import {toolboxPitch} from '../src/field_pitch';
 import MicroModal from 'micromodal';
 
 /**
@@ -27,7 +28,7 @@ function createWorkspace(blocklyDiv, options) {
 
 document.addEventListener('DOMContentLoaded', function() {
   const defaultOptions = {
-    toolbox: toolboxCategories,
+    toolbox: toolboxPitch,
   };
   MicroModal.init();
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13686399/98600777-f1122580-2292-11eb-8ea8-b5fb6ab72b1e.png)

It's still not showing up properly (probably a media issue) but now it's converted to es6 and has a test block so that it can be loaded in the playground, imported, etc.