### PR TITLE
feat: Configurable backpack open

### DIFF
--- a/plugins/workspace-backpack/README.md
+++ b/plugins/workspace-backpack/README.md
@@ -45,6 +45,7 @@ backpack.init();
 This plugin takes an optional configuration object.
 ```
 {
+  allowEmptyBackpackOpen: (boolean|undefined),
   contextMenu: {
     emptyBackpack: (boolean|undefined),
     removeFromBackpack: (boolean|undefined),
@@ -61,6 +62,7 @@ configuration object, you can currently configure which context menu options are
 registered at `init`.
 ```js
 const backpackOptions = {
+  allowEmptyBackpackOpen: true,
   contextMenu: {
     emptyBackpack: true,
     removeFromBackpack: true,
@@ -74,6 +76,7 @@ The following options are the default values used for any property in the
 passed in options that is undefined:
 ```js
 const defaultOptions = {
+  allowEmptyBackpackOpen: true,
   contextMenu: {
     emptyBackpack: true,
     removeFromBackpack: true,
@@ -84,6 +87,9 @@ const defaultOptions = {
   },
 };
 ```
+
+The `allowEmptyBackpackOpen` property, if set to `false`, will prevent the backpack flyout from
+being opened if the backpack is empty.
 
 The `disablePreconditionChecks` property will prevent the "Copy to Backpack"
 context menu option from disabling the context menu option if the block is

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -578,7 +578,8 @@ export class Backpack extends Blockly.DragTarget {
    * @protected
    */
   isOpenable_() {
-    return !this.isOpen();
+    return !this.isOpen() &&
+    this.options_.allowEmptyBackpackOpen ? true : this.getCount() > 0;
   }
 
   /**

--- a/plugins/workspace-backpack/src/options.js
+++ b/plugins/workspace-backpack/src/options.js
@@ -24,6 +24,7 @@ export let BackpackContextMenuOptions;
 
 /**
  * @typedef {{
+ *    allowEmptyBackpackOpen: (boolean|undefined),
  *    contextMenu:(!BackpackContextMenuOptions|undefined),
  * }}
  */
@@ -37,6 +38,7 @@ export let BackpackOptions;
  */
 export function parseOptions(options) {
   const defaultOptions = {
+    allowEmptyBackpackOpen: true,
     contextMenu: {
       emptyBackpack: true,
       removeFromBackpack: true,
@@ -52,5 +54,7 @@ export function parseOptions(options) {
   const mergedOptions = {};
   mergedOptions.contextMenu = {
     ...defaultOptions.contextMenu, ...options.contextMenu};
+  mergedOptions.allowEmptyBackpackOpen = options.allowEmptyBackpackOpen ??
+      defaultOptions.allowEmptyBackpackOpen;
   return mergedOptions;
 }


### PR DESCRIPTION
**Description**

Added functionality for configuring whether the backpack should open if empty. 

**Testing**

When instantiating the backpack, add  `allowEmptyBackpackOpen: false` as an option. This defaults to true, which keeps the default blockly behaviour. 