### PR TITLE
fix!: bump the blockly peer dependency in dev-tools and remove version probing

### DIFF
--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -57,7 +57,7 @@
     "blockly": "^8.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <9"
+    "blockly": ">=8 <9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/dev-tools/src/block_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/block_test_helpers.mocha.js
@@ -211,25 +211,8 @@ export const runSerializationTestSuite = (testCases) => {
     });
     suite('xml round-trip', function() {
       setup(function() {
-        // The genUid is undergoing change as part of the 2021Q3
-        // goog.module migration:
-        //
-        // - It is being moved from Blockly.utils to
-        //   Blockly.utils.idGenerator (which itself is being renamed
-        //   from IdGenerator).
-        // - For compatibility with changes to the module system (from
-        //   goog.provide to goog.module and in future to ES modules),
-        //   .genUid is now a wrapper around .TEST_ONLY.genUid, which
-        //   can be safely stubbed by sinon or other similar
-        //   frameworks in a way that will continue to work.
-        if (Blockly.utils.idGenerator &&
-            Blockly.utils.idGenerator.TEST_ONLY) {
-          sinon.stub(Blockly.utils.idGenerator.TEST_ONLY, 'genUid')
-              .returns('1');
-        } else {
-          // Fall back to stubbing original version on Blockly.utils.
-          sinon.stub(Blockly.utils, 'genUid').returns('1');
-        }
+        sinon.stub(Blockly.utils.idGenerator.TEST_ONLY, 'genUid')
+            .returns('1');
       });
 
       teardown(function() {

--- a/plugins/dev-tools/src/index.js
+++ b/plugins/dev-tools/src/index.js
@@ -29,13 +29,7 @@ if (typeof window !== 'undefined') {
 
 // Export Blockly into the global namespace to make it easier to debug from the
 // console.
-if (Blockly.utils.global) {
-  if (Blockly.utils.global.globalThis) {
-    Blockly.utils.global.globalThis.Blockly = Blockly;
-  } else {
-    Blockly.utils.global.Blockly = Blockly;
-  }
-}
+globalThis.Blockly = Blockly;
 
 export {
   addCodeEditor,

--- a/plugins/eslint-config/index.js
+++ b/plugins/eslint-config/index.js
@@ -18,7 +18,7 @@ module.exports = {
   env: {
     browser: true,
     commonjs: true,
-    es6: true,
+    es2020: true,
     node: true,
   },
 


### PR DESCRIPTION
### Description

Closes #882 Also fix https://github.com/google/blockly/pull/6204

Requires us to bump devtools to only work with v8+.

### Additional Info

Dupe of #1183 but with the correct commit message.