### PR TITLE
Fix @this annotations in block-plus-minus

### DIFF
--- a/plugins/block-plus-minus/src/if.js
+++ b/plugins/block-plus-minus/src/if.js
@@ -30,7 +30,7 @@ const controlsIfMutator = {
   /**
    * Creates XML to represent the number of else-if and else inputs.
    * @return {Element} XML storage element.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   mutationToDom: function() {
     if (!this.elseIfCount_ && !this.hasElse_) {
@@ -48,7 +48,7 @@ const controlsIfMutator = {
   /**
    * Parses XML to restore the else-if and else inputs.
    * @param {!Element} xmlElement XML storage element.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   domToMutation: function(xmlElement) {
     const targetCount = parseInt(xmlElement.getAttribute('elseif'), 10) || 0;
@@ -64,7 +64,7 @@ const controlsIfMutator = {
    * Adds else-if and do inputs to the block until the block matches the
    * target else-if count.
    * @param {number} targetCount The target number of else-if inputs.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @private
    */
   updateShape_: function(targetCount) {
@@ -88,7 +88,7 @@ const controlsIfMutator = {
    * index.
    * @see removeInput_
    * @param {number} index The index of the else-if input to "remove".
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   minus: function(index) {
     if (this.elseIfCount_ == 0) {
@@ -99,7 +99,7 @@ const controlsIfMutator = {
 
   /**
    * Adds an else-if and a do input to the bottom of the block.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @private
    */
   addElseIf_: function() {
@@ -125,7 +125,7 @@ const controlsIfMutator = {
    * make sure the inputs are always IF0, IF1, etc with no gaps.
    * @param {number?} opt_index The index of the input to "remove", or undefined
    *     to remove the last input.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @private
    */
   removeElseIf_: function(opt_index) {
@@ -169,7 +169,7 @@ const controlsIfMutator = {
 
 /**
  * Adds the initial plus button to the if block.
- * @this Blockly.Block
+ * @this {Blockly.Block}
  */
 const controlsIfHelper = function() {
   this.getInput('IF0').insertFieldAt(0, createPlusField(), 'PLUS');

--- a/plugins/block-plus-minus/src/list_create.js
+++ b/plugins/block-plus-minus/src/list_create.js
@@ -42,7 +42,7 @@ const listCreateMutator = {
   /**
    * Creates XML to represent number of text inputs.
    * @return {!Element} XML storage element.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   mutationToDom: function() {
     const container = Blockly.utils.xml.createElement('mutation');
@@ -52,7 +52,7 @@ const listCreateMutator = {
   /**
    * Parses XML to restore the text inputs.
    * @param {!Element} xmlElement XML storage element.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   domToMutation: function(xmlElement) {
     const targetCount = parseInt(xmlElement.getAttribute('items'), 10);
@@ -62,7 +62,7 @@ const listCreateMutator = {
   /**
    * Adds inputs to the block until it reaches the target number of inputs.
    * @param {number} targetCount The target number of inputs for the block.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @private
    */
   updateShape_: function(targetCount) {
@@ -103,7 +103,7 @@ const listCreateMutator = {
   /**
    * Adds an input to the end of the block. If the block currently has no
    * inputs it updates the top 'EMPTY' input to receive a block.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @private
    */
   addPart_: function() {
@@ -121,7 +121,7 @@ const listCreateMutator = {
   /**
    * Removes an input from the end of the block. If we are removing the last
    * input this updates the block to have an 'EMPTY' top input.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @private
    */
   removePart_: function() {
@@ -150,7 +150,7 @@ const listCreateMutator = {
 
 /**
  * Updates the shape of the block to have 3 inputs if no mutation is provided.
- * @this Blockly.Block
+ * @this {Blockly.Block}
  */
 const listCreateHelper = function() {
   this.getInput('EMPTY').insertFieldAt(0, createPlusField(), 'PLUS');

--- a/plugins/block-plus-minus/src/procedures.js
+++ b/plugins/block-plus-minus/src/procedures.js
@@ -100,7 +100,7 @@ const getDefNoReturn = {
   /**
    * Returns info about this block to be used by the Blockly.Procedures.
    * @return {Array} An array of info.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   getProcedureDef: function() {
     const argNames = this.argData_.map((elem) => elem.model.name);
@@ -125,7 +125,7 @@ const getDefReturn = {
   /**
    * Returns info about this block to be used by the Blockly.Procedures.
    * @return {Array} An array of info.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   getProcedureDef: function() {
     const argNames = this.argData_.map((elem) => elem.model.name);
@@ -145,7 +145,7 @@ const procedureContextMenu = {
    * Adds an option to create a caller block.
    * Adds an option to create a variable getter for each variable included in
    * the procedure definition.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @param {!Array} options The current options for the context menu.
    */
   customContextMenu: function(options) {
@@ -202,7 +202,7 @@ const procedureDefMutator = {
    *     argument IDs. Used by Blockly.Procedures.mutateCallers for
    *     reconnection.
    * @return {!Element} XML storage element.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   mutationToDom: function(isForCaller = false) {
     const container = Blockly.utils.xml.createElement('mutation');
@@ -232,7 +232,7 @@ const procedureDefMutator = {
   /**
    * Parse XML to restore the argument inputs.
    * @param {!Element} xmlElement XML storage element.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   domToMutation: function(xmlElement) {
     // We have to handle this so that the user doesn't add blocks to the stack,
@@ -259,7 +259,7 @@ const procedureDefMutator = {
    * @param {!Array<string>} names An array of argument names to display.
    * @param {!Array<string>} varIds An array of variable IDs associated with
    *     those names.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @private
    */
   updateShape_: function(names, varIds) {
@@ -296,7 +296,7 @@ const procedureDefMutator = {
    * Callback for the minus image. Removes the argument associated with the
    * given argument ID and mutates the callers to match.
    * @param {string} argId The argId of the argument to remove.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   minus: function(argId) {
     if (!this.argData_.length) {
@@ -311,7 +311,7 @@ const procedureDefMutator = {
    * arrays as appropriate.
    * @param {?string=} name An optional name for the argument.
    * @param {?string=} varId An optional variable ID for the argument.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @private
    */
   addArg_: function(name = null, varId = null) {
@@ -361,7 +361,7 @@ const procedureDefMutator = {
    * block.
    * @param {string} name The name of the argument.
    * @param {string} argId The UUID of the argument (different from var ID).
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @private
    */
   addVarInput_: function(name, argId) {
@@ -481,7 +481,7 @@ const procedureDefMutator = {
 
 /**
  * Initializes some private variables for procedure blocks.
- * @this Blockly.Block
+ * @this {Blockly.Block}
  */
 const procedureDefHelper = function() {
   /**
@@ -509,7 +509,7 @@ Blockly.Extensions.registerMutator('procedure_def_mutator',
 
 /**
  * Sets the validator for the procedure's name field.
- * @this Blockly.Block
+ * @this {Blockly.Block}
  */
 const procedureRename = function() {
   this.getField('NAME').setValidator(Blockly.Procedures.rename);
@@ -519,7 +519,7 @@ Blockly.Extensions.register('procedure_rename', procedureRename);
 
 /**
  * Defines functions for dealing with variables and renaming variables.
- * @this Blockly.Block
+ * @this {Blockly.Block}
  */
 const procedureVars = function() {
   // This is a hack to get around the don't-override-builtins check.
@@ -527,7 +527,7 @@ const procedureVars = function() {
     /**
      * Return all variables referenced by this block.
      * @return {!Array.<string>} List of variable names.
-     * @this Blockly.Block
+     * @this {Blockly.Block}
      */
     getVars: function() {
       return this.argData_.map((elem) => elem.model.name);
@@ -536,7 +536,7 @@ const procedureVars = function() {
     /**
      * Return all variables referenced by this block.
      * @return {!Array.<!Blockly.VariableModel>} List of variable models.
-     * @this Blockly.Block
+     * @this {Blockly.Block}
      */
     getVarModels: function() {
       return this.argData_.map((elem) => elem.model);
@@ -572,7 +572,7 @@ const procedureVars = function() {
      * @param {!Blockly.VariableModel} variable The variable being renamed.
      * @package
      * @override
-     * @this Blockly.Block
+     * @this {Blockly.Block}
      */
     updateVarName: function(variable) {
       const id = variable.getId();

--- a/plugins/block-plus-minus/src/text_join.js
+++ b/plugins/block-plus-minus/src/text_join.js
@@ -22,7 +22,7 @@ const textJoinMutator = {
   /**
    * Creates XML to represent number of inputs.
    * @return {!Element} XML storage element.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   mutationToDom: function() {
     const container = Blockly.utils.xml.createElement('mutation');
@@ -32,7 +32,7 @@ const textJoinMutator = {
   /**
    * Parses XML to restore the inputs.
    * @param {!Element} xmlElement XML storage element.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   domToMutation: function(xmlElement) {
     const targetCount = parseInt(xmlElement.getAttribute('items'), 10);
@@ -42,7 +42,7 @@ const textJoinMutator = {
   /**
    * Adds inputs to the block until the block reaches the target input count.
    * @param {number} targetCount The number of inputs the block should have.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @private
    */
   updateShape_: function(targetCount) {
@@ -58,7 +58,7 @@ const textJoinMutator = {
   /**
    * Callback for the plus image. Adds an input to the block and updates the
    * state of the minus.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   plus: function() {
     this.addPart_();
@@ -68,7 +68,7 @@ const textJoinMutator = {
   /**
    * Callback for the minus image. Removes the input at the end of the block and
    * updates the state of the minus.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    */
   minus: function() {
     if (this.itemCount_ == 0) {
@@ -81,7 +81,7 @@ const textJoinMutator = {
   /**
    * Adds an input to the end of the block. If the block currently has no
    * inputs it updates the top 'EMPTY' input to receive a block.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @private
    */
   addPart_: function() {
@@ -102,7 +102,7 @@ const textJoinMutator = {
   /**
    * Removes an input from the end of the block. If we are removing the last
    * input this updates the block to have an 'EMPTY' top input.
-   * @this Blockly.Block
+   * @this {Blockly.Block}
    * @private
    */
   removePart_: function() {
@@ -133,7 +133,7 @@ const textJoinMutator = {
 /**
  * Adds the quotes mixin to the block. Also updates the shape so that if no
  * mutator is provided the block has two inputs.
- * @this Blockly.Block
+ * @this {Blockly.Block}
  */
 const textJoinHelper = function() {
   this.mixin(Blockly.Constants.Text.QUOTE_IMAGE_MIXIN);


### PR DESCRIPTION
`@this Blockly.Block` -> `@this {Blockly.Block}`.

Resolves 39 lint errors.

I believe we were using the former because of [this jsdoc documentation](https://jsdoc.app/tags-this.html) but the latter is correct for Closure compiler and fixes the lint errors as well.

Part of #630