### PR TITLE
fix: expand excludes for plugins directory

### DIFF
--- a/plugins/jsconfig.json
+++ b/plugins/jsconfig.json
@@ -5,5 +5,9 @@
     "checkJs": true,
     "resolveJsonModule": true,
   },
-  "exclude": ["node_modules", "build", "dist", "field-date"]
+  "exclude": [
+    "**/node_modules",
+    "**/build",
+    "**/dist",
+  ]
 }


### PR DESCRIPTION
This makes it so VSCode Javascript/Typescript features can handle the project size.

Not sure if I'm missing some context as to why this hasn't been updated, or if it just got lost by the wayside.