### PR TITLE
Add tutorial

### DIFF
--- a/examples/keyboard-accessibility/src/help_modal.js
+++ b/examples/keyboard-accessibility/src/help_modal.js
@@ -11,7 +11,16 @@
 
 import {speaker} from './speaker';
 
+/**
+ * Modal to show a help menu to the user.
+ */
 export class HelpModal {
+  /**
+   * Constructor for the help modal.
+   * @param {string} modalId The id of the modal.
+   * @param {string} modalButtonId The id of the button that opens the modal.
+   * @constructor
+   */
   constructor(modalId, modalButtonId) {
     /**
      * The id of the modal.
@@ -49,6 +58,7 @@ export class HelpModal {
    * Creates the dom for the modal.
    */
   createDom() {
+    /* eslint-disable max-len */
     document.getElementById(this.modalId).innerHTML = `
      <div class="modal__overlay" tabindex="-1" data-micromodal-close>
       <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="modal-1-title">
@@ -69,6 +79,6 @@ export class HelpModal {
         </footer>
       </div>
     </div>`;
+    /* eslint-enable max-len */
   }
-
 }

--- a/examples/keyboard-accessibility/src/key_press_modal.js
+++ b/examples/keyboard-accessibility/src/key_press_modal.js
@@ -13,7 +13,14 @@ import {speaker} from './speaker';
 import MicroModal from 'micromodal';
 import {WelcomeModal} from './welcome_modal';
 
+/**
+ * A modal that prompts the user to press a key, which enables the speaker.
+ */
 export class KeyPressModal {
+  /**
+   * Constructor for the key press modal.
+   * @constructor
+   */
   constructor() {
     /**
      * The id of the modal.
@@ -55,6 +62,7 @@ export class KeyPressModal {
    * Creates the dom for the modal.
    */
   createDom() {
+    /* eslint-disable max-len */
     document.getElementById(this.modalId).innerHTML = `
      <div class="modal__overlay" tabindex="-1" data-micromodal-close>
       <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="modal-1-title">
@@ -66,6 +74,6 @@ export class KeyPressModal {
         </header>
       </div>
     </div>`;
+    /* eslint-enable max-len */
   }
-
 }

--- a/examples/keyboard-accessibility/src/line_cursor.js
+++ b/examples/keyboard-accessibility/src/line_cursor.js
@@ -83,7 +83,8 @@ export class LineCursor extends Blockly.BasicCursor {
 
   /**
    * For a basic cursor we only have the ability to go next and previous, so
-   * in will also allow the user to get to the next node in the pre order traversal.
+   * in will also allow the user to get to the next node in the pre order
+   * traversal.
    * @return {Blockly.ASTNode} The next node, or null if the current node is
    *     not set or there is no next value.
    * @override
@@ -103,9 +104,10 @@ export class LineCursor extends Blockly.BasicCursor {
 
   /**
    * For a basic cursor we only have the ability to go next and previous, so
-   * out will allow the user to get to the previous node in the pre order traversal.
-   * @return {Blockly.ASTNode} The previous node, or null if the current node is
-   *     not set or there is no previous value.
+   * out will allow the user to get to the previous node in the pre order
+   * traversal.
+   * @return {Blockly.ASTNode} The previous node, or null if the current
+   *     node is not set or there is no previous value.
    * @override
    */
   out() {
@@ -165,7 +167,8 @@ export class LineCursor extends Blockly.BasicCursor {
     const type = node && node.getType();
     if (type === Blockly.ASTNode.types.FIELD) {
       isValid = true;
-    } else if (type === Blockly.ASTNode.types.INPUT && location.type === Blockly.INPUT_VALUE) {
+    } else if (type === Blockly.ASTNode.types.INPUT &&
+        location.type === Blockly.INPUT_VALUE) {
       isValid = true;
     } else if (type == Blockly.ASTNode.types.OUTPUT) {
       isValid = true;

--- a/examples/keyboard-accessibility/src/music.js
+++ b/examples/keyboard-accessibility/src/music.js
@@ -56,7 +56,8 @@ export class Music {
     Blockly.ASTNode.NAVIGATE_ALL_FIELDS = true;
     workspace.getMarkerManager().setCursor(new LineCursor());
     workspace.addChangeListener((event) => speaker.nodeToSpeech(event));
-    workspace.getFlyout().getWorkspace().addChangeListener((event) => speaker.nodeToSpeech(event));
+    workspace.getFlyout().getWorkspace().addChangeListener(
+        (event) => speaker.nodeToSpeech(event));
     return workspace;
   }
 

--- a/examples/keyboard-accessibility/src/tutorial.js
+++ b/examples/keyboard-accessibility/src/tutorial.js
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Multi-step tutorial using modals.
+ */
+'use strict';
+
+import {TutorialStep} from './tutorial_step';
+import MicroModal from 'micromodal';
+
+/**
+ * A multi-step tutorial for the accessible music game.
+ */
+export class Tutorial {
+  /**
+   * Class for a tutorial.
+   * @constructor
+   */
+  constructor() {
+    /**
+     * The id of the modal.
+     * @type {string}
+     */
+    this.modalId = 'tutorialModal';
+
+    /**
+     * The id of the tutorial text.
+     * @type {string}
+     */
+    this.stepTextId = this.modalId + 'Text';
+
+    /**
+     * The id of the next step button.
+     * @type {string}
+     */
+    this.stepButtonId = this.modalId + 'Btn';
+
+    /**
+     * An array of steps in the tutorial.
+     * @type {Array<!TutorialStep>}
+     */
+    this.steps = Tutorial.STEPS_TEXT.map(
+        (text) => new TutorialStep(text, this.stepTextId, this.nextStep)
+    );
+
+    /**
+     * The index of the currently active step.
+     * @type {number}
+     */
+    this.curStepIndex = 0;
+
+    /**
+     * The currently active step.
+     * @type {TutorialStep}
+     */
+    this.curStep = this.steps[this.curStepIndex];
+  }
+
+  /**
+   * Initialize DOM and show.
+   */
+  init() {
+    this.createDom();
+    this.addCallbacks();
+    MicroModal.show(this.modalId);
+    this.curStep.show();
+  }
+
+  /**
+   * Display the next step, or end the tutorial if there are no more steps.
+   */
+  nextStep() {
+    this.curStepIndex++;
+    if (this.curStepIndex < this.steps.length) {
+      this.curStep = this.steps[this.curStepIndex];
+      this.curStep.show();
+    } else {
+      this.done();
+    }
+  }
+
+  /**
+   * End the tutorial.
+   */
+  done() {
+    MicroModal.close(this.modalId);
+  }
+
+  /**
+   * Add necessary handlers for any buttons on the modal.
+   */
+  addCallbacks() {
+    document.getElementById(this.stepButtonId).addEventListener('click',
+        () => {
+          this.nextStep();
+        });
+  }
+
+  /**
+   * Create the dom for the modal.
+   */
+  createDom() {
+    /* eslint-disable max-len */
+    document.getElementById(this.modalId).innerHTML = `
+     <div class="modal__overlay" tabindex="-1" data-micromodal-close>
+      <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="modal-1-title">
+        <header class="modal__header">
+          <button class="modal__close" aria-label="Close modal" id="tutorialCloseBtn" data-micromodal-close></button>
+        </header>
+        <main class="modal__content" id="modal-1-content">
+          <h2 class="modal__title" id="${this.stepTextId}"></h2>
+        </main>
+        <footer class="modal__footer">
+          <button class="modal__btn modal__btn-primary" aria-label="Next step" id="${this.stepButtonId}">Next step</button>
+        </footer>
+      </div>
+    </div>`;
+    /* eslint-enable max-len */
+  }
+}
+
+Tutorial.STEPS_TEXT = [
+  'Hit enter to move focus to the workspace',
+  'Enable keyboard nav by pressing Cmd+Shift+K',
+  'Press X to navigate to the first stack of blocks',
+  'Press Y to navigate to the first block',
+  'Press enter to mark the first block',
+];

--- a/examples/keyboard-accessibility/src/tutorial_step.js
+++ b/examples/keyboard-accessibility/src/tutorial_step.js
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview A single step in the tutorial.
+ */
+'use strict';
+
+import {speaker} from './speaker';
+/**
+ * A step in the tutorial.
+ */
+export class TutorialStep {
+  /**
+   * Class for a single step in the tutorial.
+   * @param {string} text The text to show on the modal.
+   * @param {string} textId The ID of the element where the text will be
+   *     displayed.
+   * @param {Function} doneCb The function to call when the step is completed
+   *     by the user.
+   * @constructor
+   */
+  constructor(text, textId, doneCb) {
+    /**
+     * The text being displayed to the user.
+     * @type {string}
+     */
+    this.text = text;
+
+    /**
+     * The ID of the element where the text will be displayed.
+     * @type {string}
+     */
+    this.textId = textId;
+
+    /**
+     * The function to call when the step is completed by the user.
+     * @type {Function}
+     */
+    this.doneCb = doneCb;
+  }
+
+  /**
+   * Show this step in the modal, and speak it out loud.
+   */
+  show() {
+    document.getElementById(this.textId).innerHTML = this.text;
+    speaker.speak(this.text, true);
+  }
+}

--- a/examples/keyboard-accessibility/src/welcome_modal.js
+++ b/examples/keyboard-accessibility/src/welcome_modal.js
@@ -11,8 +11,16 @@
 
 import {speaker} from './speaker';
 import MicroModal from 'micromodal';
+import {Tutorial} from './tutorial';
 
+/**
+ * A class for a modal that welcomes the users and helps them get oriented.
+ */
 export class WelcomeModal {
+  /**
+   * Constructor for the welcome modal.
+   * @constructor
+   */
   constructor() {
     /**
      * The id of the modal.
@@ -40,12 +48,26 @@ export class WelcomeModal {
           speaker.modalToText(document.getElementById(this.modalId));
         });
     speaker.modalToText(document.getElementById(this.modalId));
+    this.registerTutorialButton();
+  }
+
+  /**
+   * Adds a callback to the tutorial button.
+   */
+  registerTutorialButton() {
+    document.getElementById('tutorialButton').addEventListener('click',
+        () => {
+          MicroModal.close(this.modalId);
+          const tutorial = new Tutorial();
+          tutorial.init();
+        });
   }
 
   /**
    * Creates the dom for the modal.
    */
   createDom() {
+    /* eslint-disable max-len */
     document.getElementById(this.modalId).innerHTML = `
      <div class="modal__overlay" tabindex="-1" data-micromodal-close>
       <div class="modal__container" role="dialog" aria-modal="true" aria-labelledby="modal-1-title">
@@ -68,6 +90,6 @@ export class WelcomeModal {
         </footer>
       </div>
     </div>`;
+    /* eslint-enable max-len */
   }
-
 }

--- a/examples/keyboard-accessibility/test/index.html
+++ b/examples/keyboard-accessibility/test/index.html
@@ -44,6 +44,7 @@
 
   <div class="modal micromodal-slide" id="modal-1" aria-hidden="true"></div>
   <div class="modal micromodal-slide" id="welcomeModal" aria-hidden="true"></div>
-<div class="modal micromodal-slide" id="keyPressModal" aria-hidden="true"></div>
+  <div class="modal micromodal-slide" id="keyPressModal" aria-hidden="true"></div>
+  <div class="modal micromodal-slide" id="tutorialModal" aria-hidden="true"></div>
 </body>
 </html>


### PR DESCRIPTION
Adds the Tutorial and TutorialStep classes, and wires up the tutorial to show (with some arbitrary steps) when the tutorial button is pushed from the welcome modal.

Fixes lint in a variety of files, mostly by fixing line length or adding jsdoc.

Right now you go from step to step in the tutorial by pressing the next step button, but I wired it up so that there's a callback that the tutorial step can call as well. Next up is figuring out how to know when to call that. @alschmiedt can I just override the handler for the key press I care about, so that it does the normal action *and* calls out to my tutorial step? Then for each step I could reset the handler back to the original action and move on to the next step.