### PR TITLE
Use npm ci for release tasks

### DIFF
--- a/gh-pages/README.md
+++ b/gh-pages/README.md
@@ -31,7 +31,21 @@ cd ..
 npm run deploy:prepare
 ```
 
-This runs `install` for all of the plugins and all of the examples, then runs the `deploy:prepare` script to copy over built files into the gh-pages directory. 
+This runs `install` for all of the plugins and all of the examples, then runs the `deploy:prepare` script to copy over built files into the gh-pages directory.
+
+### Test locally with beta
+
+From the root directory run:
+
+```
+npm install
+cd examples && npm install
+cd ..
+# This copies necessary files to gh-pages folder. This is necessary to run gh-pages locally.
+npm run test:ghpages
+```
+
+This runs `install` for all of the plugins and all of the examples, then directly installs the current beta release of Blockly, then runs the `deploy:prepare` script to copy over built files into the gh-pages directory.
 
 ### Serve
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,9 +78,9 @@ function publish(dryRun, force) {
         `git clone https://github.com/google/blockly-samples ${releaseDir}`,
         {stdio: 'pipe'});
 
-    // Run npm install.
-    console.log('Running npm install.');
-    execSync(`npm install`, {cwd: releaseDir, stdio: 'inherit'});
+    // Run npm ci.
+    console.log('Running npm ci to install.');
+    execSync(`npm ci`, {cwd: releaseDir, stdio: 'inherit'});
 
     // Run npm publish.
     execSync(
@@ -270,7 +270,9 @@ function deployToGhPages(repo) {
  * @param {Function} done Completed callback.
  */
 function preparePluginsForBeta(done) {
-  execSync(`npm install`, {stdio: 'inherit'});
+  // Install with npm ci, which will not update package-locks.
+  execSync(`npm ci`, {stdio: 'inherit'});
+  // npm ci cannot install individual packages.
   execSync(`lerna exec -- npm install blockly@beta`, {stdio: 'inherit'});
   execSync(`npm run boot`, {stdio: 'inherit'});
   execSync(`npm run deploy:prepare:plugins`, {stdio: 'inherit'});
@@ -283,7 +285,9 @@ function preparePluginsForBeta(done) {
  */
 function prepareExamplesForBeta(done) {
   const examplesDirectory = 'examples';
-  execSync(`npm install`, {cwd: examplesDirectory, stdio: 'inherit'});
+  // Install with npm ci, which will not update package-locks.
+  execSync(`npm ci`, {cwd: examplesDirectory, stdio: 'inherit'});
+  // npm ci cannot install individual packages.
   execSync(`lerna exec -- npm install blockly@beta`,
       {cwd: examplesDirectory, stdio: 'inherit'});
   execSync(`npm run boot`, {cwd: examplesDirectory, stdio: 'inherit'});


### PR DESCRIPTION
Use `npm ci` instead of `npm install` for publish and beta test tasks.

(I think) fixes #632.

Note: The beta test tasks (`preparePluginsForBeta` and `prepareExamplesForBeta`) both install and do `deploy:prepare`, so I swapped them to use `npm ci`. The deploy tasks for actually deploying to personal gh-pages or upstream gh-pages don't do the installations at all. For consistency we should add another wrapper that does the installation.

