### PR TITLE
Prevent field-grid-dropdown overflow out of workspace

### DIFF
--- a/plugins/field-grid-dropdown/src/index.js
+++ b/plugins/field-grid-dropdown/src/index.js
@@ -105,6 +105,9 @@ export class FieldGridDropdown extends Blockly.FieldDropdown {
     Blockly.utils.dom.addClass(
         this.menu_.getElement(), 'fieldGridDropDownContainer');
     this.updateColumnsStyling_();
+
+    Blockly.DropDownDiv.showPositionedByField(
+            this, this.dropdownDispose_.bind(this));
   }
 
   /**


### PR DESCRIPTION
Currenlty, if you open the dropdown field of field-grid-dropdown when a block is at the edge of the workspace, the dropdown menu div overflows out of the workspace. Following screenshots demonstrates this.

![Capture](https://user-images.githubusercontent.com/6296505/108514434-2b448780-72c4-11eb-98d0-afa5003bdded.PNG)
![Capture2](https://user-images.githubusercontent.com/6296505/108514442-2da6e180-72c4-11eb-872a-32e5574863eb.PNG)

This PR fixes this issue.