### PR TITLE
Update continuous-toolbox readme

### DIFF
--- a/plugins/continuous-toolbox/README.md
+++ b/plugins/continuous-toolbox/README.md
@@ -18,19 +18,20 @@ npm install @blockly/continuous-toolbox --save
 ```
 
 ## Usage
-Simply include both the toolbox and flyout classes from the plugin in the options struct used when injecting Blockly. This style of flyout works best with a toolbox definition that does not use collapsible categories.
+Include the toolbox, flyout, and metrics manager classes from the plugin in the options struct used when injecting Blockly. This style of flyout works best with a toolbox definition that does not use collapsible categories.
 
 Note that this plugin uses APIs introduced in the `3.20200924.3` release of Blockly, so you will need to use at least this version or higher.
 
 ```js
 import * as Blockly from 'blockly';
-import {ContinuousToolbox, ContinuousFlyout} from '@blockly/continuous-toolbox';
+import {ContinuousToolbox, ContinuousFlyout, ContinuousMetrics} from '@blockly/continuous-toolbox';
 
 // Inject Blockly.
 const workspace = Blockly.inject('blocklyDiv', {
   plugins: {
       'toolbox': ContinuousToolbox,
       'flyoutsVerticalToolbox': ContinuousFlyout,
+      'metricsManager': ContinuousMetrics,
     },
   toolbox: toolboxCategories,
   // ... your other options here ...


### PR DESCRIPTION
Update Readme to include instructions for including the MetricsManager class in the plugin options.