### PR TITLE
chore: update the publish config for suggested blocks

### DIFF
--- a/plugins/suggested-blocks/package.json
+++ b/plugins/suggested-blocks/package.json
@@ -50,7 +50,10 @@
   "peerDependencies": {
     "blockly": "^8.0.2"
   },
-  "publishConfig": {},
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://wombat-dressing-room.appspot.com"
+  },
   "eslintConfig": {
     "extends": "@blockly/eslint-config"
   },


### PR DESCRIPTION
The new plugin @blockly/suggested-blocks has never been published before, and I discovered it was missing the publish config when I tried to publish samples today.

This PR adds the publish config. Also, I double checked the rest of the new plugin review checklist and everything else is fine.