### PR TITLE
Add context menus for backpack.

### DIFF
--- a/plugins/workspace-backpack/README.md
+++ b/plugins/workspace-backpack/README.md
@@ -37,8 +37,8 @@ can be translated by assigning the following properties of Blockly.Msg
 - `EMPTY_BACKPACK` (Default: "Empty") context menu - Empty the backpack.
 - `REMOVE_FROM_BACKPACK` (Default: "Remove from Backpack") context menu - Remove
 the selected Block from the backpack.
-- `COPY_TO_BACKPACK` (Default: "Add to Backpack") context menu - Add the
-selected block to the backpack.
+- `COPY_TO_BACKPACK` (Default: "Copy to Backpack") context menu - Copy the
+selected Block to the backpack.
 - `COPY_ALL_TO_BACKPACK` (Default: "Copy All Blocks to Backpack") Context menu -
 copy all Blocks on the workspace to the backpack.
 - `PASTE_ALL_FROM_BACKPACK` (Default: "Paste All Blocks from Backpack") context

--- a/plugins/workspace-backpack/README.md
+++ b/plugins/workspace-backpack/README.md
@@ -30,15 +30,49 @@ const backpack = new Backpack(workspace);
 backpack.init();
 ```
 
+### Blockly Languages
+We do not currently support translating the text in this plugin to different
+languages. However, if you would like to support multiple languages the messages
+can be translated by assigning the following properties of Blockly.Msg
+- `EMPTY_BACKPACK` (Default: "Empty") context menu - Empty the backpack.
+- `REMOVE_FROM_BACKPACK` (Default: "Remove from Backpack") context menu - Remove
+the selected Block from the backpack.
+- `COPY_TO_BACKPACK` (Default: "Add to Backpack") context menu - Add the
+selected block to the backpack.
+- `COPY_ALL_TO_BACKPACK` (Default: "Copy All Blocks to Backpack") Context menu -
+copy all Blocks on the workspace to the backpack.
+- `PASTE_ALL_FROM_BACKPACK` (Default: "Paste All Blocks from Backpack") context
+menu - Paste all Blocks from the backpack to the workspace.
+
+```javascript
+Blockly.Msg['EMPTY_BACKPACK'] = 'Opróżnij plecak';  // Polish 
+// Inject workspace, etc...
+```
+
 ## API
 
 - `init`: Initializes the backpack.
 - `dispose`: Disposes of backpack.
+
+- `isOpen`: Returns whether the backpack is open.
+- `open`: Opens the backpack flyout.
+- `close`: Closes the backpack flyout.
+
+- `getCount`: Returns the count of items in the backpack.
+- `getContents` Returns backpack contents.
+- `empty`: Empties the backpack's contents. If the contents-flyout is currently
+open it will be closed.
+- `addItem`: Adds item to backpack.
+- `deleteItem`: Deletes item from the backpack.
+- `setContents`: Sets backpack contents.
+
+- `handleBlockDrop`: Handles a block drop on this backpack.
+- `onDragEnter`: Handle mouse over.
+- `onDragExit`: Handle mouse exit.
+
 - `getBoundingRectangle`: Returns the bounding rectangle of the UI element in
 pixel units relative to the Blockly injection div.
 - `position`: Positions the backpack UI element.
-- `open`: Opens the backpack flyout.
-- `close`: Closes the backpack flyout.
 
 ## License
 Apache 2.0

--- a/plugins/workspace-backpack/README.md
+++ b/plugins/workspace-backpack/README.md
@@ -74,5 +74,21 @@ open it will be closed.
 pixel units relative to the Blockly injection div.
 - `position`: Positions the backpack UI element.
 
+## Compatibility
+This plugin registers a custom context menu by overriding
+`Blockly.configureContextMenu` in `init` in order to support the context menu
+for emptying the Backpack.
+If you also override `Blockly.configureContextMenu` after initializing this
+plugin, you must also call the old `Blockly.configureContextMenu` function.
+Example:
+```
+const prevConfigureContextMenu = workspace.configureContextMenu;
+workspace.configureContextMenu = (menuOptions, e) => {
+  prevConfigureContextMenu &&
+      prevConfigureContextMenu.call(null, menuOptions, e);
+  ...
+}      
+```
+
 ## License
 Apache 2.0

--- a/plugins/workspace-backpack/README.md
+++ b/plugins/workspace-backpack/README.md
@@ -54,17 +54,20 @@ Blockly.Msg['EMPTY_BACKPACK'] = 'Opróżnij plecak';  // Polish
 - `init`: Initializes the backpack.
 - `dispose`: Disposes of backpack.
 
-- `isOpen`: Returns whether the backpack is open.
-- `open`: Opens the backpack flyout.
-- `close`: Closes the backpack flyout.
-
 - `getCount`: Returns the count of items in the backpack.
 - `getContents` Returns backpack contents.
 - `empty`: Empties the backpack's contents. If the contents-flyout is currently
 open it will be closed.
+- `addBlock`: Adds Block to backpack.
+- `addBlocks`: Adds Blocks to backpack.
+- `removeBlock`: Removes Block to backpack.
 - `addItem`: Adds item to backpack.
-- `deleteItem`: Deletes item from the backpack.
+- `removeItem`: Removes item from the backpack.
 - `setContents`: Sets backpack contents.
+
+- `isOpen`: Returns whether the backpack is open.
+- `open`: Opens the backpack flyout.
+- `close`: Closes the backpack flyout.
 
 - `handleBlockDrop`: Handles a block drop on this backpack.
 - `onDragEnter`: Handle mouse over.
@@ -75,6 +78,11 @@ pixel units relative to the Blockly injection div.
 - `position`: Positions the backpack UI element.
 
 ## Compatibility
+
+### Multiple Backpacks per Workspace
+This plugin also currently only supports one Backpack per Workspace.
+
+### Blockly.configureContextMenu
 This plugin registers a custom context menu by overriding
 `Blockly.configureContextMenu` in `init` in order to support the context menu
 for emptying the Backpack.
@@ -90,7 +98,12 @@ workspace.configureContextMenu = (menuOptions, e) => {
 }      
 ```
 
-This plugin also currently only supports one Backpack per Workspace.
+### Backpack Flyout
+The Backpack Flyout uses the registered Flyout for either
+`Blockly.registry.Type.FLYOUTS_HORIZONTAL_TOOLBOX` or
+`Blockly.registry.Type.FLYOUTS_VERTICAL_TOOLBOX`, similar to the implementation
+for `Blockly.Trashcan`. If a custom class is registered for either of these
+types, then the Backpack Flyout may need to be tested for compatibility.
 
 ## License
 Apache 2.0

--- a/plugins/workspace-backpack/README.md
+++ b/plugins/workspace-backpack/README.md
@@ -90,5 +90,7 @@ workspace.configureContextMenu = (menuOptions, e) => {
 }      
 ```
 
+This plugin also currently only supports one Backpack per Workspace.
+
 ## License
 Apache 2.0

--- a/plugins/workspace-backpack/src/backpack_helpers.js
+++ b/plugins/workspace-backpack/src/backpack_helpers.js
@@ -48,7 +48,6 @@ function registerRemoveFromBackpack() {
         /** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
       const ws = scope.block.workspace;
       if (ws.isFlyout && ws.targetWorkspace && !! ws.targetWorkspace.backpack) {
-        // If this is a flyout for a targetWorkpace with a backpack.
         const backpack = ws.targetWorkspace.backpack;
         if (backpack.getFlyout().getWorkspace().id === ws.id) {
           return 'enabled';

--- a/plugins/workspace-backpack/src/backpack_helpers.js
+++ b/plugins/workspace-backpack/src/backpack_helpers.js
@@ -18,9 +18,12 @@ import './msg';
  *   context menu option on.
  */
 function registerEmptyBackpack(workspace) {
+  const prevConfigureContextMenu = workspace.configureContextMenu;
   workspace.configureContextMenu = (menuOptions, e) => {
     const backpack = workspace.backpack;
     if (!backpack || !backpack.getTargetArea().contains(e.clientX, e.clientY)) {
+      prevConfigureContextMenu &&
+      prevConfigureContextMenu.call(null, menuOptions, e);
       return;
     }
     menuOptions.length = 0;

--- a/plugins/workspace-backpack/src/backpack_helpers.js
+++ b/plugins/workspace-backpack/src/backpack_helpers.js
@@ -47,8 +47,12 @@ function registerRemoveFromBackpack() {
     preconditionFn: function(
         /** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
       const ws = scope.block.workspace;
-      if (ws.isFlyout && ws.targetWorkspace && !!ws.targetWorkspace.backpack) {
-        return 'enabled';
+      if (ws.isFlyout && ws.targetWorkspace && !! ws.targetWorkspace.backpack) {
+        // If this is a flyout for a targetWorkpace with a backpack.
+        const backpack = ws.targetWorkspace.backpack;
+        if (backpack.getFlyout().getWorkspace().id === ws.id) {
+          return 'enabled';
+        }
       }
       return 'hidden';
     },

--- a/plugins/workspace-backpack/src/backpack_helpers.js
+++ b/plugins/workspace-backpack/src/backpack_helpers.js
@@ -58,8 +58,7 @@ function registerRemoveFromBackpack() {
     callback: function(
         /** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
       const backpack = scope.block.workspace.targetWorkspace.backpack;
-      const blockXml = Blockly.Xml.blockToDomWithXY(scope.block);
-      backpack.deleteItem(cleanBlockXML(blockXml));
+      backpack.removeBlock(scope.block);
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
     id: 'remove_from_backpack',
@@ -86,15 +85,14 @@ function registerAddToBackpack() {
         /** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
       const ws = scope.block.workspace;
       if (!ws.isFlyout && !!ws.backpack) {
-        return 'enabled';
+        return ws.backpack.containsBlock(scope.block) ? 'disabled' : 'enabled';
       }
       return 'hidden';
     },
     callback: function(
         /** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
       const backpack = scope.block.workspace.backpack;
-      const blockXml = Blockly.Xml.blockToDomWithXY(scope.block);
-      backpack.addItem(cleanBlockXML(blockXml));
+      backpack.addBlock(scope.block);
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
     id: 'copy_to_backpack',
@@ -122,10 +120,7 @@ function registerCopyPasteAllBackpack() {
         /** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
       const ws = scope.workspace;
       const topBlocks = ws.getTopBlocks();
-      topBlocks.forEach((block) => {
-        ws.backpack.addItem(
-            cleanBlockXML(Blockly.Xml.blockToDomWithXY(block)));
-      });
+      topBlocks.forEach((block) => ws.backpack.addBlock(block));
       // TODO: Fire UI event for Backpack content change.
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,

--- a/plugins/workspace-backpack/src/index.js
+++ b/plugins/workspace-backpack/src/index.js
@@ -236,7 +236,7 @@ export class Backpack {
   }
 
   /**
-   * Creates DOM for ui element.
+   * Creates DOM for ui element and attaches event listeners.
    * @protected
    */
   createDom_() {
@@ -439,8 +439,44 @@ export class Backpack {
    * @param {!Blockly.BlockSvg} block The block being dropped on the backpack.
    */
   handleBlockDrop(block) {
-    const blockXml = Blockly.Xml.blockToDom(block);
-    this.addItem(cleanBlockXML(blockXml));
+    this.addBlock(block);
+  }
+
+  /**
+   * Converts the provided block into a cleaned XML string.
+   * @param {!Blockly.Block} block Block to convert.
+   * @return {string} The cleaned XML string.
+   * @private
+   */
+  blockToCleanXmlString_(block) {
+    return cleanBlockXML(Blockly.Xml.blockToDom(block));
+  }
+
+  /**
+   * Returns whether the backpack contains a duplicate of the provided Block.
+   * @param {!Blockly.Block} block Block to check.
+   * @return {boolean} Whether the backpack contains a duplicate of the provided
+   *     Block.
+   */
+  containsBlock(block) {
+    const cleanedBlockXml = this.blockToCleanXmlString_(block);
+    return this.contents_.indexOf(cleanedBlockXml) !== -1;
+  }
+
+  /**
+   * Adds Block to backpack.
+   * @param {!Blockly.Block} block Block to be added to the backpack.
+   */
+  addBlock(block) {
+    this.addItem(this.blockToCleanXmlString_(block));
+  }
+
+  /**
+   * Removes Block from the backpack.
+   * @param {!Blockly.Block} block Block to be removed from the backpack.
+   */
+  removeBlock(block) {
+    this.removeItem(this.blockToCleanXmlString_(block));
   }
 
   /**
@@ -461,11 +497,11 @@ export class Backpack {
   }
 
   /**
-   * Deletes item from the backpack.
+   * Removes item from the backpack.
    * @param {string} item Text representing the XML tree of a block to remove,
    * cleaned of all unnecessary attributes.
    */
-  deleteItem(item) {
+  removeItem(item) {
     const itemIndex = this.contents_.indexOf(item);
     if (itemIndex !== -1) {
       this.contents_.splice(itemIndex, 1);

--- a/plugins/workspace-backpack/src/index.js
+++ b/plugins/workspace-backpack/src/index.js
@@ -149,10 +149,10 @@ export class Backpack {
 
     /**
      * The backpack flyout. Initialized during init.
-     * @type {!Blockly.IFlyout|undefined}
+     * @type {?Blockly.IFlyout}
      * @protected
      */
-    this.flyout = undefined;
+    this.flyout_ = null;
   }
 
   /**
@@ -217,7 +217,7 @@ export class Backpack {
       const HorizontalFlyout = Blockly.registry.getClassFromOptions(
           Blockly.registry.Type.FLYOUTS_HORIZONTAL_TOOLBOX,
           this.workspace_.options, true);
-      this.flyout = new HorizontalFlyout(flyoutWorkspaceOptions);
+      this.flyout_ = new HorizontalFlyout(flyoutWorkspaceOptions);
     } else {
       flyoutWorkspaceOptions.toolboxPosition =
           (this.workspace_.toolboxPosition ===
@@ -227,12 +227,12 @@ export class Backpack {
       const VerticalFlyout = Blockly.registry.getClassFromOptions(
           Blockly.registry.Type.FLYOUTS_VERTICAL_TOOLBOX,
           this.workspace_.options, true);
-      this.flyout = new VerticalFlyout(flyoutWorkspaceOptions);
+      this.flyout_ = new VerticalFlyout(flyoutWorkspaceOptions);
     }
     // Add flyout to DOM.
     const parentNode = this.workspace_.getParentSvg().parentNode;
-    parentNode.appendChild(this.flyout.createDom(Blockly.utils.Svg.SVG));
-    this.flyout.init(this.workspace_);
+    parentNode.appendChild(this.flyout_.createDom(Blockly.utils.Svg.SVG));
+    this.flyout_.init(this.workspace_);
   }
 
   /**
@@ -297,6 +297,15 @@ export class Backpack {
     // See #4303
     const event = Blockly.bindEvent_(node, name, thisObject, func);
     this.boundEvents_.push(event);
+  }
+
+  /**
+   * Returns the backpack flyout.
+   * @return {?Blockly.IFlyout} The backpack flyout.
+   * @public
+   */
+  getFlyout() {
+    return this.flyout_;
   }
 
   /**
@@ -503,7 +512,7 @@ export class Backpack {
    * @return {boolean} Whether the backpack is open.
    */
   isOpen() {
-    return this.flyout.isVisible();
+    return this.flyout_.isVisible();
   }
 
   /**
@@ -514,7 +523,7 @@ export class Backpack {
       return;
     }
     const xml = this.contents_.map((text) => Blockly.Xml.textToDom(text));
-    this.flyout.show(xml);
+    this.flyout_.show(xml);
     // TODO: Fire UI event for Backpack open.
   }
 
@@ -527,7 +536,7 @@ export class Backpack {
       return;
     }
     const xml = this.contents_.map((text) => Blockly.Xml.textToDom(text));
-    this.flyout.show(xml);
+    this.flyout_.show(xml);
   }
 
   /**
@@ -538,7 +547,7 @@ export class Backpack {
       return;
     }
 
-    this.flyout.hide();
+    this.flyout_.hide();
     // TODO: Fire UI event for Backpack close.
   }
 

--- a/plugins/workspace-backpack/src/msg.js
+++ b/plugins/workspace-backpack/src/msg.js
@@ -15,7 +15,7 @@ import * as Blockly from 'blockly/core';
 // context menu - Copy all Blocks on the workspace to the backpack.
 Blockly.Msg['COPY_ALL_TO_BACKPACK'] = 'Copy All Blocks to Backpack';
 /** @type {string} */
-// ontext menu - Copy the selected Block to the backpack.
+// context menu - Copy the selected Block to the backpack.
 Blockly.Msg['COPY_TO_BACKPACK'] = 'Copy to Backpack';
 /** @type {string} */
 // context menu - Empty the backpack.

--- a/plugins/workspace-backpack/src/msg.js
+++ b/plugins/workspace-backpack/src/msg.js
@@ -15,8 +15,8 @@ import * as Blockly from 'blockly/core';
 // context menu - Copy all Blocks on the workspace to the backpack.
 Blockly.Msg['COPY_ALL_TO_BACKPACK'] = 'Copy All Blocks to Backpack';
 /** @type {string} */
-// ontext menu - Add the selected block to the backpack.
-Blockly.Msg['COPY_TO_BACKPACK'] = 'Add to Backpack';
+// ontext menu - Copy the selected Block to the backpack.
+Blockly.Msg['COPY_TO_BACKPACK'] = 'Copy to Backpack';
 /** @type {string} */
 // context menu - Empty the backpack.
 Blockly.Msg['EMPTY_BACKPACK'] = 'Empty';
@@ -24,5 +24,5 @@ Blockly.Msg['EMPTY_BACKPACK'] = 'Empty';
 // context menu - Paste all Blocks from the backpack to the workspace.
 Blockly.Msg['PASTE_ALL_FROM_BACKPACK'] = 'Paste All Blocks from Backpack';
 /** @type {string} */
-// context menu - Remove  the selected Block from the backpack.
+// context menu - Remove the selected Block from the backpack.
 Blockly.Msg['REMOVE_FROM_BACKPACK'] = 'Remove from Backpack';

--- a/plugins/workspace-backpack/src/msg.js
+++ b/plugins/workspace-backpack/src/msg.js
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Translatable messages used in backpack.
+ * @author kozbial@google.com (Monica Kozbial)
+ */
+
+import * as Blockly from 'blockly/core';
+
+/** @type {string} */
+// context menu - Copy all Blocks on the workspace to the backpack.
+Blockly.Msg['COPY_ALL_TO_BACKPACK'] = 'Copy All Blocks to Backpack';
+/** @type {string} */
+// ontext menu - Add the selected block to the backpack.
+Blockly.Msg['COPY_TO_BACKPACK'] = 'Add to Backpack';
+/** @type {string} */
+// context menu - Empty the backpack.
+Blockly.Msg['EMPTY_BACKPACK'] = 'Empty';
+/** @type {string} */
+// context menu - Paste all Blocks from the backpack to the workspace.
+Blockly.Msg['PASTE_ALL_FROM_BACKPACK'] = 'Paste All Blocks from Backpack';
+/** @type {string} */
+// context menu - Remove  the selected Block from the backpack.
+Blockly.Msg['REMOVE_FROM_BACKPACK'] = 'Remove from Backpack';


### PR DESCRIPTION
### Description
Updates the README documentation and
adds the following context menu options for the backpack:
- "Copy all Blocks" to Backpack in main Workspace
- "Paste all Blocks" from Backpack in main Workspace
- "Remove from Backpack" on Block stack in Backpack Flyout
- "Add to Backpack" on Block stack in main Workspace
- "Empty" option when right clicking the Backpack that is disabled if the Backpack is empty

#### Screenshots
![c28008d3-d4b1-4d48-832a-8b42e549d5a2](https://user-images.githubusercontent.com/6621618/119092438-4e65fc80-b9c3-11eb-8049-aa1c6e1b08aa.gif)

### Additional Information
Merges into `backpack` branch rather than `master` as the plugin is under development