### PR TITLE
fix: new category not being selected when dragging flyout

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousFlyout.js
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.js
@@ -51,6 +51,12 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
     this.workspace_.setMetricsManager(
         new ContinuousFlyoutMetrics(this.workspace_, this));
 
+    this.workspace_.addChangeListener((e) => {
+      if (e.type === Blockly.Events.VIEWPORT_CHANGE) {
+        this.selectCategoryByScrollPosition_(-this.workspace_.scrollY);
+      }
+    });
+
     this.autoClose = false;
   }
 
@@ -181,14 +187,6 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
       }
     }
     return 0;
-  }
-
-  /** @override */
-  setMetrics_(xyRatio) {
-    super.setMetrics_(xyRatio);
-    if (this.scrollPositions) {
-      this.selectCategoryByScrollPosition_(-this.workspace_.scrollY);
-    }
   }
 
   /**


### PR DESCRIPTION
### Description

Closes #603 

* Dragging the scrollbars triggers setMetrics
* Scrolling with the mouse wheel moves the scrollbars which triggers setMetrics
* Dragging the flyout workspace calls `scroll` which [sets the scrollbar positions without triggering setMetrics](https://github.com/google/blockly/blob/61322294da70c770b32abb28b9d695af75f61a16/core/workspace_svg.js#L2407) (b/c that would be an infinitely recursive call afaict)

If we always want updates, we need to listen to viewport events, not depend on setMetrics.