### PR TITLE
Disable spellcheck on pitch field

### DIFF
--- a/examples/pitch-field-demo/field_pitch.js
+++ b/examples/pitch-field-demo/field_pitch.js
@@ -29,6 +29,9 @@ var CustomFields = CustomFields || {};
 CustomFields.FieldPitch = function(text) {
   CustomFields.FieldPitch.superClass_.constructor.call(this, text);
 
+  // Disable spellcheck.
+  this.setSpellcheck(false);
+
   /**
    * Click event data.
    * @type {?Blockly.EventData}


### PR DESCRIPTION
Disables spell check on pitch field so that the text is not underlined as if it is misspelled

Before:
![938x42QNTByunnr](https://user-images.githubusercontent.com/6621618/123710896-5c116c00-d824-11eb-943d-3bc5ea0f1367.png)

After:
![B6wq5pwEmBXZKdv](https://user-images.githubusercontent.com/6621618/123710911-616eb680-d824-11eb-96e0-037fabeb4416.png)
