### PR TITLE
Adding flyout support for backpack.

### DIFF
--- a/plugins/workspace-backpack/src/backpack_helpers.js
+++ b/plugins/workspace-backpack/src/backpack_helpers.js
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Helper and utility methods for the Backpack plugin.
+ * @author kozbial@google.com (Monica Kozbial)
+ */
+
+import * as Blockly from 'blockly/core';
+
+/**
+ * Creates a backpack flyout.
+ * @param {!Blockly.WorkspaceSvg} targetWorkspace The target workspace for the
+ *    backpack.
+ * @return {!Blockly.IFlyout} The backpack flyout.
+ */
+export function createBackpackFlyout(targetWorkspace) {
+  // Create flyout options.
+  const flyoutWorkspaceOptions = new Blockly.Options(
+      /** @type {!Blockly.BlocklyOptions} */
+      ({
+        'scrollbars': true,
+        'parentWorkspace': targetWorkspace,
+        'rtl': targetWorkspace.RTL,
+        'oneBasedIndex': targetWorkspace.options.oneBasedIndex,
+        'renderer': targetWorkspace.options.renderer,
+        'rendererOverrides': targetWorkspace.options.rendererOverrides,
+        'move': {
+          'scrollbars': true,
+        },
+      }));
+  // Create vertical or horizontal flyout.
+  if (targetWorkspace.horizontalLayout) {
+    flyoutWorkspaceOptions.toolboxPosition =
+        (targetWorkspace.toolboxPosition ===
+            Blockly.utils.toolbox.Position.TOP) ?
+            Blockly.utils.toolbox.Position.BOTTOM :
+            Blockly.utils.toolbox.Position.TOP;
+    const HorizontalFlyout = Blockly.registry.getClassFromOptions(
+        Blockly.registry.Type.FLYOUTS_HORIZONTAL_TOOLBOX,
+        targetWorkspace.options, true);
+    return new HorizontalFlyout(flyoutWorkspaceOptions);
+  }
+  flyoutWorkspaceOptions.toolboxPosition =
+      (targetWorkspace.toolboxPosition ===
+          Blockly.utils.toolbox.Position.RIGHT) ?
+          Blockly.utils.toolbox.Position.LEFT :
+          Blockly.utils.toolbox.Position.RIGHT;
+  const VerticalFlyout = Blockly.registry.getClassFromOptions(
+      Blockly.registry.Type.FLYOUTS_VERTICAL_TOOLBOX,
+      targetWorkspace.options, true);
+  return new VerticalFlyout(flyoutWorkspaceOptions);
+}
+
+/**
+ * Converts XML representing a block into text that can be stored in the
+ *    content array.
+ * @param {!Element} xml An XML tree defining the block and any
+ *    connected child blocks.
+ * @return {string} Text representing the XML tree, cleaned of all unnecessary
+ * attributes.
+ * @private
+ */
+export function cleanBlockXML(xml) {
+  const xmlBlock = xml.cloneNode(true);
+  let node = xmlBlock;
+  while (node) {
+    // Things like text inside tags are still treated as nodes, but they
+    // don't have attributes (or the removeAttribute function) so we can
+    // skip removing attributes from them.
+    if (node.removeAttribute) {
+      node.removeAttribute('x');
+      node.removeAttribute('y');
+      node.removeAttribute('id');
+      node.removeAttribute('disabled');
+      if (node.nodeName == 'comment') { // Future proof just in case.
+        node.removeAttribute('h');
+        node.removeAttribute('w');
+        node.removeAttribute('pinned');
+      }
+    }
+
+    // Try to go down the tree
+    let nextNode = node.firstChild || node.nextSibling;
+    // If we can't go down, try to go back up the tree.
+    if (!nextNode) {
+      nextNode = node.parentNode;
+      while (nextNode) {
+        // We are valid again!
+        if (nextNode.nextSibling) {
+          nextNode = nextNode.nextSibling;
+          break;
+        }
+        // Try going up again. If parentNode is null that means we have
+        // reached the top, and we will break out of both loops.
+        nextNode = nextNode.parentNode;
+      }
+    }
+    node = nextNode;
+  }
+  return Blockly.Xml.domToText(xmlBlock);
+}

--- a/plugins/workspace-backpack/src/backpack_helpers.js
+++ b/plugins/workspace-backpack/src/backpack_helpers.js
@@ -31,7 +31,7 @@ export function cleanBlockXML(xml) {
       node.removeAttribute('y');
       node.removeAttribute('id');
       node.removeAttribute('disabled');
-      if (node.nodeName == 'comment') { // Future proof just in case.
+      if (node.nodeName == 'comment') {
         node.removeAttribute('h');
         node.removeAttribute('w');
         node.removeAttribute('pinned');

--- a/plugins/workspace-backpack/src/backpack_helpers.js
+++ b/plugins/workspace-backpack/src/backpack_helpers.js
@@ -13,12 +13,11 @@ import * as Blockly from 'blockly/core';
 
 /**
  * Converts XML representing a block into text that can be stored in the
- *    content array.
+ * content array.
  * @param {!Element} xml An XML tree defining the block and any
  *    connected child blocks.
  * @return {string} Text representing the XML tree, cleaned of all unnecessary
  * attributes.
- * @private
  */
 export function cleanBlockXML(xml) {
   const xmlBlock = xml.cloneNode(true);

--- a/plugins/workspace-backpack/src/backpack_helpers.js
+++ b/plugins/workspace-backpack/src/backpack_helpers.js
@@ -12,50 +12,6 @@
 import * as Blockly from 'blockly/core';
 
 /**
- * Creates a backpack flyout.
- * @param {!Blockly.WorkspaceSvg} targetWorkspace The target workspace for the
- *    backpack.
- * @return {!Blockly.IFlyout} The backpack flyout.
- */
-export function createBackpackFlyout(targetWorkspace) {
-  // Create flyout options.
-  const flyoutWorkspaceOptions = new Blockly.Options(
-      /** @type {!Blockly.BlocklyOptions} */
-      ({
-        'scrollbars': true,
-        'parentWorkspace': targetWorkspace,
-        'rtl': targetWorkspace.RTL,
-        'oneBasedIndex': targetWorkspace.options.oneBasedIndex,
-        'renderer': targetWorkspace.options.renderer,
-        'rendererOverrides': targetWorkspace.options.rendererOverrides,
-        'move': {
-          'scrollbars': true,
-        },
-      }));
-  // Create vertical or horizontal flyout.
-  if (targetWorkspace.horizontalLayout) {
-    flyoutWorkspaceOptions.toolboxPosition =
-        (targetWorkspace.toolboxPosition ===
-            Blockly.utils.toolbox.Position.TOP) ?
-            Blockly.utils.toolbox.Position.BOTTOM :
-            Blockly.utils.toolbox.Position.TOP;
-    const HorizontalFlyout = Blockly.registry.getClassFromOptions(
-        Blockly.registry.Type.FLYOUTS_HORIZONTAL_TOOLBOX,
-        targetWorkspace.options, true);
-    return new HorizontalFlyout(flyoutWorkspaceOptions);
-  }
-  flyoutWorkspaceOptions.toolboxPosition =
-      (targetWorkspace.toolboxPosition ===
-          Blockly.utils.toolbox.Position.RIGHT) ?
-          Blockly.utils.toolbox.Position.LEFT :
-          Blockly.utils.toolbox.Position.RIGHT;
-  const VerticalFlyout = Blockly.registry.getClassFromOptions(
-      Blockly.registry.Type.FLYOUTS_VERTICAL_TOOLBOX,
-      targetWorkspace.options, true);
-  return new VerticalFlyout(flyoutWorkspaceOptions);
-}
-
-/**
  * Converts XML representing a block into text that can be stored in the
  *    content array.
  * @param {!Element} xml An XML tree defining the block and any

--- a/plugins/workspace-backpack/src/backpack_monkey_patch.js
+++ b/plugins/workspace-backpack/src/backpack_monkey_patch.js
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview A monkeypatch in Blockly to support a backpack.
+ * @author kozbial@google.com (Monica Kozbial)
+ */
+import * as Blockly from 'blockly/core';
+
+
+// TODO: No way to do this currently without monkeypatching Blockly.
+(() => {
+  /* eslint-disable no-import-assign */
+  /**
+   * Close tooltips, context menus, dropdown selections, etc.
+   * @param {boolean=} opt_allowToolbox If true, don't close the toolbox.
+   */
+  Blockly.hideChaff = function(opt_allowToolbox) {
+    Blockly.Tooltip.hide();
+    Blockly.WidgetDiv.hide();
+    Blockly.DropDownDiv.hideWithoutAnimation();
+    if (!opt_allowToolbox) {
+      const workspace = Blockly.getMainWorkspace();
+      // For now the trashcan flyout always autocloses because it overlays the
+      // trashcan UI (no trashcan to click to close it).
+      if (workspace.trashcan &&
+          workspace.trashcan.flyout) {
+        workspace.trashcan.closeFlyout();
+      }
+      const toolbox = workspace.getToolbox();
+      if (toolbox &&
+          toolbox.getFlyout() &&
+          toolbox.getFlyout().autoClose) {
+        toolbox.clearSelection();
+      }
+      if (workspace.backpack) {
+        workspace.backpack.close();
+      }
+    }
+  };
+
+  /**
+   * Update the cursor (and possibly the trash can lid) to reflect whether the
+   * dragging block would be deleted if released immediately.
+   * @private
+   */
+  Blockly.BlockDragger.prototype.updateCursorDuringBlockDrag_ = function() {
+    this.wouldDeleteBlock_ = this.draggedConnectionManager_.wouldDeleteBlock();
+    const trashcan = this.workspace_.trashcan;
+    if (this.wouldDeleteBlock_) {
+      this.draggingBlock_.setDeleteStyle(true);
+      if (this.deleteArea_ == Blockly.DELETE_AREA_TRASH && trashcan) {
+        trashcan.setLidOpen(true);
+      }
+    } else {
+      this.draggingBlock_.setDeleteStyle(false);
+      if (trashcan) {
+        trashcan.setLidOpen(false);
+      }
+    }
+    // start monkeypatch edit
+    if (this.isOverBackpack_) {
+      this.workspace_.backpack.onDragOver_();
+    } else {
+      this.workspace_.backpack.onDragExit_();
+    }
+    // end Monkeypatch edit
+  };
+
+  /**
+   * Execute a step of block dragging, based on the given event.  Update the
+   * display accordingly.
+   * @param {!Event} e The most recent move event.
+   * @param {!Blockly.utils.Coordinate} currentDragDeltaXY How far the pointer
+   *     has moved from the position at the start of the drag, in pixel units.
+   * @package
+   */
+  Blockly.BlockDragger.prototype.dragBlock = function(e, currentDragDeltaXY) {
+    const delta = this.pixelsToWorkspaceUnits_(currentDragDeltaXY);
+    const newLoc = Blockly.utils.Coordinate.sum(this.startXY_, delta);
+
+    this.draggingBlock_.moveDuringDrag(newLoc);
+    this.dragIcons_(delta);
+
+    // start monkeypatch edit
+    if (this.workspace_.backpack &&
+        this.workspace_.backpack.getTargetArea()
+            .contains(e.clientX, e.clientY)) {
+      this.isOverBackpack_ = true;
+      this.deleteArea_ = Blockly.DELETE_AREA_NONE;
+    } else {
+      this.isOverBackpack_ = false;
+      this.deleteArea_ = this.workspace_.isDeleteArea(e);
+    }
+    // end Monkeypatch edit
+
+    this.draggedConnectionManager_.update(delta, this.deleteArea_);
+
+    this.updateCursorDuringBlockDrag_();
+  };
+
+  /**
+   * Finish a block drag and put the block back on the workspace.
+   * @param {!Event} e The mouseup/touchend event.
+   * @param {!Blockly.utils.Coordinate} currentDragDeltaXY How far the pointer
+   *     has moved from the position at the start of the drag, in pixel units.
+   * @package
+   */
+  Blockly.BlockDragger.prototype.endBlockDrag = function(
+      e, currentDragDeltaXY) {
+    // Make sure internal state is fresh.
+    this.dragBlock(e, currentDragDeltaXY);
+    this.dragIconData_ = [];
+    this.fireDragEndEvent_();
+
+    Blockly.utils.dom.stopTextWidthCache();
+
+    Blockly.blockAnimations.disconnectUiStop();
+
+    // start monkeypatch edit
+    const delta = this.pixelsToWorkspaceUnits_(currentDragDeltaXY);
+    const newLoc = this.isOverBackpack_ ?
+        this.startXY_ : Blockly.utils.Coordinate.sum(this.startXY_, delta);
+    this.draggingBlock_.moveOffDragSurface(newLoc);
+
+    if (this.isOverBackpack_) {
+      // Handle adding to Backpack
+      const blockXml = Blockly.Xml.blockToDomWithXY(this.draggingBlock_);
+      const backpack = this.workspace_.backpack;
+      backpack.addItem(blockXml);
+      this.draggingBlock_.setDragging(false);
+      this.draggingBlock_.render();
+      this.draggingBlock_.scheduleSnapAndBump();
+    } else if (!this.maybeDeleteBlock_()) {
+      // These are expensive and don't need to be done if we're deleting.
+      this.draggingBlock_.moveConnections(delta.x, delta.y);
+      this.draggingBlock_.setDragging(false);
+      this.fireMoveEvent_();
+      if (this.draggedConnectionManager_.wouldConnectBlock()) {
+        // Applying connections also rerenders the relevant blocks.
+        this.draggedConnectionManager_.applyConnections();
+      } else {
+        this.draggingBlock_.render();
+      }
+      this.draggingBlock_.scheduleSnapAndBump();
+    }
+    // end monkeypatch edit
+
+    this.workspace_.setResizesEnabled(true);
+
+    let toolbox = this.workspace_.getToolbox();
+    let style;
+    if (toolbox && typeof toolbox.removeStyle == 'function') {
+      style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
+          'blocklyToolboxGrab';
+      toolbox.removeStyle(style);
+    }
+    this.workspace_.setResizesEnabled(true);
+
+    toolbox = this.workspace_.getToolbox();
+    if (toolbox && typeof toolbox.removeStyle == 'function') {
+      style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
+          'blocklyToolboxGrab';
+      toolbox.removeStyle(style);
+    }
+    Blockly.Events.setGroup(false);
+  };
+  /* eslint-enable no-import-assign */
+})();

--- a/plugins/workspace-backpack/src/backpack_monkey_patch.js
+++ b/plugins/workspace-backpack/src/backpack_monkey_patch.js
@@ -128,9 +128,8 @@ import * as Blockly from 'blockly/core';
 
     if (this.isOverBackpack_) {
       // Handle adding to Backpack
-      const blockXml = Blockly.Xml.blockToDomWithXY(this.draggingBlock_);
       const backpack = this.workspace_.backpack;
-      backpack.addItem(blockXml);
+      backpack.handleBlockDrop(this.draggingBlock_);
       this.draggingBlock_.setDragging(false);
       this.draggingBlock_.render();
       this.draggingBlock_.scheduleSnapAndBump();

--- a/plugins/workspace-backpack/src/backpack_monkey_patch.js
+++ b/plugins/workspace-backpack/src/backpack_monkey_patch.js
@@ -131,8 +131,12 @@ import * as Blockly from 'blockly/core';
       const backpack = this.workspace_.backpack;
       backpack.handleBlockDrop(this.draggingBlock_);
       this.draggingBlock_.setDragging(false);
+      // Blocks dragged directly from a flyout may need to be bumped.
+      Blockly.bumpObjectIntoBounds_(
+          this.draggingBlock_.workspace,
+          this.workspace_.getMetricsManager()
+              .getScrollMetrics(true), this.draggingBlock_);
       this.draggingBlock_.render();
-      this.draggingBlock_.scheduleSnapAndBump();
     } else if (!this.maybeDeleteBlock_()) {
       // These are expensive and don't need to be done if we're deleting.
       this.draggingBlock_.moveConnections(delta.x, delta.y);

--- a/plugins/workspace-backpack/src/backpack_monkey_patch.js
+++ b/plugins/workspace-backpack/src/backpack_monkey_patch.js
@@ -154,18 +154,9 @@ import * as Blockly from 'blockly/core';
 
     this.workspace_.setResizesEnabled(true);
 
-    let toolbox = this.workspace_.getToolbox();
-    let style;
+    const toolbox = this.workspace_.getToolbox();
     if (toolbox && typeof toolbox.removeStyle == 'function') {
-      style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
-          'blocklyToolboxGrab';
-      toolbox.removeStyle(style);
-    }
-    this.workspace_.setResizesEnabled(true);
-
-    toolbox = this.workspace_.getToolbox();
-    if (toolbox && typeof toolbox.removeStyle == 'function') {
-      style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
+      const style = this.draggingBlock_.isDeletable() ? 'blocklyToolboxDelete' :
           'blocklyToolboxGrab';
       toolbox.removeStyle(style);
     }

--- a/plugins/workspace-backpack/src/backpack_monkey_patch.js
+++ b/plugins/workspace-backpack/src/backpack_monkey_patch.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/workspace-backpack/src/index.js
+++ b/plugins/workspace-backpack/src/index.js
@@ -273,9 +273,9 @@ export class Backpack {
     this.addEvent_(
         this.svgGroup_, 'mouseup', this, this.onClick_);
     this.addEvent_(
-        this.svgGroup_, 'mouseover', this, this.onDragOver_);
+        this.svgGroup_, 'mouseover', this, this.onDragEnter);
     this.addEvent_(
-        this.svgGroup_, 'mouseout', this, this.onDragExit_);
+        this.svgGroup_, 'mouseout', this, this.onDragExit);
   }
 
   /**
@@ -523,18 +523,16 @@ export class Backpack {
 
   /**
    * Handle mouse over.
-   * @protected
    */
-  onDragOver_() {
+  onDragEnter() {
     Blockly.utils.dom.addClass(
         /** @type {!SVGElement} */ (this.svgImg_), 'blocklyBackpackDarken');
   }
 
   /**
    * Handle mouse exit.
-   * @protected
    */
-  onDragExit_() {
+  onDragExit() {
     Blockly.utils.dom.removeClass(
         /** @type {!SVGElement} */ (this.svgImg_), 'blocklyBackpackDarken');
   }

--- a/plugins/workspace-backpack/src/index.js
+++ b/plugins/workspace-backpack/src/index.js
@@ -415,9 +415,11 @@ export class Backpack {
    */
   setContents(contents) {
     this.contents_.length = 0;
-    contents.forEach((item) => {
-      this.addItem(item);
-    });
+    this.contents_ = [...contents];
+    while (this.contents_.length > this.maxItems_) {
+      this.contents_.pop();
+    }
+    // TODO: Fire UI event for Backpack content change.
   }
 
   /**

--- a/plugins/workspace-backpack/src/index.js
+++ b/plugins/workspace-backpack/src/index.js
@@ -14,7 +14,8 @@ import {createBackpackFlyout, cleanBlockXML} from './backpack_helpers';
 import './backpack_monkey_patch';
 
 /**
- * Class for backpack.
+ * Class for backpack that can be used save blocks from the workspace for
+ * future use.
  * @param {!Blockly.WorkspaceSvg} workspace The workspace to sit in.
  * @implements {Blockly.IPositionable}
  */
@@ -355,7 +356,7 @@ export class Backpack {
 
   /**
    * Returns the count of items in the backpack.
-   * @return {number} The count.
+   * @return {number} The count of items.
    */
   getCount() {
     return this.contents_.length;
@@ -388,14 +389,14 @@ export class Backpack {
    * @param {!Blockly.BlockSvg} block The block being dropped on the backpack.
    */
   handleBlockDrop(block) {
-    const blockXml = Blockly.Xml.blockToDomWithXY(block);
+    const blockXml = Blockly.Xml.blockToDom(block);
     this.addItem(cleanBlockXML(blockXml));
   }
 
   /**
    * Adds item to backpack.
    * @param {string} item Text representing the XML tree of a block to add,
-   * cleaned of all unnecessary attributes.
+   *     cleaned of all unnecessary attributes.
    */
   addItem(item) {
     if (this.contents_.indexOf(item) !== -1) {
@@ -414,7 +415,6 @@ export class Backpack {
    * @param {!Array<string>} contents The new backpack contents.
    */
   setContents(contents) {
-    this.contents_.length = 0;
     this.contents_ = [...contents];
     while (this.contents_.length > this.maxItems_) {
       this.contents_.pop();
@@ -437,8 +437,8 @@ export class Backpack {
    * @return {boolean} Whether the backpack is open-able.
    * @private
    */
-  isOpenable() {
-    return this.isOpen() && !!this.getCount();
+  isOpenable_() {
+    return !this.isOpen();
   }
 
   /**
@@ -453,7 +453,7 @@ export class Backpack {
    * Opens the backpack flyout.
    */
   open() {
-    if (this.isOpenable()) {
+    if (!this.isOpenable_()) {
       return;
     }
     const xml = this.contents_.map((text) => Blockly.Xml.textToDom(text));
@@ -508,7 +508,7 @@ export class Backpack {
    * @protected
    */
   blockMouseDownWhenOpenable_(e) {
-    if (this.isOpenable()) {
+    if (this.isOpenable_()) {
       e.stopPropagation(); // Don't start a workspace scroll.
     }
   }

--- a/plugins/workspace-backpack/src/index.js
+++ b/plugins/workspace-backpack/src/index.js
@@ -142,12 +142,14 @@ export class Backpack {
 
     /**
      * The maximum items that can be stored on the backpack.
+     * @type {number}
+     * @private
      */
     this.maxItems_ = 32;
 
     /**
      * The backpack flyout. Initialized during init.
-     * @type {Blockly.IFlyout|undefined}
+     * @type {!Blockly.IFlyout|undefined}
      * @package
      */
     this.flyout = undefined;

--- a/plugins/workspace-backpack/src/index.js
+++ b/plugins/workspace-backpack/src/index.js
@@ -150,7 +150,7 @@ export class Backpack {
     /**
      * The backpack flyout. Initialized during init.
      * @type {!Blockly.IFlyout|undefined}
-     * @package
+     * @protected
      */
     this.flyout = undefined;
   }


### PR DESCRIPTION
### Description
- Darkens backpack when stack of blocks is dragged over it (previously button did not change if mouse was dragging a stack of blocks)
- Adds flyout to Backpack that opens when the backpack button is clicked
- Adds block stack to backpack flyout if dropped on button 
  - returns position of stack back to the start of the drag
  - ignores duplicate blocks

#### Screenshots
![61624897-429c-4b7d-941e-66ce3cf83d47 (2)](https://user-images.githubusercontent.com/6621618/118339462-c452fb00-b4cd-11eb-9482-47c7b50cff12.gif)


### Additional Information
Merges into `backpack` branch rather than `master` as the plugin is under development