### PR TITLE
docs: Cleanup and Expanded Explanations in the "Getting Started" codelab

### DIFF
--- a/codelabs/getting_started/getting_started.md
+++ b/codelabs/getting_started/getting_started.md
@@ -320,18 +320,19 @@ It clears the workspace from any blocks and then loads blocks from the provided 
 
 Call this function from `enableBlocklyMode`:
 
-```
+```js
+/** Navigates to the Blockly editor to edit a button's code. */
 function enableBlocklyMode(e) {
   ...
-  loadWorkspace(currentButton);
+  loadMainWorkspace(currentButton.blocklyXml);
 }
 ```
 
-Now, test the code. Edit the workspace for one of the buttons, add some blocks, save it, and reopen it. The workspace should still contain the blocks you added.
+Now, test the code. Open the editor for one of the buttons, add some blocks, save it, and reopen it. The editor should still contain the blocks you added.
 
 ## Generate JavaScript code
 
-Now that each button can be configured with its own Blockly workspace, the next thing we want to do is to generate JavaScript code from each workspace.
+Now that each button can be configured with a set of Blockly blocks, the next thing we want to do is to generate JavaScript code from each workspace.
 
 This generated code will be run by the browser, effectively executing the blocks set up in the Blockly workspace.
 

--- a/examples/getting-started-codelab/complete-code/scripts/main.js
+++ b/examples/getting-started-codelab/complete-code/scripts/main.js
@@ -67,6 +67,7 @@
   function enableBlocklyMode(e) {
     document.body.setAttribute('mode', 'blockly');
     currentButton = e.target;
+    loadMainWorkspace(currentButton.blocklyXml);
   }
 
   document.querySelector('#edit').addEventListener('click', enableEditMode);

--- a/examples/getting-started-codelab/complete-code/scripts/main.js
+++ b/examples/getting-started-codelab/complete-code/scripts/main.js
@@ -3,13 +3,14 @@
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
- (function() {
+(function () {
 
   let currentButton;
 
+  /** Handles clicks on the main buttons when the page is in play mode. */
   function handlePlay(event) {
-    loadWorkspace(event.target);
-    let code = Blockly.JavaScript.workspaceToCode(Blockly.getMainWorkspace());
+    const button = event.target;
+    let code = convertToCode(button.blocklyXml);
     code += 'MusicMaker.play();';
     // Eval can be dangerous. For more controlled execution, check
     // https://github.com/NeilFraser/JS-Interpreter.
@@ -20,23 +21,31 @@
     }
   }
 
-  function loadWorkspace(button) {
+  /** Handles click event for the "save" button on the blockly workspace screen */
+  function handleSave() {
+    document.body.setAttribute('mode', 'edit');
+    currentButton.blocklyXml = Blockly.Xml.workspaceToDom(Blockly.getMainWorkspace());
+  }
+
+  /** Converts Blockly XML to Javascript code. */
+  function convertToCode(blocklyXml) {
+    loadMainWorkspace(blocklyXml);
+    return Blockly.JavaScript.workspaceToCode(Blockly.getMainWorkspace());
+  }
+
+  /**
+   * Loads the main Blockly workspace from provided XML.
+   * If there is no XML provided, it clears the workspace.
+   */
+   function loadMainWorkspace(blocklyXml) {
     let workspace = Blockly.getMainWorkspace();
     workspace.clear();
-    if (button.blocklyXml) {
-      Blockly.Xml.domToWorkspace(button.blocklyXml, workspace);
+    if (blocklyXml) {
+      Blockly.Xml.domToWorkspace(blocklyXml, workspace);
     }
   }
 
-  function save(button) {
-    button.blocklyXml = Blockly.Xml.workspaceToDom(Blockly.getMainWorkspace());
-  }
-
-  function handleSave() {
-    document.body.setAttribute('mode', 'edit');
-    save(currentButton);
-  }
-
+  /** Enables edit mode on the main screen, such that clicking a button enters Blockly mode. */
   function enableEditMode() {
     document.body.setAttribute('mode', 'edit');
     document.querySelectorAll('.button').forEach(btn => {
@@ -45,6 +54,7 @@
     });
   }
 
+  /** Enables maker mode on the main screen, such that clicking a button runs that button's code. */
   function enableMakerMode() {
     document.body.setAttribute('mode', 'maker');
     document.querySelectorAll('.button').forEach(btn => {
@@ -53,10 +63,10 @@
     });
   }
 
+  /** Navigates to the Blockly editor to edit a button's code. */
   function enableBlocklyMode(e) {
     document.body.setAttribute('mode', 'blockly');
     currentButton = e.target;
-    loadWorkspace(currentButton);
   }
 
   document.querySelector('#edit').addEventListener('click', enableEditMode);

--- a/examples/getting-started-codelab/complete-code/scripts/main.js
+++ b/examples/getting-started-codelab/complete-code/scripts/main.js
@@ -37,7 +37,7 @@
    * Loads the main Blockly workspace from provided XML.
    * If there is no XML provided, it clears the workspace.
    */
-   function loadMainWorkspace(blocklyXml) {
+  function loadMainWorkspace(blocklyXml) {
     let workspace = Blockly.getMainWorkspace();
     workspace.clear();
     if (blocklyXml) {

--- a/examples/getting-started-codelab/complete-code/scripts/sound_blocks.js
+++ b/examples/getting-started-codelab/complete-code/scripts/sound_blocks.js
@@ -5,7 +5,6 @@
  */
 
 Blockly.defineBlocksWithJsonArray([
-  // Block for colour picker.
   {
     "type": "play_sound",
     "message0": "Play %1",

--- a/examples/getting-started-codelab/starter-code/scripts/main.js
+++ b/examples/getting-started-codelab/starter-code/scripts/main.js
@@ -3,23 +3,35 @@
  * Copyright 2017 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
- (function() {
+(function () {
 
   let currentButton;
 
+  /** Handles clicks on the main buttons when the page is in play mode. */
   function handlePlay(event) {
-    // Add code for playing sound.
+    // TODO: Add code for playing sound.
   }
 
-  function save(button) {
-    // Add code for saving the behavior of a button.
-  }
-
+  /** Handles click event for the "save" button on the blockly workspace screen */
   function handleSave() {
     document.body.setAttribute('mode', 'edit');
-    save(currentButton);
+    // TODO: Add code for saving the behavior of a button.
   }
 
+  /** Converts Blockly XML to Javascript code. */
+  function convertToCode(blocklyXml) {
+    // TODO: Implement this function
+  }
+
+  /**
+   * Loads the main Blockly workspace from provided XML.
+   * If there is no XML provided, it clears the workspace.
+   */
+   function loadMainWorkspace(blocklyXml) {
+    // TODO: Implement this function
+  }
+
+  /** Enables edit mode on the main screen, such that clicking a button enters Blockly mode. */
   function enableEditMode() {
     document.body.setAttribute('mode', 'edit');
     document.querySelectorAll('.button').forEach(btn => {
@@ -28,6 +40,7 @@
     });
   }
 
+  /** Enables maker mode on the main screen, such that clicking a button runs that button's code. */
   function enableMakerMode() {
     document.body.setAttribute('mode', 'maker');
     document.querySelectorAll('.button').forEach(btn => {
@@ -36,9 +49,11 @@
     });
   }
 
+  /** Navigates to the Blockly editor to edit a button's code. */
   function enableBlocklyMode(e) {
     document.body.setAttribute('mode', 'blockly');
     currentButton = e.target;
+    loadMainWorkspace(currentButton.blocklyXml);
   }
 
   document.querySelector('#edit').addEventListener('click', enableEditMode);

--- a/examples/getting-started-codelab/starter-code/scripts/main.js
+++ b/examples/getting-started-codelab/starter-code/scripts/main.js
@@ -53,7 +53,6 @@
   function enableBlocklyMode(e) {
     document.body.setAttribute('mode', 'blockly');
     currentButton = e.target;
-    loadMainWorkspace(currentButton.blocklyXml);
   }
 
   document.querySelector('#edit').addEventListener('click', enableEditMode);


### PR DESCRIPTION
A set of improvements I would propose to the source of the "Getting Started" codelab after going through it as a new Blockly contributor.

Summary:
- Add comments to the major functions
- Add a helper function convertToCode(blocklyXml) to clarify that flow during the save process
- Make loadWorkspace take the XML data as a parameter instead of the button DOM object
- Clarify the instructions for some of the more confusing aspects of the codelab (e.g. the UI screen called a "workspace" vs. the Blockly code object called a "workspace")