### PR TITLE
fix: Remove host option to work on Windows.

### DIFF
--- a/plugins/dev-scripts/config/webpackDevServer.config.js
+++ b/plugins/dev-scripts/config/webpackDevServer.config.js
@@ -12,7 +12,6 @@
 module.exports = () => {
   return {
     port: 3000,
-    host: '0.0.0.0',
     hot: true,
     static: ['./test'],
     watchFiles: {


### PR DESCRIPTION
### Resolves

#832

### Proposed Changes

Remove host option from webpackDevServer.config.js.

This config works on both Windows and Linux.