### PR TITLE
Prevent field-grid-dropdown overflow out of workspace

### DIFF
--- a/plugins/field-grid-dropdown/src/index.js
+++ b/plugins/field-grid-dropdown/src/index.js
@@ -107,7 +107,7 @@ export class FieldGridDropdown extends Blockly.FieldDropdown {
     this.updateColumnsStyling_();
 
     Blockly.DropDownDiv.showPositionedByField(
-            this, this.dropdownDispose_.bind(this));
+        this, this.dropdownDispose_.bind(this));
   }
 
   /**

--- a/plugins/field-grid-dropdown/src/index.js
+++ b/plugins/field-grid-dropdown/src/index.js
@@ -105,6 +105,9 @@ export class FieldGridDropdown extends Blockly.FieldDropdown {
     Blockly.utils.dom.addClass(
         this.menu_.getElement(), 'fieldGridDropDownContainer');
     this.updateColumnsStyling_();
+
+    Blockly.DropDownDiv.showPositionedByField(
+            this, this.dropdownDispose_.bind(this));
   }
 
   /**


### PR DESCRIPTION
Currently, if you open the dropdown field of field-grid-dropdown when a block is at the edge of the workspace, the dropdown menu div overflows out of the workspace. Following screenshots demonstrates this.

![image](https://user-images.githubusercontent.com/6296505/108516297-56c87180-72c6-11eb-8a92-17ee16741ab6.png)
![image](https://user-images.githubusercontent.com/6296505/108516307-5a5bf880-72c6-11eb-9d78-9903e78a51cb.png)

This PR fixes this issue. Following screenshot shows the dropdown menu after applying the fix.

![Capture3](https://user-images.githubusercontent.com/6296505/108591635-0c003580-736a-11eb-943c-c67933150c76.PNG)
