### PR TITLE
fix: update the keyboard nav codelab

### DIFF
--- a/codelabs/keyboard_navigation/keyboard_navigation.md
+++ b/codelabs/keyboard_navigation/keyboard_navigation.md
@@ -497,8 +497,9 @@ following line to your `index.js` file.
 import {Constants} from '../src/index';
 ```
 
-In `index.js` we set the keys for the next, previous, in and out actions. Here
-is our [full list of actions](https://github.com/google/blockly/blob/07762ff4da3c713f7592c80052b1fa7cadb461a2/core/keyboard_nav/navigation.js#L957).
+In `index.js` we set the keys for the next, previous, in and out actions. For a
+full list of the shortcuts registered in the keyboard navigation plugin see the
+[constants file](https://github.com/google/blockly-samples/blob/35edbc9d7b882ec9a24ff0811e1e255f5d565fe8/plugins/keyboard-navigation/src/constants.js#L31).
 ```js
 Blockly.ShortcutRegistry.registry.removeAllKeyMappings(Constants.SHORTCUT_NAMES.OUT);
 Blockly.ShortcutRegistry.registry.addKeyMapping(Blockly.utils.KeyCodes.LEFT, Constants.SHORTCUT_NAMES.OUT);

--- a/codelabs/keyboard_navigation/keyboard_navigation.md
+++ b/codelabs/keyboard_navigation/keyboard_navigation.md
@@ -267,7 +267,7 @@ next() {
     return null;
   }
   // The next Blockly.ASTNode.
-  const newNode = curNode.next();
+  let newNode = curNode.next();
   if (newNode) {
     // This in charge of updating the current location and drawing the cursor.
     this.setCurNode(newNode);
@@ -280,7 +280,7 @@ in() {
   if (!curNode) {
     return null;
   }
-  const newNode = curNode.in();
+  let newNode = curNode.in();
   if (newNode) {
     this.setCurNode(newNode);
   }
@@ -292,7 +292,7 @@ prev() {
   if (!curNode) {
     return null;
   }
-  const newNode = curNode.prev();
+  let newNode = curNode.prev();
   if (newNode) {
     this.setCurNode(newNode);
   }
@@ -304,7 +304,7 @@ out() {
   if (!curNode) {
     return null;
   }
-  const newNode = curNode.out();
+  let newNode = curNode.out();
   if (newNode) {
     this.setCurNode(newNode);
   }
@@ -326,7 +326,7 @@ next() {
   if (!curNode) {
     return null;
   }
-  const newNode = curNode.next();
+  let newNode = curNode.next();
   // While the newNode exists and is either a previous or next type go to the
   // next value.
   while (newNode && (newNode.getType() === Blockly.ASTNode.types.PREVIOUS ||
@@ -347,7 +347,7 @@ prev() {
   if (!curNode) {
     return null;
   }
-  const newNode = curNode.prev();
+  let newNode = curNode.prev();
   // While the newNode exists and is either a previous or next connection go to
   // the previous value.
   while (newNode && (newNode.getType() === Blockly.ASTNode.types.PREVIOUS ||
@@ -368,7 +368,7 @@ in() {
   if (!curNode) {
     return null;
   }
-  const newNode = curNode.in();
+  let newNode = curNode.in();
   // If the newNode is a previous connection go to the next value in the level. 
   // This will be the block.
   if (newNode && newNode.getType() === Blockly.ASTNode.types.PREVIOUS) {

--- a/codelabs/keyboard_navigation/keyboard_navigation.md
+++ b/codelabs/keyboard_navigation/keyboard_navigation.md
@@ -28,7 +28,7 @@ Over the course of this codelab you will build the following:
 1. A keyboard shortcut for moving your cursor to the top of a stack.
 
 ### What you'll need
-1. A Blockly version greater than or equal to `3.20200402.0`.
+1. A Blockly version greater than or equal to `5.20210325.0` and the [keyboard navigation plugin](https://www.npmjs.com/package/@blockly/keyboard-navigation).
 
 ## Terminology
 A **Marker** holds a location and is not movable. 
@@ -39,28 +39,42 @@ The below image displays different parts of a block that a user can navigate to 
 ![Displays the different parts of a block. The previous connection on the top of a block. The next connection on the bottom of a block. Input value as a cut out of a puzzle piece. The statement input as a connection inside of a block. The output connection as a puzzle piece.](./block_terms.png)
 
 ## Setup
-In this codelab you will add code to the Blockly playground to create and use a new cursor. You can find the playground at [`tests/playground.html`](https://github.com/google/blockly/blob/master/tests/playground.html).
+In this codelab you will add code to a Blockly playground that has the [keyboard navigation plugin](https://www.npmjs.com/package/@blockly/keyboard-navigation) initialized.
+We will be using the playground created in the keyboard
+navigation plugin, which can be found in [`tests/index.js`](https://github.com/google/blockly-samples/blob/master/plugins/keyboard-navigation/test/index.js). 
 
-To start, create a file named `custom_cursor.js` and a file named `custom_marker_svg.js` in the same folder as the playground.  In `playground.html` include both files with a script tag.
+To get the playground up and working follow these steps:
+1. Clone the [blockly-samples](https://github.com/google/blockly-samples) repository.
+1. Move to the [plugins/keyboard-navigation](https://github.com/google/blockly-samples/blob/master/plugins/keyboard-navigation/README.md) directory.
+1. Run `npm install`.
+1. Run `npm run start`.
 
-```xml
-<script src="custom_cursor.js"></script>
-<script src="custom_marker_svg.js"></script>
-```
+If you would rather not pull the blockly-samples repository, you should also
+be able to follow along by creating a simple Blockly application that
+uses the keyboard navigation plugin.
+
+To start, create a file named `custom_cursor.js` and a file named `custom_marker_svg.js` in the same folder as [`test/index.js`](https://github.com/google/blockly-samples/blob/master/plugins/keyboard-navigation/test/index.js).
 
 Note: you must include your custom code *after* including the Blockly library.
 
 ## Define and set a cursor
 We extend `Blockly.Cursor` to make our new cursor. Add the following code to your `custom_cursor.js` file.
 ```js
-CustomCursor = function() {
-  CustomCursor.superClass_.constructor.call(this);
-};
-Blockly.utils.object.inherits(CustomCursor, Blockly.Cursor);
+export class CustomCursor extends Blockly.Cursor {
+  constructor() {
+    super();
+  }
+}
+```
+
+Import your cursor in `test/index.js`.
+
+```js
+import {CustomCursor} from './custom_cursor';
 ```
 
 Tell the workspace to use your new cursor.
-In the `playground.html` after the workspace is initialized call `setCursor` on the `markerManager`.
+In `test/index.js` after the workspace is initialized in `createWorkspace` call `setCursor` on the `markerManager`.
 ```js
 workspace.getMarkerManager().setCursor(new CustomCursor());
 ```
@@ -77,8 +91,7 @@ There are four different levels to the AST:
 1. Block and Connection Level (red): Holds all block and connection nodes.
 1. Field and Input Level (yellow): Holds all field and input nodes.
 
-For a more detailed explanation of the different levels please see the keyboard
-navigation [documentation](https://developers.google.com/blockly/guides/configure/web/keyboard-nav#using_the_default_cursor).
+For a more detailed explanation of the different levels please see the [keyboard navigation documentation](https://developers.google.com/blockly/guides/configure/web/keyboard-nav#using_the_default_cursor).
 
 
 ### Create AST nodes
@@ -102,7 +115,7 @@ Every node can:
 1. Return the previous node (`prev()`)
 1. Return the next node (`next()`)
 
-For example, use the below code to get the stack node from a workspace node.
+For example, you can use the below code to get the stack node from a workspace node.
 ```js
 const stackNode = workspaceNode.in();
 ```
@@ -116,105 +129,124 @@ Create a new custom marker that will change the look of cursors and markers when
 Add the below code to your `custom_marker_svg.js` file.
 Create a new class that extends `Blockly.blockRendering.MarkerSvg`. 
 ```js
-CustomMarkerSvg = function(workspace, constants, marker) {
-  CustomMarkerSvg.superClass_.constructor.call(
-      this, workspace, constants, marker);
-};
-Blockly.utils.object.inherits(CustomMarkerSvg,
-    Blockly.blockRendering.MarkerSvg);
+class CustomMarkerSvg extends Blockly.blockRendering.MarkerSvg {
+  constructor(workspace, constants, marker) {
+    super(workspace, constants, marker);
+  }
+}
 ```
 
-Override `createDomInternal_`. This method is in charge of creating all dom elements for the marker. Add a new path element for when the cursor is on a block.
+In the class you just created, override `createDomInternal_`. This method is in charge of creating all dom elements for the marker. Add a new path element for when the cursor is on a block.
 ```js
-CustomMarkerSvg.prototype.createDomInternal_ = function() {
-  CustomMarkerSvg.superClass_.createDomInternal_.call(this);
-  // Create the svg element for the marker when it is on a block and set the parent to markerSvg_.
-  this.blockPath_ = Blockly.utils.dom.createSvgElement('path', {}, this.markerSvg_);
+  /**
+   * @override
+   */
+  createDomInternal_() {
+    super.createDomInternal_();
 
-  // If this is a cursor make the cursor blink.
-  if (this.isCursor()) {
-    var blinkProperties = this.getBlinkProperties_();
-    Blockly.utils.dom.createSvgElement('animate', blinkProperties,
-        this.blockPath_);
+    // Create the svg element for the marker when it is on a block and set the parent to markerSvg_.
+    this.blockPath_ = Blockly.utils.dom.createSvgElement('path', {}, this.markerSvg_);
+
+    // If this is a cursor make the cursor blink.
+    if (this.isCursor()) {
+      var blinkProperties = this.getBlinkProperties_();
+      Blockly.utils.dom.createSvgElement('animate', blinkProperties,
+          this.blockPath_);
+    }
   }
-};
 ```
 
 Create a method that will update the path of `blockPath_` when we move
 to a new block.
 ```js
-CustomMarkerSvg.prototype.showWithBlock_ = function(curNode) {
-  // Get the block from the AST Node
-  var block = curNode.getLocation();
-  // Get the path of the block.
-  var blockPath = block.pathObject.svgPath.getAttribute('d');
-  // Set the path for the cursor.
-  this.blockPath_.setAttribute('d', blockPath);
+  /**
+   * @override
+   */
+  showWithBlock_(curNode) {
+    // Get the block from the AST Node
+    const block = curNode.getLocation();
+    // Get the path of the block.
+    const blockPath = block.pathObject.svgPath.getAttribute('d');
+    // Set the path for the cursor.
+    this.blockPath_.setAttribute('d', blockPath);
 
-  // Set the current marker.
-  this.currentMarkerSvg = this.blockPath_;
-  // Set the parent of the cursor as the block.
-  this.setParent_(block);
-  // Show the current marker.
-  this.showCurrent_();
-};
+    // Set the current marker.
+    this.currentMarkerSvg = this.blockPath_;
+    // Set the parent of the cursor as the block.
+    this.setParent_(block);
+    // Show the current marker.
+    this.showCurrent_();
+  }
 ```
 
 Override `showAtLocation_`. This method is used to decide what to display at a given node.
 ```js
-CustomMarkerSvg.prototype.showAtLocation_ = function(curNode) {
-  var handled = false;
-  // If the cursor is on a block call the new method we created to draw the cursor.
-  if (curNode.getType() == Blockly.ASTNode.types.BLOCK) {
-    this.showWithBlock_(curNode);
-    handled = true;
-  }
+  /**
+   * @override
+   */
+  showAtLocation_(curNode) {
+    var handled = false;
+    // If the cursor is on a block call the new method we created to draw the cursor.
+    if (curNode.getType() == Blockly.ASTNode.types.BLOCK) {
+      this.showWithBlock_(curNode);
+      handled = true;
+    }
 
-  // If we have not drawn the cursor let the parent draw it.
-  if (!handled) {
-    CustomMarkerSvg.superClass_.showAtLocation_.call(this, curNode);
+    // If we have not drawn the cursor let the parent draw it.
+    if (!handled) {
+      super.showAtLocation_.call(this, curNode);
+    }
   }
-};
 ```
 
 Override the `hide` method.
 ```js
-CustomMarkerSvg.prototype.hide = function() {
-  CustomMarkerSvg.superClass_.hide.call(this);
-  // Hide the marker we created.
-  this.markerBlock_.style.display = 'none';
-};
+  /**
+   * @override
+   */
+  hide() {
+    super.hide();
+    // Hide the marker we created.
+    this.blockPath_.style.display = 'none';
+  }
 ```
 
 ### Renderer setup
-In order to change the look of the cursor to use `CustomMarkerSvg` we need to
+In order to have the cursor use `CustomMarkerSvg` we need to
 override the renderer. For more information on customizing a renderer see the
 custom renderer [codelab](https://blocklycodelabs.dev/codelabs/custom-renderer/index.html?index=..%2F..index#2).
 
 Add the below code to your `custom_marker_svg.js` file. 
 ```js
-CustomRenderer = function(name) {
-  CustomRenderer.superClass_.constructor.call(this, name);
-};
-Blockly.utils.object.inherits(CustomRenderer,
-    Blockly.geras.Renderer);
-
+class CustomRenderer extends Blockly.geras.Renderer {
+  constructor(name) {
+    super(name);
+  }
+}
 Blockly.blockRendering.register('custom_renderer', CustomRenderer);
 ```
 
 Now we need to override the method responsible for returning the drawer for markers and cursors.
+In the `CustomRenderer` class add the following method.
 ```js
-CustomRenderer.prototype.makeMarkerDrawer = function(workspace, marker) {
+makeMarkerDrawer(workspace, marker) {
   return new CustomMarkerSvg(workspace, this.getConstants(), marker);
-};
+}
 ```
 
-Set the renderer property in the configuration struct in `playground.html` in order to use your custom renderer.
+In order to use your custom renderer, import it and set the renderer property in `index.js`.
+
 ```js
-Blockly.inject('blocklyDiv', {
-    renderer: 'custom_renderer'
-  }
-);
+import './custom_marker_svg';
+```
+
+In the 'DomContentLoaded' event listener add the renderer to the default
+options so it looks like the below code. 
+```js
+  const defaultOptions = {
+    toolbox: toolboxCategories,
+    renderer: 'custom_renderer',
+  };
 ```
 
 ### Test it out
@@ -228,7 +260,8 @@ In order to create a cursor that skips over previous and next connections overri
 
 Add the below code to your `custom_cursor.js` file.
 ```js
-CustomCursor.prototype.next = function() {
+
+next() {
   // The current Blockly.ASTNode the cursor is on.
   var curNode = this.getCurNode();
   if (!curNode) {
@@ -241,9 +274,9 @@ CustomCursor.prototype.next = function() {
     this.setCurNode(newNode);
   }
   return newNode;
-};
+}
 
-CustomCursor.prototype.in = function() {
+in() {
   var curNode = this.getCurNode();
   if (!curNode) {
     return null;
@@ -253,9 +286,9 @@ CustomCursor.prototype.in = function() {
     this.setCurNode(newNode);
   }
   return newNode;
-};
+}
 
-CustomCursor.prototype.prev = function() {
+prev() {
   var curNode = this.getCurNode();
   if (!curNode) {
     return null;
@@ -265,9 +298,9 @@ CustomCursor.prototype.prev = function() {
     this.setCurNode(newNode);
   }
   return newNode;
-};
+}
 
-CustomCursor.prototype.out = function() {
+out() {
   var curNode = this.getCurNode();
   if (!curNode) {
     return null;
@@ -277,7 +310,7 @@ CustomCursor.prototype.out = function() {
     this.setCurNode(newNode);
   }
   return newNode;
-};
+}
 ```
 
 ### Modify the move methods
@@ -289,7 +322,7 @@ move methods. The red boxes represent the nodes we want to skip.
 
 Change the `next` method so it will skip over any previous or next connections.
 ```js
-CustomCursor.prototype.next = function() {
+next() {
   var curNode = this.getCurNode();
   if (!curNode) {
     return null;
@@ -305,12 +338,12 @@ CustomCursor.prototype.next = function() {
     this.setCurNode(newNode);
   }
   return newNode;
-};
+}
 ```
 
 Change the `prev` method so it will skip over any previous or next connections.
 ```js
-CustomCursor.prototype.prev = function() {
+prev() {
   var curNode = this.getCurNode();
   if (!curNode) {
     return null;
@@ -326,12 +359,12 @@ CustomCursor.prototype.prev = function() {
     this.setCurNode(newNode);
   }
   return newNode;
-};
+}
 ```
 
 Change the `in` method so that it will skip over any previous connections and go straight to the block. 
 ```js
-CustomCursor.prototype.in = function() {
+in() {
   var curNode = this.getCurNode();
   if (!curNode) {
     return null;
@@ -346,7 +379,7 @@ CustomCursor.prototype.in = function() {
     this.setCurNode(newNode);
   }
   return newNode;
-};
+}
 ```
 
 #### Test it out
@@ -371,37 +404,39 @@ false otherwise.
 - `callback`: A function called when the shortcut has been executed. This should
 return true if the shortcut has been handled. If a shortcut has been handled, no
 other shortcuts with the same key mapping will be handled.
+- `keyCodes`: A list of key codes that when pressed will trigger this
+shortcut. (Only available in version of Blockly >= 9.)
 
 Our below shortcut is set up to only run when the user is in keyboard navigation
-mode. Add the below code in `playground.html`.
+mode. Add the below code in `index.js`.
 ```js
-var moveToStack = {
+let moveToStack = {
   name: 'moveToStack',
   preconditionFn: function(workspace) {
     return workspace.keyboardAccessibilityMode;
   },
   callback: function(workspace) {
-    var cursor = workspace.getCursor();
+    const cursor = workspace.getCursor();
     // Gets the current node.
-    var currentNode = cursor.getCurNode();
+    const currentNode = cursor.getCurNode();
     // Gets the source block from the current node.
-    var currentBlock = currentNode.getSourceBlock();
+    const currentBlock = currentNode.getSourceBlock();
     // If we are on a workspace node there will be no source block.
     if (currentBlock) {
       // Gets the top block in the stack.
-      var rootBlock = currentBlock.getRootBlock();
+      const rootBlock = currentBlock.getRootBlock();
       // Gets the top node on a block. This is either the previous connection,
       // output connection, or the block itself.
-      var topNode = Blockly.ASTNode.createTopNode(rootBlock);
+      const topNode = Blockly.ASTNode.createTopNode(rootBlock);
       // Update the location of the cursor.
       cursor.setCurNode(topNode);
       return true;
     }
-  }
+  },
 };
 ```
 Once we have created the shortcut, we can now register it. Add the below code
-to your `playground.html` after you have created your shortcut.
+to your `index.js` after you have created your shortcut.
 ```js
 Blockly.ShortcutRegistry.registry.register(moveToStack);
 ```
@@ -419,18 +454,29 @@ method. A list of the available modifier keys are:
 1. `Blockly.ShortcutRegistry.modifierKeys.META`
 
 For our example we will create a key code for control W by using the below code.
-Add the following code to your `playground.html`.
+Add the following code to your `index.js` file.
 ```js
 // Create a serialized key from the primary key and any modifiers.
-var ctrlW = Blockly.ShortcutRegistry.registry.createSerializedKey(
+const ctrlW = Blockly.ShortcutRegistry.registry.createSerializedKey(
     Blockly.utils.KeyCodes.W, [Blockly.ShortcutRegistry.modifierKeys.Control]);
 ```
 
 Once the serialized key has been created, we can then add a key mapping for
 the 'moveToStack' shortcut. Add the below code to
-the `playground.html` file after we have registered our shortcut.
+the `index.js` file after we have registered our shortcut.
 ```js
 Blockly.ShortcutRegistry.registry.addKeyMapping(ctrlW, 'moveToStack');
+```
+
+As of version 9 of Blockly you can also add this key mapping when you first
+create the keyboard shortcut by adding a keyCodes property to your shortcut
+object. 
+
+```js
+var moveToStack = {
+  ...
+  keyCodes: [ctrlW]
+};
 ```
 
 ### Test it out
@@ -445,20 +491,27 @@ the stack of blocks.
 In this section, we update our key mappings so we can use the arrow
 keys for our cursor instead of the **WASD** keys. 
 
-In `playground.html` we set the keys for the next, previous, in
-and out actions. For a full list of built in actions see [here](https://github.com/google/blockly/blob/07762ff4da3c713f7592c80052b1fa7cadb461a2/core/keyboard_nav/navigation.js#L957).
+Before adding the key mappings below, import the shortcut names by adding the
+following line to your `index.js` file.
+
 ```js
-Blockly.ShortcutRegistry.registry.removeAllKeyMappings(Blockly.navigation.actionNames.OUT);
-Blockly.ShortcutRegistry.registry.addKeyMapping(Blockly.utils.KeyCodes.LEFT, Blockly.navigation.actionNames.OUT);
+import {Constants} from '../src/index';
+```
 
-Blockly.ShortcutRegistry.registry.removeAllKeyMappings(Blockly.navigation.actionNames.IN);
-Blockly.ShortcutRegistry.registry.addKeyMapping(Blockly.utils.KeyCodes.RIGHT, Blockly.navigation.actionNames.IN);
+In `index.js` we set the keys for the next, previous, in and out actions. Here
+is our [full list of actions](https://github.com/google/blockly/blob/07762ff4da3c713f7592c80052b1fa7cadb461a2/core/keyboard_nav/navigation.js#L957).
+```js
+Blockly.ShortcutRegistry.registry.removeAllKeyMappings(Constants.SHORTCUT_NAMES.OUT);
+Blockly.ShortcutRegistry.registry.addKeyMapping(Blockly.utils.KeyCodes.LEFT, Constants.SHORTCUT_NAMES.OUT);
 
-Blockly.ShortcutRegistry.registry.removeAllKeyMappings(Blockly.navigation.actionNames.PREVIOUS);
-Blockly.ShortcutRegistry.registry.addKeyMapping(Blockly.utils.KeyCodes.UP, Blockly.navigation.actionNames.PREVIOUS);
+Blockly.ShortcutRegistry.registry.removeAllKeyMappings(Constants.SHORTCUT_NAMES.IN);
+Blockly.ShortcutRegistry.registry.addKeyMapping(Blockly.utils.KeyCodes.RIGHT, Constants.SHORTCUT_NAMES.IN);
 
-Blockly.ShortcutRegistry.registry.removeAllKeyMappings(Blockly.navigation.actionNames.NEXT)
-Blockly.ShortcutRegistry.registry.addKeyMapping(Blockly.utils.KeyCodes.DOWN, Blockly.navigation.actionNames.NEXT)
+Blockly.ShortcutRegistry.registry.removeAllKeyMappings(Constants.SHORTCUT_NAMES.PREVIOUS);
+Blockly.ShortcutRegistry.registry.addKeyMapping(Blockly.utils.KeyCodes.UP, Constants.SHORTCUT_NAMES.PREVIOUS);
+
+Blockly.ShortcutRegistry.registry.removeAllKeyMappings(Constants.SHORTCUT_NAMES.NEXT)
+Blockly.ShortcutRegistry.registry.addKeyMapping(Blockly.utils.KeyCodes.DOWN, Constants.SHORTCUT_NAMES.NEXT)
 ```
 ### Test it out
 Open the playground and enter keyboard navigation mode (**ctrl + shift + k**). You can now use the arrow

--- a/codelabs/keyboard_navigation/keyboard_navigation.md
+++ b/codelabs/keyboard_navigation/keyboard_navigation.md
@@ -149,7 +149,7 @@ In the class you just created, override `createDomInternal_`. This method is in 
 
     // If this is a cursor make the cursor blink.
     if (this.isCursor()) {
-      var blinkProperties = this.getBlinkProperties_();
+      const blinkProperties = this.getBlinkProperties_();
       Blockly.utils.dom.createSvgElement('animate', blinkProperties,
           this.blockPath_);
     }
@@ -185,7 +185,7 @@ Override `showAtLocation_`. This method is used to decide what to display at a g
    * @override
    */
   showAtLocation_(curNode) {
-    var handled = false;
+    let handled = false;
     // If the cursor is on a block call the new method we created to draw the cursor.
     if (curNode.getType() == Blockly.ASTNode.types.BLOCK) {
       this.showWithBlock_(curNode);
@@ -227,7 +227,7 @@ Blockly.blockRendering.register('custom_renderer', CustomRenderer);
 ```
 
 Now we need to override the method responsible for returning the drawer for markers and cursors.
-In the `CustomRenderer` class add the following method.
+Add the following method in the `CustomRenderer` class.
 ```js
 makeMarkerDrawer(workspace, marker) {
   return new CustomMarkerSvg(workspace, this.getConstants(), marker);
@@ -240,8 +240,7 @@ In order to use your custom renderer, import it and set the renderer property in
 import './custom_marker_svg';
 ```
 
-In the 'DomContentLoaded' event listener add the renderer to the default
-options so it looks like the below code. 
+Pass the renderer name to the default options in the 'DomContentLoaded' event listener.
 ```js
   const defaultOptions = {
     toolbox: toolboxCategories,
@@ -263,12 +262,12 @@ Add the below code to your `custom_cursor.js` file.
 
 next() {
   // The current Blockly.ASTNode the cursor is on.
-  var curNode = this.getCurNode();
+  const curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
   // The next Blockly.ASTNode.
-  var newNode = curNode.next();
+  const newNode = curNode.next();
   if (newNode) {
     // This in charge of updating the current location and drawing the cursor.
     this.setCurNode(newNode);
@@ -277,11 +276,11 @@ next() {
 }
 
 in() {
-  var curNode = this.getCurNode();
+  const curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
-  var newNode = curNode.in();
+  const newNode = curNode.in();
   if (newNode) {
     this.setCurNode(newNode);
   }
@@ -289,11 +288,11 @@ in() {
 }
 
 prev() {
-  var curNode = this.getCurNode();
+  const curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
-  var newNode = curNode.prev();
+  const newNode = curNode.prev();
   if (newNode) {
     this.setCurNode(newNode);
   }
@@ -301,11 +300,11 @@ prev() {
 }
 
 out() {
-  var curNode = this.getCurNode();
+  const curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
-  var newNode = curNode.out();
+  const newNode = curNode.out();
   if (newNode) {
     this.setCurNode(newNode);
   }
@@ -323,11 +322,11 @@ move methods. The red boxes represent the nodes we want to skip.
 Change the `next` method so it will skip over any previous or next connections.
 ```js
 next() {
-  var curNode = this.getCurNode();
+  const curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
-  var newNode = curNode.next();
+  const newNode = curNode.next();
   // While the newNode exists and is either a previous or next type go to the
   // next value.
   while (newNode && (newNode.getType() === Blockly.ASTNode.types.PREVIOUS ||
@@ -344,11 +343,11 @@ next() {
 Change the `prev` method so it will skip over any previous or next connections.
 ```js
 prev() {
-  var curNode = this.getCurNode();
+  const curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
-  var newNode = curNode.prev();
+  const newNode = curNode.prev();
   // While the newNode exists and is either a previous or next connection go to
   // the previous value.
   while (newNode && (newNode.getType() === Blockly.ASTNode.types.PREVIOUS ||
@@ -365,11 +364,11 @@ prev() {
 Change the `in` method so that it will skip over any previous connections and go straight to the block. 
 ```js
 in() {
-  var curNode = this.getCurNode();
+  const curNode = this.getCurNode();
   if (!curNode) {
     return null;
   }
-  var newNode = curNode.in();
+  const newNode = curNode.in();
   // If the newNode is a previous connection go to the next value in the level. 
   // This will be the block.
   if (newNode && newNode.getType() === Blockly.ASTNode.types.PREVIOUS) {
@@ -473,7 +472,7 @@ create the keyboard shortcut by adding a keyCodes property to your shortcut
 object. 
 
 ```js
-var moveToStack = {
+const moveToStack = {
   ...
   keyCodes: [ctrlW]
 };


### PR DESCRIPTION
This PR updates the keyboard nav codelab to:
- Use the keyboard navigation plugin. (We moved keyboard navigation out of core in November 2021)
- Use es6 classes

## Additional Information ##
This code lab now has developers pull blockly-samples and modify the keyboard-navigation/test directory. This is not ideal and once a new create script has been made it should be updated.