### PR TITLE
fix: add configuring NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,8 @@ jobs:
 
     - name: Configure npm
       run: npm config set //wombat-dressing-room.appspot.com/:_authToken=$NODE_AUTH_TOKEN
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.RELEASE_BACKED_NPM_TOKEN }}
 
     - name: NPM install
       # Use CI so that we don't update dependencies in this step.
@@ -46,6 +48,5 @@ jobs:
 
     - name: Publish
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.RELEASE_BACKED_NPM_TOKEN }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: npx lerna publish --conventional-commits --create-release github --yes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,9 @@ jobs:
       with:
         node-version: 16
 
+    - name: Configure npm
+      run: npm config set //wombat-dressing-room.appspot.com/:_authToken=$NODE_AUTH_TOKEN
+
     - name: NPM install
       # Use CI so that we don't update dependencies in this step.
       run: npm ci


### PR DESCRIPTION
### Description

Maybe fix the "Publish key not found" error we're getting when running the action.

Based on: (some of which are internal)
  * https://groups.google.com/a/google.com/g/node-team/c/-IwpBEtJWOI/m/dOou1WuXCgAJ
  * https://sites.google.com/corp/google.com/node-team/publishing-npm-packages#h.p_jGg6QLAWAwDp
  * https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#set-the-token-as-an-environment-variable-on-the-cicd-server
  * https://github.com/hsubox76/firebase-js-sdk/blob/master/.github/workflows/deploy-canary.yml