### PR TITLE
fix: procedure callers not appearing in continuous toolbox

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousToolbox.js
+++ b/plugins/continuous-toolbox/src/ContinuousToolbox.js
@@ -30,7 +30,6 @@ export class ContinuousToolbox extends Blockly.Toolbox {
     flyout.recordScrollPositions();
 
     this.workspace_.addChangeListener((e) => {
-      console.log('triggered');
       if (e.type === Blockly.Events.BLOCK_CREATE ||
           e.type === Blockly.Events.BLOCK_DELETE) {
         this.refreshSelection();

--- a/plugins/continuous-toolbox/src/ContinuousToolbox.js
+++ b/plugins/continuous-toolbox/src/ContinuousToolbox.js
@@ -28,6 +28,14 @@ export class ContinuousToolbox extends Blockly.Toolbox {
     const flyout = this.getFlyout();
     flyout.show(this.getInitialFlyoutContents_());
     flyout.recordScrollPositions();
+
+    this.workspace_.addChangeListener((e) => {
+      console.log('triggered');
+      if (e.type === Blockly.Events.BLOCK_CREATE ||
+          e.type === Blockly.Events.BLOCK_DELETE) {
+        this.refreshSelection();
+      }
+    });
   }
 
   /** @override */


### PR DESCRIPTION
### Description

Temporary fix for #857 so external devs don't have to register the change listener themselves.

If we ever get procedure-specific events, this plugin should be changed to use those instead, so I'm leaving that issue open.