### PR TITLE
fix: the debug renderer to work with dec 2021 release

### DIFF
--- a/plugins/dev-tools/src/debugRenderer.js
+++ b/plugins/dev-tools/src/debugRenderer.js
@@ -50,7 +50,7 @@ export class DebugRenderer {
    * @public
    */
   static init() {
-    Blockly.blockRendering.useDebugger = true;
+    Blockly.blockRendering.debug.startDebugger();
     Blockly.blockRendering.Debug = DebugRenderer;
   }
 

--- a/plugins/dev-tools/src/debugRenderer.js
+++ b/plugins/dev-tools/src/debugRenderer.js
@@ -51,6 +51,8 @@ export class DebugRenderer {
    */
   static init() {
     Blockly.blockRendering.debug.startDebugger();
+    // TODO(google/blockly-samples##944): Remove this once #944 is complete.
+    Blockly.blockRendering.debug.stopDebugger();
     Blockly.blockRendering.Debug = DebugRenderer;
   }
 


### PR DESCRIPTION
This uses the new API to start the debugger. Setting it equal to true was causing an error when trying to run the advanced playground in core.


I added `stopDebugger` in right after so that we won't have the debug rectangles constantly around all of our blocks when using the advanced playground. This should be removed when #944 is addressed.