### PR TITLE
Add support for parameterized types to type hierarch (only) - project static

### DIFF
--- a/plugins/nominal-connection-checker/src/index.js
+++ b/plugins/nominal-connection-checker/src/index.js
@@ -13,7 +13,6 @@ import * as Blockly from 'blockly/core';
 import {TypeHierarchy} from './type_hierarchy';
 import {getCheck, isExplicitConnection, isGenericConnection} from './utils';
 
-// TODO: Fix the version of Blockly being required in package.json.
 
 /**
  * A connection checker that is targeted at helping Blockly model languages with

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -250,8 +250,13 @@ export class TypeHierarchy {
     }, [types[0]]);
   }
 
-  // TODO: Might be useful to look into how lexers do this.
   // TODO: Move all the TypeStructure stuff into its own file in the next PR.
+  /**
+   * Parses a string into a TypeStructure.
+   * @param {string} str The string to parse into a TypeStructure.
+   * @return {!TypeStructure} The created TypeStructure.
+   * @private
+   */
   parseType_(str) {
     const typeStruct = {};
     const bracketIndex = str.indexOf('[');
@@ -267,6 +272,13 @@ export class TypeHierarchy {
     return typeStruct;
   }
 
+  /**
+   * Parses a string into an array of type structures.
+   * @param {string} str The string to parse into an array of type structures.
+   *     The string is expected to not be surrounded by brackets.
+   * @return {!Array<!TypeStructure>} The created TypeStructure array.
+   * @private
+   */
   parseParamsArray_(str) {
     const params = [];
     let latestIndex = 0;
@@ -362,7 +374,7 @@ class TypeDef {
 
     /**
      * The caseless names of the parameters of this type.
-     * @type {!Array<Param>}
+     * @type {!Array<ParamDef>}
      * @private
      */
     this.params_ = [];
@@ -574,10 +586,21 @@ class TypeDef {
     return this.paramsMap_.get(ancestorName);
   }
 
+  /**
+   * Returns the index of the parameter with the given name.
+   * @param {string} paramName The name of the parameter.
+   * @return {number} The index of hte parameter.
+   */
   getIndexOfParam(paramName) {
     return this.params_.findIndex((param) => param.name == paramName);
   }
 
+  /**
+   * Returns the parameter definition for the parameter at the given index.
+   * @param {number} index The index to get the parameter definition of.
+   * @return {!ParamDef} The parameter definition for the parameter at the
+   *     given index.
+   */
   getParamForIndex(index) {
     return this.params_[index];
   }

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -217,9 +217,6 @@ export class TypeHierarchy {
     const superStructure = this.parseType_(superType);
 
     return this.types_.get(subStructure.name).hasAncestor(superStructure.name);
-
-    // return this.types_.get(subName.toLowerCase())
-    //     .hasAncestor(superName.toLowerCase());
   }
 
   /**
@@ -254,12 +251,7 @@ export class TypeHierarchy {
   }
 
   // TODO: Might be useful to look into how lexers do this.
-  /**
-   *
-   * @param str
-   * @return {TypeStructure}
-   * @private
-   */
+  // TODO: Move all the TypeStructure stuff into its own file in the next PR.
   parseType_(str) {
     const typeStruct = {};
     const bracketIndex = str.indexOf('[');
@@ -438,7 +430,7 @@ class TypeDef {
    *     the parameter will be added at the end.
    */
   addParam(paramName, variance, index = undefined) {
-    const param = new Param(paramName, variance);
+    const param = new ParamDef(paramName, variance);
     if (index != undefined) {
       this.params_.splice(index, param);
     } else {
@@ -562,20 +554,28 @@ class TypeDef {
 
   /**
    * Returns an array of this type's parameters, in the order for its superType.
-   * @param {string} ancestorName The name of the ancestor to get the parameters
-   *     for.
+   * @param {string} ancestorName The caseless name of the ancestor to get the
+   *     parameters for.
    * @param {!Array<!TypeStructure>=} explicitTypes Optional explicit types to
    *     substitute for parameters.
    * @return {!Array<!TypeStructure>} This type's parameters, in the order for
    *     its superType.
    */
   getParamsForAncestor(ancestorName, explicitTypes = undefined) {
+    if (ancestorName == this.name && !this.paramsMap_.has(this.name)) {
+      // Convert this type's params to a type structure.
+      this.paramsMap_.set(
+          this.name,
+          this.params_.map((param) => {
+            return {name: param.name, params: []};
+          }));
+    }
     // TODO: Add support for the explicit types.
     return this.paramsMap_.get(ancestorName);
   }
 
   getIndexOfParam(paramName) {
-    return this.params_.indexOf((param) => param.name == paramName);
+    return this.params_.findIndex((param) => param.name == paramName);
   }
 
   getParamForIndex(index) {
@@ -615,7 +615,7 @@ function stringToVariance(str) {
 /**
  * Represents a type parameter.
  */
-class Param {
+class ParamDef {
   /**
    * Constructs the type parameter given its name and variance.
    * @param {string} name The caseless name of the type parameter.
@@ -625,31 +625,13 @@ class Param {
     /**
      * The caseless name of this type parameter.
      * @type {string}
-     * @private
      */
-    this.name_ = name;
+    this.name = name;
 
     /**
      * The variance of this type parameter.
      * @type {!Variance}
-     * @private
      */
-    this.variance_ = variance;
-  }
-
-  /**
-   * Returns the name of this parameter.
-   * @return {string} The name of this parameter.
-   */
-  getName() {
-    return this.name_;
-  }
-
-  /**
-   * Returns the variance of this parameter.
-   * @return {!Variance} The variance of this parameter.
-   */
-  getVariance() {
-    return this.variance_;
+    this.variance = variance;
   }
 }

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -582,8 +582,19 @@ class TypeDef {
             return {name: param.name, params: []};
           }));
     }
-    // TODO: Add support for the explicit types.
-    return this.paramsMap_.get(ancestorName);
+    const params = this.paramsMap_.get(ancestorName);
+    if (explicitTypes) {
+      const replaceFn = (param, i, array) => {
+        const paramIndex = this.getIndexOfParam(param.name);
+        if (paramIndex != -1) {
+          array[i] = explicitTypes[paramIndex];
+        } else {
+          param.params.forEach(replaceFn, this);
+        }
+      };
+      params.forEach(replaceFn, this);
+    }
+    return params;
   }
 
   /**

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -444,7 +444,7 @@ class TypeDef {
   addParam(paramName, variance, index = undefined) {
     const param = new ParamDef(paramName, variance);
     if (index != undefined) {
-      this.params_.splice(index, param);
+      this.params_.splice(index, 0, param);
     } else {
       this.params_.push(param);
     }
@@ -582,7 +582,8 @@ class TypeDef {
             return {name: param.name, params: []};
           }));
     }
-    const params = this.paramsMap_.get(ancestorName);
+    // Copy array so that we don't have to worry about corruption.
+    const params = [...this.paramsMap_.get(ancestorName)];
     if (actualTypes) {
       const replaceFn = (param, i, array) => {
         const paramIndex = this.getIndexOfParam(param.name);
@@ -620,7 +621,7 @@ class TypeDef {
    * Returns the index of the parameter with the given name, or -1 if the
    * parameter does not exist..
    * @param {string} paramName The name of the parameter.
-   * @return {number} The index of hte parameter.
+   * @return {number} The index of the parameter.
    */
   getIndexOfParam(paramName) {
     return this.params_.findIndex((param) => param.name == paramName);
@@ -638,8 +639,8 @@ class TypeDef {
 
   /**
    * Returns the ParamDef with the given name, or undefined if not found.
-   * @param {string} paramName The name of the parameter to find the
-   *     ParamDef of.
+   * @param {string} paramName The name of the parameter to find
+   *     the ParamDef of.
    * @return {!ParamDef|undefined} The parameter with the given name, or
    *     undefined if not found.
    */

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -568,12 +568,12 @@ class TypeDef {
    * Returns an array of this type's parameters, in the order for its superType.
    * @param {string} ancestorName The caseless name of the ancestor to get the
    *     parameters for.
-   * @param {!Array<!TypeStructure>=} explicitTypes Optional explicit types to
-   *     substitute for parameters.
+   * @param {!Array<!TypeStructure>=} actualTypes Optional actual types to
+   *     substitute for parameters. These types may be generic.
    * @return {!Array<!TypeStructure>} This type's parameters, in the order for
    *     its superType.
    */
-  getParamsForAncestor(ancestorName, explicitTypes = undefined) {
+  getParamsForAncestor(ancestorName, actualTypes = undefined) {
     if (ancestorName == this.name && !this.paramsMap_.has(this.name)) {
       // Convert this type's params to a type structure.
       this.paramsMap_.set(
@@ -583,11 +583,11 @@ class TypeDef {
           }));
     }
     const params = this.paramsMap_.get(ancestorName);
-    if (explicitTypes) {
+    if (actualTypes) {
       const replaceFn = (param, i, array) => {
         const paramIndex = this.getIndexOfParam(param.name);
         if (paramIndex != -1) {
-          array[i] = explicitTypes[paramIndex];
+          array[i] = actualTypes[paramIndex];
         } else {
           param.params.forEach(replaceFn, this);
         }

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -587,7 +587,27 @@ class TypeDef {
   }
 
   /**
-   * Returns the index of the parameter with the given name.
+   * Returns true if this type has any parameters. False otherwise.
+   * @return {boolean} True if this type has any parameters. False otherwise.
+   */
+  hasParameters() {
+    return !!this.params_.length;
+  }
+
+  /**
+   * Returns true if this type has a parameter with the given name.
+   * False otherwise.
+   * @param {string} paramName The caseless name of the possible parameter.
+   * @return {boolean} True if this type has a parameter with the given name.
+   *     False otherwise.
+   */
+  hasParameter(paramName) {
+    return this.params_.some((param) => param.name == paramName);
+  }
+
+  /**
+   * Returns the index of the parameter with the given name, or -1 if the
+   * parameter does not exist..
    * @param {string} paramName The name of the parameter.
    * @return {number} The index of hte parameter.
    */
@@ -603,6 +623,17 @@ class TypeDef {
    */
   getParamForIndex(index) {
     return this.params_[index];
+  }
+
+  /**
+   * Returns the ParamDef with the given name, or undefined if not found.
+   * @param {string} paramName The name of the parameter to find the
+   *     ParamDef of.
+   * @return {!ParamDef|undefined} The parameter with the given name, or
+   *     undefined if not found.
+   */
+  getParamWithName(paramName) {
+    return this.params_.find((param) => param.name == paramName);
   }
 }
 

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -302,6 +302,13 @@ suite('Hierarchy Validation', function() {
       chai.assert.isTrue(this.errorStub.notCalled);
     });
 
+    test('"123"', function() {
+      validateHierarchy({
+        '123': { },
+      });
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+
     test('"a"', function() {
       validateHierarchy({
         'a': { },

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -658,4 +658,233 @@ suite('TypeHierarchy', function() {
       });
     });
   });
+
+  suite('getTypeStructure', function() {
+    setup(function() {
+      const hierarchy = new TypeHierarchy({
+        'typeA': { },
+      });
+
+      this.assertStructure = function(str, struct) {
+        chai.assert.deepEqual(hierarchy.getTypeStructure_(str), struct);
+      };
+    });
+
+    test('Just type', function() {
+      this.assertStructure(
+          'typeA',
+          {
+            name: 'typea',
+            params: [],
+          });
+    });
+
+    test('Single param', function() {
+      this.assertStructure(
+          'typeA[typeA]',
+          {
+            name: 'typea',
+            params: [
+              {
+                name: 'typea',
+                params: [],
+              },
+            ],
+          });
+    });
+
+    test('Multiple params, commas and spaces', function() {
+      this.assertStructure(
+          'typeA[typeA, typeA]',
+          {
+            name: 'typea',
+            params: [
+              {
+                name: 'typea',
+                params: [],
+              },
+              {
+                name: 'typea',
+                params: [],
+              },
+            ],
+          });
+    });
+
+    test('Multiple params, commas', function() {
+      this.assertStructure(
+          'typeA[typeA,typeA]',
+          {
+            name: 'typea',
+            params: [
+              {
+                name: 'typea',
+                params: [],
+              },
+              {
+                name: 'typea',
+                params: [],
+              },
+            ],
+          });
+    });
+
+    test('Multiple params, spaces', function() {
+      this.assertStructure(
+          'typeA[typeA typeA]',
+          {
+            name: 'typea',
+            params: [
+              {
+                name: 'typea',
+                params: [],
+              },
+              {
+                name: 'typea',
+                params: [],
+              },
+            ],
+          });
+    });
+
+    test('Nested params', function() {
+      this.assertStructure(
+          'typeA[typeA[typeA]]',
+          {
+            name: 'typea',
+            params: [
+              {
+                name: 'typea',
+                params: [
+                  {
+                    name: 'typea',
+                    params: [],
+                  },
+                ],
+              },
+            ],
+          });
+    });
+
+    test('Nested params with following, comma and space', function() {
+      this.assertStructure(
+          'typeA[typeA[typeA], typeA]',
+          {
+            name: 'typea',
+            params: [
+              {
+                name: 'typea',
+                params: [
+                  {
+                    name: 'typea',
+                    params: [],
+                  },
+                ],
+              },
+              {
+                name: 'typea',
+                params: [],
+              },
+            ],
+          });
+    });
+
+    test('Nested params with following, comma', function() {
+      this.assertStructure(
+          'typeA[typeA[typeA],typeA]',
+          {
+            name: 'typea',
+            params: [
+              {
+                name: 'typea',
+                params: [
+                  {
+                    name: 'typea',
+                    params: [],
+                  },
+                ],
+              },
+              {
+                name: 'typea',
+                params: [],
+              },
+            ],
+          });
+    });
+
+    test('Nested params with following, space', function() {
+      this.assertStructure(
+          'typeA[typeA[typeA] typeA]',
+          {
+            name: 'typea',
+            params: [
+              {
+                name: 'typea',
+                params: [
+                  {
+                    name: 'typea',
+                    params: [],
+                  },
+                ],
+              },
+              {
+                name: 'typea',
+                params: [],
+              },
+            ],
+          });
+    });
+
+    test('Nested params with following, nothing', function() {
+      this.assertStructure(
+          'typeA[typeA[typeA]typeA]',
+          {
+            name: 'typea',
+            params: [
+              {
+                name: 'typea',
+                params: [
+                  {
+                    name: 'typea',
+                    params: [],
+                  },
+                ],
+              },
+              {
+                name: 'typea',
+                params: [],
+              },
+            ],
+          });
+    });
+
+    test('Deep nesting', function() {
+      this.assertStructure(
+          'typeA[typeA[typeA[typeA[typeA]]]]',
+          {
+            name: 'typea',
+            params: [
+              {
+                name: 'typea',
+                params: [
+                  {
+                    name: 'typea',
+                    params: [
+                      {
+                        name: 'typea',
+                        params: [
+                          {
+                            name: 'typea',
+                            params: [],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          });
+    });
+  });
 });

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -666,7 +666,7 @@ suite('TypeHierarchy', function() {
       });
 
       this.assertStructure = function(str, struct) {
-        chai.assert.deepEqual(hierarchy.getTypeStructure_(str), struct);
+        chai.assert.deepEqual(hierarchy.parseType_(str), struct);
       };
     });
 

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -1128,26 +1128,26 @@ suite('TypeHierarchy', function() {
             ],
           },
       );
+    });
 
-      test('Nested generic param', function() {
-        this.assertStructure(
-            'typeA[typeA[B]]',
-            {
-              name: 'typea',
-              params: [
-                {
-                  name: 'typea',
-                  params: [
-                    {
-                      name: 'b',
-                      params: [],
-                    },
-                  ],
-                },
-              ],
-            },
-        );
-      });
+    test('Nested generic param', function() {
+      this.assertStructure(
+          'typeA[typeA[B]]',
+          {
+            name: 'typea',
+            params: [
+              {
+                name: 'typea',
+                params: [
+                  {
+                    name: 'b',
+                    params: [],
+                  },
+                ],
+              },
+            ],
+          },
+      );
     });
   });
 });


### PR DESCRIPTION
### Description

The first step towards Lists, Dictionaries, Functions, and Sets!

This PR adds support for parameters to the TypeDef class, and adds logic in the TypeHierarchy to initialize those values.

Every TypeDef now has a property called `params` which is an array of ParamDefs. ParamDefs have a `name` and a `variance`, which is specified using json like:
```javascript
{
  'List': {
    'params': [
      {
        'name': 'A',
        'variance': 'co'
      }
    ]
  }
}
```
For information about what variance is and how it works see the [glossary](https://docs.google.com/document/d/1QKYkmWjkle1JWCi3O8jXr8-7Toazh1pW_4EaVVgB_OI/edit#heading=h.bviy0z22j7ic) section of the design document.

Because types can now have parameters, we need a way to subtype those types and fulfill those parameters. This is done using a string (like the below) which can be parsed into a TypeStructure. TypeStructures are like the instantiation of a TypeDef. They have a `name` and a `params` array, which contains other TypeStructures. As more support for parameterized types is added, many functions will switch from using strings to TypeStructures.
```javascript
{
  'ProducerList': {
    'params': [
      {
        'name': 'A',
        'variance': 'inv'
      }
    ]
  },
  'List': {
    'fulfills': ['ProducerList[A]'],  // Here!
    'params': [
      {
        'name': 'A',
        'variance': 'inv'
      }
    ]
  }
}
```
One important function to look at is the `getParamsForAncestor` method. This method puts the params of the TypeDef the method is called on into a state so that they can easily be compared to a type of an ancestor. This is important for future type checking. For example say we had the following hierarchy definition:
```javascript
{
  "List": {
    "params": [
      {
        "name": "T",
        "variance": "inv"
      }
    ]
  },
  "Tuple": {
    "params": [
      {
        "name": "A",
        "variance": "co"
      },
      {
        "name": "B",
        "variance": "co"
      }
    ]
  },
  "Dictionary": {
    // Dictionary fulfills all functionality of a list of tuples
    //  (most don't but just for example's sake)
    "fulfills": [
      "List[Tuple[K, V]]"
    ],
    "params": [
      {
        "name": "K",
        "variance": "inv"
      },
      {
        "name": "V",
        "variance": "inv"
      }
    ]
  }
}
```
And that we wanted to see if a Dictionary[String, Dog] can be used as a List[Tuple[String, Dog]]. To do this we need to "map" [String, Dog] to Tuple[String, Dog], which this system handles.

# Testing

* Adds a bunch of tests for getParamsForAncestor that should cover all edge cases.
* Adds some tests for TypeStructure parsing, but this will get filled out more in the next PR when I move the parsing logic.