### PR TITLE
chore: make block-extension-tooltip private so it doesn't get published

### DIFF
--- a/plugins/block-extension-tooltip/package.json
+++ b/plugins/block-extension-tooltip/package.json
@@ -12,6 +12,7 @@
     "prepublishOnly": "npm run clean && npm run dist",
     "start": "blockly-scripts start"
   },
+  "private": true,
   "main": "./dist/index.js",
   "module": "./src/index.js",
   "unpkg": "./dist/index.js",


### PR DESCRIPTION
We don't want lerna to publish this package again. See the deprecation guide for this plugin in the internal docs.