### PR TITLE
Add predeploy script to field-grid-dropdown

### DIFF
--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -6,6 +6,7 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
+    "predeploy": "npm run build && blockly-scripts predeploy",
     "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"


### PR DESCRIPTION
It looks like this package was created before we added predeploy to the template.