### PR TITLE
chore: update license year in create-package templates

### DIFF
--- a/plugins/dev-create/templates/block/template/src/index.js
+++ b/plugins/dev-create/templates/block/template/src/index.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/block/template/test/block_test.mocha.js
+++ b/plugins/dev-create/templates/block/template/test/block_test.mocha.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/block/template/test/index.js
+++ b/plugins/dev-create/templates/block/template/test/index.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/field/template/src/index.js
+++ b/plugins/dev-create/templates/field/template/src/index.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/field/template/test/field_test.mocha.js
+++ b/plugins/dev-create/templates/field/template/test/field_test.mocha.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/field/template/test/index.js
+++ b/plugins/dev-create/templates/field/template/test/index.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/plugin/template/src/index.js
+++ b/plugins/dev-create/templates/plugin/template/src/index.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/plugin/template/test/index.js
+++ b/plugins/dev-create/templates/plugin/template/test/index.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/theme/template/src/index.js
+++ b/plugins/dev-create/templates/theme/template/src/index.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/theme/template/test/index.js
+++ b/plugins/dev-create/templates/theme/template/test/index.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/typescript-block/template/src/index.ts
+++ b/plugins/dev-create/templates/typescript-block/template/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/typescript-block/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-block/template/test/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/typescript-field/template/src/index.ts
+++ b/plugins/dev-create/templates/typescript-field/template/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/typescript-field/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-field/template/test/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/typescript-plugin/template/src/index.ts
+++ b/plugins/dev-create/templates/typescript-plugin/template/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/typescript-plugin/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-plugin/template/test/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/typescript-theme/template/src/index.ts
+++ b/plugins/dev-create/templates/typescript-theme/template/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/plugins/dev-create/templates/typescript-theme/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-theme/template/test/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
Update all the template files so someone using the `@blockly/create-package` template gets the correct year in the copyright notice.