### PR TITLE
chore: use lerna clean instead of custom command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "boot": "lerna bootstrap",
         "build": "lerna run build",
         "clean": "lerna run clean",
-        "clean:node": "find . -name \"node_modules\" -type d -prune -exec rm -rf '{}' +",
+        "clean:node": "lerna clean --yes",
         "deploy:prepare": "npm run deploy:prepare:plugins && npm run deploy:prepare:examples && gulp predeploy",
         "deploy:prepare:examples": "cd examples && npm run predeploy",
         "deploy:prepare:plugins": "npm run clean && lerna run predeploy",

--- a/scripts.md
+++ b/scripts.md
@@ -21,7 +21,7 @@ This script runs `npm run clean` on each of the Blockly plugins.
 In general, clean deletes the `/build` and `/dist` folders in these plugins.
 
 ### `npm run clean:node`
-This script recursively deletes all `node_modules/` directories in this repo.
+This script deletes `node_modules/` from each plugin in this repo.
 This may be useful if you feel your node modules have wound up in a bad state.
 
 ### `npm run deploy`


### PR DESCRIPTION
Lerna clean was built to do what our custom command does. It's also faster.

One difference: the old command removed every node_modules directory even if buried in subdirectories. This only matters in examples, where some examples have subdirectories that have node_modules directories. But I have never wanted to delete those folders when running this command, this is only ever run when dealing specifically with plugins, as far as I am aware, so I don't think this is a problem. The examples subdirectories can't otherwise be interacted with via lerna so I don't think they need to be cleaned via lerna either.

This command will now only remove node_modules from plugins.