### PR TITLE
Use new location for `genUid` on `Blockly.utils.idGenerator`

### DIFF
--- a/plugins/dev-tools/src/block_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/block_test_helpers.mocha.js
@@ -186,7 +186,25 @@ export const runSerializationTestSuite = (testCases) => {
     });
     suite('xml round-trip', function() {
       setup(function() {
-        sinon.stub(Blockly.utils, 'genUid').returns('1');
+        // The genUid is undergoing change as part of the 2021Q3
+        // goog.module migration:
+        //
+        // - It is being moved from Blockly.utils to
+        //   Blockly.utils.idGenerator (which itself is being renamed
+        //   from IdGenerator).
+        // - For compatibility with changes to the module system (from
+        //   goog.provide to goog.module and in future to ES modules),
+        //   .genUid is now a wrapper around .TEST_ONLY.genUid, which
+        //   can be safely stubbed by sinon or other similar
+        //   frameworks in a way that will continue to work.
+        if (Blockly.utils.idGenerator &&
+            Blockly.utils.idGenerator.TEST_ONLY) {
+          sinon.stub(Blockly.utils.idGenerator.TEST_ONLY, 'genUid')
+              .returns('1');
+        } else {
+          // Fall back to stubbing original version on Blockly.utils.
+          sinon.stub(Blockly.utils, 'genUid').returns('1');
+        }
       });
 
       teardown(function() {


### PR DESCRIPTION
`genUid` is being moved from `Blockly.utils` to `Blockly.utils.idGenerator`.  Probe for the new location and, if found, stub it there instead of the old location.

See google/blockly#5441.