### PR TITLE
Updates the scroll plugin to work with new APIs

### DIFF
--- a/plugins/scroll-options/package-lock.json
+++ b/plugins/scroll-options/package-lock.json
@@ -1937,9 +1937,9 @@
       }
     },
     "blockly": {
-      "version": "5.20210325.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-5.20210325.1.tgz",
-      "integrity": "sha512-qrilYPovJeDfxKDWm1YBUCPVNElh/iyC1szaHTIPZHj9C9YPpSzZOeFyyrPBbYRudzbo8kjBOWMtHnN1bLjkoQ==",
+      "version": "5.20210624.0-beta.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-5.20210624.0-beta.1.tgz",
+      "integrity": "sha512-PGwkt/RgyVqlEvhe2fJisJhkTI7IeiV1n82l5XxfA21a1qp2NO8nKnj8VD5R6hP3bNKd6oDfR36YQ7gcSq7WeA==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.6",
     "@blockly/dev-tools": "^2.2.1",
-    "blockly": "^5.20210325.1"
+    "blockly": "5.20210624.0-beta.1"
   },
   "peerDependencies": {
     "blockly": ">=5"

--- a/plugins/scroll-options/src/ScrollBlockDragger.js
+++ b/plugins/scroll-options/src/ScrollBlockDragger.js
@@ -16,30 +16,110 @@ import * as Blockly from 'blockly/core';
  * someone is dragging it.
  */
 export class ScrollBlockDragger extends Blockly.BlockDragger {
+  /** @override */
+  constructor(block, workspace) {
+    super(block, workspace);
+
+    /**
+     * How much the block has been moved due to scrolling.
+     * @type {!Blockly.utils.Coordinate}
+     * @protected
+     */
+    this.scrollDelta_ = new Blockly.utils.Coordinate(0, 0);
+
+    /**
+     * How much the block has been moved due to dragging.
+     * @type {!Blockly.utils.Coordinate}
+     * @protected
+     */
+    this.dragDelta_ = new Blockly.utils.Coordinate(0, 0);
+  }
   /**
    * Updates the location of the block that is being dragged.
    * @param {number} deltaX Horizontal offset in pixel units.
    * @param {number} deltaY Vertical offset in pixel units.
    */
   moveBlockWhileDragging(deltaX, deltaY) {
+    this.scrollDelta_.x -= deltaX;
+    this.scrollDelta_.y -= deltaY;
+
     // Moves the parent block drag surface in the opposite direction of the
     // child drag surface. This makes the block stay under the cursor.
     this.workspace_.getBlockDragSurface().translateBy(-deltaX, -deltaY);
 
-    const deltaXWs = deltaX / this.workspace_.scale;
-    const deltaYWs = deltaY / this.workspace_.scale;
 
-    // Update the start location of the block, so that when we drag the block
-    // it starts in the correct location. startXY is in workspace coordinates.
-    this.startXY_.x -= deltaXWs;
-    this.startXY_.y -= deltaYWs;
+    // The total amount the block has moved since being picked up.
+    const totalDelta =
+        Blockly.utils.Coordinate.sum(this.scrollDelta_, this.dragDelta_);
 
-    // Move the connections on the block. Workspace coordinates.
-    this.draggingBlock_.moveConnections(-deltaXWs, -deltaYWs);
+    this.dragIcons_(totalDelta);
 
     // As we scroll, show the insertion markers.
-    // TODO: This is broken. So completely broken.
     this.draggedConnectionManager_.update(
-        new Blockly.utils.Coordinate(deltaXWs, deltaYWs), null);
+        new Blockly.utils.Coordinate(
+            totalDelta.x / this.workspace_.scale,
+            totalDelta.y / this.workspace_.scale),
+        null);
+  }
+
+  /**
+   * Passes the total amount the block has moved (both from dragging and from
+   * scrolling) since it was picked up.
+   * @override
+   */
+  startDrag(currentDragDeltaXY, healStack) {
+    const totalDelta =
+        Blockly.utils.Coordinate.sum(this.scrollDelta_, currentDragDeltaXY);
+    super.startDrag(totalDelta, healStack);
+    this.dragDelta_ = currentDragDeltaXY;
+  }
+
+  /**
+   * Passes the total amount the block has moved (both from dragging and from
+   * scrolling) since it was picked up.
+   * @override
+   */
+  drag(e, currentDragDeltaXY) {
+    const totalDelta =
+        Blockly.utils.Coordinate.sum(this.scrollDelta_, currentDragDeltaXY);
+    super.drag(e, totalDelta);
+    this.dragDelta_ = currentDragDeltaXY;
+  }
+
+  /**
+   * Passes the total amount the block has moved (both from dragging and from
+   * scrolling) since it was picked up.
+   * @override
+   */
+  endDrag(e, currentDragDeltaXY) {
+    // We can not override this method similar to the others because we call
+    // drag here with the passed in value.
+    // Make sure internal state is fresh.
+    this.drag(e, currentDragDeltaXY);
+    this.dragIconData_ = [];
+    this.fireDragEndEvent_();
+
+    Blockly.utils.dom.stopTextWidthCache();
+
+    Blockly.blockAnimations.disconnectUiStop();
+    // Start Change
+    const totalDelta =
+        Blockly.utils.Coordinate.sum(this.scrollDelta_, currentDragDeltaXY);
+    const delta = this.pixelsToWorkspaceUnits_(totalDelta);
+    // End Change
+    const newLoc = Blockly.utils.Coordinate.sum(this.startXY_, delta);
+    this.draggingBlock_.moveOffDragSurface(newLoc);
+
+    const deleted = this.maybeDeleteBlock_();
+    if (!deleted) {
+      // Moving the block is expensive, so only do it if the block is not
+      // deleted.
+      this.updateBlockAfterMove_(delta);
+    }
+    this.workspace_.setResizesEnabled(true);
+
+    this.updateToolboxStyle_(true);
+
+    this.dragDelta_ = currentDragDeltaXY;
   }
 }


### PR DESCRIPTION
- Uses the new APIs in drag surface to get the translation of the workspace.
- Instead of trying to move the connections and the block as we move, track the total delta (dragDelta + scrollDelta) and pass this in to the  block dragger methods.
- Call dragIcons_ to move a bubble as the block is being scrolled.