### PR TITLE
feat: add JSO serialization to advanced playground

### DIFF
--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -118,6 +118,8 @@ export function createPlayground(
         const errorModel = window.monaco.editor.createModel('');
         const editorXmlContextKey =
             editor.createContextKey('isEditorXml', true);
+        const editorJsonContextKey =
+            editor.createContextKey('isEditorJson', true);
 
         // Load / Save playground state.
         const playgroundState = new LocalStorageState(`playgroundState_${id}`, {
@@ -191,6 +193,7 @@ export function createPlayground(
           currentTab = tab;
           currentGenerate = tab.generate;
           const isXml = tab.state.name == 'XML';
+          const isJson = tab.state.name == 'JSON';
           editor.setModel(currentTab.state.model);
           editor.updateOptions({
             readOnly: !isXml,
@@ -203,6 +206,7 @@ export function createPlayground(
                   (t.tabElement == tab.tabElement) ? '#1E1E1E' : '#2D2D2D');
           // Update editor state.
           editorXmlContextKey.set(isXml);
+          editorJsonContextKey.set(isJson);
           playgroundState.set('activeTab', tab.state.name);
           playgroundState.save();
         };
@@ -242,29 +246,47 @@ export function createPlayground(
 
         // Register default tabs.
         const tabs = {
+          'JSON': registerGenerator(
+              'JSON',
+              'json',
+              (ws) => {
+                return JSON.stringify(
+                    Blockly.serialization.workspaces.save(ws), null, 2);
+              }
+          ),
           'XML': registerGenerator(
-              'XML', 'xml',
+              'XML',
+              'xml',
               (ws) => {
                 return Blockly.Xml.domToPrettyText(
                     Blockly.Xml.workspaceToDom(ws));
-              }),
+              }
+          ),
           'JavaScript': registerGenerator(
-              'JavaScript', 'javascript',
+              'JavaScript',
+              'javascript',
               (ws) => (BlocklyJS || Blockly.JavaScript).workspaceToCode(ws),
               true),
           'Python': registerGenerator(
-              'Python', 'python',
+              'Python',
+              'python',
               (ws) => (BlocklyPython || Blockly.Python).workspaceToCode(ws),
               true),
           'Dart': registerGenerator(
-              'Dart', 'dart',
-              (ws) => (BlocklyDart || Blockly.Dart).workspaceToCode(ws), true),
+              'Dart',
+              'dart',
+              (ws) => (BlocklyDart || Blockly.Dart).workspaceToCode(ws),
+              true),
           'Lua': registerGenerator(
-              'Lua', 'lua',
-              (ws) => (BlocklyLua || Blockly.Lua).workspaceToCode(ws), true),
+              'Lua',
+              'lua',
+              (ws) => (BlocklyLua || Blockly.Lua).workspaceToCode(ws),
+              true),
           'PHP': registerGenerator(
-              'PHP', 'php',
-              (ws) => (BlocklyPHP || Blockly.PHP).workspaceToCode(ws), true),
+              'PHP',
+              'php',
+              (ws) => (BlocklyPHP || Blockly.PHP).workspaceToCode(ws),
+              true),
         };
 
         // Handle tab click.
@@ -487,13 +509,23 @@ function registerTabButtons(editor, playground, tabButtons, updateEditor) {
  * @param {PlaygroundAPI} playground The current playground.
  */
 function registerEditorCommands(editor, playground) {
-  const load = () => {
-    if (playground.getCurrentTab().state.name !== 'XML') {
-      return;
-    }
+  const loadXml = () => {
     const xml = editor.getModel().getValue();
     const workspace = playground.getWorkspace();
-    Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
+    try {
+      Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
+    } catch(e) {
+      // If this fails that's fine.
+    }
+  };
+  const loadJson = () => {
+    const json = editor.getModel().getValue();
+    const workspace = playground.getWorkspace();
+    try {
+      Blockly.serialization.workspaces.load(JSON.parse(json), workspace);
+    } catch(e) {
+      // If this fails that's fine.
+    }
   };
   const save = () => {
     playground.getCurrentTab().generate();
@@ -509,7 +541,7 @@ function registerEditorCommands(editor, playground) {
     precondition: 'isEditorXml',
     contextMenuGroupId: 'playground',
     contextMenuOrder: 0,
-    run: load,
+    run: loadXml,
   });
   // Add XMl Export action (only available on the XML tab).
   editor.addAction({
@@ -523,6 +555,7 @@ function registerEditorCommands(editor, playground) {
     contextMenuOrder: 1,
     run: save,
   });
+  // Add Clean XML action (only available on thee JSON tab).
   editor.addAction({
     id: 'clean-xml',
     label: 'Clean XML',
@@ -536,6 +569,18 @@ function registerEditorCommands(editor, playground) {
           [], [{range: model.getFullModelRange(), text}], () => null);
       editor.setSelection(new window.monaco.Range(0, 0, 0, 0));
     },
+  });
+  // Add JSON Import action (only available on the XML tab).
+  editor.addAction({
+    id: 'import-json',
+    label: 'Import from JSON',
+    keybindings: [
+      window.monaco.KeyMod.CtrlCmd | window.monaco.KeyCode.Enter,
+    ],
+    precondition: 'isEditorJson',
+    contextMenuGroupId: 'playground',
+    contextMenuOrder: 0,
+    run: loadJson,
   });
   // Add a Generator generate action.
   editor.addAction({
@@ -552,12 +597,11 @@ function registerEditorCommands(editor, playground) {
   document.addEventListener('keydown', (e) => {
     const ctrlCmd = e.metaKey || e.ctrlKey;
     if (ctrlCmd && e.keyCode === Blockly.utils.KeyCodes.S) {
-      // Save.
       save();
       e.preventDefault();
     } else if (ctrlCmd && e.keyCode === Blockly.utils.KeyCodes.ENTER) {
-      // Load.
-      load();
+      loadXml();
+      loadJson();
       e.preventDefault();
     }
   });

--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -514,18 +514,22 @@ function registerEditorCommands(editor, playground) {
     const workspace = playground.getWorkspace();
     try {
       Blockly.Xml.domToWorkspace(Blockly.Xml.textToDom(xml), workspace);
-    } catch(e) {
+    } catch (e) {
       // If this fails that's fine.
+      return false;
     }
+    return true;
   };
   const loadJson = () => {
     const json = editor.getModel().getValue();
     const workspace = playground.getWorkspace();
     try {
       Blockly.serialization.workspaces.load(JSON.parse(json), workspace);
-    } catch(e) {
+    } catch (e) {
       // If this fails that's fine.
+      return false;
     }
+    return true;
   };
   const save = () => {
     playground.getCurrentTab().generate();
@@ -555,7 +559,7 @@ function registerEditorCommands(editor, playground) {
     contextMenuOrder: 1,
     run: save,
   });
-  // Add Clean XML action (only available on thee JSON tab).
+  // Add Clean XML action (only available on the XML tab).
   editor.addAction({
     id: 'clean-xml',
     label: 'Clean XML',
@@ -570,7 +574,7 @@ function registerEditorCommands(editor, playground) {
       editor.setSelection(new window.monaco.Range(0, 0, 0, 0));
     },
   });
-  // Add JSON Import action (only available on the XML tab).
+  // Add JSON Import action (only available on the JSON tab).
   editor.addAction({
     id: 'import-json',
     label: 'Import from JSON',
@@ -600,8 +604,7 @@ function registerEditorCommands(editor, playground) {
       save();
       e.preventDefault();
     } else if (ctrlCmd && e.keyCode === Blockly.utils.KeyCodes.ENTER) {
-      loadXml();
-      loadJson();
+      if (!loadJson()) loadXml();
       e.preventDefault();
     }
   });

--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -196,7 +196,7 @@ export function createPlayground(
           const isJson = tab.state.name == 'JSON';
           editor.setModel(currentTab.state.model);
           editor.updateOptions({
-            readOnly: !isXml,
+            readOnly: !isXml && !isJson,
             wordWrap: false,
           });
 

--- a/plugins/dev-tools/src/playground/options.js
+++ b/plugins/dev-tools/src/playground/options.js
@@ -132,13 +132,13 @@ export function addGUIControls(genWorkspace, defaultOptions, config = {}) {
 
   const onChangeInternal = () => {
     // Serialize current workspace state.
-    const state = Blockly.Xml.workspaceToDom(workspace);
+    const state = Blockly.serialization.workspaces.save(workspace);
     // Dispose of the current workspace
     workspace.dispose();
     // Create a new workspace with options.
     workspace = genWorkspace(saveOptions);
     // Deserialize state into workspace.
-    Blockly.Xml.domToWorkspace(state, workspace);
+    Blockly.serialization.workspaces.load(state, workspace);
     // Resize the gui.
     if (resizeEnabled) {
       onResize();


### PR DESCRIPTION
### Description

This should be merged after the JSO serializer is released.

Adds support for the new JSO serializer to the advanced playground. This will make it easy to use/test the JSO serializer.

### Testing
Manually tested that the tab and context menu items are properly added. But the actual serialization can't be tested until the JSO serializer is released
