### PR TITLE
Use blockly develop in order to use unreleased APIs

### DIFF
--- a/examples/keyboard-accessibility/package-lock.json
+++ b/examples/keyboard-accessibility/package-lock.json
@@ -1052,9 +1052,9 @@
       }
     },
     "@blockly/block-test": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-1.0.3.tgz",
-      "integrity": "sha512-0mPO+Z8yStg3zQoGTtYjIGU1wcvbhclnLMK3OMPscJCIgPyehPkdXL0gtXphIHTYVDr8DvfnTpDHjvolJNAlVw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-1.0.4.tgz",
+      "integrity": "sha512-Q5aNxqkgIPbOBmAGMeSOVu6zuGScB/33TcHani2XGNf+trq9TWOO4eWovQ1JP+cxH64JsfHZWJqyzyYaX2bT0Q==",
       "dev": true
     },
     "@blockly/dev-scripts": {
@@ -1082,12 +1082,12 @@
       }
     },
     "@blockly/dev-tools": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-2.0.5.tgz",
-      "integrity": "sha512-md+izjZx8hMk57jPwynWx9L5jprorQ0f0R0ykj50NmBvUK25UGJEXn72NpywmjpsvaHr8VoxrfMfhFgihEud1Q==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-2.0.6.tgz",
+      "integrity": "sha512-eOmDwGFwXBDrs8msFuiMbL4F4l2zHuMZ930jrPlxudH1QZsz6/sy37bKu6C1kMXnSxU6OcO3r1gO3IBxm2WAeA==",
       "dev": true,
       "requires": {
-        "@blockly/block-test": "^1.0.3",
+        "@blockly/block-test": "^1.0.4",
         "chai": "^4.2.0",
         "dat.gui": "^0.7.7",
         "lodash.assign": "^4.2.0",
@@ -1183,9 +1183,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
-      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==",
+      "version": "14.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -1750,13 +1750,6 @@
       "requires": {
         "@babel/runtime": "^7.12.1",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-        }
       }
     },
     "aws-sign2": {
@@ -1912,9 +1905,8 @@
       }
     },
     "blockly": {
-      "version": "3.20200924.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-3.20200924.4.tgz",
-      "integrity": "sha512-KDPVLJSguxwKXL6GVdVaYRINoxtojTsQ4lOhuWS9LkzyMhmQVZKMgFzlQum5rE5+hlhzj1BqqUQHe8JbfvL+dQ==",
+      "version": "git://github.com/google/blockly.git#cc2bb546250e6ae6f91f98467cb2061a63ecee17",
+      "from": "git://github.com/google/blockly.git#develop",
       "dev": true,
       "requires": {
         "jsdom": "^15.2.1"
@@ -2150,15 +2142,16 @@
       }
     },
     "browserslist": {
-      "version": "4.14.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.6.tgz",
-      "integrity": "sha512-zeFYcUo85ENhc/zxHbiIp0LGzzTrE2Pv2JhxvS7kpUb9Q9D38kUX6Bie7pGutJ/5iF5rOxE7CepAuWD56xJ33A==",
+      "version": "4.14.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
+      "integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001154",
-        "electron-to-chromium": "^1.3.585",
+        "caniuse-lite": "^1.0.30001157",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.591",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.65"
+        "node-releases": "^1.1.66"
       }
     },
     "buffer": {
@@ -2276,9 +2269,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001156",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001156.tgz",
-      "integrity": "sha512-z7qztybA2eFZTB6Z3yvaQBIoJpQtsewRD74adw2UbRWwsRq3jIPvgrQGawBMbfafekQaD21FWuXNcywtTDGGCw==",
+      "version": "1.0.30001157",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz",
+      "integrity": "sha512-gOerH9Wz2IRZ2ZPdMfBvyOi3cjaz4O4dgNwPGzx8EhqAs4+2IL/O+fJsbt+znSigujoZG8bVcIAUM/I/E5K3MA==",
       "dev": true
     },
     "caseless": {
@@ -2428,6 +2421,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "cipher-base": {
@@ -2537,6 +2538,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colorette": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
       "dev": true
     },
     "combined-stream": {
@@ -2717,12 +2724,12 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
-      "integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.7.0.tgz",
+      "integrity": "sha512-V8yBI3+ZLDVomoWICO6kq/CD28Y4r1M7CWeO4AGpMdMfseu8bkSubBmUPySMGKRTS+su4XQ07zUkAsiu9FCWTg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.8.5",
+        "browserslist": "^4.14.6",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -3151,9 +3158,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.589",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.589.tgz",
-      "integrity": "sha512-rQItBTFnol20HaaLm26UgSUduX7iGerwW7pEYX17MB1tI6LzFajiLV7iZ7LVcUcsN/7HrZUoCLrBauChy/IqEg==",
+      "version": "1.3.591",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.591.tgz",
+      "integrity": "sha512-ol/0WzjL4NS4Kqy9VD6xXQON91xIihDT36sYCew/G/bnd1v0/4D+kahp26JauQhgFUjrdva3kRSo7URcUmQ+qw==",
       "dev": true
     },
     "elliptic": {
@@ -5084,9 +5091,9 @@
       },
       "dependencies": {
         "ws": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+          "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
           "dev": true
         }
       }
@@ -5807,9 +5814,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.65",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.65.tgz",
-      "integrity": "sha512-YpzJOe2WFIW0V4ZkJQd/DGR/zdVwc/pI4Nl1CZrBO19FdRcSTmsuhdttw9rsTzzJLrNcSloLiBbEYx1C4f6gpA==",
+      "version": "1.1.66",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.66.tgz",
+      "integrity": "sha512-JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg==",
       "dev": true
     },
     "normalize-path": {
@@ -6848,6 +6855,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -7544,13 +7559,6 @@
         "@babel/runtime": "^7.12.1",
         "automation-events": "^3.0.2",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-        }
       }
     },
     "static-extend": {
@@ -7975,13 +7983,6 @@
       "requires": {
         "standardized-audio-context": "^25.0.4",
         "tslib": "^2.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
-        }
       }
     },
     "tough-cookie": {
@@ -8005,10 +8006,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
     },
     "tsutils": {
       "version": "3.17.1",
@@ -8017,6 +8017,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "tty-browserify": {

--- a/examples/keyboard-accessibility/package.json
+++ b/examples/keyboard-accessibility/package.json
@@ -8,7 +8,8 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "prepublishOnly": "npm run clean && npm run build",
-    "start": "blockly-scripts start"
+    "start": "blockly-scripts start",
+    "postinstall": "blockly-scripts postinstall"
   },
   "main": "./dist/index.js",
   "module": "./src/index.js",
@@ -40,7 +41,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.1",
     "@blockly/dev-tools": "^2.0.5",
-    "blockly": "^3.20200924.4"
+    "blockly": "git://github.com/google/blockly.git#develop"
   },
   "peerDependencies": {
     "blockly": ">=3"


### PR DESCRIPTION
Use the version of blockly from the develop branch on github instead of npm. This is needed to use the new keyboard shortcuts registry.