### PR TITLE
Update build and test scripts to accept a skip-lint option

### DIFF
--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -67,59 +67,6 @@ module.exports = (env) => {
     blocklyAliasSuffix = '/dist';
   }
 
-
-  const rules = [];
-  // Run the linter. Skip if directed.
-  if (!env.skipLint) {
-    rules.push(
-        {
-          test: /\.(js|mjs|ts)$/,
-          enforce: 'pre',
-          use: [
-            {
-              options: {
-                cache: true,
-                formatter: 'stylish',
-                emitWarning: true,
-                eslintPath: require.resolve('eslint'),
-                resolvePluginsRelativeTo: __dirname,
-                useEslintrc: false,
-                baseConfig: {
-                  extends: [require.resolve('@blockly/eslint-config')],
-                },
-              },
-              loader: require.resolve('eslint-loader'),
-            },
-          ],
-          include: [resolveApp('./src/'), resolveApp('./test/')],
-        }
-    );
-  }
-  // The following rules are always in effect.
-  rules.push(
-      // Load Blockly source maps.
-      {
-        test: /(blockly\/.*\.js)$/,
-        use: [require.resolve('source-map-loader')],
-        enforce: 'pre',
-      },
-      // Run babel to compile both JS and TS.
-      {
-        test: /\.(js|mjs|ts)$/,
-        exclude: /(node_modules|build|dist)/,
-        loader: require.resolve('babel-loader'),
-        options: {
-          babelrc: false,
-          configFile: false,
-          presets: [
-            require.resolve('@babel/preset-env'),
-            isTypescript && require.resolve('@babel/preset-typescript'),
-          ].filter(Boolean),
-          compact: isProduction,
-        },
-      },
-  );
-
   return {
     target,
     mode: isProduction ? 'production' : 'development',
@@ -140,7 +87,51 @@ module.exports = (env) => {
           .filter((ext) => isTypescript || !ext.includes('ts')),
     },
     module: {
-      rules: rules,
+      rules: [
+        // Run the linter.
+        !env.skipLint && {
+          test: /\.(js|mjs|ts)$/,
+          enforce: 'pre',
+          use: [
+            {
+              options: {
+                cache: true,
+                formatter: 'stylish',
+                emitWarning: true,
+                eslintPath: require.resolve('eslint'),
+                resolvePluginsRelativeTo: __dirname,
+                useEslintrc: false,
+                baseConfig: {
+                  extends: [require.resolve('@blockly/eslint-config')],
+                },
+              },
+              loader: require.resolve('eslint-loader'),
+            },
+          ],
+          include: [resolveApp('./src/'), resolveApp('./test/')],
+        },
+        // Load Blockly source maps.
+        {
+          test: /(blockly\/.*\.js)$/,
+          use: [require.resolve('source-map-loader')],
+          enforce: 'pre',
+        },
+        // Run babel to compile both JS and TS.
+        {
+          test: /\.(js|mjs|ts)$/,
+          exclude: /(node_modules|build|dist)/,
+          loader: require.resolve('babel-loader'),
+          options: {
+            babelrc: false,
+            configFile: false,
+            presets: [
+              require.resolve('@babel/preset-env'),
+              isTypescript && require.resolve('@babel/preset-typescript'),
+            ].filter(Boolean),
+            compact: isProduction,
+          },
+        },
+      ].filter(Boolean),
     },
     plugins: [
       // Add package name.

--- a/plugins/dev-scripts/scripts/build.js
+++ b/plugins/dev-scripts/scripts/build.js
@@ -30,8 +30,11 @@ const packageJson = require(resolveApp('package.json'));
 console.log(`Running production build for ${packageJson.name}`);
 
 // Create the webpack configuration for based on the build environment.
+const args = process.argv.slice(2);
+const skipLint = args.includes('--skip-lint');
 const config = webpackConfig({
   mode: 'production',
+  skipLint: skipLint,
 });
 if (!config.entry) {
   console.log(`${chalk.red(`Configuration error.`)}

--- a/plugins/dev-scripts/scripts/test.js
+++ b/plugins/dev-scripts/scripts/test.js
@@ -27,8 +27,11 @@ const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
 const packageJson = require(resolveApp('package.json'));
 console.log(`Building tests for ${packageJson.name}`);
 
+const args = process.argv.slice(2);
+const skipLint = args.includes('--skip-lint');
 const config = webpackConfig({
   mode: 'test',
+  skipLint: skipLint,
 });
 if (!config.entry) {
   console.log(chalk.yellow(`Warning: No tests found`) + '\n' +


### PR DESCRIPTION
This PR adds a `--skip-lint` option to the `test` and `build` scripts. For example:

```
npm run test -- --skip-lint
```

This is required for #635. 

Before change: The linter is always run on build or test. This causes problems because the GitHub Action runs all of build, test, and lint, so all lint errors show up 3-9 times (for multiple versions of node, etc).
After change: If the flag is passed, webpack doesn't lint when it runs. If the flag is not passed, there is no change from before and linter is run.

Tested:
from `blockly-samples/plugins/block-plus-minus` ran

```
node ../dev-scripts/scripts/build -- --skip-lint
node ../dev-scripts/scripts/build 
node ../dev-scripts/scripts/test -- --skip-lint
node ../dev-scripts/scripts/test
```

 and saw correct behavior in all cases.