### PR TITLE
Add a function to allow removing generators in the playground

### DIFF
--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -413,6 +413,28 @@ export function createPlayground(
           }
         };
 
+        /**
+         * Removes a generator tab.
+         * @param {string} label The label of the generator tab to remove.
+         */
+        const removeGenerator = function(label) {
+          if (!label) {
+            throw Error('usage: removeGenerator(label);');
+          }
+          if (!(label in tabs)) {
+            throw Error('removeGenerator called on invalid label: ' + label);
+          }
+          const tab = tabs[label];
+          tabsDiv.removeChild(tab.tabElement);
+          delete tabs[label];
+          const tabsKeys = Object.keys(tabs);
+          if (activeTab === label && tabsKeys.length) {
+            // Set the active tab to another tab if the active tab corresponded
+            // to a removed generator.
+            setActiveTab(tabs[tabsKeys[0]]);
+          }
+        };
+
         const playground = {
           state: playgroundState,
           addAction: (/** @type {?} */ (gui)).addAction,
@@ -421,6 +443,7 @@ export function createPlayground(
           getCurrentTab,
           getGUI,
           getWorkspace,
+          removeGenerator,
         };
 
         // Add tab buttons.


### PR DESCRIPTION
This addresses: #739 - "RemoveGenerator function for playground"

This adds the "removeGenerator" function that allows users to hide generator tabs in the advanced playground. 

I tested the change by manually bringing up the advanced_playground and adding these lines:

```
   playground.addGenerator('Codelab', codelabGenerator);
   playground.removeGenerator('JavaScript');
   playground.removeGenerator('Python');
   playground.removeGenerator('Lua');
   playground.removeGenerator('PHP');
```

![Screenshot](https://user-images.githubusercontent.com/3144531/121993821-c8429900-cd69-11eb-98b6-05d7a436ece4.png)

I couldn't find unit tests for the addGenerator functionality, but please let me know if I should add unit tests for this (/ pointers to where I should add them) if needed. Thanks! 