### PR TITLE
Make playground createWorkspace optional

### DIFF
--- a/plugins/dev-tools/src/index.d.ts
+++ b/plugins/dev-tools/src/index.d.ts
@@ -49,9 +49,9 @@ declare namespace DevTools {
   /**
    * Create the Blockly playground.
    */
-  function createPlayground(container: HTMLElement, createWorkspace:
+  function createPlayground(container: HTMLElement, createWorkspace?:
   (blocklyDiv: HTMLElement, options: Blockly.BlocklyOptions) =>
-  Blockly.Workspace, defaultOptions: Blockly.BlocklyOptions,
+  Blockly.Workspace, defaultOptions?: Blockly.BlocklyOptions,
     vsEditorPath?: string): Promise<PlaygroundAPI>;
 
   /**

--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -72,16 +72,17 @@ let PlaygroundAPI;
 /**
  * Create the Blockly playground.
  * @param {!HTMLElement} container Container element.
- * @param {CreateWorkspaceFn} createWorkspace A workspace creation method called
- *     every time the toolbox is re-configured.
- * @param {Blockly.BlocklyOptions} defaultOptions The default workspace options
+ * @param {CreateWorkspaceFn=} createWorkspace A workspace creation method
+ *     called every time the toolbox is re-configured.
+ * @param {Blockly.BlocklyOptions=} defaultOptions The default workspace options
  *     to use.
  * @param {PlaygroundConfig=} config Optional Playground config.
  * @param {string=} vsEditorPath Optional editor path.
  * @return {Promise<PlaygroundAPI>} A promise to the playground API.
  */
-export function createPlayground(container, createWorkspace,
-    defaultOptions, config = {}, vsEditorPath) {
+export function createPlayground(container, createWorkspace =
+    (blocklyDiv, options) => Blockly.inject(blocklyDiv, options),
+    defaultOptions = {toolbox: toolboxCategories}, config = {}, vsEditorPath) {
   const {blocklyDiv, minimizeButton, monacoDiv, guiContainer, playgroundDiv, tabButtons, tabsDiv} =
     renderPlayground(container);
 

--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -80,8 +80,7 @@ let PlaygroundAPI;
  * @param {string=} vsEditorPath Optional editor path.
  * @return {Promise<PlaygroundAPI>} A promise to the playground API.
  */
-export function createPlayground(container, createWorkspace =
-    (blocklyDiv, options) => Blockly.inject(blocklyDiv, options),
+export function createPlayground(container, createWorkspace = Blockly.inject,
     defaultOptions = {toolbox: toolboxCategories}, config = {}, vsEditorPath) {
   const {blocklyDiv, minimizeButton, monacoDiv, guiContainer, playgroundDiv, tabButtons, tabsDiv} =
     renderPlayground(container);


### PR DESCRIPTION
Use Blockly.inject as the default workspace creator resulting in:
- createWorkspace
- defaultOptions

as optional parameters to `createPlayground`.