### PR TITLE
fix: add git identity

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    # This uses a reverse-engineered email for the github actions bot. See
+    # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+    - name: Git Identity
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email '<41898282+github-actions[bot]@users.noreply.github.com'
+
     - name: Setup Node
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
### Description

First attempt at publishing using the github action failed due to not having a git identity. This attempts to fix that.