### PR TITLE
fix: bugs in the new debug renderer

### DIFF
--- a/plugins/dev-tools/src/playground/options.js
+++ b/plugins/dev-tools/src/playground/options.js
@@ -76,6 +76,7 @@ export function addGUIControls(genWorkspace, defaultOptions, config = {}) {
   const defaultRendererName = defaultOptions.renderer ?
       defaultOptions.renderer : 'geras';
   guiState.renderer = guiState.renderer || defaultRendererName;
+  guiState.debugEnabled = guiState.debugEnabled || false;
 
   // Merge default and saved state.
   const saveOptions = /** @type {!Blockly.BlocklyOptions} */ ({

--- a/plugins/dev-tools/src/playground/options.js
+++ b/plugins/dev-tools/src/playground/options.js
@@ -235,7 +235,7 @@ export function addGUIControls(genWorkspace, defaultOptions, config = {}) {
   // Debug renderer.
   const debugFolder = gui.addFolder('Debug');
   // Adds the checkbox to toggle using the debug renderer.
-  const debugController = debugFolder.add(guiState, 'Enable Debug Renderer');
+  const debugController = debugFolder.add(guiState, 'debugEnabled');
   // Folder with all the debug options. Hidden if the debugger is not enabled.
   const debugOptionsFolder = debugFolder.addFolder('Debug Options');
 


### PR DESCRIPTION
Fixes two bugs with the debug renderer that were found when testing with core blockly. 
- I changed the name of the folder to make it more readable in my last commit. This was bad because the folder name is also mapped to the name of the field it corresponds to on the object.
- When you have an old bag of options it fails because the defaultState is not used and so it does not have any default value.