### PR TITLE
chore: update scroll options plugin

### DIFF
--- a/plugins/scroll-options/README.md
+++ b/plugins/scroll-options/README.md
@@ -48,8 +48,8 @@ const workspace = Blockly.inject('blocklyDiv', {
       'blockDragger': ScrollBlockDragger,
       'metricsManager': ScrollMetricsManager,
     },
-  move:{
-    wheel: true // Required for wheel scroll to work.
+  move: {
+    wheel: true, // Required for wheel scroll to work.
   },
 });
 

--- a/plugins/scroll-options/README.md
+++ b/plugins/scroll-options/README.md
@@ -48,6 +48,9 @@ const workspace = Blockly.inject('blocklyDiv', {
       'blockDragger': ScrollBlockDragger,
       'metricsManager': ScrollMetricsManager,
     },
+  move:{
+    wheel: true // Required for wheel scroll to work.
+  },
 });
 
 // Initialize plugin.

--- a/plugins/scroll-options/test/index.js
+++ b/plugins/scroll-options/test/index.js
@@ -39,6 +39,9 @@ document.addEventListener('DOMContentLoaded', function() {
       'blockDragger': ScrollBlockDragger,
       'metricsManager': ScrollMetricsManager,
     },
+    move:{
+      wheel: true
+    },
   };
   createPlayground(
       document.getElementById('root'), createWorkspace, defaultOptions);

--- a/plugins/scroll-options/test/index.js
+++ b/plugins/scroll-options/test/index.js
@@ -39,8 +39,8 @@ document.addEventListener('DOMContentLoaded', function() {
       'blockDragger': ScrollBlockDragger,
       'metricsManager': ScrollMetricsManager,
     },
-    move:{
-      wheel: true
+    move: {
+      wheel: true,
     },
   };
   createPlayground(


### PR DESCRIPTION
Updates the scroll options README and test page to include information on setting `wheel: true` in the options struct.

This is in response to [this question](https://groups.google.com/g/blockly/c/kmt_ZdSz5q8/m/ZFRTUABTAQAJ?utm_medium=email&utm_source=footer) on the forum.