### PR TITLE
Typed variable modal: order flyout elements

### DIFF
--- a/plugins/typed-variable-modal/test/index.js
+++ b/plugins/typed-variable-modal/test/index.js
@@ -36,7 +36,7 @@ function createWorkspace(blocklyDiv, options) {
     xmlList.push(button);
 
     const blockList = Blockly.VariablesDynamic.flyoutCategoryBlocks(workspace);
-    xmlList = blockList.concat(xmlList);
+    xmlList = xmlList.concat(blockList);
     return xmlList;
   };
 


### PR DESCRIPTION
This PR fixes #959 by changing the order of the elements in the toolbox's typed variable category.