### PR TITLE
Fix typing and update declaration of @record types to match style guide

### DIFF
--- a/plugins/dev-tools/src/block_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/block_test_helpers.mocha.js
@@ -17,66 +17,81 @@ const {
 } = commonTestHelpers;
 
 /**
- * Code generation test case.
- * @extends {TestCase}
+ * Code generation test case configuration.
+ * @implements {TestCase}
  * @record
  */
-export function CodeGenerationTestCase() {}
-CodeGenerationTestCase.prototype = new TestCase();
-/**
- * @type {string} The expected code.
- */
-CodeGenerationTestCase.prototype.expectedCode = '';
-/**
- * @type {number|undefined} The expected inner order.
- */
-CodeGenerationTestCase.prototype.expectedInnerOrder = undefined;
-/**
- * @type {boolean|undefined} Whether to use workspaceToCode instead of
- * blockToCode for test.
- */
-CodeGenerationTestCase.prototype.useWorkspaceToCode = false;
-/**
- * A function that creates the block for the test.
- * @param {!Blockly.Workspace} workspace The workspace context for this test.
- * @return {!Blockly.Block}
- */
-CodeGenerationTestCase.prototype.createBlock = undefined;
+export class CodeGenerationTestCase {
+  /**
+   * Class for a code generation test case.
+   */
+  constructor() {
+    /**
+     * Creates the block to use for this test case.
+     * @param {!Blockly.Workspace} workspace The workspace context for this
+     *    test.
+     * @return {!Blockly.Block}
+     */
+    this.createBlock;
+    /**
+     * @type {string} The expected code.
+     */
+    this.expectedCode;
+    /**
+     * @type {boolean|undefined} Whether to use workspaceToCode instead of
+     * blockToCode for test.
+     */
+    this.useWorkspaceToCode;
+    /**
+     * @type {number|undefined} The expected inner order.
+     */
+    this.expectedInnerOrder;
+  }
+}
 
 /**
  * Code generation test suite.
  * @extends {TestSuite<CodeGenerationTestCase>}
  * @record
  */
-export function CodeGenerationTestSuite() {}
-CodeGenerationTestSuite.prototype = new TestSuite();
-/**
- * @type {!Blockly.Generator} The generator to use for running test cases.
- */
-CodeGenerationTestSuite.prototype.generator = undefined;
+export class CodeGenerationTestSuite {
+  /**
+   * Class for a code generation test suite.
+   */
+  constructor() {
+    /**
+     * @type {!Blockly.Generator} The generator to use for running test cases.
+     */
+    this.generator;
+  }
+}
 
 /**
  * Serialization test case.
- * @extends {TestCase}
+ * @implements {TestCase}
  * @record
  */
-export function SerializationTestCase() {}
-SerializationTestCase.prototype = new TestCase();
-/**
- * @type {string} The xml to use for test.
- */
-SerializationTestCase.prototype.xml = '';
-/**
- * @type {string|undefined} The expected xml after round trip. Provided if
- *    different from xml that is passed in.
- */
-SerializationTestCase.prototype.expectedXml = '';
-/**
- * A function that asserts tests has the expected structure after converting to
- *    block from given xml.
- * @param {!Blockly.Block} block The block to check.
- */
-SerializationTestCase.prototype.assertBlockStructure = undefined;
+export class SerializationTestCase {
+  /**
+   * Class for a block serialization test case.
+   */
+  constructor() {
+    /**
+     * @type {string} The block xml to use for test.
+     */
+    this.xml;
+    /**
+     * Asserts that the block created from xml has the expected structure.
+     * @param {!Blockly.Block} block The block to check.
+     */
+    this.assertBlockStructure;
+    /**
+     * @type {string|undefined} The expected xml after round trip. Provided if
+     *    it different from xml that was passed in.
+     */
+    this.expectedXml;
+  }
+}
 
 /**
  * Returns mocha test callback for code generation based on provided

--- a/plugins/dev-tools/src/block_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/block_test_helpers.mocha.js
@@ -51,7 +51,7 @@ export class CodeGenerationTestCase {
 
 /**
  * Code generation test suite.
- * @extends {TestSuite<CodeGenerationTestCase>}
+ * @extends {TestSuite<CodeGenerationTestCase, CodeGenerationTestSuite>}
  * @record
  */
 export class CodeGenerationTestSuite {

--- a/plugins/dev-tools/src/block_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/block_test_helpers.mocha.js
@@ -27,13 +27,6 @@ export class CodeGenerationTestCase {
    */
   constructor() {
     /**
-     * Creates the block to use for this test case.
-     * @param {!Blockly.Workspace} workspace The workspace context for this
-     *    test.
-     * @return {!Blockly.Block}
-     */
-    this.createBlock;
-    /**
      * @type {string} The expected code.
      */
     this.expectedCode;
@@ -47,6 +40,14 @@ export class CodeGenerationTestCase {
      */
     this.expectedInnerOrder;
   }
+
+  /**
+   * Creates the block to use for this test case.
+   * @param {!Blockly.Workspace} workspace The workspace context for this
+   *    test.
+   * @return {!Blockly.Block} The block to use for the test case.
+   */
+  createBlock(workspace) {}
 }
 
 /**
@@ -81,16 +82,16 @@ export class SerializationTestCase {
      */
     this.xml;
     /**
-     * Asserts that the block created from xml has the expected structure.
-     * @param {!Blockly.Block} block The block to check.
-     */
-    this.assertBlockStructure;
-    /**
      * @type {string|undefined} The expected xml after round trip. Provided if
      *    it different from xml that was passed in.
      */
     this.expectedXml;
   }
+  /**
+   * Asserts that the block created from xml has the expected structure.
+   * @param {!Blockly.Block} block The block to check.
+   */
+  assertBlockStructure(block) {}
 }
 
 /**

--- a/plugins/dev-tools/src/common_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/common_test_helpers.mocha.js
@@ -34,7 +34,7 @@ export class TestCase {
  * Test suite configuration.
  * @record
  * @template {TestCase} T
- * @template {TestSuite<T>} U
+ * @template {TestSuite} U
  */
 export class TestSuite {
   /**
@@ -84,8 +84,9 @@ export function runTestCases(testCases, createTestCallback) {
 /**
  * Runs provided test suite.
  * @template {TestCase} T
- * @param {Array<!TestSuite<T, ?>>} testSuites The test suites to run.
- * @param {function(!TestSuite<T, ?>):(function(T):!Function)
+ * @template {TestSuite<T, U>} U
+ * @param {Array<!U>} testSuites The test suites to run.
+ * @param {function(!U):(function(T):!Function)
  *    } createTestCaseCallback Creates test case callback using given test
  *    suite.
  */

--- a/plugins/dev-tools/src/common_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/common_test_helpers.mocha.js
@@ -34,6 +34,7 @@ export class TestCase {
  * Test suite configuration.
  * @record
  * @template {TestCase} T
+ * @template {TestSuite<T>} U
  */
 export class TestSuite {
   /**
@@ -49,7 +50,7 @@ export class TestSuite {
      */
     this.testCases;
     /**
-     * @type {?Array<TestCase<T>>} Optional inner test suites.
+     * @type {?Array<U>} List of nested inner test suites.
      */
     this.testSuites;
     /**
@@ -83,8 +84,8 @@ export function runTestCases(testCases, createTestCallback) {
 /**
  * Runs provided test suite.
  * @template {TestCase} T
- * @param {Array<!TestSuite<T>>} testSuites The test suites to run.
- * @param {function(!TestSuite<T>):(function(T):!Function)
+ * @param {Array<!TestSuite<T, ?>>} testSuites The test suites to run.
+ * @param {function(!TestSuite<T, ?>):(function(T):!Function)
  *    } createTestCaseCallback Creates test case callback using given test
  *    suite.
  */
@@ -97,8 +98,7 @@ export function runTestSuites(testSuites, createTestCaseCallback) {
         runTestSuites(testSuite.testSuites, createTestCaseCallback);
       }
       if (testSuite.testCases && testSuite.testCases.length) {
-        runTestCases(/** @type {!Array<TestCase>} */ (testSuite.testCases),
-            createTestCaseCallback(testSuite));
+        runTestCases(testSuite.testCases, createTestCaseCallback(testSuite));
       }
     });
   });

--- a/plugins/dev-tools/src/common_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/common_test_helpers.mocha.js
@@ -5,54 +5,65 @@
  */
 
 /**
- * Test case configuration information.
+ * Test case configuration.
  * @record
  */
-export function TestCase() {}
-/**
- * @type {string} The title for the test case.
- */
-TestCase.prototype.title = '';
-/**
- * @type {boolean|undefined} Whether this test case should be skipped. Used to
- *    skip buggy test case and should have an associated bug.
- */
-TestCase.prototype.skip = false;
-/**
- * @type {boolean|undefined} Whether this test case should be called as only.
- *    Used for debugging.
- */
-TestCase.prototype.only = false;
+export class TestCase {
+  /**
+   * Class for a test case configuration.
+   */
+  constructor() {
+    /**
+     * @type {string} The title for the test case.
+     */
+    this.title;
+    /**
+     * @type {boolean|undefined} Whether this test case should be skipped.
+     *   Used to skip buggy test case and should have an associated bug.
+     */
+    this.skip;
+    /**
+     * @type {boolean|undefined} Whether this test case should be called as
+     *   only. Used for debugging.
+     */
+    this.only;
+  }
+}
 
 /**
- * Test suite configuration information.
+ * Test suite configuration.
  * @record
  * @template {TestCase} T
- * @template {TestSuite} U
  */
-export function TestSuite() {}
-/**
- * @type {string} The title for the test case.
- */
-TestSuite.prototype.title = '';
-/**
- * @type {boolean} Whether this test suite should be skipped. Used to
- *    skip buggy test case and should have an associated bug.
- */
-TestSuite.prototype.skip = false;
-/**
- * @type {boolean} Whether this test suite should be called as only.
- *    Used for debugging.s
- */
-TestSuite.prototype.only = false;
-/**
- * @type {?Array<T>} The associated test cases.
- */
-TestSuite.prototype.testCases = [];
-/**
- * @type {?Array<U>} Optional inner test suites.
- */
-TestSuite.prototype.testSuites = [];
+export class TestSuite {
+  /**
+   * Class for a test suite configuration.
+   */
+  constructor() {
+    /**
+     * @type {string} The title for the test case.
+     */
+    this.title;
+    /**
+     * @type {?Array<T>} The associated test cases.
+     */
+    this.testCases;
+    /**
+     * @type {?Array<TestCase<T>>} Optional inner test suites.
+     */
+    this.testSuites;
+    /**
+     * @type {boolean|undefined} Whether this test suite should be skipped.
+     *   Used to skip buggy test case and should have an associated bug.
+     */
+    this.skip;
+    /**
+     * @type {boolean|undefined} Whether this test suite should be called as
+     *   only. Used for debugging.
+     */
+    this.only;
+  }
+}
 
 /**
  * Runs provided test cases.
@@ -71,7 +82,7 @@ export function runTestCases(testCases, createTestCallback) {
 
 /**
  * Runs provided test suite.
- * @template {TestSuite} T
+ * @template {TestCase} T
  * @param {Array<!TestSuite<T>>} testSuites The test suites to run.
  * @param {function(!TestSuite<T>):(function(T):!Function)
  *    } createTestCaseCallback Creates test case callback using given test
@@ -86,7 +97,8 @@ export function runTestSuites(testSuites, createTestCaseCallback) {
         runTestSuites(testSuite.testSuites, createTestCaseCallback);
       }
       if (testSuite.testCases && testSuite.testCases.length) {
-        runTestCases(testSuite.testCases, createTestCaseCallback(testSuite));
+        runTestCases(/** @type {!Array<TestCase>} */ (testSuite.testCases),
+            createTestCaseCallback(testSuite));
       }
     });
   });

--- a/plugins/dev-tools/src/field_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/field_test_helpers.mocha.js
@@ -9,45 +9,55 @@ import {runTestCases, TestCase} from './common_test_helpers.mocha';
 
 /**
  * Field value test case.
- * @extends {TestCase}
+ * @implements {TestCase}
  * @record
  */
-export function FieldValueTestCase() {}
-FieldValueTestCase.prototype = new TestCase();
-/**
- * @type {*} The value to use in test.
- */
-FieldValueTestCase.prototype.value = undefined;
-/**
- * @type {*} The expected value.
- */
-FieldValueTestCase.prototype.expectedValue = undefined;
-/**
- * @type {string|undefined} Optional expected text (if not specified, default is
- *    String(expectedValue).
- */
-FieldValueTestCase.prototype.expectedText = undefined;
-/**
- * @type {!RegExp|string|undefined} Optional error message matcher if test case
- *    is expected to throw.
- */
-FieldValueTestCase.prototype.errMsgMatcher = undefined;
+export class FieldValueTestCase {
+  /**
+   * Class for a a field value test case.
+   */
+  constructor() {
+    /**
+     * @type {*} The value to use in test.
+     */
+    this.value;
+    /**
+     * @type {*} The expected value.
+     */
+    this.expectedValue;
+    /**
+     * @type {string|undefined} The expected text value. Provided if different
+     *    from String(expectedValue).
+     */
+    this.expectedText;
+    /**
+     * @type {!RegExp|string|undefined} The optional error message matcher.
+     *    Provided if test case is expected to throw.
+     */
+    this.errMsgMatcher;
+  }
+}
 
 /**
  * Field creation test case.
  * @extends {FieldValueTestCase}
  * @record
  */
-export function FieldCreationTestCase() {}
-FieldCreationTestCase.prototype = new FieldValueTestCase();
-/**
- * @type {Array<*>} The arguments to pass to field constructor.
- */
-FieldCreationTestCase.prototype.args = [];
-/**
- * @type {string} The json to use in field creation.
- */
-FieldCreationTestCase.prototype.json = undefined;
+export class FieldCreationTestCase {
+  /**
+   * Class for a field creation test case.
+   */
+  constructor() {
+    /**
+     * @type {Array<*>} The arguments to pass to field constructor.
+     */
+    this.args;
+    /**
+     * @type {string} The json to use in field creation.
+     */
+    this.json;
+  }
+}
 
 /**
  * Assert a field's value is the same as the expected value.

--- a/plugins/eslint-config/index.js
+++ b/plugins/eslint-config/index.js
@@ -53,6 +53,9 @@ module.exports = {
     'no-warning-comments': 'warn',
     'new-cap': ['error', {'capIsNewExceptionPattern': '^.*Error'}],
     'no-invalid-this': 'off',
+    // valid-jsdoc does not work properly for interface methods.
+    // https://github.com/eslint/eslint/issues/9978
+    'valid-jsdoc': 'off',
 
     // https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules
     'require-jsdoc': 'off',


### PR DESCRIPTION
Update typing for test types:
- Use syntax for declaring `@record` type as recommended in [style guide](https://google.github.io/styleguide/jsguide.html#features-classes-interfaces)
- Correct typing in `runTestSuites`
- Remove second template type from `TestSuite`

### Additional Information
The eslint warnings that this fixes are:
```
/usr/local/google/home/kozbial/github/blockly/samples-moniika/plugins/dev-tools/src/common_test_helpers.mocha.js
  49:0  warning  The type 'T' is undefined  jsdoc/no-undefined-types
  53:0  warning  The type 'U' is undefined  jsdoc/no-undefined-types
```