### PR TITLE
fix: update workflow to fetch all tags for lerna publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      # fetch all tags and commits so that lerna can version appropriately
+      with:
+        fetch-depth: 0
 
     # This uses a reverse-engineered email for the github actions bot. See
     # https://github.com/actions/checkout/issues/13#issuecomment-724415212


### PR DESCRIPTION
The checkout workflow by default only fetches the most recent commit. This behavior is why the lerna version command in CI says "assuming all versions changed" and just publishes a patch release for every plugin.

See https://github.com/lerna/lerna/issues/2542

(the second `git fetch` command is no longer required since the `checkout` workflow will now fetch tags if you set the fetch-depth to 0, according to its readme.)