### PR TITLE
feat: add cross-tab-copy-paste plugin type declaration

### DIFF
--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -13,6 +13,7 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
+  "types": "./src/index.d.ts",
   "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "",

--- a/plugins/cross-tab-copy-paste/src/index.d.ts
+++ b/plugins/cross-tab-copy-paste/src/index.d.ts
@@ -1,0 +1,21 @@
+/**
+ * A Blockly plugin that adds context menu items and keyboard shortcuts
+ * to allow users to copy and paste a block between tabs.
+ */
+export class CrossTabCopyPaste {
+  /**
+   * Initializes the cross tab copy paste plugin. If no options are selected
+   * then both context menu items and keyboard shortcuts are added.
+   * @param {{contextMenu: boolean, shortcut: boolean}} options
+   * `contextMenu` Register copy and paste in the context menu.
+   * `shortcut` Register cut (ctr + x), copy (ctr + c) and paste (ctr + v)
+   * in the shortcut.
+   */
+  init({
+    contextMenu,
+    shortcut,
+  }?: {
+    contextMenu: boolean;
+    shortcut: boolean;
+  }): void;
+}


### PR DESCRIPTION
## Problem

The `cross-tab-copy-paste` plugin doesn't include a type declaration file. As a result, importing it into a TypeScript project results in this error:

![image](https://user-images.githubusercontent.com/504505/170366656-805a3cd5-dd8b-4a5e-b3b2-b4f2aeaeed5a.png)

Searching on [DefinitelyTyped[(https://github.com/DefinitelyTyped/DefinitelyTyped) for a type declaration file yields no results.

## PR Summary:

* Adds a type declaration file in `plugins/cross-tab-copy-paste/src/index.d.ts`
* Adds `"types": "./src/index.d.ts"` to cross-tab-copy-paste's package.json. If all contents of `src` is copied to `dist` during build, than this change is not required. However I'm not familiar with the build pipeline so I added this to instruct code editors to look in the `src` folder for the type declaration file.

## Results

This change allows `cross-tab-copy-paste` plugin to be imported into a TypeScript project and improves intellisense:

![image](https://user-images.githubusercontent.com/504505/170367594-4ecb9898-cea2-4459-95c9-3a6c0a52824f.png)

![image](https://user-images.githubusercontent.com/504505/170367705-7ee4d04a-3c76-4fe2-9121-31fb4b025674.png)

## Note

I'm not familiar with the build system, so it should be confirmed that the `index.d.ts` file gets properly copied before this PR is merged.