### PR TITLE
Remove unregisters from theme plugins

### DIFF
--- a/plugins/theme-dark/src/index.js
+++ b/plugins/theme-dark/src/index.js
@@ -11,10 +11,6 @@
 import Blockly from 'blockly/core';
 
 
-// Temporarily required to ensure there's no conflict with
-// Blockly.Themes.Dark
-Blockly.registry.unregister('theme', 'dark');
-
 /**
  * Dark theme.
  */

--- a/plugins/theme-deuteranopia/src/index.js
+++ b/plugins/theme-deuteranopia/src/index.js
@@ -88,10 +88,6 @@ const categoryStyles = {
   },
 };
 
-// Temporarily required to ensure there's no conflict with
-// Blockly.Themes.Deuteranopia
-Blockly.registry.unregister('theme', 'deuteranopia');
-
 /**
  * Deuteranopia theme.
  * A colour palette for people that have deuteranopia (the inability to perceive

--- a/plugins/theme-highcontrast/src/index.js
+++ b/plugins/theme-highcontrast/src/index.js
@@ -78,10 +78,6 @@ const categoryStyles = {
   'variable_dynamic_category': {'colour': '#880e4f'},
 };
 
-// Temporarily required to ensure there's no conflict with
-// Blockly.Themes.HighContrast
-Blockly.registry.unregister('theme', 'highcontrast');
-
 /**
  * High contrast theme.
  */

--- a/plugins/theme-tritanopia/src/index.js
+++ b/plugins/theme-tritanopia/src/index.js
@@ -88,10 +88,6 @@ const categoryStyles = {
   },
 };
 
-// Temporarily required to ensure there's no conflict with
-// Blockly.Themes.Tritanopia
-Blockly.registry.unregister('theme', 'tritanopia');
-
 /**
  * Tritanopia theme.
  * A colour palette for people that have tritanopia (the inability to perceive


### PR DESCRIPTION
We had to add `Blockly.registry.unregister('theme', 'dark');` because the themes were still in core, so registering them again under the same name would result in an error. 

This quarter we removed themes from core, so these are no longer needed and are causing warnings in the playground.

This will throw an error in the case that someone updates their plugin, but does not update their Blockly version. This is because we will not be unregistering the theme and the old version of Blockly will contain the old theme causing us to register the theme under the same name twice.

Still left to do: 
- Update peerDependency of each plugin.
- Update major version of each plugin.