### PR TITLE
Fix insertion

### DIFF
--- a/plugins/scroll-options/src/ScrollBlockDragger.js
+++ b/plugins/scroll-options/src/ScrollBlockDragger.js
@@ -16,81 +16,86 @@ import * as Blockly from 'blockly/core';
  * someone is dragging it.
  */
 export class ScrollBlockDragger extends Blockly.BlockDragger {
+  /** @override */
   constructor(block, workspace) {
     super(block, workspace);
 
-    this.scrollDelta = new Blockly.utils.Coordinate(0, 0);
+    /**
+     * How much the block has been moved due to scrolling.
+     * @type {!Blockly.utils.Coordinate}
+     * @protected
+     * TODO: Do we still do underscore in Blockly samples?
+     */
+    this.scrollDelta_ = new Blockly.utils.Coordinate(0, 0);
+
+    /**
+     * How much the block has been moved due to dragging.
+     * @type {!Blockly.utils.Coordinate}
+     * @protected
+     */
+    this.dragDelta_ = new Blockly.utils.Coordinate(0, 0);
   }
   /**
    * Updates the location of the block that is being dragged.
    * @param {number} deltaX Horizontal offset in pixel units.
    * @param {number} deltaY Vertical offset in pixel units.
    */
-  moveBlockWhileDragging(deltaX, deltaY, currentGesture) {
-    this.scrollDelta.x -= deltaX;
-    this.scrollDelta.y -= deltaY;
+  moveBlockWhileDragging(deltaX, deltaY) {
+    this.scrollDelta_.x -= deltaX;
+    this.scrollDelta_.y -= deltaY;
 
-    const totalChange =
-        Blockly.utils.Coordinate.sum(this.scrollDelta, this.dragDelta);
-    console.log(totalChange);
     // Moves the parent block drag surface in the opposite direction of the
     // child drag surface. This makes the block stay under the cursor.
     this.workspace_.getBlockDragSurface().translateBy(-deltaX, -deltaY);
 
-    const deltaXWs = deltaX / this.workspace_.scale;
-    const deltaYWs = deltaY / this.workspace_.scale;
-
-    // Update the start location of the block, so that when we drag the block
-    // it starts in the correct location. startXY is in workspace coordinates.
-    // this.startXY_.x -= deltaXWs;
-    // this.startXY_.y -= deltaYWs;
-
-    // Move the connections on the block. Workspace coordinates.
-    // this.draggingBlock_.moveConnections(-deltaXWs, -deltaYWs);
+    // The total amount the block has moved since being picked up.
+    const totalDelta =
+        Blockly.utils.Coordinate.sum(this.scrollDelta_, this.dragDelta_);
 
     // As we scroll, show the insertion markers.
-    // TODO: This is broken. So completely broken.
     this.draggedConnectionManager_.update(
         new Blockly.utils.Coordinate(
-            totalChange.x / this.workspace_.scale,
-            totalChange.y / this.workspace_.scale),
+            totalDelta.x / this.workspace_.scale,
+            totalDelta.y / this.workspace_.scale),
         null);
   }
 
-
   /** @override */
-  dragBlock(e, currentDragDeltaXY) {
-    const totalChange =
-        Blockly.utils.Coordinate.sum(this.scrollDelta, currentDragDeltaXY);
-    super.dragBlock(e, totalChange);
-    this.dragDelta = currentDragDeltaXY;
-    // const delta = this.pixelsToWorkspaceUnits_(totalChange);
-
-    // const newLoc = Blockly.utils.Coordinate.sum(this.startXY_, delta);
-
-    // this.draggingBlock_.moveDuringDrag(newLoc);
-    // this.dragIcons_(delta);
-
-    // this.deleteArea_ = this.workspace_.isDeleteArea(e);
-    // this.draggedConnectionManager_.update(delta, this.deleteArea_);
-
-    // this.updateCursorDuringBlockDrag_();
-    // this.dragDelta = currentDragDeltaXY;
+  startBlockDrag(currentDragDeltaXY, healStack) {
+    super.startBlockDrag(currentDragDeltaXY, healStack);
+    this.dragDelta_ = currentDragDeltaXY;
   }
 
+  /**
+   * Passes the total amount the block has moved (both from dragging and from
+   * scrolling) since it was picked up.
+   * @override
+   */
+  dragBlock(e, currentDragDeltaXY) {
+    const totalDelta =
+        Blockly.utils.Coordinate.sum(this.scrollDelta_, currentDragDeltaXY);
+    super.dragBlock(e, totalDelta);
+    this.dragDelta_ = currentDragDeltaXY;
+  }
+
+  /** @override */
   endBlockDrag(e, currentDragDeltaXY) {
     // Make sure internal state is fresh.
     // TODO: Figure out a way to call super here.
     this.dragBlock(e, currentDragDeltaXY);
     this.dragIconData_ = [];
     this.fireDragEndEvent_();
+
     Blockly.utils.dom.stopTextWidthCache();
 
     Blockly.blockAnimations.disconnectUiStop();
+
+    // START CHANGE
     const totalChange =
-        Blockly.utils.Coordinate.sum(this.scrollDelta, currentDragDeltaXY);
+        Blockly.utils.Coordinate.sum(this.scrollDelta_, currentDragDeltaXY);
     const delta = this.pixelsToWorkspaceUnits_(totalChange);
     const newLoc = Blockly.utils.Coordinate.sum(this.startXY_, delta);
+    // END CHANGE
     this.draggingBlock_.moveOffDragSurface(newLoc);
 
     const deleted = this.maybeDeleteBlock_();
@@ -112,7 +117,7 @@ export class ScrollBlockDragger extends Blockly.BlockDragger {
     const toolbox = this.workspace_.getToolbox();
     if (toolbox && typeof toolbox.removeStyle == 'function') {
       const style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
-                                                      'blocklyToolboxGrab';
+                                                        'blocklyToolboxGrab';
       toolbox.removeStyle(style);
     }
     Blockly.Events.setGroup(false);

--- a/plugins/scroll-options/src/ScrollBlockDragger.js
+++ b/plugins/scroll-options/src/ScrollBlockDragger.js
@@ -16,12 +16,23 @@ import * as Blockly from 'blockly/core';
  * someone is dragging it.
  */
 export class ScrollBlockDragger extends Blockly.BlockDragger {
+  constructor(block, workspace) {
+    super(block, workspace);
+
+    this.scrollDelta = new Blockly.utils.Coordinate(0, 0);
+  }
   /**
    * Updates the location of the block that is being dragged.
    * @param {number} deltaX Horizontal offset in pixel units.
    * @param {number} deltaY Vertical offset in pixel units.
    */
-  moveBlockWhileDragging(deltaX, deltaY) {
+  moveBlockWhileDragging(deltaX, deltaY, currentGesture) {
+    this.scrollDelta.x -= deltaX;
+    this.scrollDelta.y -= deltaY;
+
+    const totalChange =
+        Blockly.utils.Coordinate.sum(this.scrollDelta, this.dragDelta);
+    console.log(totalChange);
     // Moves the parent block drag surface in the opposite direction of the
     // child drag surface. This makes the block stay under the cursor.
     this.workspace_.getBlockDragSurface().translateBy(-deltaX, -deltaY);
@@ -31,15 +42,79 @@ export class ScrollBlockDragger extends Blockly.BlockDragger {
 
     // Update the start location of the block, so that when we drag the block
     // it starts in the correct location. startXY is in workspace coordinates.
-    this.startXY_.x -= deltaXWs;
-    this.startXY_.y -= deltaYWs;
+    // this.startXY_.x -= deltaXWs;
+    // this.startXY_.y -= deltaYWs;
 
     // Move the connections on the block. Workspace coordinates.
-    this.draggingBlock_.moveConnections(-deltaXWs, -deltaYWs);
+    // this.draggingBlock_.moveConnections(-deltaXWs, -deltaYWs);
 
     // As we scroll, show the insertion markers.
     // TODO: This is broken. So completely broken.
     this.draggedConnectionManager_.update(
-        new Blockly.utils.Coordinate(deltaXWs, deltaYWs), null);
+        new Blockly.utils.Coordinate(
+            totalChange.x / this.workspace_.scale,
+            totalChange.y / this.workspace_.scale),
+        null);
+  }
+
+
+  /** @override */
+  dragBlock(e, currentDragDeltaXY) {
+    const totalChange =
+        Blockly.utils.Coordinate.sum(this.scrollDelta, currentDragDeltaXY);
+    super.dragBlock(e, totalChange);
+    this.dragDelta = currentDragDeltaXY;
+    // const delta = this.pixelsToWorkspaceUnits_(totalChange);
+
+    // const newLoc = Blockly.utils.Coordinate.sum(this.startXY_, delta);
+
+    // this.draggingBlock_.moveDuringDrag(newLoc);
+    // this.dragIcons_(delta);
+
+    // this.deleteArea_ = this.workspace_.isDeleteArea(e);
+    // this.draggedConnectionManager_.update(delta, this.deleteArea_);
+
+    // this.updateCursorDuringBlockDrag_();
+    // this.dragDelta = currentDragDeltaXY;
+  }
+
+  endBlockDrag(e, currentDragDeltaXY) {
+    // Make sure internal state is fresh.
+    // TODO: Figure out a way to call super here.
+    this.dragBlock(e, currentDragDeltaXY);
+    this.dragIconData_ = [];
+    this.fireDragEndEvent_();
+    Blockly.utils.dom.stopTextWidthCache();
+
+    Blockly.blockAnimations.disconnectUiStop();
+    const totalChange =
+        Blockly.utils.Coordinate.sum(this.scrollDelta, currentDragDeltaXY);
+    const delta = this.pixelsToWorkspaceUnits_(totalChange);
+    const newLoc = Blockly.utils.Coordinate.sum(this.startXY_, delta);
+    this.draggingBlock_.moveOffDragSurface(newLoc);
+
+    const deleted = this.maybeDeleteBlock_();
+    if (!deleted) {
+      // These are expensive and don't need to be done if we're deleting.
+      this.draggingBlock_.moveConnections(delta.x, delta.y);
+      this.draggingBlock_.setDragging(false);
+      this.fireMoveEvent_();
+      if (this.draggedConnectionManager_.wouldConnectBlock()) {
+        // Applying connections also rerenders the relevant blocks.
+        this.draggedConnectionManager_.applyConnections();
+      } else {
+        this.draggingBlock_.render();
+      }
+      this.draggingBlock_.scheduleSnapAndBump();
+    }
+    this.workspace_.setResizesEnabled(true);
+
+    const toolbox = this.workspace_.getToolbox();
+    if (toolbox && typeof toolbox.removeStyle == 'function') {
+      const style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
+                                                      'blocklyToolboxGrab';
+      toolbox.removeStyle(style);
+    }
+    Blockly.Events.setGroup(false);
   }
 }

--- a/plugins/scroll-options/src/ScrollBlockDragger.js
+++ b/plugins/scroll-options/src/ScrollBlockDragger.js
@@ -48,9 +48,12 @@ export class ScrollBlockDragger extends Blockly.BlockDragger {
     // child drag surface. This makes the block stay under the cursor.
     this.workspace_.getBlockDragSurface().translateBy(-deltaX, -deltaY);
 
+
     // The total amount the block has moved since being picked up.
     const totalDelta =
         Blockly.utils.Coordinate.sum(this.scrollDelta_, this.dragDelta_);
+
+    this.dragIcons_(totalDelta);
 
     // As we scroll, show the insertion markers.
     this.draggedConnectionManager_.update(
@@ -73,53 +76,20 @@ export class ScrollBlockDragger extends Blockly.BlockDragger {
    */
   dragBlock(e, currentDragDeltaXY) {
     const totalDelta =
-        Blockly.utils.Coordinate.sum(this.scrollDelta_, currentDragDeltaXY);
-    super.dragBlock(e, totalDelta);
+    Blockly.utils.Coordinate.sum(this.scrollDelta_, currentDragDeltaXY);
+    console.log(totalDelta);
+    super.dragBlock(e, currentDragDeltaXY);
     this.dragDelta_ = currentDragDeltaXY;
   }
 
-  /** @override */
   endBlockDrag(e, currentDragDeltaXY) {
-    // Make sure internal state is fresh.
-    // TODO: Figure out a way to call super here.
-    this.dragBlock(e, currentDragDeltaXY);
-    this.dragIconData_ = [];
-    this.fireDragEndEvent_();
-
-    Blockly.utils.dom.stopTextWidthCache();
-
-    Blockly.blockAnimations.disconnectUiStop();
-
-    // START CHANGE
-    const totalChange =
-        Blockly.utils.Coordinate.sum(this.scrollDelta_, currentDragDeltaXY);
-    const delta = this.pixelsToWorkspaceUnits_(totalChange);
-    const newLoc = Blockly.utils.Coordinate.sum(this.startXY_, delta);
-    // END CHANGE
-    this.draggingBlock_.moveOffDragSurface(newLoc);
-
-    const deleted = this.maybeDeleteBlock_();
-    if (!deleted) {
-      // These are expensive and don't need to be done if we're deleting.
-      this.draggingBlock_.moveConnections(delta.x, delta.y);
-      this.draggingBlock_.setDragging(false);
-      this.fireMoveEvent_();
-      if (this.draggedConnectionManager_.wouldConnectBlock()) {
-        // Applying connections also rerenders the relevant blocks.
-        this.draggedConnectionManager_.applyConnections();
-      } else {
-        this.draggingBlock_.render();
-      }
-      this.draggingBlock_.scheduleSnapAndBump();
-    }
-    this.workspace_.setResizesEnabled(true);
-
-    const toolbox = this.workspace_.getToolbox();
-    if (toolbox && typeof toolbox.removeStyle == 'function') {
-      const style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
-                                                        'blocklyToolboxGrab';
-      toolbox.removeStyle(style);
-    }
-    Blockly.Events.setGroup(false);
+    super.endBlockDrag(e, currentDragDeltaXY);
+    this.dragDelta_ = currentDragDeltaXY;
   }
+
+//   getDelta_(currentDragDeltaXY) {
+//     const totalDelta =
+//     Blockly.utils.Coordinate.sum(this.scrollDelta_, currentDragDeltaXY);
+//     return this.pixelsToWorkspaceUnits_(totalDelta);
+//   }
 }

--- a/plugins/scroll-options/src/ScrollMetricsManager.js
+++ b/plugins/scroll-options/src/ScrollMetricsManager.js
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// TODO: Edit plugin overview.
+/**
+ * @fileoverview This adds a method to the block dragger to allow a block
+ * to be moved on scroll.
+ */
+
+import * as Blockly from 'blockly/core';
+
+/**
+ * A block dragger that adds the functionality for a block to be moved while
+ * someone is dragging it.
+ */
+export class ScrollMetricsManager extends Blockly.MetricsManager {
+  constructor(workspace) {
+    super(workspace);
+    this.stopCalculating = false;
+  }
+  getMetrics() {
+    const toolboxMetrics = this.getToolboxMetrics();
+    const flyoutMetrics = this.getFlyoutMetrics(true);
+    const svgMetrics = this.getSvgMetrics();
+    const absoluteMetrics = this.getAbsoluteMetrics();
+    const viewMetrics = this.getViewMetrics();
+    if (!this.stopCalculating || !this.contentMetrics) {
+      console.log("CALCULATING");
+      this.contentMetrics = this.getContentMetrics();
+    }
+    const scrollMetrics =
+        this.getScrollMetrics(false, viewMetrics, this.contentMetrics);
+
+    return {
+      contentHeight: this.contentMetrics.height,
+      contentWidth: this.contentMetrics.width,
+      contentTop: this.contentMetrics.top,
+      contentLeft: this.contentMetrics.left,
+
+      scrollHeight: scrollMetrics.height,
+      scrollWidth: scrollMetrics.width,
+      scrollTop: scrollMetrics.top,
+      scrollLeft: scrollMetrics.left,
+      viewHeight: viewMetrics.height,
+      viewWidth: viewMetrics.width,
+      viewTop: viewMetrics.top,
+      viewLeft: viewMetrics.left,
+      absoluteTop: absoluteMetrics.top,
+      absoluteLeft: absoluteMetrics.left,
+      svgHeight: svgMetrics.height,
+      svgWidth: svgMetrics.width,
+      toolboxWidth: toolboxMetrics.width,
+      toolboxHeight: toolboxMetrics.height,
+      toolboxPosition: toolboxMetrics.position,
+      flyoutWidth: flyoutMetrics.width,
+      flyoutHeight: flyoutMetrics.height,
+    };
+  }
+}

--- a/plugins/scroll-options/src/index.js
+++ b/plugins/scroll-options/src/index.js
@@ -33,7 +33,7 @@ export class Plugin {
    */
   init() {
     const dragSurface = this.workspace_.getBlockDragSurface();
-    Blockly.bindEventWithChecks_(
+    Blockly.browserEvents.conditionalBind(
         dragSurface.getSvgRoot(), 'wheel', this, this.onMouseWheel_);
   }
 
@@ -63,16 +63,21 @@ export class Plugin {
 
     // Try to scroll to the desired location.
     this.workspace_.getMetricsManager().stopCalculating = true;
+    const absoluteMetrics =
+        this.workspace_.getMetricsManager().getAbsoluteMetrics();
+
     this.workspace_.scroll(x, y);
+
+    const newLocation = new Blockly.utils.Coordinate(
+        this.workspace_.scrollX + absoluteMetrics.left,
+        this.workspace_.scrollY + absoluteMetrics.top);
     this.workspace_.getMetricsManager().stopCalculating = false;
 
     // Get the new location of the block dragger after scrolling the workspace.
     // TODO: is this more expensive than just calculating ourselves?
-    const newLocation = this.getDragSurfaceLocation_(dragSurface);
-
     // How much we actually ended up scrolling.
-    const deltaX = newLocation.x - oldLocation.x;
-    const deltaY = newLocation.y - oldLocation.y;
+    const deltaX = newLocation.x.toFixed() - oldLocation.x;
+    const deltaY = newLocation.y.toFixed() - oldLocation.y;
 
     if (deltaX || deltaY) {
       // TODO: Can not access private blockDragger.

--- a/plugins/scroll-options/src/index.js
+++ b/plugins/scroll-options/src/index.js
@@ -50,51 +50,44 @@ export class Plugin {
       return;
     }
 
-    const dragSurface = this.workspace_.getBlockDragSurface();
-
-    // The location of the block dragger before we scroll the workspace.
-    // TODO: Should this just be stored on the block drag surface?
-    const oldLocation = this.getDragSurfaceLocation_(dragSurface);
-
     // Figure out the desired location to scroll to.
     const scrollDelta = Blockly.utils.getScrollDeltaPixels(e);
     const x = this.workspace_.scrollX - scrollDelta.x;
     const y = this.workspace_.scrollY - scrollDelta.y;
 
-    // Try to scroll to the desired location.
+    const oldLocation = this.getDragSurfaceLocation_();
+
     this.workspace_.getMetricsManager().stopCalculating = true;
-    const absoluteMetrics =
-        this.workspace_.getMetricsManager().getAbsoluteMetrics();
-
+    // Try to scroll to the desired location.
     this.workspace_.scroll(x, y);
-
-    const newLocation = new Blockly.utils.Coordinate(
-        this.workspace_.scrollX + absoluteMetrics.left,
-        this.workspace_.scrollY + absoluteMetrics.top);
     this.workspace_.getMetricsManager().stopCalculating = false;
 
+    const newLocation = this.getDragSurfaceLocation_();
+
     // Get the new location of the block dragger after scrolling the workspace.
-    // TODO: is this more expensive than just calculating ourselves?
     // How much we actually ended up scrolling.
-    const deltaX = newLocation.x.toFixed() - oldLocation.x;
-    const deltaY = newLocation.y.toFixed() - oldLocation.y;
+    const deltaX = newLocation.x - oldLocation.x;
+    const deltaY = newLocation.y - oldLocation.y;
 
     if (deltaX || deltaY) {
       // TODO: Can not access private blockDragger.
+      // TODO: Update block dragger with better documentation.
       currentGesture.blockDragger_.moveBlockWhileDragging(deltaX, deltaY);
+      // TODO: Is this preventDefault in the correct place?
       e.preventDefault();
     }
   }
 
   /**
    * Gets the current location of the drag surface.
-   * @param {!Blockly.BlockDragSurface} dragSurface The block drag surface.
    * @return {Blockly.utils.Coordinate} The current coordinate.
    * @private
    */
-  getDragSurfaceLocation_(dragSurface) {
+  getDragSurfaceLocation_() {
+    const dragSurface = this.workspace_.getBlockDragSurface();
+    // TODO: Double check that this can not fall out of
     return new Blockly.utils.Coordinate(
-        dragSurface.getGroup().transform.baseVal.consolidate().matrix.e,
-        dragSurface.getGroup().transform.baseVal.consolidate().matrix.f);
+        Math.round(dragSurface.dragSurfaceXY_.x),
+        Math.round(dragSurface.dragSurfaceXY_.y));
   }
 }

--- a/plugins/scroll-options/src/index.js
+++ b/plugins/scroll-options/src/index.js
@@ -49,8 +49,7 @@ export class Plugin {
     // Do not try to scroll if we are not dragging a block, or the workspace
     // does not allow moving by wheel.
     if (!canWheelMove || !currentGesture ||
-        currentGesture.getCurrentDraggingType() !==
-            Blockly.Gesture.DraggingType.BLOCK) {
+        !(currentGesture.isDraggingBlock_)) {
       return;
     }
 
@@ -74,7 +73,7 @@ export class Plugin {
 
     if (deltaX || deltaY) {
       // TODO: Don't like these APIS. Figure out better ones.
-      currentGesture.getCurrentDragger().moveBlockWhileDragging(deltaX, deltaY);
+      currentGesture.blockDragger_.moveBlockWhileDragging(deltaX, deltaY);
       e.preventDefault();
     }
   }
@@ -85,10 +84,8 @@ export class Plugin {
    * @private
    */
   getDragSurfaceLocation_() {
-    const dragSurface = this.workspace_.getBlockDragSurface();
-    const workspaceOffset = dragSurface.getCachedChildOffset();
     // TODO: Double check that this can not fall out of sync.
     return new Blockly.utils.Coordinate(
-        Math.round(workspaceOffset.x), Math.round(workspaceOffset.y));
+        this.workspace_.scrollX + 107, this.workspace_.scrollY);
   }
 }

--- a/plugins/scroll-options/test/index.js
+++ b/plugins/scroll-options/test/index.js
@@ -12,6 +12,7 @@ import * as Blockly from 'blockly';
 import {toolboxCategories, createPlayground} from '@blockly/dev-tools';
 import {Plugin} from '../src/index';
 import {ScrollBlockDragger} from '../src/ScrollBlockDragger';
+import {ScrollMetricsManager} from '../src/ScrollMetricsManager';
 
 
 /**
@@ -35,6 +36,7 @@ document.addEventListener('DOMContentLoaded', function() {
     toolbox: toolboxCategories,
     plugins: {
       'blockDragger': ScrollBlockDragger,
+      'metricsManager': ScrollMetricsManager,
     },
   };
   createPlayground(document.getElementById('root'), createWorkspace,


### PR DESCRIPTION
Stores the drag and scroll delta in the ScrollBlockDragger. We use these values to find the total distance that the block has moved from the original location that it was picked up from. This totalDelta can be used to update the insertion markers and to move the block off of the drag surface.

I am still trying to figure out a better way to add my changes to the `endBlockDrag` method so that we don't have to copy the entire method.

Uses the APIs in google/blockly#4828