### PR TITLE
Separate playground state by plugin

### DIFF
--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -134,6 +134,10 @@ module.exports = (env) => {
       ],
     },
     plugins: [
+      // Add package name.
+      new webpack.DefinePlugin({
+        'process.env.PACKAGE_NAME': JSON.stringify(packageJson.name),
+      }),
       // Typecheck TS.
       isTypescript &&
       new ForkTsCheckerWebpackPlugin({

--- a/plugins/dev-tools/src/index.js
+++ b/plugins/dev-tools/src/index.js
@@ -21,7 +21,7 @@ let addGUIControls;
 let addCodeEditor;
 let createPlayground;
 if (typeof window !== 'undefined') {
-  addGUIControls = require('./addGUIControls').addGUIControls;
+  addGUIControls = require('./playground/options').addGUIControls;
   addCodeEditor = require('./playground/monaco').addCodeEditor;
   createPlayground = require('./playground/').createPlayground;
 }

--- a/plugins/dev-tools/src/playground/id.js
+++ b/plugins/dev-tools/src/playground/id.js
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Returns the package name.
+ * @author samelh@google.com (Sam El-Husseini)
+ */
+
+export const id = process.env.PACKAGE_NAME;

--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -18,8 +18,9 @@ import * as BlocklyPHP from 'blockly/php';
 
 import {renderPlayground, renderCheckbox, renderCodeTab} from './ui';
 import {addCodeEditor} from './monaco';
-import {addGUIControls} from '../addGUIControls';
+import {addGUIControls} from './options';
 import {LocalStorageState} from './state';
+import {id} from './id';
 
 import toolboxCategories from '../toolboxCategories';
 import toolboxSimple from '../toolboxSimple';
@@ -101,7 +102,7 @@ export function createPlayground(container, createWorkspace,
     const editorXmlContextKey = editor.createContextKey('isEditorXml', true);
 
     // Load / Save playground state.
-    const playgroundState = new LocalStorageState('playgroundState', {
+    const playgroundState = new LocalStorageState(`playgroundState_${id}`, {
       activeTab: 'XML',
       autoGenerate: config && config.auto != undefined ? config.auto : true,
       workspaceXml: '',

--- a/plugins/dev-tools/src/playground/options.js
+++ b/plugins/dev-tools/src/playground/options.js
@@ -12,13 +12,14 @@
 import * as Blockly from 'blockly/core';
 import * as dat from 'dat.gui';
 
-import {DebugRenderer} from './debugRenderer';
-import {disableLogger, enableLogger} from './logger';
-import {HashState} from './playground/hash_state';
-import {populateRandom} from './populateRandom';
-import {spaghetti} from './spaghetti';
-import toolboxCategories from './toolboxCategories';
-import toolboxSimple from './toolboxSimple';
+import {DebugRenderer} from '../debugRenderer';
+import {disableLogger, enableLogger} from '../logger';
+import {HashState} from './hash_state';
+import {populateRandom} from '../populateRandom';
+import {spaghetti} from '../spaghetti';
+import {id} from './id';
+import toolboxCategories from '../toolboxCategories';
+import toolboxSimple from '../toolboxSimple';
 
 const assign = require('lodash.assign');
 const merge = require('lodash.merge');
@@ -321,7 +322,8 @@ function saveGUIState(guiState, defaultToolboxName, defaultThemeName) {
   delete guiState.options['theme'];
 
   // Save GUI control options to local storage.
-  localStorage.setItem('guiState', JSON.stringify(guiState));
+  const guiStateKey = `guiState_${id}`;
+  localStorage.setItem(guiStateKey, JSON.stringify(guiState));
 
   // Save GUI state into the URL:
   const hashGuiState = Object.assign({}, guiState.options);
@@ -340,7 +342,8 @@ function saveGUIState(guiState, defaultToolboxName, defaultThemeName) {
  */
 function loadGUIState() {
   const defaultState = {options: {}, debug: {}};
-  const guiState = JSON.parse(localStorage.getItem('guiState')) || defaultState;
+  const guiStateKey = `guiState_${id}`;
+  const guiState = JSON.parse(localStorage.getItem(guiStateKey)) || defaultState;
   if (window.location.hash) {
     HashState.parse(window.location.hash, guiState.options);
   }


### PR DESCRIPTION
Separate playground state by plugin making it so each plugin has it's own state in local storage.

Fixes https://github.com/google/blockly-samples/issues/336