### PR TITLE
Fix invalid XML error

### DIFF
--- a/plugins/nominal-connection-checker/test/index.js
+++ b/plugins/nominal-connection-checker/test/index.js
@@ -211,7 +211,7 @@ document.addEventListener('DOMContentLoaded', function() {
     };
 
     const playgroundState = new LocalStorageState('playgroundState', {
-      workspaceXml: '',
+      workspaceXml: '<xml></xml>',
       activeTab: typesTabName,
       [typesTabName]: '{\n  \n}',
       [blocksTabName]:


### PR DESCRIPTION
### Description

Closes #660 

Changes the default xml from an empty string to a stringified empty xml node (which is valid to pass to Blockly..Xml.domToText).

### Testing

Could not replicate #660 