### PR TITLE
chore: update major versions for packages that rely on dec 2021 release

### DIFF
--- a/plugins/block-plus-minus/package-lock.json
+++ b/plugins/block-plus-minus/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@blockly/block-plus-minus",
-    "version": "2.0.39",
+    "version": "3.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@blockly/block-plus-minus",
-            "version": "2.0.39",
+            "version": "3.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@blockly/dev-scripts": "^1.2.10",

--- a/plugins/block-plus-minus/package.json
+++ b/plugins/block-plus-minus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blockly/block-plus-minus",
-    "version": "2.0.39",
+    "version": "3.0.0",
     "description": "A group of blocks that replace the built-in mutator UI with a +/- based UI.",
     "scripts": {
         "audit:fix": "blockly-scripts auditFix",

--- a/plugins/keyboard-navigation/package-lock.json
+++ b/plugins/keyboard-navigation/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/keyboard-navigation",
-  "version": "0.1.18",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/keyboard-navigation",
-      "version": "0.1.18",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/dev-scripts": "^1.2.10",

--- a/plugins/keyboard-navigation/package.json
+++ b/plugins/keyboard-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/keyboard-navigation",
-  "version": "0.1.18",
+  "version": "0.2.0",
   "description": "A Blockly plugin that adds keyboard navigation support.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",


### PR DESCRIPTION
These should have been done in previous PRs, but I forgot so here we are. 

- Updates major version for block-plus-minus since it relies on the most recent release of Blockly
- Updates the minor version of keyboard navigation. This plugin is still in beta which is why it has a 0 as the major version. I think updating the minor version here is the right call, but not entirely sure.