### PR TITLE
fix!: remove recycling logic from continous flyout

### DIFF
--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/continuous-toolbox",
-  "version": "1.0.20",
+  "version": "2.0.20",
   "description": "A Blockly plugin that adds a continous-scrolling style toolbox and flyout",
   "scripts": {
     "build": "blockly-scripts build",
@@ -44,7 +44,7 @@
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {
-    "blockly": "5.20210325.0 - 7"
+    "blockly": "^7.20211209.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
### Description

This is dependent on changes made by the new JSO serialization system.

Removes the recycling logic from the continuous toolbox since it has been moved in to core.

### Testing

~~Was not able to test whether this works correctly or not because it is dependent on changes in core, and linking is being uncooperative.~~

Manually tested this by editing one of the shadows of the color blend block, and then creating a variable to refresh the flyout. The edits to the shadow were maintained, signaling that recycling was occuring.

### API Change

Along with https://github.com/google/blockly/pull/5392 this removes the protected `createBlock_` and `clearOldBlocks_` functions from the public API