### PR TITLE
Add deleting defs prior to registering them

### DIFF
--- a/plugins/block-plus-minus/src/list_create.js
+++ b/plugins/block-plus-minus/src/list_create.js
@@ -12,6 +12,8 @@ import Blockly from 'blockly/core';
 import {createPlusField} from './field_plus';
 import {createMinusField} from './field_minus';
 
+delete Blockly.Blocks['lists_create_with'];
+
 /* eslint-disable quotes */
 Blockly.defineBlocksWithJsonArray([
   {

--- a/plugins/block-plus-minus/src/procedures.js
+++ b/plugins/block-plus-minus/src/procedures.js
@@ -14,6 +14,9 @@ import {createPlusField} from './field_plus';
 
 Blockly.Msg['PROCEDURE_VARIABLE'] = 'variable:';
 
+delete Blockly.Blocks['procedures_defnoreturn'];
+delete Blockly.Blocks['procedures_defreturn'];
+
 /* eslint-disable quotes */
 Blockly.defineBlocksWithJsonArray([
   {


### PR DESCRIPTION
### Description

Closes #768 

Deletes prior definitions definitions for the blocks the plus-minus plugin registers before registering them, so that we don't get warnings about overwriting previous definitions.

### Testing

Ran `npm run start` observed that there were no warnings in the console (specific to this).