### PR TITLE
Backpack notification

### DIFF
--- a/examples/backpack-demo/index.html
+++ b/examples/backpack-demo/index.html
@@ -7,6 +7,8 @@
   <script src="./node_modules/blockly/blocks_compressed.js"></script>
   <script src="./node_modules/blockly/msg/en.js"></script>
   <script src="./node_modules/@blockly/workspace-backpack/dist/index.js"></script>
+  <script src="./notification_backpack.js"></script>
+  <script src="./index.js"></script>
   <style>
     body {
       background-color: #fff;
@@ -18,150 +20,91 @@
     }
   </style>
 </head>
-<body>
-<p>This is a simple demo of two Blockly instances sharing a common Backpack.</p>
+<body onload="init()">
+  <p>This is a demo of two Blockly instances with a custom Backpack "sharing" Backpack contents.</p>
 
-<table width="100%">
-  <tr>
-    <td>
-      <div id="primaryDiv" style="height: 480px; width: 600px;"></div>
-    </td>
-    <td>
-      <div id="secondaryDiv" style="height: 480px; width: 600px;"></div>
-    </td>
-  </tr>
-</table>
+  <table width="100%">
+    <tr>
+      <td>
+        <div id="primaryDiv" style="height: 480px; width: 600px;"></div>
+      </td>
+      <td>
+        <div id="secondaryDiv" style="height: 480px; width: 600px;"></div>
+      </td>
+    </tr>
+  </table>
 
-<xml xmlns="https://developers.google.com/blockly/xml" id="toolbox" style="display: none">
-  <category name="Logic" categorystyle="logic_category">
-    <block type="controls_if"></block>
-    <block type="logic_compare"></block>
-    <block type="logic_operation"></block>
-    <block type="logic_negate"></block>
-    <block type="logic_boolean"></block>
-  </category>
-  <category name="Loops" categorystyle="loop_category">
-    <block type="controls_repeat_ext">
-      <value name="TIMES">
-        <shadow type="math_number">
-          <field name="NUM">10</field>
-        </shadow>
-      </value>
-    </block>
-    <block type="controls_flow_statements"></block>
-  </category>
-  <category name="Math" categorystyle="math_category">
-    <block type="math_number" gap="32">
-      <field name="NUM">123</field>
-    </block>
-    <block type="math_arithmetic">
-      <value name="A">
-        <shadow type="math_number">
-          <field name="NUM">1</field>
-        </shadow>
-      </value>
-      <value name="B">
-        <shadow type="math_number">
-          <field name="NUM">1</field>
-        </shadow>
-      </value>
-    </block>
-    <block type="math_single">
-      <value name="NUM">
-        <shadow type="math_number">
-          <field name="NUM">9</field>
-        </shadow>
-      </value>
-    </block>
-    <block type="math_number_property">
-      <value name="NUMBER_TO_CHECK">
-        <shadow type="math_number">
-          <field name="NUM">0</field>
-        </shadow>
-      </value>
-    </block>
-  </category>
-  <category name="Text" categorystyle="text_category">
-    <block type="text"></block>
-    <block type="text_multiline"></block>
-    <label text="Input/Output:" web-class="ioLabel"></label>
-    <block type="text_print">
-      <value name="TEXT">
-        <shadow type="text">
-          <field name="TEXT">abc</field>
-        </shadow>
-      </value>
-    </block>
-    <block type="text_prompt_ext">
-      <value name="TEXT">
-        <shadow type="text">
-          <field name="TEXT">abc</field>
-        </shadow>
-      </value>
-    </block>
-  </category>
-  <sep></sep>
-  <category name="Variables" categorystyle="variable_category" custom="VARIABLE"></category>
-  <category name="Functions" categorystyle="procedure_category" custom="PROCEDURE"></category>
-</xml>
-
-<script>
-  // Inject primary workspace.
-  var primaryWorkspace = Blockly.inject('primaryDiv',
-      {
-        media: 'https://unpkg.com/blockly/media/',
-        toolbox: document.getElementById('toolbox'),
-        trashcan: true,
-      });
-  // Inject secondary workspace.
-  var secondaryWorkspace = Blockly.inject('secondaryDiv',
-      {
-        media: 'https://unpkg.com/blockly/media/',
-        toolbox: document.getElementById('toolbox'),
-        trashcan: true
-      });
-
-
-  const backpackOptions = {
-    contextMenu: {
-      emptyBackpack: true,
-      removeFromBackpack: true,
-      copyToBackpack: true,
-      copyAllToBackpack: true,
-      pasteAllToBackpack: true,
-      disablePreconditionChecks: false,
-    },
-  };
-  // Add backpacks
-  const primaryBackpack = new Backpack(primaryWorkspace, backpackOptions);
-  primaryBackpack.init();
-  const secondaryBackpack = new Backpack(secondaryWorkspace, backpackOptions);
-  secondaryBackpack.init();
-
-  // Listen to events on both workspace.
-  primaryWorkspace.addChangeListener(updateBackpack);
-  secondaryWorkspace.addChangeListener(updateBackpack);
-
-  function updateBackpack(event) {
-    if (event.type !== 'backpack_change') {
-      return;
-    }
-    Blockly.Events.disable();
-    let contents;
-    let targetBackpack;
-    if (primaryWorkspace.id === event.workspaceId) {
-      targetBackpack = secondaryBackpack;
-      contents = primaryBackpack.getContents();
-      console.log('second workspace backpack updated');
-    } else { // secondaryWorkspace.id === event.workspaceId
-      targetBackpack = primaryBackpack;
-      contents = secondaryBackpack.getContents();
-      console.log('first workspace backpack updated');
-    }
-    targetBackpack.setContents(contents);
-    Blockly.Events.enable();
-  }
-</script>
-
+  <xml xmlns="https://developers.google.com/blockly/xml" id="toolbox" style="display: none">
+    <category name="Logic" categorystyle="logic_category">
+      <block type="controls_if"></block>
+      <block type="logic_compare"></block>
+      <block type="logic_operation"></block>
+      <block type="logic_negate"></block>
+      <block type="logic_boolean"></block>
+    </category>
+    <category name="Loops" categorystyle="loop_category">
+      <block type="controls_repeat_ext">
+        <value name="TIMES">
+          <shadow type="math_number">
+            <field name="NUM">10</field>
+          </shadow>
+        </value>
+      </block>
+      <block type="controls_flow_statements"></block>
+    </category>
+    <category name="Math" categorystyle="math_category">
+      <block type="math_number" gap="32">
+        <field name="NUM">123</field>
+      </block>
+      <block type="math_arithmetic">
+        <value name="A">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+        </value>
+        <value name="B">
+          <shadow type="math_number">
+            <field name="NUM">1</field>
+          </shadow>
+        </value>
+      </block>
+      <block type="math_single">
+        <value name="NUM">
+          <shadow type="math_number">
+            <field name="NUM">9</field>
+          </shadow>
+        </value>
+      </block>
+      <block type="math_number_property">
+        <value name="NUMBER_TO_CHECK">
+          <shadow type="math_number">
+            <field name="NUM">0</field>
+          </shadow>
+        </value>
+      </block>
+    </category>
+    <category name="Text" categorystyle="text_category">
+      <block type="text"></block>
+      <block type="text_multiline"></block>
+      <label text="Input/Output:" web-class="ioLabel"></label>
+      <block type="text_print">
+        <value name="TEXT">
+          <shadow type="text">
+            <field name="TEXT">abc</field>
+          </shadow>
+        </value>
+      </block>
+      <block type="text_prompt_ext">
+        <value name="TEXT">
+          <shadow type="text">
+            <field name="TEXT">abc</field>
+          </shadow>
+        </value>
+      </block>
+    </category>
+    <sep></sep>
+    <category name="Variables" categorystyle="variable_category" custom="VARIABLE"></category>
+    <category name="Functions" categorystyle="procedure_category" custom="PROCEDURE"></category>
+  </xml>
 </body>
 </html>

--- a/examples/backpack-demo/index.js
+++ b/examples/backpack-demo/index.js
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Backpack demo initialization.
+ */
+
+function init() {
+  // Inject primary workspace.
+  const primaryWorkspace = Blockly.inject('primaryDiv',
+      {
+        media: 'https://unpkg.com/blockly/media/',
+        toolbox: document.getElementById('toolbox'),
+        trashcan: true,
+      });
+  // Inject secondary workspace.
+  var secondaryWorkspace = Blockly.inject('secondaryDiv',
+      {
+        media: 'https://unpkg.com/blockly/media/',
+        toolbox: document.getElementById('toolbox'),
+        trashcan: true,
+      });
+
+  // Add backpacks
+  const primaryBackpack = new NotificationBackpack(primaryWorkspace);
+  primaryBackpack.init();
+  const secondaryBackpack = new NotificationBackpack(secondaryWorkspace);
+  secondaryBackpack.init();
+
+  // Listen to events on both workspace.
+  primaryWorkspace.addChangeListener(updateBackpack);
+  secondaryWorkspace.addChangeListener(updateBackpack);
+
+  function updateBackpack(event) {
+    if (event.type !== 'backpack_change') {
+      return;
+    }
+    Blockly.Events.disable();
+    let contents;
+    let targetBackpack;
+    if (primaryWorkspace.id === event.workspaceId) {
+      targetBackpack = secondaryBackpack;
+      contents = primaryBackpack.getContents();
+      console.log('second workspace backpack updated');
+    } else { // secondaryWorkspace.id === event.workspaceId
+      targetBackpack = primaryBackpack;
+      contents = secondaryBackpack.getContents();
+      console.log('first workspace backpack updated');
+    }
+    targetBackpack.setContentsAndNotify(contents);
+    Blockly.Events.enable();
+  }
+}

--- a/examples/backpack-demo/notification_backpack.js
+++ b/examples/backpack-demo/notification_backpack.js
@@ -1,0 +1,236 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Backpack with a notification.
+ */
+
+class NotificationBackpack extends Backpack {
+  /**
+   * Constructor for a backpack.
+   * @param {!Blockly.WorkspaceSvg} targetWorkspace The target workspace that
+   *     the plugin will be added to.
+   */
+  constructor(targetWorkspace) {
+    super(targetWorkspace);
+
+    /**
+     * The SVG group containing notification circle that shows either the
+     * total count of tiems or the number of items added since the backapck
+     * flyout was last opened.
+     * @type {?SVGElement}
+     * @private
+     */
+    this.countSvg_ = null;
+
+    /**
+     * The SVG text for the notification circle.
+     * @type {SVGTextElement}
+     * @private
+     */
+    this.countSvgText_ = null;
+
+    /**
+     * The CSS color to use on the count svg circle fill.
+     * @type {string}
+     * @private
+     */
+    this.countSvgColour_ = 'blue';
+
+    /**
+     * The CSS color to use on the count svg text.
+     * @type {string}
+     * @private
+     */
+    this.countSvgTextColour_ = 'white';
+
+    /**
+     * The backpack content since the backpack was last opened, stored as a list
+     * of XML (stored as strings) representing blocks in the backpack.
+     * @type {!Array<string>}
+     * @protected
+     */
+    this.cachedContents_ = [];
+
+    /**
+     * Whether to disable caching contents.
+     * @type {boolean}
+     * @private
+     */
+    this.disableCaching_ = false;
+
+    /**
+     * The notification count to display. Cleared on backpack open.
+     * @type {number}
+     * @private
+     */
+    this.notificationCount_ = 0;
+  }
+
+  /**
+   * Creates DOM for ui element and attaches event listeners.
+   * @protected
+   * @override
+   */
+  createDom_() {
+    super.createDom_();
+    this.createNotificationSvg_();
+  }
+
+  /**
+   * Creates notification circle.
+   * @private
+   */
+  createNotificationSvg_() {
+    this.countSvg_ = Blockly.utils.dom.createSvgElement(
+        Blockly.utils.Svg.G, {'opacity': 0}, this.svgGroup_);
+    const circleRadius = this.WIDTH_ / 4;
+    Blockly.utils.dom.createSvgElement(
+        Blockly.utils.Svg.CIRCLE,
+        {
+          'cx': this.WIDTH_ * 4 / 5,
+          'cy': this.HEIGHT_ / 4,
+          'fill': this.countSvgColour_,
+          'r': circleRadius,
+          'stroke': '#888',
+          'stroke-width': 1,
+        },
+        this.countSvg_);
+    this.countSvgText_ = Blockly.utils.dom.createSvgElement(
+        Blockly.utils.Svg.TEXT,
+        {
+          'dominant-baseline': 'central',
+          'fill': this.countSvgTextColour_,
+          'font-family': 'sans-serif',
+          'font-size': '0.75em',
+          'font-weight': '600',
+          'height': circleRadius * 2,
+          'text-anchor': 'middle',
+          'width': circleRadius * 2,
+          'x': this.WIDTH_ * 4 / 5,
+          'y': this.HEIGHT_ / 4,
+        },
+        this.countSvg_);
+  }
+
+  /**
+   * Updates the notification circle icon.
+   * @private
+   */
+  updateNotification_() {
+    if (this.notificationCount_) {
+      if (this.getCount() === 0) {
+        this.countSvgText_.textContent = '!';
+        this.countSvg_.setAttribute('opacity', '1');
+      } else {
+        this.countSvgText_.textContent = this.notificationCount_ > 99 ?
+            '99+' : this.notificationCount_.toString();
+      }
+      this.countSvg_.setAttribute('opacity', '1');
+    } else {
+      this.countSvg_.setAttribute('opacity', '0');
+    }
+  }
+
+  /**
+   * Adds multiple items to the backpack.
+   * @param {!Array<string>} items The backpack contents to add.
+   * @override
+   */
+  addItems(items) {
+    super.addItems(items);
+    if (!this.disableCaching_) {
+      this.cachedContents_ = this.contents_;
+    }
+  }
+
+  /**
+   * Removes item from the backpack.
+   * @param {string} item Text representing the XML tree of a block to remove,
+   * cleaned of all unnecessary attributes.
+   * @override
+   */
+  removeItem(item) {
+    super.item(item);
+    if (!this.disableCaching_) {
+      this.cachedContents_ = this.contents_;
+    }
+  }
+
+  /**
+   * Sets backpack contents.
+   * @param {!Array<string>} contents The new backpack contents.
+   * @override
+   */
+  setContents(contents) {
+    super.setContents(contents);
+    if (!this.disableCaching_) {
+      this.cachedContents_ = this.contents_;
+    }
+  }
+
+  /**
+   * Empties the backpack's contents. If the contents-flyout is currently open
+   * it will be closed.
+   * @override
+   */
+  empty() {
+    super.empty();
+    if (!this.disableCaching_) {
+      this.cachedContents_ = this.contents_;
+    }
+  }
+
+  /**
+   * Opens the backpack flyout.
+   * @override
+   */
+  open() {
+    super.open();
+    this.cachedContents_ = this.contents_;
+    this.notificationCount_ = 0;
+    this.updateNotification_();
+  }
+
+  /**
+   * Updates the notification count based on the cached and new contents.
+   * @param {!Array<string>} contents The new backpack contents.
+   */
+  updateNotificationCount_(contents) {
+    // Count removed items.
+    let changeCount = this.cachedContents_.reduce((accumulator, currentItem
+    ) => {
+      if (contents.indexOf(currentItem) !== -1) {
+        return accumulator;
+      }
+      return accumulator + 1;
+    }, 0);
+    // Count added items.
+    changeCount = contents.reduce((accumulator, currentItem) => {
+      if (this.cachedContents_.indexOf(currentItem) !== -1) {
+        return accumulator;
+      }
+      return accumulator + 1;
+    }, changeCount);
+    this.notificationCount_ = changeCount;
+  }
+
+  /**
+   * Sets backpack contents and updates the notification.
+   * @param {!Array<string>} contents The new backpack contents.
+   */
+  setContentsAndNotify(contents) {
+    if (this.isOpen()) {
+      this.notificationCount_ = 0;
+    } else {
+      this.updateNotificationCount_(contents);
+    }
+    this.disableCaching_ = true;
+    this.setContents(contents);
+    this.disableCaching_ = false;
+    this.updateNotification_();
+  }
+}

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -486,6 +486,7 @@ export class Backpack {
     this.addItems(cleanedBlocks);
   }
 
+
   /**
    * Removes the specified block from the backpack.
    * @param {!Blockly.Block} block The block to be removed from the backpack.

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -427,19 +427,6 @@ export class Backpack {
   }
 
   /**
-   * Empties the backpack's contents. If the contents-flyout is currently open
-   * it will be closed.
-   */
-  empty() {
-    if (!this.getCount()) {
-      return;
-    }
-    this.contents_ = [];
-    Blockly.Events.fire(new BackpackChange(this.workspace_.id));
-    this.close();
-  }
-
-  /**
    * Handles a block drop on this backpack.
    * @param {!Blockly.BlockSvg} block The block being dropped on the backpack.
    */
@@ -509,8 +496,11 @@ export class Backpack {
    * @param {!Array<string>} items The backpack contents to add.
    */
   addItems(items) {
-    this.contents_.unshift(...this.filterDuplicates_(items));
-    Blockly.Events.fire(new BackpackChange(this.workspace_.id));
+    const addedItems = this.filterDuplicates_(items);
+    if (addedItems.length) {
+      this.contents_.unshift(...addedItems);
+      this.onContentChange_();
+    }
   }
 
   /**
@@ -522,8 +512,7 @@ export class Backpack {
     const itemIndex = this.contents_.indexOf(item);
     if (itemIndex !== -1) {
       this.contents_.splice(itemIndex, 1);
-      this.maybeRefreshFlyoutContents_();
-      Blockly.Events.fire(new BackpackChange(this.workspace_.id));
+      this.onContentChange_();
     }
   }
 
@@ -534,6 +523,29 @@ export class Backpack {
   setContents(contents) {
     this.contents_ = [];
     this.contents_ = this.filterDuplicates_(contents);
+    this.onContentChange_();
+  }
+
+  /**
+   * Empties the backpack's contents. If the contents-flyout is currently open
+   * it will be closed.
+   */
+  empty() {
+    if (!this.getCount()) {
+      return;
+    }
+    if (this.contents_.length) {
+      this.contents_ = [];
+      this.onContentChange_();
+    }
+    this.close();
+  }
+
+  /**
+   * Handles content change.
+   * @protected
+   */
+  onContentChange_() {
     this.maybeRefreshFlyoutContents_();
     Blockly.Events.fire(new BackpackChange(this.workspace_.id));
   }


### PR DESCRIPTION
### Description
Adds a custom Backpack to the Backpack Example which shows a notification that indicates how many items have changed (added and removed) as a result of calls to `setContentsAndNotify` since it was last opened.

If more than 99 items are in the backpack, the icon displays "99+" so that the text doesn't overflow and if the backpack is cleared (and it wasn't empty since it was last openend) then it it will display a "!".

#### Screenshots
![577ffb8d-f934-47a3-982f-a7a089bd5d66 (1)](https://user-images.githubusercontent.com/6621618/121756912-a11d6a80-cad0-11eb-9512-971a222d1ef2.gif)

![Notification with text 99+ to represent off 99 items in the backpack](https://user-images.githubusercontent.com/6621618/121757027-0ffac380-cad1-11eb-9e76-067c1b5b187b.png)
![Notification with exclamation point to represent that the backpack was cleared](https://user-images.githubusercontent.com/6621618/121757029-112bf080-cad1-11eb-8fb4-cb5830f56a68.png)


### Additional Information
Merges into `backpack` branch rather than `master` as the plugin is under development