### PR TITLE
Add a link to old demos site from gh-pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -70,3 +70,5 @@ layout: index
 
 ## Plane
 * [Plane](examples/plane-demo/index.html)
+
+Looking for the old demos site? [Click here](https://blockly-demo.appspot.com/static/demos/index.html)


### PR DESCRIPTION
I think that the "Samples" link on the devsite navbar should point to the fancy new page. However, not all of the demos have been ported over yet (notably the Developer Tools) so I added a link to the old page from here. If we think this is a good idea, I'll update the devsite links after this is live.