### PR TITLE
fix: add more links to readmes and gh-pages index.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,37 @@ to include and extend the [Blockly](http://github.com/google/blockly) library.
 
 ## Samples
 
+### Usage Demos
+
+- [``backpack-demo``](backpack-demo/): A demo of two Blockly instances with a shared backpack.
+- [``custom-dialogs-demo``](custom-dialogs-demo/): A demo overriding Blockly browser dialogs with custom implementations.
+- [``custom-tooltips-demo``](custom-tooltips-demo/): An example of using a custom tooltip renderer.
+- [``fixed-demo``](fixed-demo/): A demo injecting Blockly into a page as a fixed element.
+- [``generator-demo``](generator-demo/): A demo of generating code from blocks and running it in a sandboxed JavaScript interpreter
+- [``graph-demo``](graph-demo/): A demo of giving instant feedback as blocks are changed.
+- [``headless-demo``](headless-demo/): A demo of generating Python code from XML with no graphics.
+- [``interpreter-demo``](interpreter-demo/): A demo of executing code step-by-step with a sandboxed JavaScript interpreter.
+- [``max-blocks-demo``](max-blocks-demo/): A demo limiting the total number of blocks allowed for academic exercises.
+- [``mirror-demo``](mirror-demo/): A demo using two Blockly instances connected as leader-follower.
+- [``pitch-field-demo``](pitch-field-demo/): A demo of creating custom block fields.
+- [``plane-demo``](plane-demo/): A demo sing Closure Templates to support 35 languages.
+- [``resizable-demo``](resizable-demo/): A demo of injecting Blockly into a page as a resizable element.
+- [``rtl-demo``](rtl-demo/): A demo of what Blockly looks like in right-to-left mode (for Arabic and Hebrew).
+- [``single-direction-scroll-demo``](single-direction-scroll-demo/): A demo of configuring single-direction scrollbars.
+- [``toolbox-demo``](toolbox-demo/): A demo of a complex category structure for the toolbox.
+- [``turtle-field-demo``](turtle-field-demo/): A demo of creating custom block fields.
+
+### Codelabs
+
+The [Blockly Codelabs](https://blocklycodelabs.dev/) refer to this example code.
+
+- [``context-menu-codelab``](context-menu-codelab/): Starter code and completed code for the [codelab](https://blocklycodelabs.dev/codelabs/context-menu-option/index.html) on context menu options.
+- [``custom-toolbox-codelab``](custom-toolbox-codelab/): Starter code and completed code for the [codelab](https://blocklycodelabs.dev/codelabs/custom_toolbox/index.html) on how to customize your toolbox.
+- [``getting-started-codelab``](getting-started-codelab/): Code for the [Blockly getting started codelab](https://blocklycodelabs.dev/codelabs/getting-started/index.html).
+- [``theme-extension-codelab``](theme-extension-codelab/): Starter code and completed code for the [codelab](https://blocklycodelabs.dev/codelabs/theme-extension-identifier/index.html) on applying themes.
+
 ### Integrating Blockly
+
 - [``blockly-requirejs-sample``](blockly-requirejs/): Loads RequireJS from a CDN and loads Blockly using ``AMD``.
 - [``blockly-umd-sample``](blockly-umd/): Loads the UMD build of Blockly (``blockly.min.js``), both from node_modules and from Unpkg.
 - [``blockly-webpack-sample``](blockly-webpack/): Using Blockly in Webpack.

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -12,6 +12,7 @@ layout: index
 * [Block Extension Tooltip](plugins/block-extension-tooltip/test/index.html)
 
 ## Fields
+* [Field Bitmap](plugins/field-bitmap/test/index.html)
 * [Field Date](plugins/field-date/test/index.html)
 * [Field Slider](plugins/field-slider/test/index.html)
 * [Field Grid Dropdown](plugins/field-grid-dropdown/test/index.html)

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -11,6 +11,8 @@ tag on [npm](https://www.npmjs.com/search?q=%40blockly).
 
 ### Fields
 
+- [``@blockly/field-bitmap``](field-bitmap/): A Blockly field that allows for
+user-inputted pixel grids.
 - [``@blockly/field-date``](field-date/): A date picker field that uses the
 Google Closure date picker.
 - [``@blockly/field-grid-dropdown``](field-grid-dropdown/): A Blockly dropdown
@@ -29,7 +31,7 @@ blocks that add connections dynamically.
 
 - [``@blockly/create-package``](dev-create/): A tool for creating a Blockly
 plugin based on a pre-existing template.
-- [``@blockly/migrate``](migrate/): A tool for migrating apps built on Blockly
+- [``@blockly/migrate``](migration/): A tool for migrating apps built on Blockly
 to newer versions of Blockly that make breaking changes.
 - [``@blockly/eslint-config``](eslint-config/): ESlint configuration used by
 Blockly plugins.
@@ -42,6 +44,12 @@ plugins.
 
 - [``@blockly/theme-modern``](theme-modern/): A Blockly modern theme.
 - [``@blockly/theme-dark``](theme-dark/): A Blockly dark theme.
+- [``@blockly/theme-highcontrast``](theme-highcontrast/): A Blockly high
+contrast theme.
+- [``@blockly/theme-deuteranopia``](theme-deuteranopia/): A Blockly theme for
+people who have deuteranopia.
+- [``@blockly/theme-tritanopia``](theme-tritanopia/): A Blockly theme for people
+who have tritanopia.
 
 ### Block Extension
 
@@ -70,6 +78,8 @@ zoom-to-fit control to the workspace.
 adds additional scrolling features.
 - [``@blockly/plugin-cross-tab-copy-paste``](cross-tab-copy-paste/): A Blockly plugin
 that allows a user to copy and paste blocks between tabs.
+- [``@blockly/workspace-backpack``](workspace-backpack/): A Blockly plugin that
+adds Backpack support.
 
 ### Serializers
 


### PR DESCRIPTION
Fixes #733. Updates READMEs for examples and plugins to include links to everything that seemed to be ready, and updates the gh-pages index.md to add a link to the field-bitmap demo.