### PR TITLE
Add params checks to hierarchy validation - project static

### DIFF
--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -563,7 +563,7 @@ function checkCircularDependencies(hierarchyDef) {
 
       if (typeInfo.fulfills && Array.isArray(typeInfo.fulfills)) {
         for (const superType of typeInfo.fulfills) {
-          searchForCyclesRec(superType, currentTraversal);
+          searchForCyclesRec(types, superType, currentTraversal);
         }
       }
 

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -35,7 +35,7 @@ export function validateHierarchy(hierarchyDef) {
   ]);
   checkGenerics(hierarchyDef);
   checkConflictingTypes(hierarchyDef);
-  checkVariances(hierarchyDef);
+  checkParamVariances(hierarchyDef);
   checkSupersParsing(hierarchyDef);
   checkSupersDefined(hierarchyDef);
   checkSuperParamsDefined(hierarchyDef);
@@ -80,7 +80,7 @@ function checkConflictingTypes(hierarchyDef) {
  * valid.
  * @param {!Object} hierarchyDef The definition of the type hierarchy.
  */
-function checkVariances(hierarchyDef) {
+function checkParamVariances(hierarchyDef) {
   const noVarianceMsg = 'The parameter %s of %s does not declare a variance, ' +
       'which is required.';
   const errorMsg = 'The parameter %s of %s threw the following error: %s';

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -78,7 +78,9 @@ function checkConflictingTypes(hierarchyDef) {
  */
 function checkSupersDefined(hierarchyDef) {
   const errorMsg = 'The type %s says it fulfills the type %s, but that type' +
-      ' is not defined';
+      ' is not defined.';
+  const genericMsg = 'The type %s says it fulfills the type %s, but that type' +
+      ' appears to be generic, which is not allowed.';
 
   const types = new Set();
   const keys = Object.keys(hierarchyDef);
@@ -94,7 +96,11 @@ function checkSupersDefined(hierarchyDef) {
       try {
         const superName = parseType(superType, false).name;
         if (!types.has(superName.toLowerCase())) {
-          console.error(errorMsg, type, superName);
+          if (isGeneric(superName)) {
+            console.error(genericMsg, type, superName);
+          } else {
+            console.error(errorMsg, type, superName);
+          }
         }
       } catch (e) {
         if (!(e instanceof TypeParseError)) {

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -28,6 +28,12 @@ export function validateHierarchy(hierarchyDef) {
   checkSupersDefined(hierarchyDef);
   checkCircularDependencies(hierarchyDef);
   checkGenerics(hierarchyDef);
+  checkCharacters(hierarchyDef, [
+    [',', 'comma'],
+    [' ', 'space'],
+    ['[', 'left bracket'],
+    [']', 'right bracket'],
+  ]);
 }
 
 /**
@@ -181,6 +187,23 @@ function checkGenerics(hierarchyDef) {
   for (const type of Object.keys(hierarchyDef)) {
     if (isGeneric(type)) {
       console.error(error, type);
+    }
+  }
+}
+
+/**
+ *
+ * @param hierarchyDef
+ * @param {!Array<!Array<string>>} chars
+ */
+function checkCharacters(hierarchyDef, chars) {
+  const error = 'The type %s includes an illegal %s character (\'%s\').';
+
+  for (const type of Object.keys(hierarchyDef)) {
+    for (const [char, charName] of chars) {
+      if (type.includes(char)) {
+        console.error(error, type, charName, char);
+      }
     }
   }
 }

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -10,6 +10,7 @@
 'use strict';
 
 import {isGeneric} from './utils';
+import {parseType} from './type_structure';
 
 /**
  * Validates the given hierarchy definition. Does checks for duplicate types,
@@ -87,8 +88,9 @@ function checkSupersDefined(hierarchyDef) {
       continue;
     }
     for (const superType of typeInfo.fulfills) {
-      if (!types.has(superType.toLowerCase())) {
-        console.error(errorMsg, type, superType);
+      const superName = parseType(superType, false).name;
+      if (!types.has(superName.toLowerCase())) {
+        console.error(errorMsg, type, superName);
       }
     }
   }

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -35,9 +35,11 @@ export function validateHierarchy(hierarchyDef) {
   ]);
   checkGenerics(hierarchyDef);
   checkConflictingTypes(hierarchyDef);
+  checkParamsIsArray(hierarchyDef);
   checkParamNames(hierarchyDef);
   checkConflictingParams(hierarchyDef);
   checkParamVariances(hierarchyDef);
+  checkFulfillsIsArray(hierarchyDef);
   checkSupersParsing(hierarchyDef);
   checkSupersDefined(hierarchyDef);
   checkSuperParamsDefined(hierarchyDef);
@@ -91,7 +93,7 @@ function checkParamNames(hierarchyDef) {
 
   for (const type of Object.keys(hierarchyDef)) {
     const typeDef = hierarchyDef[type];
-    if (!typeDef.params) {
+    if (!typeDef.params || !Array.isArray(typeDef.params)) {
       continue;
     }
 
@@ -119,7 +121,7 @@ function checkConflictingParams(hierarchyDef) {
 
   for (const type of Object.keys(hierarchyDef)) {
     const typeDef = hierarchyDef[type];
-    if (!typeDef.params) {
+    if (!typeDef.params || !Array.isArray(typeDef.params)) {
       continue;
     }
 
@@ -165,7 +167,7 @@ function checkParamVariances(hierarchyDef) {
 
   for (const type of Object.keys(hierarchyDef)) {
     const typeDef = hierarchyDef[type];
-    if (!typeDef.params) {
+    if (!typeDef.params || !Array.isArray(typeDef.params)) {
       continue;
     }
     for (const param of typeDef.params) {
@@ -204,7 +206,7 @@ function checkSupersDefined(hierarchyDef) {
   }
   for (const type of keys) {
     const typeInfo = hierarchyDef[type];
-    if (!typeInfo.fulfills) {
+    if (!typeInfo.fulfills || !Array.isArray(typeInfo.fulfills)) {
       continue;
     }
     for (const superType of typeInfo.fulfills) {
@@ -277,7 +279,7 @@ function checkSuperParamsDefined(hierarchyDef) {
   }
   for (const type of keys) {
     const typeInfo = hierarchyDef[type];
-    if (!typeInfo.fulfills) {
+    if (!typeInfo.fulfills || !Array.isArray(typeInfo.fulfills)) {
       continue;
     }
     for (const superType of typeInfo.fulfills) {
@@ -338,7 +340,8 @@ function checkSuperNumParamsCorrect(hierarchyDef) {
       // Super is not defined, this is handled elsewhere.
       return;
     }
-    const required = superDef.params ? superDef.params.length : 0;
+    const required = superDef.params && Array.isArray(superDef.params) ?
+        superDef.params.length : 0;
     const provided = superStructure.params.length;
     if (required != provided) {
       console.error(
@@ -351,7 +354,7 @@ function checkSuperNumParamsCorrect(hierarchyDef) {
 
   for (const type of keys) {
     const typeInfo = types.get(type.toLowerCase());
-    if (!typeInfo.fulfills) {
+    if (!typeInfo.fulfills || !Array.isArray(typeInfo.fulfills)) {
       continue;
     }
     for (const superType of typeInfo.fulfills) {
@@ -473,7 +476,7 @@ function checkSuperParamVariancesCompatible(hierarchyDef) {
 
     const typeDef = types.get(typeName.toLowerCase());
     const superDef = types.get(superStructure.name.toLowerCase());
-    if (!superDef || !superDef.params) {
+    if (!superDef || !superDef.params || !Array.isArray(superDef.params)) {
       return;
     }
 
@@ -503,7 +506,7 @@ function checkSuperParamVariancesCompatible(hierarchyDef) {
 
   for (const type of keys) {
     const typeInfo = types.get(type.toLowerCase());
-    if (!typeInfo.fulfills) {
+    if (!typeInfo.fulfills || !Array.isArray(typeInfo.fulfills)) {
       continue;
     }
     for (const superType of typeInfo.fulfills) {
@@ -553,7 +556,7 @@ function checkCircularDependencies(hierarchyDef) {
 
       currentTraversal.push(typeStructure);
 
-      if (typeInfo.fulfills) {
+      if (typeInfo.fulfills && Array.isArray(typeInfo.fulfills)) {
         for (const superType of typeInfo.fulfills) {
           searchForCyclesRec(superType, currentTraversal);
         }
@@ -647,7 +650,7 @@ function checkSupersParsing(hierarchyDef) {
 
   for (const typeName of Object.keys(hierarchyDef)) {
     const type = hierarchyDef[typeName];
-    if (!type.fulfills) {
+    if (!type.fulfills || !Array.isArray(type.fulfills)) {
       continue;
     }
     for (const superType of type.fulfills) {
@@ -656,6 +659,38 @@ function checkSupersParsing(hierarchyDef) {
       } catch (e) {
         console.error(error, typeName, superType, e);
       }
+    }
+  }
+}
+
+/**
+ * Checks that if a fulfills property is provided, it is an array.
+ * @param {!Object} hierarchyDef The definition of the type hierarchy.
+ */
+function checkFulfillsIsArray(hierarchyDef) {
+  const error = 'The type %s provides a `fulfills` property, but it is not an' +
+      ' array';
+
+  for (const typeName of Object.keys(hierarchyDef)) {
+    const type = hierarchyDef[typeName];
+    if (type.fulfills && !Array.isArray(type.fulfills)) {
+      console.error(error, typeName);
+    }
+  }
+}
+
+/**
+ * Checks that if a params property is provided, it is an array.
+ * @param {!Object} hierarchyDef The definition of the type hierarchy.
+ */
+function checkParamsIsArray(hierarchyDef) {
+  const error = 'The type %s provides a `params` property, but it is not an' +
+      ' array';
+
+  for (const typeName of Object.keys(hierarchyDef)) {
+    const type = hierarchyDef[typeName];
+    if (type.params && !Array.isArray(type.params)) {
+      console.error(error, typeName);
     }
   }
 }

--- a/plugins/nominal-connection-checker/src/hierarchy_validation.js
+++ b/plugins/nominal-connection-checker/src/hierarchy_validation.js
@@ -35,6 +35,7 @@ export function validateHierarchy(hierarchyDef) {
   ]);
   checkGenerics(hierarchyDef);
   checkConflictingTypes(hierarchyDef);
+  checkParamNames(hierarchyDef);
   checkParamVariances(hierarchyDef);
   checkSupersParsing(hierarchyDef);
   checkSupersDefined(hierarchyDef);
@@ -72,6 +73,54 @@ function checkConflictingTypes(hierarchyDef) {
 
   for (const [type, conflicts] of conflictingTypes) {
     console.error(conflictMsg, type, conflicts);
+  }
+}
+
+/**
+ * Checks the hierarchy definition for any parameters which do not have names,
+ * or have names which are not generic.
+ * @param {!Object} hierarchyDef The definition of the type hierarchy.
+ */
+function checkParamNames(hierarchyDef) {
+  const noNameMsg = 'Parameter #%s of %s does not declare a name, which is ' +
+      'required.';
+  const errorMsg = 'The parameter name %s of %s is invalid. Parameter names ' +
+      'must be a single character.';
+
+  for (const type of Object.keys(hierarchyDef)) {
+    const typeDef = hierarchyDef[type];
+    if (!typeDef.params) {
+      continue;
+    }
+
+    for (let i = 0; i < typeDef.params.length; i++) {
+      const param = typeDef.params[i];
+      if (!param.name) {
+        console.error(noNameMsg, i + 1, type);
+        continue;
+      }
+      if (!isGeneric(param.name)) {
+        console.error(errorMsg, param.name, type);
+      }
+    }
+
+    /*
+    // Map of caseless names to cased names.
+    const definedParamNames = new Map();
+    // Map of original names to arrays of conflicting names.
+    const conflictingParamNames = new Map();
+    for (let i = 0; i < typeDef.params.length; i++) {
+      const param = typeDef.params[i];
+      if (!param.name) {
+        console.error(noNameMsg, i, type);
+        continue;
+      }
+      const caselessName = param.name.toLowerCase();
+      if (definedParamNames.has(caselessName)) {
+        const originalParam = definedParamNames.get(caselessName);
+        if (!conflictingParamNames.has(originalParam))
+      }
+    }*/
   }
 }
 

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -588,7 +588,7 @@ class TypeDef {
  * Represents different parameter variances.
  * @enum {string}
  */
-const Variance = {
+export const Variance = {
   CO: 'covariant',
   CONTRA: 'contravariant',
   INV: 'invariant',
@@ -599,7 +599,7 @@ const Variance = {
  * @param {string} str The string to convert to a variance.
  * @return {!Variance} The converted variance value.
  */
-function stringToVariance(str) {
+export function stringToVariance(str) {
   str = str.toLowerCase();
   if (str.startsWith('inv')) {
     return Variance.INV;
@@ -612,6 +612,8 @@ function stringToVariance(str) {
         'Valid variances are: "co", "contra", and "inv".');
   }
 }
+
+
 
 /**
  * Represents a type parameter.

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -608,12 +608,25 @@ export function stringToVariance(str) {
   } else if (str.startsWith('co')) {
     return Variance.CO;
   } else {
-    throw new Error('The variance "' + str + '" is not a valid variance. ' +
-        'Valid variances are: "co", "contra", and "inv".');
+    throw new VarianceError('The variance "' + str + '" is not a valid ' +
+        'variance. Valid variances are: "co", "contra", and "inv".');
   }
 }
 
+/**
+ * Represents an error related to variances.
+ */
+export class VarianceError extends Error {
+  /**
+   * Constructs a VarianceError.
+   * @param {string} message The message that goes with this error.
+   */
+  constructor(message) {
+    super(message);
 
+    this.name = this.constructor.name;
+  }
+}
 
 /**
  * Represents a type parameter.

--- a/plugins/nominal-connection-checker/src/type_structure.js
+++ b/plugins/nominal-connection-checker/src/type_structure.js
@@ -76,6 +76,7 @@ const parseMap_ = new Map();
  * @param {string} str The string to parse.
  * @param {boolean=} caseless Whether we should convert names to lowercase
  *     (caseless).
+<<<<<<< HEAD
  * @return {!TypeStructure} The created TypeStructure.
  */
 export function parseType(str, caseless = true) {

--- a/plugins/nominal-connection-checker/src/type_structure.js
+++ b/plugins/nominal-connection-checker/src/type_structure.js
@@ -76,7 +76,6 @@ const parseMap_ = new Map();
  * @param {string} str The string to parse.
  * @param {boolean=} caseless Whether we should convert names to lowercase
  *     (caseless).
-<<<<<<< HEAD
  * @return {!TypeStructure} The created TypeStructure.
  */
 export function parseType(str, caseless = true) {

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -207,6 +207,36 @@ suite('Hierarchy Validation', function() {
           'The type typeA creates a circular dependency: ' +
           'typeA fulfills typeA'));
     });
+    test('Direct with case', function() {
+      validateHierarchy({
+        'typeA': {
+          'fulfills': ['TypeA'],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(
+          'The type typeA creates a circular dependency: ' +
+          'typeA fulfills TypeA'));
+    });
+
+    test('Direct w/ params', function() {
+      this.errorStub.callsFake((...params) => console.log(params));
+      validateHierarchy({
+        'typeA': {
+          'fulfills': ['typeA[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(
+          'The type typeA creates a circular dependency: ' +
+          'typeA fulfills typeA[A]'));
+    });
 
     test('Indirect cycle', function() {
       validateHierarchy({
@@ -221,6 +251,55 @@ suite('Hierarchy Validation', function() {
       chai.assert.isTrue(this.errorStub.calledWith(
           'The type typeA creates a circular dependency: ' +
           'typeA fulfills typeB fulfills typeA'));
+    });
+
+    test('Indirect cycle w/ params', function() {
+      validateHierarchy({
+        'typeA': {
+          'fulfills': ['typeB[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+          ],
+        },
+        'typeB': {
+          'fulfills': ['typeA[B]'],
+          'params': [
+            {
+              'name': 'B',
+              'variance': 'co',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(
+          'The type typeA creates a circular dependency: ' +
+          'typeA fulfills typeB[A] fulfills typeA[B]'));
+    });
+
+    test('Indirect cycle w/ one param', function() {
+      validateHierarchy({
+        'typeA': {
+          'fulfills': ['typeB[typeC]'],
+        },
+        'typeB': {
+          'fulfills': ['typeA'],
+          'params': [
+            {
+              'name': 'B',
+              'variance': 'co',
+            },
+          ],
+        },
+        'typeC': { },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(
+          'The type typeA creates a circular dependency: ' +
+          'typeA fulfills typeB[typeC] fulfills typeA'));
     });
 
     test('Really indirect cycle', function() {
@@ -315,18 +394,6 @@ suite('Hierarchy Validation', function() {
       chai.assert.isTrue(this.errorStub.calledWith(
           'The type typeC creates a circular dependency: ' +
           'typeC fulfills typeD fulfills typeC'));
-    });
-
-    test('Case', function() {
-      validateHierarchy({
-        'typeA': {
-          'fulfills': ['TypeA'],
-        },
-      });
-      chai.assert.isTrue(this.errorStub.calledOnce);
-      chai.assert.isTrue(this.errorStub.calledWith(
-          'The type typeA creates a circular dependency: ' +
-          'typeA fulfills TypeA'));
     });
   });
 

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -135,6 +135,45 @@ suite('Hierarchy Validation', function() {
       });
       chai.assert.isTrue(this.errorStub.notCalled);
     });
+
+    test('Defined with params', function() {
+      validateHierarchy({
+        'typeA': {
+          'fulfills': ['typeB[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+          ],
+        },
+        'typeB': {
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+
+    test('Undefined with params', function() {
+      validateHierarchy({
+        'typeA': {
+          'fulfills': ['typeB[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(errorMsg, 'typeA', 'typeB'));
+    });
   });
 
   suite('Circular Dependencies', function() {

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -1342,4 +1342,101 @@ suite('Hierarchy Validation', function() {
           conflictMsg, 'A', 'typeA', '#2 (a), #3 (A)'));
     });
   });
+
+  suite('Fulfills is array', function() {
+    const error = 'The type %s provides a `fulfills` property, but it is not ' +
+        'an array';
+
+    test('Array', function() {
+      validateHierarchy({
+        'typeA': {
+          'fulfills': ['typeB'],
+        },
+        'typeB': { },
+      });
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+
+    test('Object', function() {
+      validateHierarchy({
+        'typeA': {
+          'fulfills': { },
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(error, 'typeA'));
+    });
+
+    test('String', function() {
+      validateHierarchy({
+        'typeA': {
+          'fulfills': 'typeB',
+        },
+        'typeB': { },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(error, 'typeA'));
+    });
+
+    test('Number', function() {
+      validateHierarchy({
+        'typeA': {
+          'fulfills': 1,
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(error, 'typeA'));
+    });
+  });
+
+  suite('Params is array', function() {
+    const error = 'The type %s provides a `params` property, but it is not an' +
+        ' array';
+
+    test('Array', function() {
+      validateHierarchy({
+        'typeA': {
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+
+    test('Object', function() {
+      validateHierarchy({
+        'typeA': {
+          'params': {
+            'A': 'co',
+          },
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(error, 'typeA'));
+    });
+
+    test('String', function() {
+      validateHierarchy({
+        'typeA': {
+          'params': 'A:co',
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(error, 'typeA'));
+    });
+
+    test('Number', function() {
+      validateHierarchy({
+        'typeA': {
+          'params': 1,
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(error, 'typeA'));
+    });
+  });
 });

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -1260,4 +1260,39 @@ suite('Hierarchy Validation', function() {
               'are: "co", "contra", and "inv".'));
     });
   });
+
+  suite('Param names', function() {
+    test('Not provided', function() {
+      const noNameMsg = 'Parameter #%s of %s does not declare a name, which ' +
+          'is required.';
+      validateHierarchy({
+        'typeA': {
+          'params': [
+            {
+              'variance': 'co',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(noNameMsg, 1, 'typeA'));
+    });
+
+    test('Invalid', function() {
+      const errorMsg = 'The parameter name %s of %s is invalid. Parameter ' +
+          'names must be a single character.';
+      validateHierarchy({
+        'typeA': {
+          'params': [
+            {
+              'name': 'test',
+              'variance': 'co',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(errorMsg, 'test', 'typeA'));
+    });
+  });
 });

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -1180,6 +1180,50 @@ suite('Hierarchy Validation', function() {
       chai.assert.isTrue(this.errorStub.notCalled);
     });
 
+    test('Valid, case', function() {
+      validateHierarchy({
+        'typeA': {
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'CO',
+            },
+            {
+              'name': 'B',
+              'variance': 'CONTRA',
+            },
+            {
+              'name': 'C',
+              'variance': 'INV',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+
+    test('Valid, extra', function() {
+      validateHierarchy({
+        'typeA': {
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'covariant',
+            },
+            {
+              'name': 'B',
+              'variance': 'contravariant',
+            },
+            {
+              'name': 'C',
+              'variance': 'invariant',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+
     test('Not provided', function() {
       const noVarianceMsg = 'The parameter %s of %s does not declare a ' +
           'variance, which is required.';

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -1156,4 +1156,64 @@ suite('Hierarchy Validation', function() {
       }, 'invariant', 'covariant');
     });
   });
+
+  suite('Variances', function() {
+    test('Valid', function() {
+      validateHierarchy({
+        'typeA': {
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+            {
+              'name': 'B',
+              'variance': 'contra',
+            },
+            {
+              'name': 'C',
+              'variance': 'inv',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.notCalled);
+    });
+
+    test('Not provided', function() {
+      const noVarianceMsg = 'The parameter %s of %s does not declare a ' +
+          'variance, which is required.';
+      validateHierarchy({
+        'typeA': {
+          'params': [
+            {
+              'name': 'A',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(
+          this.errorStub.calledWith(noVarianceMsg, 'A', 'typeA'));
+    });
+
+    test('Invalid', function() {
+      const errorMsg = 'The parameter %s of %s threw the following error: %s';
+      validateHierarchy({
+        'typeA': {
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'test',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(
+          this.errorStub.calledWith(errorMsg, 'A', 'typeA',
+              'The variance "test" is not a valid variance. Valid variances ' +
+              'are: "co", "contra", and "inv".'));
+    });
+  });
 });

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -97,7 +97,9 @@ suite('Hierarchy Validation', function() {
 
   suite('Defined supers', function() {
     const errorMsg = 'The type %s says it fulfills the type %s, but that' +
-        ' type is not defined';
+        ' type is not defined.';
+    const genericMsg = 'The type %s says it fulfills the type %s, but that ' +
+        'type appears to be generic, which is not allowed.';
 
     test('Defined before', function() {
       validateHierarchy({
@@ -120,6 +122,7 @@ suite('Hierarchy Validation', function() {
     });
 
     test('Not defined', function() {
+      this.errorStub.callsFake((params) => console.log(params));
       validateHierarchy({
         'typeA': {
           'fulfills': ['typeB'],
@@ -163,6 +166,7 @@ suite('Hierarchy Validation', function() {
     });
 
     test('Undefined with params', function() {
+      this.errorStub.callsFake((params) => console.log(params));
       validateHierarchy({
         'typeA': {
           'fulfills': ['typeB[A]'],
@@ -176,6 +180,18 @@ suite('Hierarchy Validation', function() {
       });
       chai.assert.isTrue(this.errorStub.calledOnce);
       chai.assert.isTrue(this.errorStub.calledWith(errorMsg, 'typeA', 'typeB'));
+    });
+
+    test('Generic super', function() {
+      this.errorStub.callsFake((params) => console.log(params));
+      validateHierarchy({
+        'typeA': {
+          'fulfills': ['A'],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(
+          this.errorStub.calledWith(genericMsg, 'typeA', 'A'));
     });
   });
 

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -341,4 +341,45 @@ suite('Hierarchy Validation', function() {
       chai.assert.isTrue(this.errorStub.calledWith(errorMsg, '1'));
     });
   });
+
+  suite('Characters', function() {
+    setup(function() {
+      const errorMsg = 'The type %s includes an illegal %s character (\'%s\').';
+
+      this.assertValid = function(hierarchy) {
+        validateHierarchy(hierarchy);
+        chai.assert.isTrue(this.errorStub.notCalled);
+      };
+      this.assertInvalid = function(hierarchy, type, char, charName) {
+        validateHierarchy(hierarchy);
+        chai.assert.isTrue(this.errorStub.calledOnce);
+        chai.assert.isTrue(
+            this.errorStub.calledWith(errorMsg, type, charName, char));
+      };
+    });
+
+    test('Comma', function() {
+      this.assertInvalid({
+        'type,type': { },
+      }, 'type,type', ',', 'comma');
+    });
+
+    test('Space', function() {
+      this.assertInvalid({
+        'type type': { },
+      }, 'type type', ' ', 'space');
+    });
+
+    test('Left bracket', function() {
+      this.assertInvalid({
+        'type[': { },
+      }, 'type[', '[', 'left bracket');
+    });
+
+    test('Right bracket', function() {
+      this.assertInvalid({
+        'type]': { },
+      }, 'type]', ']', 'right bracket');
+    });
+  });
 });

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -48,7 +48,7 @@ suite('Hierarchy Validation', function() {
 
   suite('Conflicts', function() {
     const conflictMsg =
-        'The type name \'%s\' conflicts with the type name(s) %s';
+        'The type name \'%s\' conflicts with the type name(s) [%s]';
 
     test('No conflicts', function() {
       validateHierarchy({
@@ -66,7 +66,7 @@ suite('Hierarchy Validation', function() {
       });
       chai.assert.isTrue(this.errorStub.calledOnce);
       chai.assert.isTrue(this.errorStub.calledWith(
-          conflictMsg, 'typeA', ['TypeA']));
+          conflictMsg, 'typeA', 'TypeA'));
     });
 
     test('Type conflicts multiple', function() {
@@ -77,7 +77,7 @@ suite('Hierarchy Validation', function() {
       });
       chai.assert.isTrue(this.errorStub.calledOnce);
       chai.assert.isTrue(this.errorStub.calledWith(
-          conflictMsg, 'typeA', ['TypeA', 'Typea']));
+          conflictMsg, 'typeA', 'TypeA, Typea'));
     });
 
     test('Multiple conflicts', function() {
@@ -89,9 +89,9 @@ suite('Hierarchy Validation', function() {
       });
       chai.assert.isTrue(this.errorStub.calledTwice);
       chai.assert.isTrue(this.errorStub.calledWith(
-          conflictMsg, 'typeA', ['TypeA']));
+          conflictMsg, 'typeA', 'TypeA'));
       chai.assert.isTrue(this.errorStub.calledWith(
-          conflictMsg, 'typeB', ['TypeB']));
+          conflictMsg, 'typeB', 'TypeB'));
     });
   });
 
@@ -1255,9 +1255,7 @@ suite('Hierarchy Validation', function() {
       });
       chai.assert.isTrue(this.errorStub.calledOnce);
       chai.assert.isTrue(
-          this.errorStub.calledWith(errorMsg, 'A', 'typeA',
-              'The variance "test" is not a valid variance. Valid variances ' +
-              'are: "co", "contra", and "inv".'));
+          this.errorStub.calledWith(errorMsg, 'A', 'typeA'));
     });
   });
 
@@ -1293,6 +1291,55 @@ suite('Hierarchy Validation', function() {
       });
       chai.assert.isTrue(this.errorStub.calledOnce);
       chai.assert.isTrue(this.errorStub.calledWith(errorMsg, 'test', 'typeA'));
+    });
+  });
+
+  suite('Conflicting param names', function() {
+    const conflictMsg = 'The param name %s in %s conflicts with the ' +
+        'param(s) [%s]';
+    test('Param conflicts once', function() {
+      this.errorStub.callsFake((...params) => console.log(params));
+      validateHierarchy({
+        'typeA': {
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+            {
+              'name': 'a',
+              'variance': 'co',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(
+          this.errorStub.calledWith(conflictMsg, 'A', 'typeA', '#2 (a)'));
+    });
+
+    test('Param conflicts multiple', function() {
+      validateHierarchy({
+        'typeA': {
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+            {
+              'name': 'a',
+              'variance': 'co',
+            },
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+          ],
+        },
+      });
+      chai.assert.isTrue(this.errorStub.calledOnce);
+      chai.assert.isTrue(this.errorStub.calledWith(
+          conflictMsg, 'A', 'typeA', '#2 (a), #3 (A)'));
     });
   });
 });

--- a/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/hierarchy_validation_test.mocha.js
@@ -915,4 +915,245 @@ suite('Hierarchy Validation', function() {
           'typeA', 'typeB[A[typeC]]', 'A'));
     });
   });
+
+  suite('Super param variances correct', function() {
+    setup(function() {
+      this.assertInvalid = function(hierarchy, ...includes) {
+        validateHierarchy(hierarchy);
+        chai.assert.isTrue(this.errorStub.calledOnce);
+        const arg = this.errorStub.getCall(0).args[0];
+        for (const str of includes) {
+          chai.assert.isTrue(arg.includes(str));
+        }
+      };
+      this.assertValid = function(hierarchy) {
+        validateHierarchy(hierarchy);
+        chai.assert.isTrue(this.errorStub.notCalled);
+      };
+    });
+
+    test('Bad variance', function() {
+
+    });
+
+    test('Co and co', function() {
+      this.assertValid({
+        'typeA': {
+          'fulfills': ['typeB[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+          ],
+        },
+        'typeB': {
+          'params': [
+            {
+              'name': 'B',
+              'variance': 'co',
+            },
+          ],
+        },
+      });
+    });
+
+    test('Co and contra', function() {
+      this.assertInvalid({
+        'typeA': {
+          'fulfills': ['typeB[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'contra',
+            },
+          ],
+        },
+        'typeB': {
+          'params': [
+            {
+              'name': 'B',
+              'variance': 'co',
+            },
+          ],
+        },
+      }, 'covariant', 'contravariant');
+    });
+
+    test('Co and inv', function() {
+      this.assertValid({
+        'typeA': {
+          'fulfills': ['typeB[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'inv',
+            },
+          ],
+        },
+        'typeB': {
+          'params': [
+            {
+              'name': 'B',
+              'variance': 'co',
+            },
+          ],
+        },
+      });
+    });
+
+    test('Contra and co', function() {
+      this.assertInvalid({
+        'typeA': {
+          'fulfills': ['typeB[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+          ],
+        },
+        'typeB': {
+          'params': [
+            {
+              'name': 'B',
+              'variance': 'contra',
+            },
+          ],
+        },
+      }, 'contravariant', 'covariant');
+    });
+
+    test('Contra and contra', function() {
+      this.assertValid({
+        'typeA': {
+          'fulfills': ['typeB[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'contra',
+            },
+          ],
+        },
+        'typeB': {
+          'params': [
+            {
+              'name': 'B',
+              'variance': 'contra',
+            },
+          ],
+        },
+      });
+    });
+
+    test('Contra and inv', function() {
+      this.assertValid({
+        'typeA': {
+          'fulfills': ['typeB[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'inv',
+            },
+          ],
+        },
+        'typeB': {
+          'params': [
+            {
+              'name': 'B',
+              'variance': 'contra',
+            },
+          ],
+        },
+      });
+    });
+
+    test('Inv and co', function() {
+      this.assertInvalid({
+        'typeA': {
+          'fulfills': ['typeB[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+          ],
+        },
+        'typeB': {
+          'params': [
+            {
+              'name': 'B',
+              'variance': 'inv',
+            },
+          ],
+        },
+      }, 'invariant', 'covariant');
+    });
+
+    test('Inv and contra', function() {
+      this.assertInvalid({
+        'typeA': {
+          'fulfills': ['typeB[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'contra',
+            },
+          ],
+        },
+        'typeB': {
+          'params': [
+            {
+              'name': 'B',
+              'variance': 'inv',
+            },
+          ],
+        },
+      }, 'invariant', 'contravariant');
+    });
+
+    test('Inv and inv', function() {
+      this.assertValid({
+        'typeA': {
+          'fulfills': ['typeB[A]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'inv',
+            },
+          ],
+        },
+        'typeB': {
+          'params': [
+            {
+              'name': 'B',
+              'variance': 'inv',
+            },
+          ],
+        },
+      });
+    });
+
+    test('Nested bad variance', function() {
+      this.assertInvalid({
+        'typeA': {
+          'fulfills': ['typeB[typeB[A]]'],
+          'params': [
+            {
+              'name': 'A',
+              'variance': 'co',
+            },
+          ],
+        },
+        'typeB': {
+          'params': [
+            {
+              'name': 'B',
+              'variance': 'inv',
+            },
+          ],
+        },
+      }, 'invariant', 'covariant');
+    });
+  });
 });

--- a/plugins/nominal-connection-checker/test/type_structure_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_structure_test.mocha.js
@@ -337,13 +337,7 @@ suite('TypeStructure', function() {
           return e instanceof MissingTypeNameError && e.index == 5;
         });
       });
-      test('type[[type]]', function() {
-        this.assertThrows(() => {
-          parseType('type[[type]]');
-        }, (e) => {
-          return e instanceof MissingTypeNameError && e.index == 5;
-        });
-      });
+
       test('type[type[type[[type]]]]', function() {
         this.assertThrows(() => {
           parseType('type[type[type[[type]]]]');


### PR DESCRIPTION
### Description

Adds 10 new checks to hierarchy validation :D They include:
* Checking that syntactic characters are not used as names (comma, space, left bracket, right bracket)
* Checking that the 'params' property is an array.
* Checking that the names of the params are generic.
* Checking that the names of the params do not conflict.
* Checking that the variances of the params are valid.
* Checking that the 'fulfills' property is an array.
* Checking that supers in the 'fulfills' array parse properly.
* Checking that all of the params passed to supers are defined.
* Checking that the number of params passed to the supers are correct.
* Checking that the variances of the params passed to the supers are compatible with the supers' variances.

### Testing

Unit tests have been added for all new checks.