### PR TITLE
Update package-locks for release

### DIFF
--- a/plugins/block-dynamic-connection/package-lock.json
+++ b/plugins/block-dynamic-connection/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/block-dynamic-connection",
-			"version": "0.1.9",
+			"version": "0.1.10",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^4.20201217.0",

--- a/plugins/block-extension-tooltip/package-lock.json
+++ b/plugins/block-extension-tooltip/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/block-extension-tooltip",
-			"version": "1.0.15",
+			"version": "1.0.16",
 			"license": "Apache 2.0",
 			"devDependencies": {
 				"blockly": "^5.20210325.1",

--- a/plugins/block-plus-minus/package-lock.json
+++ b/plugins/block-plus-minus/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/block-plus-minus",
-			"version": "2.0.35",
+			"version": "2.0.36",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^3.20200625.1",

--- a/plugins/block-test/package-lock.json
+++ b/plugins/block-test/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/block-test",
-			"version": "1.1.3",
+			"version": "1.1.4",
 			"license": "Apache 2.0",
 			"devDependencies": {
 				"blockly": "^3.20200924.1"

--- a/plugins/content-highlight/package-lock.json
+++ b/plugins/content-highlight/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/workspace-content-highlight",
-			"version": "1.0.5",
+			"version": "1.0.6",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^5.20210325.1"

--- a/plugins/continuous-toolbox/package-lock.json
+++ b/plugins/continuous-toolbox/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/continuous-toolbox",
-			"version": "1.0.14",
+			"version": "1.0.15",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^5.20210325.0"

--- a/plugins/dev-create/package-lock.json
+++ b/plugins/dev-create/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/create-package",
-			"version": "1.1.4",
+			"version": "1.1.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"chalk": "^4.0.0",

--- a/plugins/dev-scripts/package-lock.json
+++ b/plugins/dev-scripts/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/dev-scripts",
-			"version": "1.2.8",
+			"version": "1.2.9",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@babel/code-frame": "^7.8.3",

--- a/plugins/dev-tools/package-lock.json
+++ b/plugins/dev-tools/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/dev-tools",
-			"version": "2.5.4",
+			"version": "2.5.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"chai": "^4.2.0",

--- a/plugins/disable-top-blocks/package-lock.json
+++ b/plugins/disable-top-blocks/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/disable-top-blocks",
-			"version": "0.1.16",
+			"version": "0.1.17",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^3.20200924.3"

--- a/plugins/eslint-config/package-lock.json
+++ b/plugins/eslint-config/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/eslint-config",
-			"version": "2.1.2",
+			"version": "2.1.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@typescript-eslint/eslint-plugin": "^2.29.0",

--- a/plugins/field-date/package-lock.json
+++ b/plugins/field-date/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/field-date",
-			"version": "4.2.21",
+			"version": "4.2.22",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^3.20200924.1",

--- a/plugins/field-grid-dropdown/package-lock.json
+++ b/plugins/field-grid-dropdown/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/field-grid-dropdown",
-			"version": "1.0.21",
+			"version": "1.0.22",
 			"license": "Apache 2.0",
 			"devDependencies": {
 				"blockly": "^4.20201217.0"

--- a/plugins/field-slider/package-lock.json
+++ b/plugins/field-slider/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/field-slider",
-			"version": "2.1.25",
+			"version": "2.1.26",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^3.20200924.1",

--- a/plugins/fixed-edges/package-lock.json
+++ b/plugins/fixed-edges/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/fixed-edges",
-			"version": "1.0.14",
+			"version": "1.0.15",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^5.20210325.0"

--- a/plugins/keyboard-navigation/package-lock.json
+++ b/plugins/keyboard-navigation/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/keyboard-navigation",
-			"version": "0.1.14",
+			"version": "0.1.15",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^5.20210325.0",

--- a/plugins/modal/package-lock.json
+++ b/plugins/modal/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/plugin-modal",
-			"version": "2.1.24",
+			"version": "2.1.25",
 			"license": "Apache 2.0",
 			"devDependencies": {
 				"blockly": "^6.20210701.0",

--- a/plugins/nominal-connection-checker/package-lock.json
+++ b/plugins/nominal-connection-checker/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/plugin-nominal-connection-checker",
-			"version": "1.2.5",
+			"version": "1.2.6",
 			"license": "Apache 2.0",
 			"devDependencies": {
 				"blockly": "^3.20200924.0",

--- a/plugins/scroll-options/package-lock.json
+++ b/plugins/scroll-options/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/plugin-scroll-options",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^6.20210701.0"

--- a/plugins/strict-connection-checker/package-lock.json
+++ b/plugins/strict-connection-checker/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/plugin-strict-connection-checker",
-			"version": "1.0.21",
+			"version": "1.0.22",
 			"license": "Apache 2.0",
 			"devDependencies": {
 				"blockly": "^3.20200924.1",

--- a/plugins/theme-dark/package-lock.json
+++ b/plugins/theme-dark/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/theme-dark",
-			"version": "2.0.4",
+			"version": "2.0.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^4.20201217.0"

--- a/plugins/theme-deuteranopia/package-lock.json
+++ b/plugins/theme-deuteranopia/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/theme-deuteranopia",
-			"version": "1.0.5",
+			"version": "1.0.6",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^5.20210325.1"

--- a/plugins/theme-highcontrast/package-lock.json
+++ b/plugins/theme-highcontrast/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/theme-highcontrast",
-			"version": "1.0.5",
+			"version": "1.0.6",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^5.20210325.1"

--- a/plugins/theme-modern/package-lock.json
+++ b/plugins/theme-modern/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/theme-modern",
-			"version": "2.1.22",
+			"version": "2.1.23",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^3.20200402.1"

--- a/plugins/theme-tritanopia/package-lock.json
+++ b/plugins/theme-tritanopia/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/theme-tritanopia",
-			"version": "1.0.5",
+			"version": "1.0.6",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^5.20210325.1"

--- a/plugins/typed-variable-modal/package-lock.json
+++ b/plugins/typed-variable-modal/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/plugin-typed-variable-modal",
-			"version": "3.1.24",
+			"version": "3.1.25",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^3.20200625.0",

--- a/plugins/workspace-backpack/package-lock.json
+++ b/plugins/workspace-backpack/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/workspace-backpack",
-			"version": "1.0.5",
+			"version": "1.0.6",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^6.20210701.0"

--- a/plugins/workspace-search/package-lock.json
+++ b/plugins/workspace-search/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/plugin-workspace-search",
-			"version": "4.0.5",
+			"version": "4.0.6",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^6.20210701.0",

--- a/plugins/zoom-to-fit/package-lock.json
+++ b/plugins/zoom-to-fit/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@blockly/zoom-to-fit",
-			"version": "2.0.5",
+			"version": "2.0.6",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"blockly": "^6.20210701.0"


### PR DESCRIPTION
Update all the package-locks again, similar to https://github.com/google/blockly-samples/pull/859

This is going to be an ongoing issue with package-lock v2 because it doesn't get updated after lerna bumps the versions :/ 