### PR TITLE
Add a separate lint job in the Build and Test action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,27 @@ jobs:
     - name: Npm Install
       run: npm install
 
-    - name: Lint
-      run: npm run lint
-
     - name: Build
-      run: npm run build
+      run: npm run build -- --skip-lint
 
     - name: Test
-      run: npm run test
+      run: npm run test -- --skip-lint
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+
+    - name: Npm Install Lerna
+      run: npm install -g lerna
+
+    - name: Npm Install
+      run: npm install
+
+    - name: Lint
+      run: npm run lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
       run: npm install
 
     - name: Build
-      run: npm run build -- -- --skip-lint
+      run: npm run build -- -- -- --skip-lint
 
     - name: Test
-      run: npm run test -- -- --skip-lint
+      run: npm run test -- -- -- --skip-lint
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
       run: npm install
 
     - name: Build
-      run: npm run build -- --skip-lint
+      run: npm run build -- -- --skip-lint
 
     - name: Test
-      run: npm run test -- --skip-lint
+      run: npm run test -- -- --skip-lint
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Npm Install Lerna
-      run: npm install -g lerna
-
     - name: Npm Install
       run: npm install
 
@@ -39,9 +36,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-
-    - name: Npm Install Lerna
-      run: npm install -g lerna
 
     - name: Npm Install
       run: npm install


### PR DESCRIPTION
### What changed

This PR resolves https://github.com/google/blockly-samples/issues/635. 

The `build` job will now perform just build and test steps, and those steps will no longer perform linting themselves.
There is now a separate `lint` job that will just run the linter.

### Behavior before change

After opening a PR with a lint error, the lint error would show up 3-6 times (once each for build, test, and lint steps, and for each node_version). A lint error would cause the GH Actions UI to report that the "build" step failed.

### Behavior after change

Opening a PR will cause two separate jobs to run, Build and Lint. If there is a lint error but no other build problems, the "Build" action will succeed while the "Lint" action will fail. The lint error should appear only once. This provides both more information in the Actions UI and less clutter with duplicate errors.

### Notes

There is some duplication due to the fact that each job runs on a separate machine, so you have to npm install twice etc. But these jobs happen in parallel, so I'm hoping there is no noticeable change in the amount of time it takes (or perhaps it gets faster). I looked into it and there is a somewhat involved method of cacheing items between jobs, but I figured we should get the base model working before trying to go fancier.

As far as I know, there's not a way to test this before submitting it and hoping it works? I'll only submit this at a time when I can babysit and roll back if it's not working.