### PR TITLE
Use @blockly/theme-dark in dev tools

### DIFF
--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -40,6 +40,7 @@
   ],
   "dependencies": {
     "@blockly/block-test": "^1.1.0",
+    "@blockly/theme-dark": "^1.0.0",
     "chai": "^4.2.0",
     "dat.gui": "^0.7.7",
     "lodash.assign": "^4.2.0",

--- a/plugins/dev-tools/src/playground/options.js
+++ b/plugins/dev-tools/src/playground/options.js
@@ -20,6 +20,7 @@ import {spaghetti} from '../spaghetti';
 import {id} from './id';
 import toolboxCategories from '../toolboxCategories';
 import toolboxSimple from '../toolboxSimple';
+import darkTheme from '@blockly/theme-dark';
 
 const assign = require('lodash.assign');
 const merge = require('lodash.merge');
@@ -539,7 +540,7 @@ function getThemes(defaultOptions) {
     // Fall back to a pre-set list of themes.
     themes = {
       'classic': Blockly.Themes.Classic,
-      'dark': Blockly.Themes.Dark,
+      'dark': darkTheme,
       'deuteranopia': Blockly.Themes.Deuteranopia,
       'highcontrast': Blockly.Themes.HighContrast,
       'tritanopia': Blockly.Themes.Tritanopia,

--- a/plugins/theme-dark/src/index.js
+++ b/plugins/theme-dark/src/index.js
@@ -10,10 +10,15 @@
 
 import Blockly from 'blockly/core';
 
+
+// Temporarily required to ensure there's no conflict with
+// Blockly.Themes.Dark
+Blockly.registry.unregister('theme', 'dark');
+
 /**
  * Dark theme.
  */
-export default Blockly.Theme.defineTheme('theme_dark', {
+export default Blockly.Theme.defineTheme('dark', {
   'base': Blockly.Themes.Classic,
   'componentStyles': {
     'workspaceBackgroundColour': '#1e1e1e',


### PR DESCRIPTION
Use @blockly/theme-dark in dev tools
Rename theme_dark to dark to match core. Unregister to avoid conflict.