### PR TITLE
Add note picker CSS

### DIFF
--- a/examples/keyboard-accessibility/src/field_pitch.js
+++ b/examples/keyboard-accessibility/src/field_pitch.js
@@ -214,3 +214,19 @@ FieldPitch.NOTES = 'C3 D3 E3 F3 G3 A3 B3 C4 D4 E4 F4 G4 A4'.split(/ /);
 
 
 Blockly.fieldRegistry.register('field_pitch', FieldPitch);
+
+/**
+ * CSS for the pitch field.
+ * This field is using CSS to set a background image of a series of notes, then
+ * translating left or right to show only the correct note.
+ */
+Blockly.Css.register([
+/* eslint-disable indent */
+  `#notePicker {
+    background-image: url(https://raw.githubusercontent.com/google/blockly-games/master/appengine/music/notes.png);
+    border: 1px solid #ccc;
+    height: 109px;
+    width: 46px;
+  }`,
+  /* eslint-enable indent */
+]);


### PR DESCRIPTION
Adds CSS for the note picker, which makes the note picker's image show up properly.

It's using a single background image and then sliding it left or right to highlight the correct note. I didn't expect that.

@maribethb FYI