### PR TITLE
add usage description

### DIFF
--- a/plugins/field-slider/README.md
+++ b/plugins/field-slider/README.md
@@ -15,6 +15,7 @@ npm install @blockly/field-slider --save
 ```
 
 ## Usage
+This field is an extension of the Blockly.FieldNumber field. See the [Blockly.FieldNumber documentation](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/number#creation) on what parameters and configurations this field supports.
 
 ### JavaScript
 ```js


### PR DESCRIPTION
## Description
Adds a short usage description to the field-slider plugin's readme as suggested in #727 