### PR TITLE
Orphan block's childrens are also orphans

### DIFF
--- a/plugins/disable-top-blocks/src/index.js
+++ b/plugins/disable-top-blocks/src/index.js
@@ -53,12 +53,13 @@ export class DisableTopBlocks {
 }
 
 /**
- * A block is an orphan if it doesn't have a parent, but it does have
- * a previous or output connection (so it expects to be attached to something).
+ * A block is an orphan if it doesn't have a parent (or its parent is disabled),
+ * but it does have a previous or output connection (so it expects to be
+ * attached to something).
  * @param {!Blockly.BlockSvg} block Block to check.
  * @return {boolean} Whether the block is an orphan.
  */
 function isOrphan(block) {
-  return !block.getParent() &&
+  return (!block.getParent() || !block.getParent().isEnabled()) &&
       !!(block.outputConnection || block.previousConnection);
 }

--- a/plugins/disable-top-blocks/src/index.js
+++ b/plugins/disable-top-blocks/src/index.js
@@ -53,13 +53,20 @@ export class DisableTopBlocks {
 }
 
 /**
- * A block is an orphan if it doesn't have a parent (or its parent is disabled),
- * but it does have a previous or output connection (so it expects to be
- * attached to something).
+ * A block is an orphan if its parent is an orphan, or if it doesn't have a
+ * parent but it does have a previous or output connection (so it expects to be
+ * attached to something). This means all children of orphan blocks are also
+ * orphans and cannot be manually re-enabled.
  * @param {!Blockly.BlockSvg} block Block to check.
  * @return {boolean} Whether the block is an orphan.
  */
 function isOrphan(block) {
-  return (!block.getParent() || !block.getParent().isEnabled()) &&
+  // If the parent is an orphan block, this block should also be considered
+  // an orphan so it cannot be manually re-enabled.
+  if (block.getParent() &&
+      isOrphan(/** @type {Blockly.BlockSvg} */ (block.getParent()))) {
+    return true;
+  }
+  return !block.getParent() &&
       !!(block.outputConnection || block.previousConnection);
 }

--- a/plugins/disable-top-blocks/src/index.js
+++ b/plugins/disable-top-blocks/src/index.js
@@ -63,10 +63,10 @@ export class DisableTopBlocks {
 function isOrphan(block) {
   // If the parent is an orphan block, this block should also be considered
   // an orphan so it cannot be manually re-enabled.
-  if (block.getParent() &&
-      isOrphan(/** @type {Blockly.BlockSvg} */ (block.getParent()))) {
+  const parent = /** @type {Blockly.BlockSvg} */ (block.getParent());
+  if (parent && isOrphan(parent)) {
     return true;
   }
-  return !block.getParent() &&
+  return !parent &&
       !!(block.outputConnection || block.previousConnection);
 }


### PR DESCRIPTION
Update the logic for whether a block is an orphan.

Test: 
npm run start in disable-top-blocks plugin
Drag an if-then block onto the ws.
Drag a second if-then block connected to the first.
They are both disabled automatically by disableOrphans.

Previously: Second block could be enabled through context menu because it technically had a parent
Now: Neither block can be enabled through context menu because they are both orphans.