### PR TITLE
Set upper limit on peerDependency blockly version

### DIFF
--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -48,7 +48,7 @@
     "sinon": "^9.0.1"
   },
   "peerDependencies": {
-    "blockly": ">=5.20210325.0"
+    "blockly": "^5.20210325.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -44,7 +44,7 @@
     "blockly": "^5.20210325.0"
   },
   "peerDependencies": {
-    "blockly": ">=5.20210325.0"
+    "blockly": "^5.20210325.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
The current versions of workspace-search and zoom-to-fit are actually incompatible with blockly version 6, making the peerDependency listed in the package.json incorrect.

This corrects it to require a peerDependency of major version 5 only. This should be a patch update so that anyone using these packages will get this update automatically.

We do have new versions of these plugins that are compatible with (and require) blockly version 6. Those will be major updates and developers using these plugins can update manually at the same time they update blockly.