### PR TITLE
fix: Change how dev-tools adds Blockly to the global scope for console debugging

### DIFF
--- a/plugins/dev-tools/src/index.js
+++ b/plugins/dev-tools/src/index.js
@@ -26,8 +26,15 @@ if (typeof window !== 'undefined') {
   createPlayground = require('./playground/').createPlayground;
 }
 
-// Export Blockly into the global namespace to make it easier to debug.
-Blockly.utils.global.Blockly = Blockly;
+// Export Blockly into the global namespace to make it easier to debug from the
+// console.
+if (Blockly.utils.global) {
+  if (Blockly.utils.global.globalThis) {
+    Blockly.utils.global.globalThis.Blockly = Blockly;
+  } else {
+    Blockly.utils.global.Blockly = Blockly;
+  }
+}
 
 export {
   addCodeEditor,


### PR DESCRIPTION
Previously this reached into `Blockly.utils.global` to make sure that it was getting the same global object as the rest of Blockly.

After this change the code uses [globalThis](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis). It won't work in IE, but much of dev-tools and our mocha/sinon test setup does not work in IE.

We add `Blockly` to the global object to simplify manual debugging from the console while using dev-tools. It's not necessary for automated tests.

Tested by building and starting the dev-tools package locally and inspecting the value of `Blockly` in the console. Also tested by removing the line entirely to make sure that `Blockly` was not being added to the global scope somewhere else.