### PR TITLE
Make FieldGridDropdown primaryColour and borderColour configurable

### DIFF
--- a/plugins/field-grid-dropdown/README.md
+++ b/plugins/field-grid-dropdown/README.md
@@ -22,9 +22,13 @@ npm install @blockly/field-grid-dropdown --save
 
 This field accepts the same parameters as the [Blockly.FieldDropdown](
 https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/dropdown#creation)
-in Blockly core. The config object bag passed into this field accepts an
-additional parameter `"columns"` that can be used to specify the number of
-columns in the dropdown field (must be an integer greater than 0, default to 3).
+in Blockly core. The config object bag passed into this field accepts additional optional parameters:
+- `"columns"` to specify the number of columns in the dropdown field (must be an integer greater than 0).
+If not provided, the default is 3 columns.
+- `"primaryColour"` to specify the colour of the dropdown (must be a string CSS colour). If not provided,
+the dropdown color will match the primary colour of the parent block.
+- `"borderColour"` to specify the colour of the border of the dropdown (must be a string CSS colour). If
+not provided, the border colour will match the tertiary colour of the parent block.
 
 ### JavaScript
 ```js

--- a/plugins/field-grid-dropdown/src/index.js
+++ b/plugins/field-grid-dropdown/src/index.js
@@ -44,6 +44,14 @@ export class FieldGridDropdown extends Blockly.FieldDropdown {
     if (config && config['columns']) {
       this.setColumnsInternal_(config['columns']);
     }
+
+    if (config && config['primaryColour']) {
+      this.primaryColour = config['primaryColour'];
+    }
+
+    if (config && config['borderColour']) {
+      this.borderColour = config['borderColour'];
+    }
   }
 
   /**
@@ -93,13 +101,16 @@ export class FieldGridDropdown extends Blockly.FieldDropdown {
   showEditor_(e = undefined) {
     super.showEditor_(e);
 
-    // Grid dropdown is always colored.
-    const primaryColour = (this.sourceBlock_.isShadow()) ?
+    // Dropdown should match block colour unless other colours are specified
+    // in the config.
+    const blockPrimaryColour = (this.sourceBlock_.isShadow()) ?
         this.sourceBlock_.getParent().getColour() :
         this.sourceBlock_.getColour();
-    const borderColour = (this.sourceBlock_.isShadow()) ?
+    const blockBorderColour = (this.sourceBlock_.isShadow()) ?
         this.sourceBlock_.getParent().style.colourTertiary :
         this.sourceBlock_.style.colourTertiary;
+    const primaryColour = this.primaryColour || blockPrimaryColour;
+    const borderColour = this.borderColour || blockBorderColour;
     Blockly.DropDownDiv.setColour(primaryColour, borderColour);
 
     Blockly.utils.dom.addClass(

--- a/plugins/field-grid-dropdown/test/index.js
+++ b/plugins/field-grid-dropdown/test/index.js
@@ -214,6 +214,23 @@ const toolbox = generateFieldTestBlocks('field_grid_dropdown', [
       ],
     },
   },
+  {
+    'label': 'custom colours',
+    'args': {
+      'primaryColour': '#783105',
+      'borderColour': '#d6a587',
+      'options': [
+        ['A', 'A'],
+        ['B', 'B'],
+        ['C', 'C'],
+        ['D', 'D'],
+        ['E', 'E'],
+        ['F', 'F'],
+        ['G', 'G'],
+        ['H', 'H'],
+      ],
+    },
+  },
 ]);
 
 /**


### PR DESCRIPTION
Allow users to customize the colors of the FieldGridDropdown, but still default to matching the color of the block if no colors are provided in the config

With custom colors provided in the config:
![image](https://user-images.githubusercontent.com/8787187/142475170-1e240a3b-d82a-4af7-a046-cb64da0e670b.png)

With no colors provided:
![image](https://user-images.githubusercontent.com/8787187/142475248-7b337e94-1fa9-4dd4-b46b-bfa89829c10c.png)
