### PR TITLE
Revert "Publish"

### DIFF
--- a/plugins/block-dynamic-connection/package-lock.json
+++ b/plugins/block-dynamic-connection/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/block-dynamic-connection",
-	"version": "0.1.18",
+	"version": "0.1.17",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/block-dynamic-connection",
-  "version": "0.1.18",
+  "version": "0.1.17",
   "description": "A group of blocks that add connections dynamically.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0",
     "chai": "^4.2.0",
     "mocha": "^7.1.0"

--- a/plugins/block-extension-tooltip/package-lock.json
+++ b/plugins/block-extension-tooltip/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/block-extension-tooltip",
-	"version": "1.0.21",
+	"version": "1.0.20",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/block-extension-tooltip/package.json
+++ b/plugins/block-extension-tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/block-extension-tooltip",
-  "version": "1.0.21",
+  "version": "1.0.20",
   "description": "A Blockly block extension that adds support for custom tooltip rendering.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
+    "@blockly/dev-scripts": "^1.2.11",
     "@blockly/dev-tools": "2.6.1",
     "blockly": "5.20210325.1",
     "typescript": "^4.0.5"

--- a/plugins/block-plus-minus/package-lock.json
+++ b/plugins/block-plus-minus/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/block-plus-minus",
-	"version": "3.0.4",
+	"version": "3.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/block-plus-minus/package.json
+++ b/plugins/block-plus-minus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blockly/block-plus-minus",
-    "version": "3.0.4",
+    "version": "3.0.3",
     "description": "A group of blocks that replace the built-in mutator UI with a +/- based UI.",
     "scripts": {
         "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
         "src"
     ],
     "devDependencies": {
-        "@blockly/dev-scripts": "^1.2.12",
-        "@blockly/dev-tools": "^3.0.4",
+        "@blockly/dev-scripts": "^1.2.11",
+        "@blockly/dev-tools": "^3.0.3",
         "blockly": "^7.20211209.0",
         "chai": "^4.2.0",
         "mocha": "^7.1.0",

--- a/plugins/block-test/package-lock.json
+++ b/plugins/block-test/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/block-test",
-	"version": "2.0.2",
+	"version": "2.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/block-test/package.json
+++ b/plugins/block-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/block-test",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "A group of Blockly test blocks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,7 +39,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
+    "@blockly/dev-scripts": "^1.2.11",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/content-highlight/package-lock.json
+++ b/plugins/content-highlight/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/workspace-content-highlight",
-	"version": "1.0.13",
+	"version": "1.0.12",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/workspace-content-highlight",
-  "version": "1.0.13",
+  "version": "1.0.12",
   "description": "A Blockly workspace plugin that adds a highlight around the content area.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -43,8 +43,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/continuous-toolbox/package-lock.json
+++ b/plugins/continuous-toolbox/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/continuous-toolbox",
-	"version": "2.0.22",
+	"version": "2.0.21",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/continuous-toolbox",
-  "version": "2.0.22",
+  "version": "2.0.21",
   "description": "A Blockly plugin that adds a continous-scrolling style toolbox and flyout",
   "scripts": {
     "build": "blockly-scripts build",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/dev-scripts/package-lock.json
+++ b/plugins/dev-scripts/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/dev-scripts",
-	"version": "1.2.12",
+	"version": "1.2.11",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/dev-scripts/package.json
+++ b/plugins/dev-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/dev-scripts",
-  "version": "1.2.12",
+  "version": "1.2.11",
   "description": "Configuration and scripts for Blockly plugins.",
   "scripts": {
     "lint": "eslint ."
@@ -29,7 +29,7 @@
     "@babel/core": "^7.8.6",
     "@babel/preset-env": "^7.8.6",
     "@babel/preset-typescript": "^7.9.0",
-    "@blockly/eslint-config": "^2.1.6",
+    "@blockly/eslint-config": "^2.1.5",
     "babel-loader": "^8.0.6",
     "chalk": "^4.0.0",
     "eslint": "^7.15.0",

--- a/plugins/dev-tools/package-lock.json
+++ b/plugins/dev-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/dev-tools",
-	"version": "3.0.4",
+	"version": "3.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/dev-tools",
-  "version": "3.0.4",
+  "version": "3.0.3",
   "description": "A library of common utilities for Blockly extension development.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,7 +39,7 @@
     "src"
   ],
   "dependencies": {
-    "@blockly/block-test": "^2.0.2",
+    "@blockly/block-test": "^2.0.1",
     "@blockly/theme-dark": "^2.0.7",
     "@blockly/theme-deuteranopia": "^1.0.8",
     "@blockly/theme-highcontrast": "^1.0.8",
@@ -52,7 +52,7 @@
     "sinon": "^9.0.2"
   },
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
+    "@blockly/dev-scripts": "^1.2.11",
     "@types/dat.gui": "^0.7.5",
     "blockly": "^7.20211209.0"
   },

--- a/plugins/disable-top-blocks/package-lock.json
+++ b/plugins/disable-top-blocks/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/disable-top-blocks",
-	"version": "0.1.24",
+	"version": "0.1.23",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/disable-top-blocks",
-  "version": "0.1.24",
+  "version": "0.1.23",
   "description": "A Blockly plugin that shows the 'disable' context menu option only on non-orphan blocks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/eslint-config/package-lock.json
+++ b/plugins/eslint-config/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/eslint-config",
-	"version": "2.1.6",
+	"version": "2.1.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/eslint-config/package.json
+++ b/plugins/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/eslint-config",
-  "version": "2.1.6",
+  "version": "2.1.5",
   "description": "ESlint configuration used by Blockly plugins.",
   "files": [
     "index.js"

--- a/plugins/field-date/package-lock.json
+++ b/plugins/field-date/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/field-date",
-	"version": "5.0.4",
+	"version": "5.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blockly/field-date",
-    "version": "5.0.4",
+    "version": "5.0.3",
     "description": "A Blockly date picker field that uses the Google Closure date picker.",
     "scripts": {
         "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
         "src"
     ],
     "devDependencies": {
-        "@blockly/dev-scripts": "^1.2.12",
-        "@blockly/dev-tools": "^3.0.4",
+        "@blockly/dev-scripts": "^1.2.11",
+        "@blockly/dev-tools": "^3.0.3",
         "blockly": "^7.20211209.0",
         "google-closure-compiler": "^20200920.0.0",
         "google-closure-library": "^20200830.0.0",
@@ -56,7 +56,7 @@
     },
     "eslintConfig": {
         "extends": "@blockly/eslint-config"
-    },
+      },
     "engines": {
         "node": ">=8.0.0"
     },

--- a/plugins/field-grid-dropdown/package-lock.json
+++ b/plugins/field-grid-dropdown/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/field-grid-dropdown",
-	"version": "1.0.29",
+	"version": "1.0.28",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-grid-dropdown",
-  "version": "1.0.29",
+  "version": "1.0.28",
   "description": "A Blockly dropdown field with grid layout.",
   "scripts": {
     "build": "blockly-scripts build",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/field-slider/package-lock.json
+++ b/plugins/field-slider/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/field-slider",
-	"version": "3.0.4",
+	"version": "3.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-slider",
-  "version": "3.0.4",
+  "version": "3.0.3",
   "description": "A Blockly slider field.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0",
     "chai": "^4.2.0",
     "sinon": "^9.0.1"

--- a/plugins/fixed-edges/package-lock.json
+++ b/plugins/fixed-edges/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/fixed-edges",
-	"version": "1.0.22",
+	"version": "1.0.21",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/fixed-edges",
-  "version": "1.0.22",
+  "version": "1.0.21",
   "description": "A Blockly MetricsManager for configuring fixed sides.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/keyboard-navigation/package-lock.json
+++ b/plugins/keyboard-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/keyboard-navigation",
-	"version": "0.2.4",
+	"version": "0.2.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/keyboard-navigation/package.json
+++ b/plugins/keyboard-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/keyboard-navigation",
-  "version": "0.2.4",
+  "version": "0.2.3",
   "description": "A Blockly plugin that adds keyboard navigation support.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0",
     "chai": "^4.2.0",
     "jsdom": "^16.4.0",

--- a/plugins/modal/package-lock.json
+++ b/plugins/modal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-modal",
-	"version": "3.0.4",
+	"version": "3.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-modal",
-  "version": "3.0.4",
+  "version": "3.0.3",
   "description": "A Blockly plugin that creates a modal.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",

--- a/plugins/nominal-connection-checker/package-lock.json
+++ b/plugins/nominal-connection-checker/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-nominal-connection-checker",
-	"version": "1.2.11",
+	"version": "1.2.10",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/nominal-connection-checker/package.json
+++ b/plugins/nominal-connection-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-nominal-connection-checker",
-  "version": "1.2.11",
+  "version": "1.2.10",
   "description": "A Blockly plugin for creating more advanced connection checks, targeted at nominally typed languages.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -43,8 +43,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0",
     "chai": "^4.2.0",
     "sinon": "^9.0.3"

--- a/plugins/scroll-options/package-lock.json
+++ b/plugins/scroll-options/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-scroll-options",
-	"version": "2.0.4",
+	"version": "2.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-scroll-options",
-  "version": "2.0.4",
+  "version": "2.0.3",
   "description": "A Blockly plugin that adds advanced scroll options such as scroll-on-drag and scroll while holding a block.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/serialize-disabled-interactions/package-lock.json
+++ b/plugins/serialize-disabled-interactions/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-serialize-disabled-interactions",
-	"version": "1.0.2",
+	"version": "1.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/serialize-disabled-interactions/package.json
+++ b/plugins/serialize-disabled-interactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-serialize-disabled-interactions",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "A Blockly plugin that serializes the deletable, movable, and editable attribues of blocks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
+    "@blockly/dev-scripts": "^1.2.10",
     "@blockly/dev-tools": "^2.5.6",
     "blockly": "^7.20211209.1",
     "chai": "^4.3.4"

--- a/plugins/strict-connection-checker/package-lock.json
+++ b/plugins/strict-connection-checker/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-strict-connection-checker",
-	"version": "1.0.29",
+	"version": "1.0.28",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-strict-connection-checker",
-  "version": "1.0.29",
+  "version": "1.0.28",
   "description": "A Blockly plugin that makes connection checks strict.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -42,8 +42,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0",
     "chai": "^4.2.0"
   },

--- a/plugins/theme-dark/package-lock.json
+++ b/plugins/theme-dark/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/theme-dark",
-	"version": "3.0.1",
+	"version": "3.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-dark",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "A Blockly dark theme.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
+    "@blockly/dev-scripts": "^1.2.11",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/theme-deuteranopia/package-lock.json
+++ b/plugins/theme-deuteranopia/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/theme-deuteranopia",
-	"version": "2.0.1",
+	"version": "2.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/theme-deuteranopia/package.json
+++ b/plugins/theme-deuteranopia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-deuteranopia",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "A Blockly theme for people that have deuteranopia.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
+    "@blockly/dev-scripts": "^1.2.11",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/theme-highcontrast/package-lock.json
+++ b/plugins/theme-highcontrast/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/theme-highcontrast",
-	"version": "2.0.1",
+	"version": "2.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/theme-highcontrast/package.json
+++ b/plugins/theme-highcontrast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-highcontrast",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "A Blockly high contrast theme.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
+    "@blockly/dev-scripts": "^1.2.11",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/theme-modern/package-lock.json
+++ b/plugins/theme-modern/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/theme-modern",
-	"version": "2.1.26",
+	"version": "2.1.25",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-modern",
-  "version": "2.1.26",
+  "version": "2.1.25",
   "description": "A Blockly modern theme with darker block borders.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
+    "@blockly/dev-scripts": "^1.2.11",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/theme-tritanopia/package-lock.json
+++ b/plugins/theme-tritanopia/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/theme-tritanopia",
-	"version": "2.0.1",
+	"version": "2.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/theme-tritanopia/package.json
+++ b/plugins/theme-tritanopia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-tritanopia",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "A Blockly theme for people that have tritanopia.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
+    "@blockly/dev-scripts": "^1.2.11",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/typed-variable-modal/package-lock.json
+++ b/plugins/typed-variable-modal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-typed-variable-modal",
-	"version": "4.0.4",
+	"version": "4.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-typed-variable-modal",
-  "version": "4.0.4",
+  "version": "4.0.3",
   "description": "A Blockly plugin to create a modal for creating typed variables.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",
@@ -52,7 +52,7 @@
     "blockly": "^7.20211209.0"
   },
   "dependencies": {
-    "@blockly/plugin-modal": "^3.0.4"
+    "@blockly/plugin-modal": "^3.0.3"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/workspace-backpack/package-lock.json
+++ b/plugins/workspace-backpack/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/workspace-backpack",
-	"version": "1.0.13",
+	"version": "1.0.12",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/workspace-backpack",
-  "version": "1.0.13",
+  "version": "1.0.12",
   "description": "A Blockly plugin that adds Backpack support.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,8 +41,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {

--- a/plugins/workspace-search/package-lock.json
+++ b/plugins/workspace-search/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-workspace-search",
-	"version": "5.0.4",
+	"version": "5.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-workspace-search",
-  "version": "5.0.4",
+  "version": "5.0.3",
   "description": "A Blockly plugin that adds workspace search support.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",

--- a/plugins/zoom-to-fit/package-lock.json
+++ b/plugins/zoom-to-fit/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/zoom-to-fit",
-	"version": "2.0.13",
+	"version": "2.0.12",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/zoom-to-fit",
-  "version": "2.0.13",
+  "version": "2.0.12",
   "description": "A Blockly plugin that adds a zoom-to-fit control to the workspace.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.12",
-    "@blockly/dev-tools": "^3.0.4",
+    "@blockly/dev-scripts": "^1.2.11",
+    "@blockly/dev-tools": "^3.0.3",
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This reverts commit 7649b47cbb366115604d5f3c8e4aa8b578d7121d.

The release script failed before it published to npm but not before it added a bunch of tags to github and added this commit. Reverting this will hopefully mean that npm and git are now in sync.