### PR TITLE
fix: update manual release script to use conventional commits and create github releases

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,15 +87,11 @@ function publish(dryRun, force) {
     console.log('Running tests to check for problems');
     execSync('npm run test', execSyncOptions);
 
-    // dryRun and force are never both true.
-    if (dryRun) {
-      execSync('npm run publish:check', execSyncOptions);
-    } else if (force) {
-      execSync(
-          'npm run publish:_internal -- --force-publish=*', execSyncOptions);
-    } else {
-      execSync('npm run publish:_internal', execSyncOptions);
-    }
+    console.log('Publishing on github and npm');
+    execSync(
+        `npm run publish:${dryRun ? 'check' : '_internal'}` +
+            `${force ? ' -- --force-publish=*' : ''}`,
+        execSyncOptions);
 
     done();
   };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "publish:check": "lerna changed",
         "publish:dryrun": "gulp publishDryRun",
         "publish:force": "gulp forcePublish",
-        "publish:_internal": "lerna publish",
+        "publish:_internal": "lerna publish --conventional-commits --create-release github --yes",
         "test:ghpages:beta": "gulp testGhPagesBeta",
         "test:ghpages": "gulp testGhPages"
     },

--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -7,7 +7,7 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "predeploy": "npm run build && blockly-scripts predeploy",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"

--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -7,7 +7,6 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-
     "predeploy": "npm run build && blockly-scripts predeploy",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"

--- a/plugins/block-extension-tooltip/package.json
+++ b/plugins/block-extension-tooltip/package.json
@@ -9,7 +9,6 @@
     "dist": "blockly-scripts build prod",
     "lint": "blockly-scripts lint",
     "predeploy": "npm run build && blockly-scripts predeploy",
-
     "start": "blockly-scripts start"
   },
   "private": true,

--- a/plugins/block-extension-tooltip/package.json
+++ b/plugins/block-extension-tooltip/package.json
@@ -9,7 +9,7 @@
     "dist": "blockly-scripts build prod",
     "lint": "blockly-scripts lint",
     "predeploy": "npm run build && blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run dist",
+
     "start": "blockly-scripts start"
   },
   "private": true,

--- a/plugins/block-plus-minus/package.json
+++ b/plugins/block-plus-minus/package.json
@@ -8,7 +8,7 @@
         "clean": "blockly-scripts clean",
         "lint": "blockly-scripts lint",
         "predeploy": "blockly-scripts predeploy",
-        "prepublishOnly": "npm run clean && npm run build",
+
         "start": "blockly-scripts start",
         "test": "blockly-scripts test"
     },

--- a/plugins/block-plus-minus/package.json
+++ b/plugins/block-plus-minus/package.json
@@ -8,7 +8,6 @@
         "clean": "blockly-scripts clean",
         "lint": "blockly-scripts lint",
         "predeploy": "blockly-scripts predeploy",
-
         "start": "blockly-scripts start",
         "test": "blockly-scripts test"
     },

--- a/plugins/block-test/package.json
+++ b/plugins/block-test/package.json
@@ -7,7 +7,6 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-
     "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",

--- a/plugins/block-test/package.json
+++ b/plugins/block-test/package.json
@@ -7,7 +7,7 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -6,7 +6,7 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "audit:fix": "blockly-scripts auditFix",
     "predeploy": "npm run build && blockly-scripts predeploy"

--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -6,7 +6,6 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-
     "start": "blockly-scripts start",
     "audit:fix": "blockly-scripts auditFix",
     "predeploy": "npm run build && blockly-scripts predeploy"

--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/bin/create.js
+++ b/plugins/dev-create/bin/create.js
@@ -129,7 +129,7 @@ const packageJson = {
     'dist': 'blockly-scripts build prod',
     'lint': 'blockly-scripts lint',
     'predeploy': 'blockly-scripts predeploy',
-    'prepublishOnly': 'npm run clean && npm run dist',
+
     'start': 'blockly-scripts start',
     'test': 'blockly-scripts test',
   },

--- a/plugins/dev-create/templates/block/template.json
+++ b/plugins/dev-create/templates/block/template.json
@@ -6,7 +6,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/block/template.json
+++ b/plugins/dev-create/templates/block/template.json
@@ -6,7 +6,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/field/template.json
+++ b/plugins/dev-create/templates/field/template.json
@@ -6,7 +6,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/field/template.json
+++ b/plugins/dev-create/templates/field/template.json
@@ -6,7 +6,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/plugin/template.json
+++ b/plugins/dev-create/templates/plugin/template.json
@@ -6,7 +6,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/plugin/template.json
+++ b/plugins/dev-create/templates/plugin/template.json
@@ -6,7 +6,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/theme/template.json
+++ b/plugins/dev-create/templates/theme/template.json
@@ -6,7 +6,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/theme/template.json
+++ b/plugins/dev-create/templates/theme/template.json
@@ -6,7 +6,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/typescript-block/template.json
+++ b/plugins/dev-create/templates/typescript-block/template.json
@@ -6,7 +6,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/typescript-block/template.json
+++ b/plugins/dev-create/templates/typescript-block/template.json
@@ -6,7 +6,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/typescript-field/template.json
+++ b/plugins/dev-create/templates/typescript-field/template.json
@@ -7,7 +7,6 @@
     "dist": "blockly-scripts build prod",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/typescript-field/template.json
+++ b/plugins/dev-create/templates/typescript-field/template.json
@@ -7,7 +7,7 @@
     "dist": "blockly-scripts build prod",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run dist",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/typescript-plugin/template.json
+++ b/plugins/dev-create/templates/typescript-plugin/template.json
@@ -7,7 +7,6 @@
     "dist": "blockly-scripts build prod",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/typescript-plugin/template.json
+++ b/plugins/dev-create/templates/typescript-plugin/template.json
@@ -7,7 +7,7 @@
     "dist": "blockly-scripts build prod",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run dist",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/typescript-theme/template.json
+++ b/plugins/dev-create/templates/typescript-theme/template.json
@@ -7,7 +7,6 @@
     "dist": "blockly-scripts build prod",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-create/templates/typescript-theme/template.json
+++ b/plugins/dev-create/templates/typescript-theme/template.json
@@ -7,7 +7,7 @@
     "dist": "blockly-scripts build prod",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run dist",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -7,7 +7,6 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-
     "start": "blockly-scripts start"
   },
   "main": "dist/index.js",

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -7,7 +7,7 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start"
   },
   "main": "dist/index.js",

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -7,7 +7,6 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-
     "start": "blockly-scripts start",
     "predeploy": "npm run build && blockly-scripts predeploy"
   },

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -7,7 +7,7 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "predeploy": "npm run build && blockly-scripts predeploy"
   },

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -8,7 +8,6 @@
         "clean": "blockly-scripts clean",
         "lint": "blockly-scripts lint",
         "predeploy": "npm run build && blockly-scripts predeploy",
-
         "start": "npm run build && blockly-scripts start",
         "test": "npm run build && blockly-scripts test"
     },

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -8,7 +8,7 @@
         "clean": "blockly-scripts clean",
         "lint": "blockly-scripts lint",
         "predeploy": "npm run build && blockly-scripts predeploy",
-        "prepublishOnly": "npm run clean && npm run build",
+
         "start": "npm run build && blockly-scripts start",
         "test": "npm run build && blockly-scripts test"
     },

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -7,7 +7,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "npm run build && blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -7,7 +7,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "npm run build && blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",

--- a/plugins/keyboard-navigation/package.json
+++ b/plugins/keyboard-navigation/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/keyboard-navigation/package.json
+++ b/plugins/keyboard-navigation/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/serialize-disabled-interactions/package.json
+++ b/plugins/serialize-disabled-interactions/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/serialize-disabled-interactions/package.json
+++ b/plugins/serialize-disabled-interactions/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -9,7 +9,6 @@
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
     "postinstall": "blockly-scripts postinstall",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -9,7 +9,7 @@
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
     "postinstall": "blockly-scripts postinstall",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-deuteranopia/package.json
+++ b/plugins/theme-deuteranopia/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-deuteranopia/package.json
+++ b/plugins/theme-deuteranopia/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-highcontrast/package.json
+++ b/plugins/theme-highcontrast/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-highcontrast/package.json
+++ b/plugins/theme-highcontrast/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-tritanopia/package.json
+++ b/plugins/theme-tritanopia/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-tritanopia/package.json
+++ b/plugins/theme-tritanopia/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-
     "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -8,7 +8,7 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
+
     "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
### Description

1) Removes running the build from the lerna `prepublishOnly` lifecycle hook, and instead runs it as a step in the manual publish script.
2) Changes `publish:_internal` to use conventional commits to bump versions, and to publish a github release.

Matches the design outlined in [this internal doc](https://docs.google.com/document/d/1zy5NSPxcLUKguhCCfNH7trFc3rhFY9g4DfdJmYrljAg/edit?usp=sharing).

If this works, then we can add a github action that does the same thing.