### PR TITLE
feat: make the filled backpack image optional

### DIFF
--- a/plugins/workspace-backpack/README.md
+++ b/plugins/workspace-backpack/README.md
@@ -46,6 +46,7 @@ This plugin takes an optional configuration object.
 ```
 {
   allowEmptyBackpackOpen: (boolean|undefined),
+  useFilledBackpackImage: (boolean|undefined),
   contextMenu: {
     emptyBackpack: (boolean|undefined),
     removeFromBackpack: (boolean|undefined),
@@ -63,6 +64,7 @@ registered at `init`.
 ```js
 const backpackOptions = {
   allowEmptyBackpackOpen: true,
+  useFilledBackpackImage: true,
   contextMenu: {
     emptyBackpack: true,
     removeFromBackpack: true,
@@ -77,6 +79,7 @@ passed in options that is undefined:
 ```js
 const defaultOptions = {
   allowEmptyBackpackOpen: true,
+  useFilledBackpackImage: false,
   contextMenu: {
     emptyBackpack: true,
     removeFromBackpack: true,
@@ -90,6 +93,9 @@ const defaultOptions = {
 
 The `allowEmptyBackpackOpen` property, if set to `false`, will prevent the backpack flyout from
 being opened if the backpack is empty.
+
+The `useFilledBackpackImage` property, if set to `true`, will change the
+backpack image when the backpack has something in it.
 
 The `disablePreconditionChecks` property will prevent the "Copy to Backpack"
 context menu option from disabling the context menu option if the block is

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -12,9 +12,7 @@
 import * as Blockly from 'blockly/core';
 import {cleanBlockXML, registerContextMenus} from './backpack_helpers';
 import {BackpackChange, BackpackOpen} from './ui_events';
-import {
-  BackpackContextMenuOptions, BackpackOptions, parseOptions,
-} from './options';
+import {BackpackContextMenuOptions, BackpackOptions, parseOptions} from './options';
 
 /**
  * Class for backpack that can be used save blocks from the workspace for
@@ -556,6 +554,9 @@ export class Backpack extends Blockly.DragTarget {
    */
   onContentChange_() {
     this.maybeRefreshFlyoutContents_();
+    Blockly.Events.fire(new BackpackChange(this.workspace_.id));
+
+    if (!this.options_.useFilledBackpackImage) return;
     if (this.contents_.length > 0) {
       this.svgImg_.setAttributeNS(Blockly.utils.dom.XLINK_NS, 'xlink:href',
           BACKPACK_FILLED_SVG_DATAURI);
@@ -563,8 +564,6 @@ export class Backpack extends Blockly.DragTarget {
       this.svgImg_.setAttributeNS(Blockly.utils.dom.XLINK_NS, 'xlink:href',
           BACKPACK_SVG_DATAURI);
     }
-
-    Blockly.Events.fire(new BackpackChange(this.workspace_.id));
   }
 
   /**

--- a/plugins/workspace-backpack/src/options.js
+++ b/plugins/workspace-backpack/src/options.js
@@ -25,6 +25,7 @@ export let BackpackContextMenuOptions;
 /**
  * @typedef {{
  *    allowEmptyBackpackOpen: (boolean|undefined),
+ *    useFilledBackpackImage: (boolean|undefined),
  *    contextMenu:(!BackpackContextMenuOptions|undefined)
  * }}
  */
@@ -37,8 +38,9 @@ export let BackpackOptions;
  * @return {!BackpackOptions} The created options object.
  */
 export function parseOptions(options) {
-  const defaultOptions = {
+  const defaults = {
     allowEmptyBackpackOpen: true,
+    useFilledBackpackImage: false,
     contextMenu: {
       emptyBackpack: true,
       removeFromBackpack: true,
@@ -48,13 +50,19 @@ export function parseOptions(options) {
       disablePreconditionChecks: false,
     },
   };
+
   if (!options) {
-    return defaultOptions;
+    return defaults;
   }
-  const mergedOptions = {};
-  mergedOptions.contextMenu = {
-    ...defaultOptions.contextMenu, ...options.contextMenu};
-  mergedOptions.allowEmptyBackpackOpen = options.allowEmptyBackpackOpen ??
-      defaultOptions.allowEmptyBackpackOpen;
-  return mergedOptions;
+
+  return {
+    allowEmptyBackpackOpen:
+        options.allowEmptyBackpackOpen ?? defaults.allowEmptyBackpackOpen,
+    useFilledBackpackImage:
+        options.useFilledBackpackImage ?? defaults.useFilledBackpackImage,
+    contextMenu: {
+      ...defaults.contextMenu,
+      ...options.contextMenu,
+    },
+  };
 }


### PR DESCRIPTION
### Description

After discussion, we decided that we wanted to make the new filled backpack image optional, so that developers don't unexpectedly get it by default when upgrading.

### Testing

Default config:
1. Opened the test page with the default config.
2. Dropped a block into the backpack.
3. Observed how the image did not change.

With `useFilledBackpackImage: true`:
1. Modified the test page to set the option to true.
2. Opened the test page.
3. Dropped a block into the backpack.
4. Observed how the image changed.