### PR TITLE
Fix minimum version of peer dependency to blockly

### DIFF
--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -44,7 +44,7 @@
     "blockly": "^3.20200402.1"
   },
   "peerDependencies": {
-    "blockly": ">=3.30300123.0"
+    "blockly": ">=3.20200123.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
The current peer dependency to blockly requires a version, that does not exist yet. As a result, the plugin fails to install.
Seems to by a typo.