### PR TITLE
Fix turtle mask placement on custom field

### DIFF
--- a/examples/turtle-field-demo/field_turtle.js
+++ b/examples/turtle-field-demo/field_turtle.js
@@ -236,9 +236,9 @@ CustomFields.FieldTurtle.prototype.render_ = function() {
       break;
     case 'Mask':
       this.mask_.style.display = '';
-      this.turtleGroup_.setAttribute('transform', 'translate(0,1.2)');
+      this.turtleGroup_.setAttribute('transform', 'translate(0,6)');
       this.textElement_.setAttribute('transform',
-          'translate(' + this.TEXT_OFFSET_X + ',4)');
+          'translate(' + this.TEXT_OFFSET_X + ',12)');
       break;
     case 'Propeller':
       this.propeller_.style.display = '';
@@ -625,7 +625,7 @@ CustomFields.FieldTurtle.prototype.createView_ = function() {
   this.mask_ = Blockly.utils.dom.createSvgElement('image',
     {
       'width': '50',
-      'height': '14'
+      'height': '24'
     }, scaleGroup);
   this.mask_.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
     'media/mask.svg');


### PR DESCRIPTION
Adds fix for mask placement so turtle name is contained within border around turtle picture.
Tested locally on chrome.
Identical change as https://github.com/google/blockly/pull/4962