### PR TITLE
fix: make blockly non-reactive

### DIFF
--- a/examples/blockly-vue/src/components/BlocklyComponent.vue
+++ b/examples/blockly-vue/src/components/BlocklyComponent.vue
@@ -37,11 +37,6 @@ import Blockly from 'blockly';
 export default {
   name: 'BlocklyComponent',
   props: ['options'],
-  data(){
-    return {
-      workspace: null
-    }
-  },
   mounted() {
     var options = this.$props.options || {};
     if (!options.toolbox) {


### PR DESCRIPTION
### Resolves

#1096

### Description

When you return something from the `data` function in Vue, that makes the thing deeply reactive, meaning it and all of its properties get wrapped in `Proxys`. So when we return the workspace (making it reactive) this breaks parts of Blockly like the ComponentDB that compare objects for equality.

So to fix this, we just don't return the workspace, so it never becomes reactive.

### Testing

This was tested by our [lovely forum person](https://groups.google.com/g/blockly/c/myo3FXL3r_Y/m/KluHKTtICQAJ) over on their [test repo](https://github.com/egradman/blockly-bug/commit/69256f05206d195b8d741c322383e3640d7354da).

I pulled down their changes, and tested as well.