### PR TITLE
fix: update cross-tab-copy-paste plugin peer dependency to support minor and patch updates to Blockly version 8

### DIFF
--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -44,7 +44,7 @@
     "blockly": "^8.0.0"
   },
   "peerDependencies": {
-    "blockly": "^7 - 8"
+    "blockly": ">=7 <9"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
# Problem

When installing `@blockly/plugin-cross-tab-copy-paste` into a project with `blockly@8.0.1` or `blockly@8.0.2`, npm throws this error:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: blockly-paste@0.1.0
npm ERR! Found: blockly@8.0.2
npm ERR! node_modules/blockly
npm ERR!   blockly@"^8.0.2" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer blockly@"^7 - 8" from @blockly/plugin-cross-tab-copy-paste@1.0.5
npm ERR! node_modules/@blockly/plugin-cross-tab-copy-paste
npm ERR!   @blockly/plugin-cross-tab-copy-paste@"*" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

A temporary workaround is to use the `--legacy-peer-deps` flag:

```
npm install @blockly/plugin-cross-tab-copy-paste --legacy-peer-deps
```

# Solution

This PR fixes this problem by replacing this peer dependency:

```
  "peerDependencies": {
    "blockly": "^7 - 8"
  },
```

...with this:

```
  "peerDependencies": {
    "blockly": "^7 || ^8"
  },
```

I'm not proficient with npm version dependency ranges, so if there's a better way to set this range, please feel free to change it. I tried `^7 - ^8` to be more consistent with the original code, but it didn't work.