### PR TITLE
Adds new navigation methods

### DIFF
--- a/plugins/keyboard-navigation/src/line_cursor.js
+++ b/plugins/keyboard-navigation/src/line_cursor.js
@@ -140,7 +140,7 @@ export class LineCursor extends Blockly.BasicCursor {
         isValid = true;
       }
     } else if (
-        type == Blockly.ASTNode.types.INPUT &&
+      type == Blockly.ASTNode.types.INPUT &&
         location.type == Blockly.NEXT_STATEMENT) {
       isValid = true;
     } else if (type == Blockly.ASTNode.types.NEXT) {
@@ -166,7 +166,7 @@ export class LineCursor extends Blockly.BasicCursor {
     if (type == Blockly.ASTNode.types.FIELD) {
       isValid = true;
     } else if (
-        type == Blockly.ASTNode.types.INPUT &&
+      type == Blockly.ASTNode.types.INPUT &&
         location.type == Blockly.INPUT_VALUE) {
       isValid = true;
     }

--- a/plugins/keyboard-navigation/src/navigation.js
+++ b/plugins/keyboard-navigation/src/navigation.js
@@ -492,8 +492,9 @@ export class Navigation {
   }
 
   /**
-   * Sets the cursor to the top connection point on a block or to the workspace
-   * if there are no blocks on the workspace.
+   * Moves the cursor to the top connection point on on the first top block.
+   * If the workspace is empty, moves the cursor to the default location on
+   * the workspace.
    * @param {!Blockly.WorkspaceSvg} workspace The main Blockly workspace.
    * @protected
    */
@@ -529,9 +530,9 @@ export class Navigation {
 
   /**
    * Inserts a block from the flyout.
-   * If there is a marked connection try connecting the block from the flyout to
-   * that connection. If no connection has been marked then inserting it will
-   * place it on the workspace.
+   * Tries to find a connection on the block to connect to the marked
+   * location. If no connection has been marked, or there is not a compatible
+   * connection then the block is placed on the workspace.
    * @param {!Blockly.WorkspaceSvg} workspace The main workspace. The workspace
    *     the block will be placed on.
    * @package
@@ -1147,7 +1148,9 @@ export class Navigation {
   }
 
   /**
-   * Inserts a block where the current marker is.
+   * Inserts the pasted block at the marked location if a compatible connection
+   * exists. If no connection has been marked, or there is not a compatible
+   * connection then the block is placed on the workspace.
    * @param {!Blockly.WorkspaceSvg} workspace The workspace to paste the block
    *     on.
    * @param {!Blockly.BlockSvg} block The block to paste.

--- a/plugins/keyboard-navigation/src/navigation_controller.js
+++ b/plugins/keyboard-navigation/src/navigation_controller.js
@@ -158,13 +158,13 @@ export class NavigationController {
     }
     switch (shortcut.name) {
       case Constants.SHORTCUT_NAMES.PREVIOUS:
-        return this.selectPrevious();
+        return this.selectPrevious_();
       case Constants.SHORTCUT_NAMES.OUT:
-        return this.selectParent();
+        return this.selectParent_();
       case Constants.SHORTCUT_NAMES.NEXT:
-        return this.selectNext();
+        return this.selectNext_();
       case Constants.SHORTCUT_NAMES.IN:
-        return this.selectChild();
+        return this.selectChild_();
       default:
         return false;
     }


### PR DESCRIPTION
Adds final methods for keyboard navigation and fixes linting errors. 

`paste`, `insertPastedBlock` and `dispose` are new methods. The rest are copied over from core. 
