### PR TITLE
fix: update webpack config so releases compile

### DIFF
--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -122,7 +122,7 @@ module.exports = (env) => {
         // Run babel to compile both JS and TS.
         {
           test: /\.(js|mjs|ts)$/,
-          exclude: /(node_modules|build|dist)/,
+          exclude: /(node_modules|build)/,
           loader: require.resolve('babel-loader'),
           options: {
             babelrc: false,


### PR DESCRIPTION
Fixes #1123 

Tested:
- Ran `npm run build` inside block-extension-tooltip twice without deleting the `dist` directory to make sure that not excluding it doesn't hurt. it was fine (as expected)
- Applied the same change inside a cloned repo inside a `dist` directory and ran `npx lerna run prepublishOnly` which runs the same prepublish script on each plugin that happens during publish, which is typically a clean and then a build. Verified this works with no errors including in block-extension-tooltip
- Verified after compiling inside a dist directory that block-test plugin does not contain ` characters, the presence of which previously indicated the output was not being compiled to es5.