### PR TITLE
Remove extra slash in demo template

### DIFF
--- a/gh-pages/_layouts/default.html
+++ b/gh-pages/_layouts/default.html
@@ -20,7 +20,7 @@
       <div class="subtitle">{{ page.description }}</div>
     </div>
 
-    <a href="{{ 'https://github.com/google/blockly-samples/blob/master/'
+    <a href="{{ 'https://github.com/google/blockly-samples/blob/master'
       | append: page.dir }}" class="button" target="_blank">View code</a>
 
     {% if page.packageName %}


### PR DESCRIPTION
Tested locally using `npm run test:ghpages`