### PR TITLE
Update ScrollBlockDragger to use new APIs

### DIFF
--- a/plugins/scroll-options/package-lock.json
+++ b/plugins/scroll-options/package-lock.json
@@ -1937,9 +1937,9 @@
       }
     },
     "blockly": {
-      "version": "5.20210624.0-beta.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-5.20210624.0-beta.1.tgz",
-      "integrity": "sha512-PGwkt/RgyVqlEvhe2fJisJhkTI7IeiV1n82l5XxfA21a1qp2NO8nKnj8VD5R6hP3bNKd6oDfR36YQ7gcSq7WeA==",
+      "version": "5.20210624.0-beta.3",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-5.20210624.0-beta.3.tgz",
+      "integrity": "sha512-t12+Qi7Q6+s97v1TFyGixqJUxW8W08QAw+Jr0BXMh7+9GguyA+QlHtlIFrJxyccfB5yqmAA9VCtLcZT/042Fww==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -42,10 +42,10 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.6",
     "@blockly/dev-tools": "^2.2.1",
-    "blockly": "5.20210624.0-beta.1"
+    "blockly": "5.20210624.0-beta.3"
   },
   "peerDependencies": {
-    "blockly": ">=5"
+    "blockly": ">=5.20210624.0-beta.3"
   },
   "publishConfig": {},
   "eslintConfig": {

--- a/plugins/scroll-options/src/AutoScroll.js
+++ b/plugins/scroll-options/src/AutoScroll.js
@@ -111,7 +111,8 @@ export class AutoScroll {
    * @param {number} scrollDy Amount to scroll in vertical direction.
    */
   scrollWorkspaceWithBlock(scrollDx, scrollDy) {
-    const oldLocation = this.getDragSurfaceLocation_();
+    const dragSurface = this.workspace_.getBlockDragSurface();
+    const oldLocation = dragSurface.getWsTranslation();
 
     // As we scroll, we shouldn't expand past the content area that existed
     // before the block was picked up. Therefore, we use cached ContentMetrics
@@ -125,7 +126,7 @@ export class AutoScroll {
     this.workspace_.scroll(newX, newY);
     metricsManager.useCachedContentMetrics = false;
 
-    const newLocation = this.getDragSurfaceLocation_();
+    const newLocation = dragSurface.getWsTranslation();
 
     // How much we actually ended up scrolling.
     const deltaX = newLocation.x - oldLocation.x;
@@ -138,19 +139,6 @@ export class AutoScroll {
       this.workspace_.currentGesture_.getCurrentDragger()
           .moveBlockWhileDragging(deltaX, deltaY);
     }
-  }
-
-  /**
-   * Gets the current location of the drag surface.
-   * This has to return a copy to work.
-   * TODO: Deduplicate with index.js.
-   * @return {!Blockly.utils.Coordinate} The current coordinate.
-   * @protected
-   */
-  getDragSurfaceLocation_() {
-    const dragSurface = this.workspace_.getBlockDragSurface();
-    const workspaceOffset = dragSurface.getWsTranslation();
-    return new Blockly.utils.Coordinate(workspaceOffset.x, workspaceOffset.y);
   }
 
   /**


### PR DESCRIPTION
1. `dragSurface.getWsTranslation` already returns a copy now, so we don't need a method to copy it anymore.
2. There was a bug in ScrollBlockDragger with the scroll direction vectors. We scale those unit vectors to create the scroll velocity in each direction. However, the `scale` method modifies the vector, so the mouse candidates and the block candidates were both scaling the same vector. Now, we clone the unit vector so that the different candidates are independent.
3. `endDrag` previously couldn't call `super` due to the parts of the method we were overriding. Now, the calculation of the new location after a drag are in a separate method, so we can override just that method and simplify endDrag.