### PR TITLE
fix: change json helper assert.equal to assert.deepEqual

### DIFF
--- a/plugins/dev-tools/src/block_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/block_test_helpers.mocha.js
@@ -193,7 +193,7 @@ export const runSerializationTestSuite = (testCases) => {
             testCase.json, this.workspace);
         const generatedJson = Blockly.serialization.blocks.save(block);
         const expectedJson = testCase.expectedJson || testCase.json;
-        assert.equal(generatedJson, expectedJson);
+        assert.deepEqual(generatedJson, expectedJson);
       } else {
         const block = Blockly.Xml.domToBlock(Blockly.Xml.textToDom(
             testCase.xml), this.workspace);


### PR DESCRIPTION
### Description

I was using the wrong assertion for checking json output equality. This fixes that.

### Testing

Tested by linking to #847 and it now works.