### PR TITLE
fix: Update usage of some deprecated functions

### DIFF
--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blockly/field-date",
-    "version": "4.2.25",
+    "version": "5.0.0",
     "description": "A Blockly date picker field that uses the Google Closure date picker.",
     "scripts": {
         "audit:fix": "blockly-scripts auditFix",
@@ -47,7 +47,7 @@
         "gulp-sourcemaps": "^2.6.5"
     },
     "peerDependencies": {
-        "blockly": "3.20200924.1 - 7"
+        "blockly": "^7.20211209.0"
     },
     "publishConfig": {
         "access": "public",

--- a/plugins/field-date/src/field_date.js
+++ b/plugins/field-date/src/field_date.js
@@ -269,7 +269,7 @@ Blockly.FieldDate.prototype.onClick_ = function(e) {
 Blockly.FieldDate.prototype.bindInputEvents_ = function(htmlInput) {
   Blockly.FieldDate.superClass_.bindInputEvents_.call(this, htmlInput);
 
-  this.onClickWrapper_ = Blockly.bindEventWithChecks_(htmlInput,
+  this.onClickWrapper_ = Blockly.browserEvents.conditionalBind(htmlInput,
       'click', this, this.onClick_, true);
 };
 

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-slider",
-  "version": "2.1.30",
+  "version": "3.0.0",
   "description": "A Blockly slider field.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -47,7 +47,7 @@
     "sinon": "^9.0.1"
   },
   "peerDependencies": {
-    "blockly": "3.20200924.1 - 7"
+    "blockly": "^7.20211209.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-slider/src/field_slider.js
+++ b/plugins/field-slider/src/field_slider.js
@@ -122,7 +122,7 @@ export class FieldSlider extends Blockly.FieldNumber {
     wrapper.appendChild(sliderInput);
     this.sliderInput_ = sliderInput;
 
-    this.boundEvents_.push(Blockly.bindEventWithChecks_(
+    this.boundEvents_.push(Blockly.browserEvents.conditionalBind(
         sliderInput, 'input', this, this.onSliderChange_));
 
     return wrapper;

--- a/plugins/keyboard-navigation/src/gesture_monkey_patch.js
+++ b/plugins/keyboard-navigation/src/gesture_monkey_patch.js
@@ -29,7 +29,7 @@ Blockly.Gesture.prototype.doWorkspaceClick_ = function(e) {
   const ws = this.creatorWorkspace_;
   if (e.shiftKey && ws.keyboardAccessibilityMode) {
     const screenCoord = new Blockly.utils.Coordinate(e.clientX, e.clientY);
-    const wsCoord = Blockly.utils.screenToWsCoordinates(ws, screenCoord);
+    const wsCoord = Blockly.utils.svgMath.screenToWsCoordinates(ws, screenCoord);
     const wsNode = Blockly.ASTNode.createWorkspaceNode(ws, wsCoord);
     ws.getCursor().setCurNode(wsNode);
   }

--- a/plugins/keyboard-navigation/src/gesture_monkey_patch.js
+++ b/plugins/keyboard-navigation/src/gesture_monkey_patch.js
@@ -29,7 +29,8 @@ Blockly.Gesture.prototype.doWorkspaceClick_ = function(e) {
   const ws = this.creatorWorkspace_;
   if (e.shiftKey && ws.keyboardAccessibilityMode) {
     const screenCoord = new Blockly.utils.Coordinate(e.clientX, e.clientY);
-    const wsCoord = Blockly.utils.svgMath.screenToWsCoordinates(ws, screenCoord);
+    const wsCoord =
+        Blockly.utils.svgMath.screenToWsCoordinates(ws, screenCoord);
     const wsNode = Blockly.ASTNode.createWorkspaceNode(ws, wsCoord);
     ws.getCursor().setCurNode(wsNode);
   }

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-modal",
-  "version": "2.1.29",
+  "version": "3.0.0",
   "description": "A Blockly plugin that creates a modal.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -49,7 +49,7 @@
     "sinon": "7.5.0"
   },
   "peerDependencies": {
-    "blockly": "3.20200402.0 - 7"
+    "blockly": "^7.20211209.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/modal/src/index.js
+++ b/plugins/modal/src/index.js
@@ -218,7 +218,8 @@ export class Modal {
    * @protected
    */
   addEvent_(node, name, thisObject, func) {
-    const event = Blockly.bindEventWithChecks_(node, name, thisObject, func);
+    const event =
+        Blockly.browserEvents.conditionalBind(node, name, thisObject, func);
     this.boundEvents_.push(event);
   }
 

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-scroll-options",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "A Blockly plugin that adds advanced scroll options such as scroll-on-drag and scroll while holding a block.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -45,7 +45,7 @@
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {
-    "blockly": "^6.20210701.0 - 7"
+    "blockly": "^7.20211209.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/scroll-options/src/ScrollBlockDragger.js
+++ b/plugins/scroll-options/src/ScrollBlockDragger.js
@@ -202,7 +202,7 @@ export class ScrollBlockDragger extends Blockly.BlockDragger {
       left: new Blockly.utils.Coordinate(1, 0),
       right: new Blockly.utils.Coordinate(-1, 0),
     };
-    const mouse = Blockly.utils.screenToWsCoordinates(
+    const mouse = Blockly.utils.svgMath.screenToWsCoordinates(
         this.workspace_, new Blockly.utils.Coordinate(e.clientX, e.clientY));
 
     /**

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -52,7 +52,7 @@
     "blockly": "^7.20211209.0"
   },
   "dependencies": {
-    "@blockly/plugin-modal": "^2.1.29"
+    "@blockly/plugin-modal": "^3.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-workspace-search",
-  "version": "4.0.10",
+  "version": "5.0.0",
   "description": "A Blockly plugin that adds workspace search support.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -48,7 +48,7 @@
     "sinon": "^9.0.1"
   },
   "peerDependencies": {
-    "blockly": "6.20210701.0 - 7"
+    "blockly": "^7.20211209.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/workspace-search/src/WorkspaceSearch.js
+++ b/plugins/workspace-search/src/WorkspaceSearch.js
@@ -229,7 +229,8 @@ export class WorkspaceSearch {
    * @private
    */
   addEvent_(node, name, thisObject, func) {
-    const event = Blockly.bindEventWithChecks_(node, name, thisObject, func);
+    const event =
+        Blockly.browserEvents.conditionalBind(node, name, thisObject, func);
     this.boundEvents_.push(event);
   }
 


### PR DESCRIPTION
Updates usage of `Blockly.utils.wsToScreenCoordinates` and `Blockly.bindEventWithChecks_` in plugins. This isn't all of the deprecated functions, but it gets rid of the worst offenders (the ones that create output when running tests, and the ones that trigger on every mousemove)

Also, updates the relevant plugins to rely on Blockly ^7.20211209.0 as the low end of the range since these depend on new APIs, and therefore also bumps these plugins to a new major version. And for modal, updated typed-variable-modal to depend on that new major version as well.