### PR TITLE
fix: Made workspace search plugin compatible with RTL workspaces.

### DIFF
--- a/plugins/workspace-search/src/WorkspaceSearch.js
+++ b/plugins/workspace-search/src/WorkspaceSearch.js
@@ -324,14 +324,12 @@ export class WorkspaceSearch {
   /**
    * Returns the bounding rectangle of the UI element in pixel units relative to
    * the Blockly injection div.
-   * @return {!Blockly.utils.Rect} The component’s bounding box.
+   * @return {?Blockly.utils.Rect} The component’s bounding box. Null in this
+   *     case since we don't need other elements to avoid the workspace search
+   *     field.
    */
   getBoundingRectangle() {
-    const top = this.htmlDiv_.style.top;
-    const left = this.htmlDiv_.style.left;
-    return new Blockly.utils.Rect(
-        top, top + this.htmlDiv_.style.height,
-        left, left + this.htmlDiv_.style.width);
+    return null;
   }
 
   /**


### PR DESCRIPTION
This fixes #951. The workspace search plugin had been returning its CSS style top/left/bottom/right from getBoundingRectangle(), but Rects need to be constructed with numbers, not strings. This caused errant comparisons when checking intersections/bumping elements out of the way. Since the search field is a floating element, this PR just returns null so that other blocks/items will not be moved out of the way of the field.