### PR TITLE
feat: add JSON options to serialization test helpers

### DIFF
--- a/plugins/dev-tools/src/block_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/block_test_helpers.mocha.js
@@ -94,7 +94,7 @@ export class SerializationTestCase {
     this.json;
     /**
      * @type {string|undefined} The expected json after round trip. Provided if
-     *    it different from json that was passed in.
+     *    it is different from json that was passed in.
      */
     this.expectedJson;
   }

--- a/plugins/dev-tools/src/block_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/block_test_helpers.mocha.js
@@ -168,7 +168,7 @@ export const runSerializationTestSuite = (testCases) => {
    * @param {!SerializationTestCase} testCase The test case information.
    * @return {!Function} The test callback.
    */
-  const createXmlToBlockTestCallback = (testCase) => {
+  const createSerializedDataToBlockTestCallback = (testCase) => {
     return function() {
       let block;
       if (testCase.json) {
@@ -186,7 +186,7 @@ export const runSerializationTestSuite = (testCases) => {
    * @param {!SerializationTestCase} testCase The test case information.
    * @return {!Function} The test callback.
    */
-  const createXmlRoundTripTestCallback = (testCase) => {
+  const createRoundTripTestCallback = (testCase) => {
     return function() {
       if (testCase.json) {
         const block = Blockly.serialization.blocks.append(
@@ -207,7 +207,7 @@ export const runSerializationTestSuite = (testCases) => {
   };
   suite('Serialization', function() {
     suite('xmlToBlock', function() {
-      runTestCases(testCases, createXmlToBlockTestCallback);
+      runTestCases(testCases, createSerializedDataToBlockTestCallback);
     });
     suite('xml round-trip', function() {
       setup(function() {
@@ -236,7 +236,7 @@ export const runSerializationTestSuite = (testCases) => {
         sinon.restore();
       });
 
-      runTestCases(testCases, createXmlRoundTripTestCallback);
+      runTestCases(testCases, createRoundTripTestCallback);
     });
   });
 };

--- a/plugins/dev-tools/src/block_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/block_test_helpers.mocha.js
@@ -172,7 +172,7 @@ export const runSerializationTestSuite = (testCases) => {
     return function() {
       let block;
       if (testCase.json) {
-        block = Blockly.serialization.blocks.load(
+        block = Blockly.serialization.blocks.append(
             testCase.json, this.workspace);
       } else {
         block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
@@ -189,7 +189,7 @@ export const runSerializationTestSuite = (testCases) => {
   const createXmlRoundTripTestCallback = (testCase) => {
     return function() {
       if (testCase.json) {
-        const block = Blockly.serialization.blocks.load(
+        const block = Blockly.serialization.blocks.append(
             testCase.json, this.workspace);
         const generatedJson = Blockly.serialization.blocks.save(block);
         const expectedJson = testCase.expectedJson || testCase.json;

--- a/plugins/dev-tools/src/block_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/block_test_helpers.mocha.js
@@ -78,7 +78,8 @@ export class SerializationTestCase {
    */
   constructor() {
     /**
-     * @type {string} The block xml to use for test.
+     * @type {string} The block xml to use for test. Do not provide if json is
+     *     provided.
      */
     this.xml;
     /**
@@ -86,6 +87,16 @@ export class SerializationTestCase {
      *    it different from xml that was passed in.
      */
     this.expectedXml;
+    /**
+     * @type {string} The block json to use for test. Do not provide if xml is
+     *     provided.
+     */
+    this.json;
+    /**
+     * @type {string|undefined} The expected json after round trip. Provided if
+     *    it different from json that was passed in.
+     */
+    this.expectedJson;
   }
   /**
    * Asserts that the block created from xml has the expected structure.
@@ -159,8 +170,14 @@ export const runSerializationTestSuite = (testCases) => {
    */
   const createXmlToBlockTestCallback = (testCase) => {
     return function() {
-      const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-          testCase.xml), this.workspace);
+      let block;
+      if (testCase.json) {
+        block = Blockly.serialization.blocks.load(
+            testCase.json, this.workspace);
+      } else {
+        block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+            testCase.xml), this.workspace);
+      }
       testCase.assertBlockStructure(block);
     };
   };
@@ -171,13 +188,21 @@ export const runSerializationTestSuite = (testCases) => {
    */
   const createXmlRoundTripTestCallback = (testCase) => {
     return function() {
-      const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
-          testCase.xml), this.workspace);
-      const generatedXml =
-          Blockly.Xml.domToPrettyText(
-              Blockly.Xml.blockToDom(block));
-      const expectedXml = testCase.expectedXml || testCase.xml;
-      assert.equal(generatedXml, expectedXml);
+      if (testCase.json) {
+        const block = Blockly.serialization.blocks.load(
+            testCase.json, this.workspace);
+        const generatedJson = Blockly.serialization.blocks.save(block);
+        const expectedJson = testCase.expectedJson || testCase.json;
+        assert.equal(generatedJson, expectedJson);
+      } else {
+        const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
+            testCase.xml), this.workspace);
+        const generatedXml =
+            Blockly.Xml.domToPrettyText(
+                Blockly.Xml.blockToDom(block));
+        const expectedXml = testCase.expectedXml || testCase.xml;
+        assert.equal(generatedXml, expectedXml);
+      }
     };
   };
   suite('Serialization', function() {


### PR DESCRIPTION
### Description

Adds an option to the serialization test helpers to test JSON serialization instead of XML serialization. This should not be merged until the JSON serialization system is in core.

I've also been unable to test this. I tried adding tests to the blocks-plus-minus package, but that required linking that package to dev-tools, and then linking dev-tools to my local checkout of core, which I couldn't get to work :/