### PR TITLE
fix: Close the <main> tag in the Getting Started codelab.

### DIFF
--- a/examples/getting-started-codelab/starter-code/index.html
+++ b/examples/getting-started-codelab/starter-code/index.html
@@ -44,6 +44,7 @@
     <div class="blockly-editor">
       <div id="blocklyDiv" style="height: 480px; width: 400px;"></div>
     </div>
+  </main>
 
   <script src="scripts/music_maker.js"></script>
   <script src="scripts/main.js"></script>


### PR DESCRIPTION
As noted in https://github.com/google/blockly-samples/issues/1117, the `<main>` tag in index.html in the Getting Started with Blockly codelab was not closed. This PR closes it.