### PR TITLE
Fix #393

### DIFF
--- a/codelabs/getting_started/getting_started.md
+++ b/codelabs/getting_started/getting_started.md
@@ -231,10 +231,7 @@ Blockly.defineBlocksWithJsonArray([
           ["D4", "sounds/d4.m4a"],
           ["E4", "sounds/e4.m4a"],
           ["F4", "sounds/f4.m4a"],
-          ["G4", "sounds/g4.m4a"],
-          ["A5", "sounds/a5.m4a"],
-          ["B5", "sounds/b5.m4a"],
-          ["C5", "sounds/c5.m4a"]
+          ["G4", "sounds/g4.m4a"]
         ]
       }
     ],

--- a/examples/getting-started-codelab/complete-code/scripts/sound_blocks.js
+++ b/examples/getting-started-codelab/complete-code/scripts/sound_blocks.js
@@ -18,10 +18,7 @@ Blockly.defineBlocksWithJsonArray([
           ["D4", "sounds/d4.m4a"],
           ["E4", "sounds/e4.m4a"],
           ["F4", "sounds/f4.m4a"],
-          ["G4", "sounds/g4.m4a"],
-          ["A5", "sounds/a5.m4a"],
-          ["B5", "sounds/b5.m4a"],
-          ["C5", "sounds/c5.m4a"]
+          ["G4", "sounds/g4.m4a"]
         ]
       }
     ],


### PR DESCRIPTION
Remove reference to nonexistent sounds in a block dropdown in the getting started codelab.

This fixes the issue mentioned in a [comment](https://github.com/google/blockly-samples/issues/393#issuecomment-786352231).