### PR TITLE
Add nested suites to TestSuite

### DIFF
--- a/plugins/block-plus-minus/test/procedures.mocha.js
+++ b/plugins/block-plus-minus/test/procedures.mocha.js
@@ -9,7 +9,6 @@ const sinon = require('sinon');
 const Blockly = require('blockly/node');
 const {testHelpers} = require('@blockly/dev-tools');
 const procedureTestHelpers = require('./procedures_test_helpers.mocha');
-const { runTestSuites, TestSuite } = require('../../dev-tools/src/common_test_helpers.mocha');
 
 require('../src/index');
 
@@ -158,38 +157,6 @@ suite('Procedure blocks', function() {
         ];
 
         runCodeGenerationTestSuites(codeGenerationTestSuites);
-
-        const test = {
-          title: 'outer suite',
-          testSuites: [
-            {
-              title: 'inner suite 1',
-              testCases: [
-                {
-                  title: 'test 1',
-                },
-                {
-                  title: 'test 2',
-                },
-              ],
-            },
-            {
-              title: 'inner suite 2',
-              testCases: [
-                {
-                  title: 'test 3',
-                },
-              ],
-            },
-          ],
-        };
-
-        runTestSuites([test], function(suiteOrTest) {
-          if (suiteOrTest instanceof TestSuite) {
-            return this;
-          }
-          return function() {};
-        });
       });
 
       /**

--- a/plugins/block-plus-minus/test/procedures.mocha.js
+++ b/plugins/block-plus-minus/test/procedures.mocha.js
@@ -9,6 +9,7 @@ const sinon = require('sinon');
 const Blockly = require('blockly/node');
 const {testHelpers} = require('@blockly/dev-tools');
 const procedureTestHelpers = require('./procedures_test_helpers.mocha');
+const { runTestSuites, TestSuite } = require('../../dev-tools/src/common_test_helpers.mocha');
 
 require('../src/index');
 
@@ -157,6 +158,38 @@ suite('Procedure blocks', function() {
         ];
 
         runCodeGenerationTestSuites(codeGenerationTestSuites);
+
+        const test = {
+          title: 'outer suite',
+          testSuites: [
+            {
+              title: 'inner suite 1',
+              testCases: [
+                {
+                  title: 'test 1',
+                },
+                {
+                  title: 'test 2',
+                },
+              ],
+            },
+            {
+              title: 'inner suite 2',
+              testCases: [
+                {
+                  title: 'test 3',
+                },
+              ],
+            },
+          ],
+        };
+
+        runTestSuites([test], function(suiteOrTest) {
+          if (suiteOrTest instanceof TestSuite) {
+            return this;
+          }
+          return function() {};
+        });
       });
 
       /**

--- a/plugins/dev-tools/src/common_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/common_test_helpers.mocha.js
@@ -28,6 +28,7 @@ TestCase.prototype.only = false;
  * Test suite configuration information.
  * @record
  * @template {TestCase} T
+ * @template {TestSuite} U
  */
 export function TestSuite() {}
 /**
@@ -48,6 +49,10 @@ TestSuite.prototype.only = false;
  * @type {!Array<T>} The associated test cases.
  */
 TestSuite.prototype.testCases = [];
+/**
+ * @type {!Array<U>} Optional inner test suites.
+ */
+TestSuite.prototype.testSuites = [];
 
 /**
  * Runs provided test cases.
@@ -77,7 +82,12 @@ export function runTestSuites(testSuites, createTestCaseCallback) {
     let suiteCall = (testSuite.skip ? suite.skip : suite);
     suiteCall = (testSuite.only ? suite.only : suiteCall);
     suiteCall(testSuite.title, function() {
-      runTestCases(testSuite.testCases, createTestCaseCallback(testSuite));
+      if (testSuite.testSuites && testSuite.testSuites.length) {
+        runTestSuites(testSuite.testSuites, createTestCaseCallback);
+      }
+      if (testSuite.testCases && testSuite.testCases.length) {
+        runTestCases(testSuite.testCases, createTestCaseCallback(testSuite));
+      }
     });
   });
 }

--- a/plugins/dev-tools/src/common_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/common_test_helpers.mocha.js
@@ -46,11 +46,11 @@ TestSuite.prototype.skip = false;
  */
 TestSuite.prototype.only = false;
 /**
- * @type {!Array<T>} The associated test cases.
+ * @type {?Array<T>} The associated test cases.
  */
 TestSuite.prototype.testCases = [];
 /**
- * @type {!Array<U>} Optional inner test suites.
+ * @type {?Array<U>} Optional inner test suites.
  */
 TestSuite.prototype.testSuites = [];
 

--- a/plugins/dev-tools/src/test_helpers.mocha.js
+++ b/plugins/dev-tools/src/test_helpers.mocha.js
@@ -12,6 +12,7 @@ const {
   TestCase,
   TestSuite,
   runTestCases,
+  runTestSuites,
   captureWarnings,
 } = commonHelpers;
 


### PR DESCRIPTION
### Description

I'm going to do some Test Driven Development for Project Cereal. This includes adding a test helper which makes sure that serializers round-trip the data correctly. I want the tests provided with the test helper to have a nested structure (eg Serializer.Fields.Number.Decimal) so I needed to add support for this to the TestSuite.

### Testing
In the first commit you can see a trial of this logic which I added in the blocks-plus-minus package. It output a test structure that looked like this:
```
outer suite
  inner suite 1
    - test 1
    - test 2
  inner suite 2
    - test 3
```

Which was exactly what I wanted =)

