### PR TITLE
fix: unbind the change listener correctly in content-highlight dispose

### DIFF
--- a/plugins/content-highlight/src/index.js
+++ b/plugins/content-highlight/src/index.js
@@ -174,7 +174,7 @@ export class ContentHighlight {
       Blockly.utils.dom.removeNode(this.svgGroup_);
     }
     if (this.onChangeWrapper_) {
-      Blockly.unbindEvent_(this.onChangeWrapper_);
+      this.workspace_.removeChangeListener(this.onChangeWrapper_);
     }
   }
 


### PR DESCRIPTION
Fixes #831 

Removes the change listener instead of calling unbind.

Tested dispose works correctly.

(This would have been a good first issue but since someone was asking about the fix and I already made the change to test it in discussion with them I didn't want to leave it broken)