### PR TITLE
fix: check whether extension is registered before unregistering

### DIFF
--- a/plugins/block-plus-minus/src/if.js
+++ b/plugins/block-plus-minus/src/if.js
@@ -207,6 +207,8 @@ const controlsIfHelper = function() {
   this.getInput('IF0').insertFieldAt(0, createPlusField(), 'PLUS');
 };
 
-Blockly.Extensions.unregister('controls_if_mutator');
+if (Blockly.Extensions.isRegistered('controls_if_mutator')) {
+  Blockly.Extensions.unregister('controls_if_mutator');
+}
 Blockly.Extensions.registerMutator('controls_if_mutator',
     controlsIfMutator, controlsIfHelper);

--- a/plugins/block-plus-minus/src/text_join.js
+++ b/plugins/block-plus-minus/src/text_join.js
@@ -159,6 +159,8 @@ const textJoinHelper = function() {
   this.updateShape_(2);
 };
 
-Blockly.Extensions.unregister('text_join_mutator');
+if (Blockly.Extensions.isRegistered('text_join_mutator')) {
+  Blockly.Extensions.unregister('text_join_mutator');
+}
 Blockly.Extensions.registerMutator('text_join_mutator',
     textJoinMutator, textJoinHelper);


### PR DESCRIPTION
### Description

Checks whether an extension is registered before unregistering it. 

This is dependent on https://github.com/google/blockly/pull/5500, so until then I'll keep this as a draft PR.

> ### Proposed Changes
> 
> Adds a `Blockly.Extensions.isRegistered` function.
> 
> I'm using the [block-plus-mins](https://github.com/google/blockly-samples/tree/master/plugins/block-plus-minus) plugin which attempts to [`Blockly.Extensions.unregister`](https://github.com/google/blockly-samples/blob/master/plugins/block-plus-minus/src/if.js#L178) an extension called `controls_if_mutator`. That extension only exists if you import everything from Blockly (default blocks etc.). However, In my project I'm importing Blockly as:
> 
> ```js
> import * as Blockly from "blockly/core";
> ```
> 
> which means the `controls_if_mutator` extension is not there.
> 
> Currently, any call to `Blockly.Extensions.unregister` will put a warning in the developer console (if the extension doesn't exist).
> 
> ![Screenshot from 2021-09-18 21-57-07](https://user-images.githubusercontent.com/44427668/133891277-c93b1c53-31a8-44cb-ae49-e8d31e16f68f.png)