### PR TITLE
release: update dev-tools to major version and update all plugin dependencies on it

### DIFF
--- a/examples/custom-tooltips-demo/package-lock.json
+++ b/examples/custom-tooltips-demo/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@blockly/dev-scripts": "^1.2.14",
-        "@blockly/dev-tools": "^3.0.7",
+        "@blockly/dev-tools": "^4.0.1",
         "blockly": "^8",
         "showdown": "^2.0.0"
       }

--- a/examples/custom-tooltips-demo/package.json
+++ b/examples/custom-tooltips-demo/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@blockly/dev-tools": "^3.0.7",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0"
   },
   "blocklyDemoConfig": {

--- a/plugins/block-dynamic-connection/package-lock.json
+++ b/plugins/block-dynamic-connection/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/block-dynamic-connection",
-	"version": "0.1.33",
+	"version": "0.1.34",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/block-dynamic-connection",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "A group of blocks that add connections dynamically.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0",
     "chai": "^4.2.0",

--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0",
     "chai": "^4.2.0",
     "mocha": "^7.1.0"

--- a/plugins/block-plus-minus/package-lock.json
+++ b/plugins/block-plus-minus/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/block-plus-minus",
-	"version": "3.0.19",
+	"version": "3.0.20",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/block-plus-minus/package.json
+++ b/plugins/block-plus-minus/package.json
@@ -40,7 +40,7 @@
     ],
     "devDependencies": {
         "@blockly/dev-scripts": "^1.2.25",
-        "@blockly/dev-tools": "^3.1.9",
+        "@blockly/dev-tools": "^4.0.1",
         "blockly": "^8.0.0",
         "chai": "^4.2.0",
         "mocha": "^7.1.0",

--- a/plugins/block-plus-minus/package.json
+++ b/plugins/block-plus-minus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blockly/block-plus-minus",
-    "version": "3.0.19",
+    "version": "3.0.20",
     "description": "A group of blocks that replace the built-in mutator UI with a +/- based UI.",
     "scripts": {
         "audit:fix": "blockly-scripts auditFix",
@@ -39,7 +39,7 @@
         "src"
     ],
     "devDependencies": {
-        "@blockly/dev-scripts": "^1.2.24",
+        "@blockly/dev-scripts": "^1.2.25",
         "@blockly/dev-tools": "^3.1.9",
         "blockly": "^8.0.0",
         "chai": "^4.2.0",

--- a/plugins/block-test/package-lock.json
+++ b/plugins/block-test/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/block-test",
-	"version": "2.0.15",
+	"version": "2.0.16",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/block-test/package.json
+++ b/plugins/block-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/block-test",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "A group of Blockly test blocks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,7 +39,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/content-highlight/package-lock.json
+++ b/plugins/content-highlight/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/workspace-content-highlight",
-	"version": "1.0.28",
+	"version": "1.0.29",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -44,7 +44,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/workspace-content-highlight",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "A Blockly workspace plugin that adds a highlight around the content area.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -43,7 +43,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0"
   },

--- a/plugins/continuous-toolbox/package-lock.json
+++ b/plugins/continuous-toolbox/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/continuous-toolbox",
-	"version": "2.0.37",
+	"version": "2.0.38",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/continuous-toolbox",
-  "version": "2.0.37",
+  "version": "2.0.38",
   "description": "A Blockly plugin that adds a continous-scrolling style toolbox and flyout",
   "scripts": {
     "build": "blockly-scripts build",
@@ -39,7 +39,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0"
   },

--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -40,7 +40,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/cross-tab-copy-paste/package-lock.json
+++ b/plugins/cross-tab-copy-paste/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-cross-tab-copy-paste",
-	"version": "1.0.11",
+	"version": "1.0.12",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-cross-tab-copy-paste",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Allows you to copy blocks with cross-tab.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0"
   },

--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/dev-scripts/package-lock.json
+++ b/plugins/dev-scripts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/dev-scripts",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/plugins/dev-scripts/package.json
+++ b/plugins/dev-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/dev-scripts",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "description": "Configuration and scripts for Blockly plugins.",
   "scripts": {
     "lint": "eslint ."

--- a/plugins/dev-tools/package-lock.json
+++ b/plugins/dev-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/dev-tools",
-	"version": "3.1.9",
+	"version": "4.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/dev-tools",
-  "version": "3.1.9",
+  "version": "4.0.1",
   "description": "A library of common utilities for Blockly extension development.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,11 +39,11 @@
     "src"
   ],
   "dependencies": {
-    "@blockly/block-test": "^2.0.15",
-    "@blockly/theme-dark": "^3.0.14",
-    "@blockly/theme-deuteranopia": "^2.0.14",
-    "@blockly/theme-highcontrast": "^2.0.14",
-    "@blockly/theme-tritanopia": "^2.0.14",
+    "@blockly/block-test": "^2.0.16",
+    "@blockly/theme-dark": "^3.0.15",
+    "@blockly/theme-deuteranopia": "^2.0.15",
+    "@blockly/theme-highcontrast": "^2.0.15",
+    "@blockly/theme-tritanopia": "^2.0.15",
     "chai": "^4.2.0",
     "dat.gui": "^0.7.7",
     "lodash.assign": "^4.2.0",
@@ -52,7 +52,7 @@
     "sinon": "^9.0.2"
   },
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@types/dat.gui": "^0.7.5",
     "blockly": "^8.0.0"
   },

--- a/plugins/disable-top-blocks/package-lock.json
+++ b/plugins/disable-top-blocks/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/disable-top-blocks",
-	"version": "0.1.39",
+	"version": "0.1.40",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/disable-top-blocks",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "A Blockly plugin that shows the 'disable' context menu option only on non-orphan blocks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,7 +39,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0"
   },

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -40,7 +40,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/field-bitmap/package-lock.json
+++ b/plugins/field-bitmap/package-lock.json
@@ -6,10 +6,10 @@
 	"packages": {
 		"": {
 			"name": "@blockly/field-bitmap",
-			"version": "1.0.4",
+			"version": "1.0.5",
 			"license": "Apache-2.0",
 			"devDependencies": {
-				"blockly": "^7.20211209.2",
+				"blockly": "^8.0.0",
 				"chai": "^4.3.6",
 				"mocha": "^9.2.1"
 			},
@@ -17,7 +17,7 @@
 				"node": ">=8.17.0"
 			},
 			"peerDependencies": {
-				"blockly": "^7.20211209.2"
+				"blockly": ">=7.20211209.2 <9"
 			}
 		},
 		"node_modules/@ungap/promise-all-settled": {
@@ -201,9 +201,9 @@
 			}
 		},
 		"node_modules/blockly": {
-			"version": "7.20211209.2",
-			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.2.tgz",
-			"integrity": "sha512-74HTPbnDOwVGKx6qRE/ZVVQwf+J9s/WkgDKv0vuXw/DtBLvLrew7Nf5jaZP0+DXRVJpP1u5sfu+qtHaom0i6Ug==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/blockly/-/blockly-8.0.4.tgz",
+			"integrity": "sha512-qGYrynzalzEHOMLJhZmADpuMXUH55nSTVgVd11Z1ZlVsm3NQ69ZVgBEaCSN+GsEUUpoui71g4oVzE2iHEHbAtw==",
 			"dev": true,
 			"dependencies": {
 				"jsdom": "15.2.1"
@@ -2184,9 +2184,9 @@
 			"dev": true
 		},
 		"blockly": {
-			"version": "7.20211209.2",
-			"resolved": "https://registry.npmjs.org/blockly/-/blockly-7.20211209.2.tgz",
-			"integrity": "sha512-74HTPbnDOwVGKx6qRE/ZVVQwf+J9s/WkgDKv0vuXw/DtBLvLrew7Nf5jaZP0+DXRVJpP1u5sfu+qtHaom0i6Ug==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/blockly/-/blockly-8.0.4.tgz",
+			"integrity": "sha512-qGYrynzalzEHOMLJhZmADpuMXUH55nSTVgVd11Z1ZlVsm3NQ69ZVgBEaCSN+GsEUUpoui71g4oVzE2iHEHbAtw==",
 			"dev": true,
 			"requires": {
 				"jsdom": "15.2.1"

--- a/plugins/field-bitmap/package-lock.json
+++ b/plugins/field-bitmap/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/field-bitmap",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/field-bitmap/package.json
+++ b/plugins/field-bitmap/package.json
@@ -42,13 +42,13 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
-    "blockly": "^7.20211209.2",
+    "@blockly/dev-tools": "^4.0.1",
+    "blockly": "^8.0.0",
     "chai": "^4.3.6",
     "mocha": "^9.2.1"
   },
   "peerDependencies": {
-    "blockly": "^7.20211209.2"
+    "blockly": ">=7.20211209.2 <9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-bitmap/package.json
+++ b/plugins/field-bitmap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-bitmap",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A field that lets users input a pixel grid with their mouse.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^7.20211209.2",
     "chai": "^4.3.6",

--- a/plugins/field-date/package-lock.json
+++ b/plugins/field-date/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/field-date",
-	"version": "5.0.19",
+	"version": "5.0.20",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -40,7 +40,7 @@
     ],
     "devDependencies": {
         "@blockly/dev-scripts": "^1.2.25",
-        "@blockly/dev-tools": "^3.1.9",
+        "@blockly/dev-tools": "^4.0.1",
         "blockly": "^8.0.0",
         "google-closure-compiler": "^20200920.0.0",
         "google-closure-library": "^20200830.0.0",

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blockly/field-date",
-    "version": "5.0.19",
+    "version": "5.0.20",
     "description": "A Blockly date picker field that uses the Google Closure date picker.",
     "scripts": {
         "audit:fix": "blockly-scripts auditFix",
@@ -39,7 +39,7 @@
         "src"
     ],
     "devDependencies": {
-        "@blockly/dev-scripts": "^1.2.24",
+        "@blockly/dev-scripts": "^1.2.25",
         "@blockly/dev-tools": "^3.1.9",
         "blockly": "^8.0.0",
         "google-closure-compiler": "^20200920.0.0",

--- a/plugins/field-grid-dropdown/package-lock.json
+++ b/plugins/field-grid-dropdown/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/field-grid-dropdown",
-	"version": "1.0.44",
+	"version": "1.0.45",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-grid-dropdown",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "A Blockly dropdown field with grid layout.",
   "scripts": {
     "build": "blockly-scripts build",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0"
   },

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/field-slider/package-lock.json
+++ b/plugins/field-slider/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/field-slider",
-	"version": "3.0.19",
+	"version": "3.0.20",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-slider",
-  "version": "3.0.19",
+  "version": "3.0.20",
   "description": "A Blockly slider field.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0",
     "chai": "^4.2.0",

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0",
     "chai": "^4.2.0",
     "sinon": "^9.0.1"

--- a/plugins/fixed-edges/package-lock.json
+++ b/plugins/fixed-edges/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/fixed-edges",
-	"version": "1.0.37",
+	"version": "1.0.38",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/fixed-edges",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "A Blockly MetricsManager for configuring fixed sides.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,7 +39,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0"
   },

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -40,7 +40,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/keyboard-navigation/package-lock.json
+++ b/plugins/keyboard-navigation/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/keyboard-navigation",
-	"version": "0.2.19",
+	"version": "0.2.20",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/keyboard-navigation/package.json
+++ b/plugins/keyboard-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/keyboard-navigation",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "A Blockly plugin that adds keyboard navigation support.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0",
     "chai": "^4.2.0",

--- a/plugins/keyboard-navigation/package.json
+++ b/plugins/keyboard-navigation/package.json
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0",
     "chai": "^4.2.0",
     "jsdom": "^16.4.0",

--- a/plugins/modal/package-lock.json
+++ b/plugins/modal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-modal",
-	"version": "3.0.19",
+	"version": "3.0.20",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-modal",
-  "version": "3.0.19",
+  "version": "3.0.20",
   "description": "A Blockly plugin that creates a modal.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0",
     "jsdom": "^19.0.0",

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",

--- a/plugins/scroll-options/package-lock.json
+++ b/plugins/scroll-options/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-scroll-options",
-	"version": "2.0.19",
+	"version": "2.0.20",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-scroll-options",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "A Blockly plugin that adds advanced scroll options such as scroll-on-drag and scroll while holding a block.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0"
   },

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/serialize-disabled-interactions/package-lock.json
+++ b/plugins/serialize-disabled-interactions/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-serialize-disabled-interactions",
-	"version": "1.0.15",
+	"version": "1.0.16",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/serialize-disabled-interactions/package.json
+++ b/plugins/serialize-disabled-interactions/package.json
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0",
     "chai": "^4.3.4"
   },

--- a/plugins/serialize-disabled-interactions/package.json
+++ b/plugins/serialize-disabled-interactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-serialize-disabled-interactions",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "A Blockly plugin that serializes the deletable, movable, and editable attribues of blocks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0",
     "chai": "^4.3.4"

--- a/plugins/strict-connection-checker/package-lock.json
+++ b/plugins/strict-connection-checker/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-strict-connection-checker",
-	"version": "1.0.44",
+	"version": "1.0.45",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-strict-connection-checker",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "A Blockly plugin that makes connection checks strict.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -42,7 +42,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0",
     "chai": "^4.2.0"

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -43,7 +43,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0",
     "chai": "^4.2.0"
   },

--- a/plugins/suggested-blocks/package-lock.json
+++ b/plugins/suggested-blocks/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blocky/suggested-blocks",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/suggested-blocks/package.json
+++ b/plugins/suggested-blocks/package.json
@@ -42,7 +42,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.3",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.2",
     "chai": "^4.3.6",
     "sinon": "^14.0.0"

--- a/plugins/suggested-blocks/package.json
+++ b/plugins/suggested-blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blocky/suggested-blocks",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A plugin that adds toolbox panes with suggested blocks based on the user's past usage of blocks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.18",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.3",
     "blockly": "^8.0.2",
     "chai": "^4.3.6",

--- a/plugins/theme-dark/package-lock.json
+++ b/plugins/theme-dark/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/theme-dark",
-	"version": "3.0.14",
+	"version": "3.0.15",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-dark",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "A Blockly dark theme.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/theme-deuteranopia/package-lock.json
+++ b/plugins/theme-deuteranopia/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/theme-deuteranopia",
-	"version": "2.0.14",
+	"version": "2.0.15",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/theme-deuteranopia/package.json
+++ b/plugins/theme-deuteranopia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-deuteranopia",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "A Blockly theme for people that have deuteranopia.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/theme-highcontrast/package-lock.json
+++ b/plugins/theme-highcontrast/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/theme-highcontrast",
-	"version": "2.0.14",
+	"version": "2.0.15",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/theme-highcontrast/package.json
+++ b/plugins/theme-highcontrast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-highcontrast",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "A Blockly high contrast theme.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/theme-modern/package-lock.json
+++ b/plugins/theme-modern/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/theme-modern",
-	"version": "2.1.39",
+	"version": "2.1.40",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-modern",
-  "version": "2.1.39",
+  "version": "2.1.40",
   "description": "A Blockly modern theme with darker block borders.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/theme-tritanopia/package-lock.json
+++ b/plugins/theme-tritanopia/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/theme-tritanopia",
-	"version": "2.0.14",
+	"version": "2.0.15",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/theme-tritanopia/package.json
+++ b/plugins/theme-tritanopia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-tritanopia",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "A Blockly theme for people that have tritanopia.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/typed-variable-modal/package-lock.json
+++ b/plugins/typed-variable-modal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-typed-variable-modal",
-	"version": "4.0.19",
+	"version": "4.0.20",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-typed-variable-modal",
-  "version": "4.0.19",
+  "version": "4.0.20",
   "description": "A Blockly plugin to create a modal for creating typed variables.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0",
     "jsdom": "^19.0.0",
@@ -52,7 +52,7 @@
     "blockly": ">=7 <9"
   },
   "dependencies": {
-    "@blockly/plugin-modal": "^3.0.19"
+    "@blockly/plugin-modal": "^3.0.20"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",

--- a/plugins/workspace-backpack/package-lock.json
+++ b/plugins/workspace-backpack/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/workspace-backpack",
-	"version": "2.0.13",
+	"version": "2.0.14",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -42,7 +42,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/workspace-backpack",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "A Blockly plugin that adds Backpack support.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,7 +41,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0"
   },

--- a/plugins/workspace-search/package-lock.json
+++ b/plugins/workspace-search/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/plugin-workspace-search",
-	"version": "5.0.19",
+	"version": "5.0.20",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-workspace-search",
-  "version": "5.0.19",
+  "version": "5.0.20",
   "description": "A Blockly plugin that adds workspace search support.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0",
     "jsdom": "^19.0.0",

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",

--- a/plugins/zoom-to-fit/package-lock.json
+++ b/plugins/zoom-to-fit/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blockly/zoom-to-fit",
-	"version": "2.0.28",
+	"version": "2.0.29",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/zoom-to-fit",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "description": "A Blockly plugin that adds a zoom-to-fit control to the workspace.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,7 +39,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^1.2.24",
+    "@blockly/dev-scripts": "^1.2.25",
     "@blockly/dev-tools": "^3.1.9",
     "blockly": "^8.0.0"
   },

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -40,7 +40,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.25",
-    "@blockly/dev-tools": "^3.1.9",
+    "@blockly/dev-tools": "^4.0.1",
     "blockly": "^8.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Background

https://github.com/google/blockly-samples/pull/1191 was merged but lerna did not correctly pick this up as a major version bump. This is either because
a) Something went wrong because this PR was actually after reverting an identical early PR that wasn't marked as breaking change, so we confused lerna
b) Lerna is looking at the individual commits in the PR (none of which is marked breaking) rather than the squashed commit title (which is marked breaking)

Which of these two scenarios it is needs further testing but regardless, samples is currently borked until this PR sorting things out.

## This PR
1. Manually bumps the version of dev-tools to a new major version
2. Manually bumps the version of all plugins to a new minor version (in theory, because they all depend on dev-tools; in reality because lerna always bumps all the packages for a reason I can't figure out). This was done using `lerna version` but with enough command line arguments that it didn't push and tag them automatically, so that's why I say "manually"
3. Updates every plugin to depend on v4.0.1 of dev-tools. The previous version 3.0.9 does not actually exist (it's a relic of the failed update previously) so that's why samples is currently borked.

## Details
All the plugins already relied on blockly@8 in dev-dependencies, which is required now to use this version of dev-tools, except for `field-bitmap` so I updated that plugin's versions and manually tested, everything looks good.

## Next steps
1. Publish all the plugins using the `from-git` command so that lerna doesn't bump them *again*
2. Update the templates in `dev-create` to use the new version of dev-tools. I wanted to do that in a separate publish cycle in case this one doesn't work for some reason, then we don't have inaccurate templates.
3. Update the samples site. This isn't really related to this PR but it needs to be done after this stuff is all taken care of.