### PR TITLE
fix: requiring the incorrect package file

### DIFF
--- a/plugins/migration/bin/command.js
+++ b/plugins/migration/bin/command.js
@@ -15,7 +15,7 @@ import {Command} from 'commander';
 // require() is not available in ES modules by default, so we must obtain it.
 import {createRequire} from 'module';
 const require = createRequire(import.meta.url);
-const scriptPackageJson = require('../package-lock.json');
+const scriptPackageJson = require('../package.json');
 
 
 const SCRIPT_NAME = scriptPackageJson.name;


### PR DESCRIPTION
### Description

The migration script worked using `node` but failed using `npx` with the error `Cannot find module ../package-lock.json`. I think requiring `package.json` instead will fix the issue. But this needs to be tested after releasing (because we can't test with `npx` before release.