### PR TITLE
docs: Add docs telling people not to use API

### DIFF
--- a/plugins/block-dynamic-connection/README.md
+++ b/plugins/block-dynamic-connection/README.md
@@ -16,9 +16,11 @@ import * as BlockDynamicConnection from '@blockly/block-dynamic-connection';
 ```
 
 ## API
-- `overrideOldBlockDefinitions`: Replaces the Blockly default blocks with the
+- ~~`overrideOldBlockDefinitions`: Replaces the Blockly default blocks with the
   dynamic connection blocks. This enables projects to use the dynamic block
-  plugin without changing existing XML.
+  plugin without changing existing XML.~~
+  Do not use this API unless you are already using it, because it does not
+  perform as intended. See #844 for context.
 
 ## XML
 ```xml


### PR DESCRIPTION
### Description

Related to #844 

Edits the readme to tell people not to use the `overrideOldBlockDefinitions` function, as it breaks existing projects.