### PR TITLE
Add constants and gesture overrides

### DIFF
--- a/plugins/keyboard-navigation/src/constants.js
+++ b/plugins/keyboard-navigation/src/constants.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Constants for keyboard navigation.
+ * @author aschmiedt@google.com (Abby Schmiedt)
+ */
+
+/**
+ * Keyboard navigation states.
+ * The different parts of Blockly that the user navigates between.
+ * @enum {string}
+ * @const
+ * @public
+ */
+export const STATE = {
+  WORKSPACE: 'workspace',
+  FLYOUT: 'flyout',
+  TOOLBOX: 'toolbox',
+};
+
+/**
+ * Default keyboard navigation shortcut names.
+ * @enum {string}
+ * @const
+ * @public
+ */
+export const SHORTCUT_NAMES = {
+  PREVIOUS: 'previous',
+  NEXT: 'next',
+  IN: 'in',
+  OUT: 'out',
+  INSERT: 'insert',
+  MARK: 'mark',
+  DISCONNECT: 'disconnect',
+  TOOLBOX: 'toolbox',
+  EXIT: 'exit',
+  TOGGLE_KEYBOARD_NAV: 'toggle_keyboard_nav',
+  COPY: 'keyboard_nav_copy',
+  CUT: 'keyboard_nav_cut',
+  PASTE: 'keyboard_nav_paste',
+  DELETE: 'keyboard_nav_delete',
+  MOVE_WS_CURSOR_UP: 'workspace_up',
+  MOVE_WS_CURSOR_DOWN: 'workspace_down',
+  MOVE_WS_CURSOR_LEFT: 'workspace_left',
+  MOVE_WS_CURSOR_RIGHT: 'workspace_right',
+};

--- a/plugins/keyboard-navigation/src/gesture_monkey_patch.js
+++ b/plugins/keyboard-navigation/src/gesture_monkey_patch.js
@@ -25,8 +25,8 @@ const oldDoWorkspaceClick = Blockly.Gesture.prototype.doWorkspaceClick_;
  * @override
  */
 Blockly.Gesture.prototype.doWorkspaceClick_ = function(e) {
+  oldDoWorkspaceClick.call(this, e);
   const ws = this.creatorWorkspace_;
-  oldDoWorkspaceClick.bind(this)(e);
   if (e.shiftKey && ws.keyboardAccessibilityMode) {
     const screenCoord = new Blockly.utils.Coordinate(e.clientX, e.clientY);
     const wsCoord = Blockly.utils.screenToWsCoordinates(ws, screenCoord);
@@ -44,7 +44,7 @@ const oldDoBlockClick = Blockly.Gesture.prototype.doBlockClick_;
  * @override
  */
 Blockly.Gesture.prototype.doBlockClick_ = function(e) {
-  oldDoBlockClick.bind(this)(e);
+  oldDoBlockClick.call(this, e);
   if (!this.targetBlock_.isInFlyout && this.mostRecentEvent_.shiftKey &&
       this.targetBlock_.workspace.keyboardAccessibilityMode) {
     this.creatorWorkspace_.getCursor().setCurNode(

--- a/plugins/keyboard-navigation/src/gesture_monkey_patch.js
+++ b/plugins/keyboard-navigation/src/gesture_monkey_patch.js
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Overrides methods on Blockly.Gesture in order to allow users
+ * to move the cursor to blocks or the workspace using shift click.
+ * TODO(google/blockly#4584): We do not have a way to do this currently without
+ * monkey patching Blockly.
+ * @author aschmiedt@google.com (Abby Schmiedt)
+ */
+
+import * as Blockly from 'blockly/core';
+
+
+const oldDoWorkspaceClick = Blockly.Gesture.prototype.doWorkspaceClick_;
+
+/**
+ * Execute a workspace click. When in accessibility mode shift clicking will
+ * move the cursor.
+ * @param {!Event} e A mouse up or touch end event.
+ * @this {Blockly.Gesture}
+ * @override
+ */
+Blockly.Gesture.prototype.doWorkspaceClick_ = function(e) {
+  const ws = this.creatorWorkspace_;
+  oldDoWorkspaceClick.bind(this)(e);
+  if (e.shiftKey && ws.keyboardAccessibilityMode) {
+    const screenCoord = new Blockly.utils.Coordinate(e.clientX, e.clientY);
+    const wsCoord = Blockly.utils.screenToWsCoordinates(ws, screenCoord);
+    const wsNode = Blockly.ASTNode.createWorkspaceNode(ws, wsCoord);
+    ws.getCursor().setCurNode(wsNode);
+  }
+};
+
+const oldDoBlockClick = Blockly.Gesture.prototype.doBlockClick_;
+
+/**
+ * Execute a block click. When in accessibility mode shift clicking will move
+ * the cursor to the block.
+ * @this {Blockly.Gesture}
+ * @override
+ */
+Blockly.Gesture.prototype.doBlockClick_ = function(e) {
+  oldDoBlockClick.bind(this)(e);
+  if (!this.targetBlock_.isInFlyout && this.mostRecentEvent_.shiftKey &&
+      this.targetBlock_.workspace.keyboardAccessibilityMode) {
+    this.creatorWorkspace_.getCursor().setCurNode(
+        Blockly.ASTNode.createTopNode(this.targetBlock_));
+  }
+};


### PR DESCRIPTION
Adds constants and gesture overrides needed for keyboard navigation. 

Gesture is needed for when shift clicking on the workspace or a block moves the cursor around.