### PR TITLE
Plus / Minus blocks - delete original blocks before registering new ones

### DIFF
--- a/plugins/block-plus-minus/src/list_create.js
+++ b/plugins/block-plus-minus/src/list_create.js
@@ -12,7 +12,8 @@ import Blockly from 'blockly/core';
 import {createPlusField} from './field_plus';
 import {createMinusField} from './field_minus';
 
-// Delete original block because there's no way to unregister it: https://github.com/google/blockly-samples/issues/768#issuecomment-885663394
+// Delete original block because there's no way to unregister it:
+// https://github.com/google/blockly-samples/issues/768#issuecomment-885663394
 delete Blockly.Blocks['lists_create_with'];
 
 /* eslint-disable quotes */

--- a/plugins/block-plus-minus/src/list_create.js
+++ b/plugins/block-plus-minus/src/list_create.js
@@ -12,6 +12,9 @@ import Blockly from 'blockly/core';
 import {createPlusField} from './field_plus';
 import {createMinusField} from './field_minus';
 
+// Delete original block because there's no way to unregister it: https://github.com/google/blockly-samples/issues/768#issuecomment-885663394
+delete Blockly.Blocks['lists_create_with'];
+
 /* eslint-disable quotes */
 Blockly.defineBlocksWithJsonArray([
   {

--- a/plugins/block-plus-minus/src/procedures.js
+++ b/plugins/block-plus-minus/src/procedures.js
@@ -14,7 +14,8 @@ import {createPlusField} from './field_plus';
 
 Blockly.Msg['PROCEDURE_VARIABLE'] = 'variable:';
 
-// Delete original blocks because there's no way to unregister them: https://github.com/google/blockly-samples/issues/768#issuecomment-885663394
+// Delete original blocks because there's no way to unregister them:
+// https://github.com/google/blockly-samples/issues/768#issuecomment-885663394
 delete Blockly.Blocks['procedures_defnoreturn'];
 delete Blockly.Blocks['procedures_defreturn'];
 

--- a/plugins/block-plus-minus/src/procedures.js
+++ b/plugins/block-plus-minus/src/procedures.js
@@ -14,6 +14,10 @@ import {createPlusField} from './field_plus';
 
 Blockly.Msg['PROCEDURE_VARIABLE'] = 'variable:';
 
+// Delete original blocks because there's no way to unregister them: https://github.com/google/blockly-samples/issues/768#issuecomment-885663394
+delete Blockly.Blocks['procedures_defnoreturn'];
+delete Blockly.Blocks['procedures_defreturn'];
+
 /* eslint-disable quotes */
 Blockly.defineBlocksWithJsonArray([
   {


### PR DESCRIPTION
Delete original blocks to prevent the following warnings in the console:

```
Block definition #0 in JSON array overwrites prior definition of "lists_create_with".
Block definition #0 in JSON array overwrites prior definition of "procedures_defnoreturn".
Block definition #1 in JSON array overwrites prior definition of "procedures_defreturn".
```

Relates to google/blockly-samples#768