### PR TITLE
fix: Use scope.block in place of Blockly.selected

### DIFF
--- a/plugins/cross-tab-copy-paste/src/index.js
+++ b/plugins/cross-tab-copy-paste/src/index.js
@@ -68,7 +68,7 @@ export class CrossTabCopyPaste {
       callback: function(
           /** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
         const blockText = JSON.stringify(
-            convertBlockToSaveInfo(Blockly.selected));
+            convertBlockToSaveInfo(scope.block));
         localStorage.setItem('blocklyStash', blockText);
       },
       scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,


### PR DESCRIPTION
In similar contexts, we use `scope.block`, and we should continue that pattern here.