### PR TITLE
Fixed to avoid deprecated schedule warning

### DIFF
--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -250,7 +250,7 @@ export class Backpack extends Blockly.DragTarget {
   createDom_() {
     this.svgGroup_ = Blockly.utils.dom.createSvgElement(
         Blockly.utils.Svg.G, {}, null);
-    const rnd = Blockly.utils.genUid();
+    const rnd = Blockly.utils.idGenerator.genUid();
     const clip = Blockly.utils.dom.createSvgElement(
         Blockly.utils.Svg.CLIPPATH,
         {'id': 'blocklyBackpackClipPath' + rnd},


### PR DESCRIPTION
fix:
The following warning occurred while using backpack.
`Blockly.utils.genUid was deprecated on September 2021 and will be deleted on September 2022. Use Blockly.utils.idGenerator.genUid instead.`

The version of blockly has been upgraded to Q4 2021.
Perhaps the following changes are involved:
https://github.com/google/blockly/pull/5441