### PR TITLE
fix: Blockly.utils.genUid was deprecated

### DIFF
--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/workspace-backpack",
-  "version": "1.0.15",
+  "version": "2.0.0",
   "description": "A Blockly plugin that adds Backpack support.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -46,7 +46,7 @@
     "blockly": "^7.20211209.0"
   },
   "peerDependencies": {
-    "blockly": "6.20210701.0 - 7"
+    "blockly": "^7.20211209.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -250,7 +250,7 @@ export class Backpack extends Blockly.DragTarget {
   createDom_() {
     this.svgGroup_ = Blockly.utils.dom.createSvgElement(
         Blockly.utils.Svg.G, {}, null);
-    const rnd = Blockly.utils.genUid();
+    const rnd = Blockly.utils.idGenerator.genUid();
     const clip = Blockly.utils.dom.createSvgElement(
         Blockly.utils.Svg.CLIPPATH,
         {'id': 'blocklyBackpackClipPath' + rnd},


### PR DESCRIPTION
fix: The following warning occurred while using backpack.
Blockly.utils.genUid was deprecated on September 2021 and will be deleted on September 2022. Use Blockly.utils.idGenerator.genUid instead.

The version of blockly has been upgraded to Q4 2021.
Perhaps the following changes are involved:
google/blockly#5441