### PR TITLE
Use the new positionable api in zoom-to-fit control

### DIFF
--- a/plugins/zoom-to-fit/src/index.js
+++ b/plugins/zoom-to-fit/src/index.js
@@ -72,7 +72,7 @@ export class ZoomToFitControl {
      * @type {number}
      * @private
      */
-    this.MARGIN_VERTICAL_ = 10;
+    this.MARGIN_VERTICAL_ = 20;
 
     /**
      * Horizontal margin of zoom-to-fit control.


### PR DESCRIPTION
Update zoom-to-fit control plugin to use new positionable apis from core provided in https://github.com/google/blockly/pull/4782.