### PR TITLE
Move on block

### DIFF
--- a/plugins/scroll-options/src/ScrollBlockDragger.js
+++ b/plugins/scroll-options/src/ScrollBlockDragger.js
@@ -36,7 +36,7 @@ export class ScrollBlockDragger extends Blockly.BlockDragger {
 
     // Move the connections on the block. Workspace coordinates.
     this.draggingBlock_.moveConnections(-deltaXWs, -deltaYWs);
-    
+
     // As we scroll, show the insertion markers.
     // TODO: This is broken. So completely broken.
     this.draggedConnectionManager_.update(

--- a/plugins/scroll-options/src/ScrollBlockDragger.js
+++ b/plugins/scroll-options/src/ScrollBlockDragger.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview This adds a method to the block dragger to allow a block
+ * to be moved when it is being dragged.
+ */
+
+import * as Blockly from 'blockly/core';
+
+/**
+ * A block dragger that adds the functionality for a block to be moved while
+ * someone is dragging it.
+ */
+export class ScrollBlockDragger extends Blockly.BlockDragger {
+  /**
+   * Updates the location of the block that is being dragged.
+   * @param {number} deltaX Horizontal offset in pixel units.
+   * @param {number} deltaY Vertical offset in pixel units.
+   */
+  moveBlockWhileDragging(deltaX, deltaY) {
+    // Moves the parent block drag surface in the opposite direction of the
+    // child drag surface. This makes the block stay under the cursor.
+    this.workspace_.getBlockDragSurface().translateBy(-deltaX, -deltaY);
+
+    const deltaXWs = deltaX / this.workspace_.scale;
+    const deltaYWs = deltaY / this.workspace_.scale;
+
+    // Update the start location of the block, so that when we drag the block
+    // it starts in the correct location. startXY is in workspace coordinates.
+    this.startXY_.x -= deltaXWs;
+    this.startXY_.y -= deltaYWs;
+
+    // Move the connections on the block. Workspace coordinates.
+    this.draggingBlock_.moveConnections(-deltaXWs, -deltaYWs);
+    
+    // As we scroll, show the insertion markers.
+    // TODO: This is broken. So completely broken.
+    this.draggedConnectionManager_.update(
+        new Blockly.utils.Coordinate(deltaXWs, deltaYWs), null);
+  }
+}

--- a/plugins/scroll-options/src/index.js
+++ b/plugins/scroll-options/src/index.js
@@ -50,7 +50,7 @@ export class Plugin {
 
     // The location of the block dragger before we scroll the workspace.
     // TODO: Should this just be stored on the block drag surface?
-    const oldLocation = this.getCurrentScrollLocation(dragSurface);
+    const oldLocation = this.getDragSurfaceLocation_(dragSurface);
 
     // Figure out the desired location to scroll to.
     const scrollDelta = Blockly.utils.getScrollDeltaPixels(e);
@@ -64,25 +64,26 @@ export class Plugin {
 
     // Get the new location of the block dragger after scrolling the workspace.
     // TODO: is this more expensive than just calculating ourselves?
-    const newLocation = this.getCurrentScrollLocation(dragSurface);
+    const newLocation = this.getDragSurfaceLocation_(dragSurface);
 
     // How much we actually ended up scrolling.
     const deltaX = newLocation.x - oldLocation.x;
     const deltaY = newLocation.y - oldLocation.y;
 
     if (deltaX || deltaY) {
+      // TODO: Can not access private blockDragger.
       currentGesture.blockDragger_.moveBlockWhileDragging(deltaX, deltaY);
       e.preventDefault();
     }
   }
 
   /**
-   * Gets the current scroll location.
-   * TODO: Update all docs.
+   * Gets the current location of the drag surface.
    * @param {!Blockly.BlockDragSurface} dragSurface The block drag surface.
    * @return {Blockly.utils.Coordinate} The current coordinate.
+   * @private
    */
-  getCurrentScrollLocation(dragSurface) {
+  getDragSurfaceLocation_(dragSurface) {
     return new Blockly.utils.Coordinate(
         dragSurface.getGroup().transform.baseVal.consolidate().matrix.e,
         dragSurface.getGroup().transform.baseVal.consolidate().matrix.f);

--- a/plugins/scroll-options/src/index.js
+++ b/plugins/scroll-options/src/index.js
@@ -31,5 +31,61 @@ export class Plugin {
   /**
    * Initialize.
    */
-  init() { }
+  init() {
+    const dragSurface = this.workspace_.getBlockDragSurface();
+    Blockly.bindEventWithChecks_(
+        dragSurface.getSvgRoot(), 'wheel', this, this.onMouseWheel_);
+  }
+
+  onMouseWheel_(e) {
+    // Don't scroll or zoom anything if drag is in progress.
+    const canWheelMove = this.workspace_.options.moveOptions &&
+        this.workspace_.options.moveOptions.wheel;
+    if (!canWheelMove) {
+      return;
+    }
+
+    const dragSurface = this.workspace_.getBlockDragSurface();
+
+    // The location of the block dragger before we scroll the workspace.
+    // TODO: Should this just be stored on the block drag surface?
+    const oldLocation = this.getCurrentScrollLocation(dragSurface);
+
+    // Figure out the desired location to scroll to.
+    const scrollDelta = Blockly.utils.getScrollDeltaPixels(e);
+    const x = this.workspace_.scrollX - scrollDelta.x;
+    const y = this.workspace_.scrollY - scrollDelta.y;
+
+    // Try to scroll to the desired location.
+    this.workspace_.getMetricsManager().stopCalculating = true;
+    this.workspace_.scroll(x, y);
+    this.workspace_.getMetricsManager().stopCalculating = false;
+
+    // Get the new location of the block dragger after scrolling the workspace.
+    // TODO: is this more expensive than just calculating ourselves?
+    const newLocation = this.getCurrentScrollLocation(dragSurface);
+
+    // How much we actually ended up scrolling.
+    const deltaX = newLocation.x - oldLocation.x;
+    const deltaY = newLocation.y - oldLocation.y;
+
+    const currentGesture = this.workspace_.getGesture(e);
+    if (currentGesture &&
+      currentGesture.isDraggingBlock_) {
+      currentGesture.blockDragger_.moveBlockWhileDragging(deltaX, deltaY);
+      e.preventDefault();
+    }
+  }
+
+  /**
+   * Gets the current scroll location.
+   * TODO: Update all docs.
+   * @param {!Blockly.BlockDragSurface} dragSurface The block drag surface.
+   * @return {Blockly.utils.Coordinate} The current coordinate.
+   */
+  getCurrentScrollLocation(dragSurface) {
+    return new Blockly.utils.Coordinate(
+        dragSurface.getGroup().transform.baseVal.consolidate().matrix.e,
+        dragSurface.getGroup().transform.baseVal.consolidate().matrix.f);
+  }
 }

--- a/plugins/scroll-options/src/index.js
+++ b/plugins/scroll-options/src/index.js
@@ -37,6 +37,10 @@ export class Plugin {
         dragSurface.getSvgRoot(), 'wheel', this, this.onMouseWheel_);
   }
 
+  /**
+   * Moves the currently dragged block as the user scrolls the workspace.
+   * @param {!Event} e Mouse wheel event.
+   */
   onMouseWheel_(e) {
     // Don't scroll or zoom anything if drag is in progress.
     const canWheelMove = this.workspace_.options.moveOptions &&

--- a/plugins/scroll-options/src/index.js
+++ b/plugins/scroll-options/src/index.js
@@ -41,7 +41,8 @@ export class Plugin {
     // Don't scroll or zoom anything if drag is in progress.
     const canWheelMove = this.workspace_.options.moveOptions &&
         this.workspace_.options.moveOptions.wheel;
-    if (!canWheelMove) {
+    const currentGesture = this.workspace_.getGesture(e);
+    if (!canWheelMove || !currentGesture || !currentGesture.isDraggingBlock_) {
       return;
     }
 
@@ -69,9 +70,7 @@ export class Plugin {
     const deltaX = newLocation.x - oldLocation.x;
     const deltaY = newLocation.y - oldLocation.y;
 
-    const currentGesture = this.workspace_.getGesture(e);
-    if (currentGesture &&
-      currentGesture.isDraggingBlock_) {
+    if (deltaX || deltaY) {
       currentGesture.blockDragger_.moveBlockWhileDragging(deltaX, deltaY);
       e.preventDefault();
     }

--- a/plugins/scroll-options/test/index.js
+++ b/plugins/scroll-options/test/index.js
@@ -12,8 +12,6 @@ import * as Blockly from 'blockly';
 import {toolboxCategories, createPlayground} from '@blockly/dev-tools';
 import {Plugin} from '../src/index';
 import {ScrollBlockDragger} from '../src/ScrollBlockDragger';
-import {ScrollMetricsManager} from '../src/ScrollMetricsManager';
-// import '../src/overrides';
 
 
 /**
@@ -37,7 +35,6 @@ document.addEventListener('DOMContentLoaded', function() {
     toolbox: toolboxCategories,
     plugins: {
       'blockDragger': ScrollBlockDragger,
-      'metricsManager': ScrollMetricsManager,
     },
   };
   createPlayground(document.getElementById('root'), createWorkspace,

--- a/plugins/scroll-options/test/index.js
+++ b/plugins/scroll-options/test/index.js
@@ -11,6 +11,10 @@
 import * as Blockly from 'blockly';
 import {toolboxCategories, createPlayground} from '@blockly/dev-tools';
 import {Plugin} from '../src/index';
+import {ScrollBlockDragger} from '../src/ScrollBlockDragger';
+import {ScrollMetricsManager} from '../src/ScrollMetricsManager';
+// import '../src/overrides';
+
 
 /**
  * Create a workspace.
@@ -31,6 +35,10 @@ function createWorkspace(blocklyDiv, options) {
 document.addEventListener('DOMContentLoaded', function() {
   const defaultOptions = {
     toolbox: toolboxCategories,
+    plugins: {
+      'blockDragger': ScrollBlockDragger,
+      'metricsManager': ScrollMetricsManager,
+    },
   };
   createPlayground(document.getElementById('root'), createWorkspace,
       defaultOptions);


### PR DESCRIPTION
- Adds a `BlockDragger` with `moveBlockWhileDragging` since it was taken out of core in google/blockly#4796.
- Adds most of the functionality for moving a block on scroll. However, there are still some TODOs that I need to go through and fix. 
- As stated in the comments, insertion markers are currently super broken.