### PR TITLE
fix: update renames in codelabs and examples to v7

### DIFF
--- a/codelabs/custom_generator/custom_generator.md
+++ b/codelabs/custom_generator/custom_generator.md
@@ -68,7 +68,7 @@ The blocks are:
 Copy this code into `custom_generator.js` to define the two custom blocks.
 
 ```js
-Blockly.defineBlocksWithJsonArray([{
+Blockly.common.defineBlocksWithJsonArray([{
   "type": "object",
   "message0": "{ %1 %2 }",
   "args0": [

--- a/codelabs/custom_toolbox/custom_toolbox.md
+++ b/codelabs/custom_toolbox/custom_toolbox.md
@@ -114,7 +114,7 @@ However, if you run the below commands in your console you will see that
 your toolbox is now using the `CustomCategory` class.
 
 ```js
-var toolbox = Blockly.getMainWorkspace().getToolbox();
+var toolbox = Blockly.common.getMainWorkspace().getToolbox();
 toolbox.getToolboxItems()[0];
 ```
 

--- a/codelabs/getting_started/getting_started.md
+++ b/codelabs/getting_started/getting_started.md
@@ -227,7 +227,7 @@ Create a JS file to define a new "play sound" block:
 1. Add the following code to `sound_blocks.js`:
 
 ```js
-Blockly.defineBlocksWithJsonArray([
+Blockly.common.defineBlocksWithJsonArray([
   {
     "type": "play_sound",
     "message0": "Play %1",
@@ -309,7 +309,7 @@ Once the button behavior is defined by the user, it needs to be saved for later 
 Open `scripts/main.js`. Add the following code to the `save()` method:
 
 ```js
-button.blocklySave = Blockly.serialization.workspaces.save(Blockly.getMainWorkspace());
+button.blocklySave = Blockly.serialization.workspaces.save(Blockly.common.getMainWorkspace());
 ```
 
 `workspaces.save` takes the Blockly workspace, exports its state to a JavaScript object and stores it in a `blocklySave` property on the button. This way the exported state for the block sequence gets associated with a particular button.
@@ -322,7 +322,7 @@ In the `scripts/main.js `file, add `loadWorkspace` function:
 
 ```
 function loadWorkspace(button) {
-  const workspace = Blockly.getMainWorkspace();
+  const workspace = Blockly.common.getMainWorkspace();
   if (button.blocklySave) {
     Blockly.serialization.workspaces.load(button.blocklySave, workspace);
   }
@@ -392,7 +392,7 @@ Next, you need to generate the code out of that workspace, which you can do with
 The user's code will consist of many `MusicMaker.queueSound` calls. At the end of our generated script, add `MusicMaker.play `call to play all the sounds added to the queue.
 
 ```js
-let code = Blockly.JavaScript.workspaceToCode(Blockly.getMainWorkspace());
+let code = Blockly.JavaScript.workspaceToCode(Blockly.common.getMainWorkspace());
 code += 'MusicMaker.play();';
 ```
 
@@ -413,7 +413,7 @@ The end result should look like this:
 ```js
 function handlePlay(event) {
   loadWorkspace(event.target);
-  let code = Blockly.JavaScript.workspaceToCode(Blockly.getMainWorkspace());
+  let code = Blockly.JavaScript.workspaceToCode(Blockly.common.getMainWorkspace());
   code += 'MusicMaker.play();';
   try {
     eval(code);

--- a/examples/custom-dialogs-demo/custom-dialog.js
+++ b/examples/custom-dialogs-demo/custom-dialog.js
@@ -13,7 +13,7 @@
  */
 CustomDialog = {};
 
-/** Override Blockly.dialog.setAlert()() with custom implementation. */
+/** Override Blockly.dialog.setAlert() with custom implementation. */
 Blockly.dialog.setAlert(function(message, callback) {
   console.log('Alert: ' + message);
   CustomDialog.show('Alert', message, {
@@ -21,7 +21,7 @@ Blockly.dialog.setAlert(function(message, callback) {
   });
 });
 
-/** Override Blockly.dialog.setConfirm()() with custom implementation. */
+/** Override Blockly.dialog.setConfirm() with custom implementation. */
 Blockly.dialog.setConfirm(function(message, callback) {
   console.log('Confirm: ' + message);
   CustomDialog.show('Confirm', message, {
@@ -36,7 +36,7 @@ Blockly.dialog.setConfirm(function(message, callback) {
   });
 });
 
-/** Override Blockly.dialog.setPrompt()() with custom implementation. */
+/** Override Blockly.dialog.setPrompt() with custom implementation. */
 Blockly.dialog.setPrompt(function(message, defaultValue, callback) {
   console.log('Prompt: ' + message);
   CustomDialog.show('Prompt', message, {

--- a/examples/custom-dialogs-demo/custom-dialog.js
+++ b/examples/custom-dialogs-demo/custom-dialog.js
@@ -13,16 +13,16 @@
  */
 CustomDialog = {};
 
-/** Override Blockly.alert() with custom implementation. */
-Blockly.alert = function(message, callback) {
+/** Override Blockly.dialog.setAlert()() with custom implementation. */
+Blockly.dialog.setAlert(function(message, callback) {
   console.log('Alert: ' + message);
   CustomDialog.show('Alert', message, {
     onCancel: callback
   });
-};
+});
 
-/** Override Blockly.confirm() with custom implementation. */
-Blockly.confirm = function(message, callback) {
+/** Override Blockly.dialog.setConfirm()() with custom implementation. */
+Blockly.dialog.setConfirm(function(message, callback) {
   console.log('Confirm: ' + message);
   CustomDialog.show('Confirm', message, {
     showOkay: true,
@@ -34,10 +34,10 @@ Blockly.confirm = function(message, callback) {
       callback(false);
     }
   });
-};
+});
 
-/** Override Blockly.prompt() with custom implementation. */
-Blockly.prompt = function(message, defaultValue, callback) {
+/** Override Blockly.dialog.setPrompt()() with custom implementation. */
+Blockly.dialog.setPrompt(function(message, defaultValue, callback) {
   console.log('Prompt: ' + message);
   CustomDialog.show('Prompt', message, {
     showInput: true,
@@ -48,10 +48,10 @@ Blockly.prompt = function(message, defaultValue, callback) {
     showCancel: true,
     onCancel: function() {
       callback(null);
-    }
+    },
   });
   CustomDialog.inputField.value = defaultValue;
-};
+});
 
 /** Hides any currently visible dialog. */
 CustomDialog.hide = function() {

--- a/examples/interpreter-demo/wait_block.js
+++ b/examples/interpreter-demo/wait_block.js
@@ -11,7 +11,7 @@
  *
  * See https://neil.fraser.name/software/JS-Interpreter/docs.html
  */
-Blockly.defineBlocksWithJsonArray([{
+Blockly.common.defineBlocksWithJsonArray([{
   "type": "wait_seconds",
   "message0": " wait %1 seconds",
   "args0": [{

--- a/examples/pitch-field-demo/field_pitch.js
+++ b/examples/pitch-field-demo/field_pitch.js
@@ -34,14 +34,14 @@ CustomFields.FieldPitch = function(text) {
 
   /**
    * Click event data.
-   * @type {?Blockly.eventHandling.Data}
+   * @type {?Blockly.browserEvents.Data}
    * @private
    */
   this.clickWrapper_ = null;
 
   /**
    * Move event data.
-   * @type {?Blockly.eventHandling.Data}
+   * @type {?Blockly.browserEvents.Data}
    * @private
    */
   this.moveWrapper_ = null;

--- a/examples/pitch-field-demo/field_pitch.js
+++ b/examples/pitch-field-demo/field_pitch.js
@@ -34,14 +34,14 @@ CustomFields.FieldPitch = function(text) {
 
   /**
    * Click event data.
-   * @type {?Blockly.EventData}
+   * @type {?Blockly.eventHandling.Data}
    * @private
    */
   this.clickWrapper_ = null;
 
   /**
    * Move event data.
-   * @type {?Blockly.EventData}
+   * @type {?Blockly.eventHandling.Data}
    * @private
    */
   this.moveWrapper_ = null;
@@ -73,7 +73,7 @@ CustomFields.FieldPitch.prototype.showEditor_ = function() {
 
   var div = Blockly.WidgetDiv.DIV;
   if (!div.firstChild) {
-    // Mobile interface uses Blockly.prompt.
+    // Mobile interface uses Blockly.dialog.setPrompt().
     return;
   }
   // Build the DOM.
@@ -91,10 +91,10 @@ CustomFields.FieldPitch.prototype.showEditor_ = function() {
   // change this behaviour.  For now, using bindEvent_ instead of
   // bindEventWithChecks_ allows it to work without a mousedown/touchstart.
   this.clickWrapper_ =
-      Blockly.bindEvent_(this.imageElement_, 'click', this,
+      Blockly.browserEvents.bind(this.imageElement_, 'click', this,
           this.hide_);
   this.moveWrapper_ =
-      Blockly.bindEvent_(this.imageElement_, 'mousemove', this,
+      Blockly.browserEvents.bind(this.imageElement_, 'mousemove', this,
           this.onMouseMove);
 
   this.updateGraph_();
@@ -118,11 +118,11 @@ CustomFields.FieldPitch.prototype.dropdownCreate_ = function() {
  */
 CustomFields.FieldPitch.prototype.dropdownDispose_ = function() {
   if (this.clickWrapper_) {
-    Blockly.unbindEvent_(this.clickWrapper_);
+    Blockly.browserEvents.unbind(this.clickWrapper_);
     this.clickWrapper_ = null;
   }
   if (this.moveWrapper_) {
-    Blockly.unbindEvent_(this.moveWrapper_);
+    Blockly.browserEvents.unbind(this.moveWrapper_);
     this.moveWrapper_ = null;
   }
   this.imageElement_ = null;

--- a/examples/turtle-field-demo/field_turtle.js
+++ b/examples/turtle-field-demo/field_turtle.js
@@ -404,34 +404,34 @@ CustomFields.FieldTurtle.prototype.dropdownCreate_ = function() {
   var leftArrow = createLeftArrow(row);
   widget.patternText = createTextNode(row, this.displayValue_.pattern);
   var rightArrow = createRightArrow(row);
-  this.editorListeners_.push(Blockly.bindEvent_(leftArrow, 'mouseup', this,
+  this.editorListeners_.push(Blockly.browserEvents.bind(leftArrow, 'mouseup', this,
       createArrowListener('pattern', CustomFields.FieldTurtle.PATTERNS, -1)));
-  this.editorListeners_.push(Blockly.bindEvent_(rightArrow, 'mouseup', this,
+  this.editorListeners_.push(Blockly.browserEvents.bind(rightArrow, 'mouseup', this,
       createArrowListener('pattern', CustomFields.FieldTurtle.PATTERNS, 1)));
 
   row = createRow(table);
   leftArrow = createLeftArrow(row);
   widget.hatText = createTextNode(row, this.displayValue_.hat);
   rightArrow = createRightArrow(row);
-  this.editorListeners_.push(Blockly.bindEvent_(leftArrow, 'mouseup', this,
+  this.editorListeners_.push(Blockly.browserEvents.bind(leftArrow, 'mouseup', this,
       createArrowListener('hat', CustomFields.FieldTurtle.HATS, -1)));
-  this.editorListeners_.push(Blockly.bindEvent_(rightArrow, 'mouseup', this,
+  this.editorListeners_.push(Blockly.browserEvents.bind(rightArrow, 'mouseup', this,
       createArrowListener('hat', CustomFields.FieldTurtle.HATS, 1)));
 
   row = createRow(table);
   leftArrow = createLeftArrow(row);
   widget.turtleNameText = createTextNode(row, this.displayValue_.turtleName);
   rightArrow = createRightArrow(row);
-  this.editorListeners_.push(Blockly.bindEvent_(leftArrow, 'mouseup', this,
+  this.editorListeners_.push(Blockly.browserEvents.bind(leftArrow, 'mouseup', this,
       createArrowListener('turtleName', CustomFields.FieldTurtle.NAMES, -1)));
-  this.editorListeners_.push(Blockly.bindEvent_(rightArrow, 'mouseup', this,
+  this.editorListeners_.push(Blockly.browserEvents.bind(rightArrow, 'mouseup', this,
       createArrowListener('turtleName', CustomFields.FieldTurtle.NAMES, 1)));
 
   var randomizeButton = document.createElement('button');
   randomizeButton.className = 'randomize';
   randomizeButton.setAttribute('type', 'button');
   randomizeButton.textContent = 'randomize turtle';
-  this.editorListeners_.push(Blockly.bindEvent_(randomizeButton, 'mouseup', this,
+  this.editorListeners_.push(Blockly.browserEvents.bind(randomizeButton, 'mouseup', this,
     function() {
     var value = {};
     value.pattern = CustomFields.FieldTurtle.PATTERNS[
@@ -454,7 +454,7 @@ CustomFields.FieldTurtle.prototype.dropdownCreate_ = function() {
 CustomFields.FieldTurtle.prototype.dropdownDispose_ = function() {
   for (var i = this.editorListeners_.length, listener;
       listener = this.editorListeners_[i]; i--) {
-    Blockly.unbindEvent_(listener);
+    Blockly.browserEvents.unbind(listener);
     this.editorListeners_.pop();
   }
 };


### PR DESCRIPTION
### Description

Uses the new renamings script to automatically perform renames in codelabs and samples.

Closes #884 , but this will be a continual problem haha.