### PR TITLE
fix: bump peer dependency on Blockly

### DIFF
--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -57,7 +57,7 @@
     "blockly": "^8.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <9"
+    "blockly": ">=8 <9"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
### Description

Completes https://github.com/google/blockly-samples/issues/882