### PR TITLE
Integrate nearestCommonParents into the checker - project static

### DIFF
--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -221,10 +221,10 @@ export class TypeHierarchy {
    *     given types.
    */
   getNearestCommonParents(...types) {
-    types = types.map((type) => type.toLowerCase());
-    if (types.length < 2) {
-      return types;
+    if (!types.length) {
+      return [];
     }
+    types = types.map((type) => type.toLowerCase());
     return types.reduce((accumulator, currType) => {
       const nearestCommonParentsMap = this.nearestCommonParents_.get(currType);
       // Note: neither flatMap() nor flat() work on Node 10. See #431.


### PR DESCRIPTION
### Description

This integrates the unification additions from the previous PR into the actual connection checker. Most of this PR has to do with changing functions from returning single type strings, to returning arrays of type strings. This is because two types may have two or more equally near common parents, and as such they should be treated as compatible with any of those parents.

### Testing
I had already written tests for unification, but they were skipped, so now they've been unskipped! I also added tests to make sure that parent blocks or child blocks with multiple types are compatible (as discussed above).

It looks like I also decided to do some cleanup in the test files, so I'm sorry it looks messy :/