### PR TITLE
Add captureWarnings to dev-tools plugin

### DIFF
--- a/plugins/dev-tools/src/common_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/common_test_helpers.mocha.js
@@ -64,6 +64,27 @@ export function runTestCases(testCases, createTestCallback) {
   });
 }
 
+
+/**
+ * Captures the strings sent to console.warn() when calling a function.
+ * Copies from core.
+ * @param {function} innerFunc The function where warnings may called.
+ * @return {string[]} The warning messages (only the first arguments).
+ */
+export function captureWarnings(innerFunc) {
+  const msgs = [];
+  const nativeConsoleWarn = console.warn;
+  try {
+    console.warn = function (msg) {
+      msgs.push(msg);
+    };
+    innerFunc();
+  } finally {
+    console.warn = nativeConsoleWarn;
+  }
+  return msgs;
+}
+
 /**
  * Runs provided test suite.
  * @template {TestCase} T

--- a/plugins/dev-tools/src/test_helpers.mocha.js
+++ b/plugins/dev-tools/src/test_helpers.mocha.js
@@ -12,6 +12,7 @@ const {
   TestCase,
   TestSuite,
   runTestCases,
+  captureWarnings,
 } = commonHelpers;
 
 const {
@@ -39,6 +40,7 @@ export {
   runSerializationTestSuite,
   runSetValueTests,
   runTestCases,
+  captureWarnings,
   SerializationTestCase,
   TestCase,
   TestSuite,

--- a/plugins/keyboard-navigation/test/navigation_modify_test.mocha.js
+++ b/plugins/keyboard-navigation/test/navigation_modify_test.mocha.js
@@ -10,25 +10,7 @@ const {Navigation} = require('../src/navigation');
 const assert = chai.assert;
 
 suite('Insert/Modify', function() {
-  /**
-   * Captures the strings sent to console.warn() when calling a function.
-   * Copies from core.
-   * @param {function} innerFunc The function where warnings may called.
-   * @return {string[]} The warning messages (only the first arguments).
-   */
-  function captureWarnings(innerFunc) {
-    const msgs = [];
-    const nativeConsoleWarn = console.warn;
-    try {
-      console.warn = function(msg) {
-        msgs.push(msg);
-      };
-      innerFunc();
-    } finally {
-      console.warn = nativeConsoleWarn;
-    }
-    return msgs;
-  }
+
 
   /**
    * Check that modify failed.


### PR DESCRIPTION
Issue reference:- #567 

I have moved the function `captureWarnings` from **keyboard-navigation/test** to **dev-tools/src/** as accentuated in the issue mentioned above.


