### PR TITLE
Add basic type checking for parameters - project static

### DIFF
--- a/plugins/nominal-connection-checker/src/index.js
+++ b/plugins/nominal-connection-checker/src/index.js
@@ -11,6 +11,7 @@
 
 import * as Blockly from 'blockly/core';
 import {TypeHierarchy} from './type_hierarchy';
+import {parseType} from './type_structure';
 import {getCheck, isExplicitConnection, isGenericConnection} from './utils';
 
 
@@ -92,7 +93,8 @@ export class NominalConnectionChecker extends Blockly.ConnectionChecker {
 
     return childTypes.some((childType) => {
       return parentTypes.some((parentType) => {
-        return typeHierarchy.typeFulfillsType(childType, parentType);
+        return typeHierarchy.typeFulfillsType(
+            parseType(childType), parseType(parentType));
       });
     });
   }

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -211,7 +211,7 @@ export class TypeHierarchy {
       return false;
     }
     return type1.params.every((type1Param, i) => {
-      this.typeIsExactlyType(type1Param, type2.params[i]);
+      return this.typeIsExactlyType(type1Param, type2.params[i]);
     });
   }
 
@@ -237,7 +237,8 @@ export class TypeHierarchy {
     // TODO: We need to add checks to make sure the number of actual params for
     //  the subtype is correct. Here and in typeIsExactlyType.
 
-    const orderedSubParams = subDef.getParamsForAncestor(superType.name);
+    const orderedSubParams = subDef.getParamsForAncestor(
+        superType.name, subType.params);
     return superType.params.every((actualSuper, i) => {
       const actualSub = orderedSubParams[i];
       const paramDef = superDef.getParamForIndex(i);

--- a/plugins/nominal-connection-checker/src/type_hierarchy.js
+++ b/plugins/nominal-connection-checker/src/type_hierarchy.js
@@ -201,8 +201,8 @@ export class TypeHierarchy {
 
   /**
    * Returns true if the types are exactly the same type. False otherwise.
-   * @param {!TypeStructure} type1 The name of the first type.
-   * @param {!TypeStructure} type2 The name of the second type.
+   * @param {!TypeStructure} type1 The structure of the first type.
+   * @param {!TypeStructure} type2 The structure of the second type.
    * @return {boolean} True if the types are exactly the same type. False
    *     otherwise.
    */

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -11,6 +11,7 @@
 const chai = require('chai');
 
 const {TypeHierarchy} = require('../src/type_hierarchy');
+const {parseType} = require('../src/type_structure');
 
 suite('TypeHierarchy', function() {
   test('Super not defined', function() {
@@ -1011,20 +1012,31 @@ suite('TypeHierarchy', function() {
   });
 
   suite('typeIsExactlyType', function() {
+    setup(function() {
+      this.assertMatch = function(hierarchy, sub, sup, msg) {
+        chai.assert.isTrue(
+            hierarchy.typeIsExactlyType(parseType(sub), parseType(sup)), msg);
+      };
+      this.assertNoMatch = function(hierarchy, sub, sup, msg) {
+        chai.assert.isFalse(
+            hierarchy.typeIsExactlyType(parseType(sub), parseType(sup)), msg);
+      };
+    });
+
     test('Simple', function() {
       const hierarchy = new TypeHierarchy({
         'A': { },
       });
-      chai.assert.isTrue(hierarchy.typeIsExactlyType('typeA', 'typeA'));
+      this.assertMatch(hierarchy, 'typeA', 'typeA');
     });
 
     test('Case', function() {
       const hierarchy = new TypeHierarchy({
         'typeA': { },
       });
-      chai.assert.isTrue(hierarchy.typeIsExactlyType('typeA', 'typea'),
+      this.assertMatch(hierarchy, 'typeA', 'typea',
           'Expected TypeHierarchy to be case-insensitive.');
-      chai.assert.isTrue(hierarchy.typeIsExactlyType('typea', 'typeA'),
+      this.assertMatch(hierarchy, 'typea', 'typeA',
           'Expected TypeHierarchy to be case-insensitive.');
     });
 
@@ -1032,7 +1044,7 @@ suite('TypeHierarchy', function() {
       const hierarchy = new TypeHierarchy({
         'typeA': { },
       });
-      chai.assert.isFalse(hierarchy.typeIsExactlyType('typeA', ' typeA '),
+      this.assertNoMatch(hierarchy, 'typeA', ' typeA ',
           'Expected TypeHierarchy to respect padding.');
     });
 
@@ -1043,7 +1055,7 @@ suite('TypeHierarchy', function() {
         },
         'typeB': { },
       });
-      chai.assert.isFalse(hierarchy.typeIsExactlyType('typeA', 'typeB'));
+      this.assertNoMatch(hierarchy, 'typeA', 'typeB');
     });
 
     test('Sub', function() {
@@ -1053,25 +1065,36 @@ suite('TypeHierarchy', function() {
           'fulfills': ['typeA'],
         },
       });
-      chai.assert.isFalse(hierarchy.typeIsExactlyType('typeA', 'typeB'));
+      this.assertNoMatch(hierarchy, 'typeA', 'typeB');
     });
   });
 
   suite('typeFulfillsType', function() {
+    setup(function() {
+      this.assertFulfills = function(hierarchy, sub, sup, msg) {
+        chai.assert.isTrue(
+            hierarchy.typeFulfillsType(parseType(sub), parseType(sup)), msg);
+      };
+      this.assertDoesNotFulfill = function(hierarchy, sub, sup, msg) {
+        chai.assert.isFalse(
+            hierarchy.typeFulfillsType(parseType(sub), parseType(sup)), msg);
+      };
+    });
+
     test('Empty fulfills', function() {
       const hierarchy = new TypeHierarchy({
         'typeA': {
           'fulfills': [],
         },
       });
-      chai.assert.isFalse(hierarchy.typeFulfillsType('typeA', 'typeB'));
+      this.assertDoesNotFulfill(hierarchy, 'typeA', 'typeB');
     });
 
     test('Undefined fulfills', function() {
       const hierarchy = new TypeHierarchy({
         'typeA': { },
       });
-      chai.assert.isFalse(hierarchy.typeFulfillsType('typeA', 'typeB'));
+      this.assertDoesNotFulfill(hierarchy, 'typeA', 'typeB');
     });
 
     test('Super defined first', function() {
@@ -1081,17 +1104,17 @@ suite('TypeHierarchy', function() {
           'fulfills': ['typeB'],
         },
       });
-      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeB'));
+      this.assertFulfills(hierarchy, 'typeA', 'typeB');
     });
 
     test('Super defined second', function() {
       const hierarchy = new TypeHierarchy({
-        'A': {
-          'fulfills': ['B'],
+        'typeA': {
+          'fulfills': ['typeB'],
         },
-        'B': { },
+        'typeB': { },
       });
-      chai.assert.isTrue(hierarchy.typeFulfillsType('A', 'B'));
+      this.assertFulfills(hierarchy, 'typeA', 'typeB');
     });
 
     test('Multiple supers', function() {
@@ -1103,9 +1126,9 @@ suite('TypeHierarchy', function() {
         'typeC': { },
         'typeD': { },
       });
-      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeB'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeC'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeD'));
+      this.assertFulfills(hierarchy, 'typeA', 'typeB');
+      this.assertFulfills(hierarchy, 'typeA', 'typeC');
+      this.assertFulfills(hierarchy, 'typeA', 'typeD');
     });
 
     test('Deep super', function() {
@@ -1121,9 +1144,9 @@ suite('TypeHierarchy', function() {
         },
         'typeD': { },
       });
-      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeB'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeC'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeD'));
+      this.assertFulfills(hierarchy, 'typeA', 'typeB');
+      this.assertFulfills(hierarchy, 'typeA', 'typeC');
+      this.assertFulfills(hierarchy, 'typeA', 'typeD');
     });
 
     test('Case', function() {
@@ -1133,10 +1156,10 @@ suite('TypeHierarchy', function() {
         },
         'typeb': { },
       });
-      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeb'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('typeA', 'typeB'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('typea', 'typeb'));
-      chai.assert.isTrue(hierarchy.typeFulfillsType('typea', 'typeB'));
+      this.assertFulfills(hierarchy, 'typeA', 'typeb');
+      this.assertFulfills(hierarchy, 'typeA', 'typeB');
+      this.assertFulfills(hierarchy, 'typea', 'typeb');
+      this.assertFulfills(hierarchy, 'typea', 'typeB');
     });
   });
 

--- a/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
+++ b/plugins/nominal-connection-checker/test/type_hierarchy_test.mocha.js
@@ -1585,6 +1585,34 @@ suite('TypeHierarchy', function() {
           this.assertDoesNotFulfill(
               hierarchy, 'typeB[typeC, typeD]', 'typeA[typeC, typeD]');
         });
+
+        test('Fulfill super with less params', function() {
+          const hierarchy = new TypeHierarchy({
+            'typeA': {
+              'params': [
+                {
+                  'name': 'A',
+                  'variance': 'inv',
+                },
+              ],
+            },
+            'typeB': {
+              'fulfills': ['typeA[A]'],
+              'params': [
+                {
+                  'name': 'A',
+                  'variance': 'inv',
+                },
+                {
+                  'name': 'B',
+                  'variance': 'inv',
+                },
+              ],
+            },
+            'typeC': { },
+          });
+          this.assertFulfills(hierarchy, 'typeB[typeC, typeC]', 'typeA[typeC]');
+        });
       });
 
       suite('Nested params', function() {
@@ -2344,9 +2372,6 @@ suite('TypeHierarchy', function() {
               this.hierarchy, 'typeB[typeC, typeC]', 'typeA[typeC]');
         });
       });
-
-      // TODO: Tests for:
-      //  * typeB[typeC, typeC] subtype of typeA[typeC] - is this possible?
     });
   });
 


### PR DESCRIPTION
### Description

Adds basic type checking for parameters. Only modifies `typeIsExactlyType` and `typeFulfillsType`. `getNearestCommonParents` is the next PR (be warned, it's going to get a little crazy)

### Testing

- Tests for making sure errors are properly thrown
- Tests to make sure `typeIsExactlyType` works correctly with parameters.
- Tests to make sure `typeFulfillsType` works correctly with parameters.
    - Tests for all variances (co, contra, and inv).

### Info

For a refresher on variance please see the [glossary](https://docs.google.com/document/d/1QKYkmWjkle1JWCi3O8jXr8-7Toazh1pW_4EaVVgB_OI/edit#heading=h.bviy0z22j7ic) section of the design document.