### PR TITLE
Remove extra link to source code

### DIFF
--- a/examples/custom-dialogs-demo/index.html
+++ b/examples/custom-dialogs-demo/index.html
@@ -19,8 +19,6 @@
 </head>
 <body>
   <p>This is a simple demo of replacing modal browser dialogs with HTML.
-     To see how it works, see the source code in
-     <a href="custom-dialog.js">custom-dialog.js</a>
   </p>
 
   <p>Try creating new variables, creating variables with names already in

--- a/examples/pitch-field-demo/index.html
+++ b/examples/pitch-field-demo/index.html
@@ -38,10 +38,7 @@
       is used to select a note pitch.
     </p>
 
-    <p>All of the custom field implementation is in
-     <a target="_blank" href="https://github.com/google/blockly-samples/blob/master/examples/pitch-field-demo/field_pitch.js">field_pitch.js</a>, including comments on each required
-     function.
-    </p>
+    <p>&rarr; More info on <a href="https://developers.google.com/blockly/guides/create-custom-blocks/fields/customizing-field/creating">creating a custom field</a>&hellip;</p>
 
     <p>
       <input type="button" value="Export to XML" onclick="toXml()">

--- a/examples/turtle-field-demo/index.html
+++ b/examples/turtle-field-demo/index.html
@@ -38,10 +38,7 @@
       is used to define a turtle.
     </p>
 
-    <p>All of the custom field implementation is in
-     <a target="_blank" href="https://github.com/google/blockly-samples/blob/master/examples/turtle-field-demo/field_turtle.js">field_turtle.js</a>, including comments on each required
-     function.
-    </p>
+    <p>&rarr; More info on <a href="https://developers.google.com/blockly/guides/create-custom-blocks/fields/customizing-field/creating">creating a custom field</a>&hellip;</p>
 
     <p>Click on the blocks' comment icons to learn what they are demonstrating.
       Use the buttons below to see how the fields react to changes.


### PR DESCRIPTION
Removes extra links to source code of examples. Each example already has a link to the source in the top right through the "View Code" button.
The links in the custom field demos were changed to link to the custom fields documentation as it is a similar pattern used in other demos.