### PR TITLE
fix: Make block-extension-tooltip build successfully

### DIFF
--- a/plugins/block-extension-tooltip/package.json
+++ b/plugins/block-extension-tooltip/package.json
@@ -12,6 +12,7 @@
     "prepublishOnly": "npm run clean && npm run dist",
     "start": "blockly-scripts start"
   },
+  "private": true,
   "main": "./dist/index.js",
   "module": "./src/index.js",
   "unpkg": "./dist/index.js",

--- a/plugins/block-extension-tooltip/src/index.ts
+++ b/plugins/block-extension-tooltip/src/index.ts
@@ -8,7 +8,7 @@
  * @fileoverview Custom tooltip block extension.
  * @author samelh@google.com (Sam El-Husseini)
  */
-import * as Blockly from 'blockly/core';
+import * as Blockly from 'blockly';
 import './tooltip_monkey_patch';
 
 type TooltipRender = (block: Blockly.BlockSvg) => HTMLElement;

--- a/plugins/block-extension-tooltip/src/index.ts
+++ b/plugins/block-extension-tooltip/src/index.ts
@@ -8,6 +8,10 @@
  * @fileoverview Custom tooltip block extension.
  * @author samelh@google.com (Sam El-Husseini)
  */
+
+// TODO(maribethb): This should be from 'blockly/core'; fix asap when this
+// plugin is made compatible with v7 of Blockly.
+// See https://github.com/google/blockly-samples/issues/805
 import * as Blockly from 'blockly';
 import './tooltip_monkey_patch';
 

--- a/plugins/block-extension-tooltip/tsconfig.json
+++ b/plugins/block-extension-tooltip/tsconfig.json
@@ -4,7 +4,11 @@
     "target": "es5",
     "allowJs": true,
     "sourceMap": true,
-    "lib": ["es6", "dom"]
+    "lib": ["es6", "dom"],
+    // Tell tsc to use the version of blockly local to this plugin.
+    // See https://github.com/google/blockly-samples/issues/805
+    "baseUrl": ".",
+    "paths": {"blockly": ["node_modules/blockly"]}
   },
   "include": [
     "src", "test"


### PR DESCRIPTION
Fixes #805 

Fixes two different build errors; see issue for more details.

Before: `npm run build` failed in `block-extension-tooltip`
Now: `npm run build` succeeds (with warnings, sorry)

