### PR TITLE
fix: the test configuration

### DIFF
--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -158,7 +158,9 @@ module.exports = (env) => {
       }),
       // canvas should only be required by jsdom if the 'canvas' package is
       // installed in package.json. Ignoring canvas require errors.
-      isTest && new webpack.IgnorePlugin(/canvas$/),
+      isTest && new webpack.IgnorePlugin({
+        resourceRegExp: /canvas$/
+      }),
     ].filter(Boolean),
     externals: isProduction ? {
       'blockly/core': {

--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -159,7 +159,7 @@ module.exports = (env) => {
       // canvas should only be required by jsdom if the 'canvas' package is
       // installed in package.json. Ignoring canvas require errors.
       isTest && new webpack.IgnorePlugin({
-        resourceRegExp: /canvas$/
+        resourceRegExp: /canvas$/,
       }),
     ].filter(Boolean),
     externals: isProduction ? {

--- a/plugins/dev-scripts/scripts/start.js
+++ b/plugins/dev-scripts/scripts/start.js
@@ -40,7 +40,7 @@ console.log(`Running start for ${packageJson.name}`);
 // Create the webpack configuration for the development environment.
 // Build the test directory.
 const config = webpackConfig({
-  mode: 'development',
+  mode: 'test',
 });
 if (!config.entry) {
   console.log(`${chalk.red(`Configuration error.`)}

--- a/plugins/dev-scripts/scripts/start.js
+++ b/plugins/dev-scripts/scripts/start.js
@@ -40,7 +40,7 @@ console.log(`Running start for ${packageJson.name}`);
 // Create the webpack configuration for the development environment.
 // Build the test directory.
 const config = webpackConfig({
-  mode: 'test',
+  mode: 'development',
 });
 if (!config.entry) {
   console.log(`${chalk.red(`Configuration error.`)}

--- a/plugins/dev-scripts/scripts/test.js
+++ b/plugins/dev-scripts/scripts/test.js
@@ -30,7 +30,7 @@ console.log(`Building tests for ${packageJson.name}`);
 const args = process.argv.slice(2);
 const skipLint = args.includes('--skip-lint');
 const config = webpackConfig({
-  mode: 'development',
+  mode: 'test',
   skipLint: skipLint,
 });
 if (!config.entry) {


### PR DESCRIPTION
Addresses the first half of [this comment](https://github.com/google/blockly-samples/pull/879/commits/04004b282c59ed65db0a14e8312303cd61c5d275#r788125510).

The second half I believe can be addressed with an npm install. We updated webpack versions so if we don't install then we are using v5 config with v4 of webpack.