### PR TITLE
Solve Custom fields in React demo are marked as EDITABLE but not also SERIALIZABLE warning

### DIFF
--- a/examples/blockly-react/src/fields/BlocklyReactField.jsx
+++ b/examples/blockly-react/src/fields/BlocklyReactField.jsx
@@ -31,6 +31,8 @@ import * as Blockly from 'blockly/core';
 
 class BlocklyReactField extends Blockly.Field {
 
+  SERIALIZABLE = true
+  
   static fromJson(options) {
     return new BlocklyReactField(options['text']);
   }


### PR DESCRIPTION
Added `SERIALIZABLE = true` to the class definition

Fixes #607 