### PR TITLE
Remove test script from plugins without mocha tests

### DIFF
--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -9,8 +9,7 @@
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
     "prepublishOnly": "npm run clean && npm run build",
-    "start": "blockly-scripts start",
-    "test": "blockly-scripts test"
+    "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",
   "module": "./src/index.js",

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -9,8 +9,7 @@
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
     "prepublishOnly": "npm run clean && npm run build",
-    "start": "blockly-scripts start",
-    "test": "blockly-scripts test"
+    "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",
   "module": "./src/index.js",

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -9,8 +9,7 @@
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
     "prepublishOnly": "npm run clean && npm run build",
-    "start": "blockly-scripts start",
-    "test": "blockly-scripts test"
+    "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",
   "module": "./src/index.js",


### PR DESCRIPTION
Automated tests are failing because the script tag for running tests was added to the package.json for plugins without any mocha tests defined.