### PR TITLE
Fix event grouping

### DIFF
--- a/plugins/keyboard-navigation/src/navigation.js
+++ b/plugins/keyboard-navigation/src/navigation.js
@@ -1140,9 +1140,9 @@ export class Navigation {
         if (Blockly.Events.isEnabled() && !block.isShadow()) {
           Blockly.Events.fire(new Blockly.Events.BlockCreate(block));
         }
-        Blockly.Events.setGroup(false);
         isHandled = true;
       }
+      Blockly.Events.setGroup(false);
     }
     return isHandled;
   }


### PR DESCRIPTION
Before this change, the group was only closed if the block had been created. Now the group is closed in either case.