### PR TITLE
Make no tests a warning rather than an error

### DIFF
--- a/plugins/dev-scripts/scripts/test.js
+++ b/plugins/dev-scripts/scripts/test.js
@@ -31,10 +31,10 @@ const config = webpackConfig({
   mode: 'test',
 });
 if (!config.entry) {
-  console.log(chalk.red(`Configuration error.`) + '\n' +
-  'Make sure at least one ' + chalk.red('test/*.mocha.js') + ' file is ' +
-  'included in your package.\n');
-  process.exit(1);
+  console.log(chalk.yellow(`Warning: No tests found`) + '\n' +
+  'There were no ' + chalk.yellow('test/*.mocha.js') + ' files found ' +
+  'in your package.\n');
+  process.exit(0);
 }
 
 let mochaConfig = {


### PR DESCRIPTION
We want to be able to add the `npm run test` command to all plugins on creation, even if they don't have any tests (yet (hopefully)). That way when tests are eventually added to the plugin, no additional work is needed to get them to run.

I changed the error to a warning (exit code 1 to 0). I tested this locally with a plugin with no tests and it looks good.

Fixes #623 