### PR TITLE
fix: clean up links and documentation

### DIFF
--- a/codelabs/README.md
+++ b/codelabs/README.md
@@ -23,12 +23,12 @@ You can find additional details on the
 Put your image assets associated with your codelab in the same folder as your
 markdown file. Any images you add can be linked from the Codelab using:
 ```md
-![image_caption](./codelabexample.png
+![image_caption](codelabexample.png)
 ```
 
 
 ## Resources
 
-[Sample Codelab](/sample.md)
+[Sample Codelab](sample.md)
 
 [Codelab Markdown Formatting Guide](https://github.com/googlecodelabs/tools/tree/master/claat/parser/md)

--- a/codelabs/custom_generator/custom_generator.md
+++ b/codelabs/custom_generator/custom_generator.md
@@ -576,9 +576,9 @@ Next, add a second member block and rerun the generator. Did the resulting code 
 ### The scrub_ function
 
 The `scrub_` function is called on every block from `blockToCode`. It takes in three arguments:
-- `_block` is the current block.
+- `block` is the current block.
 - `code` is the code generated for this block, which includes code from all attached value blocks.
-- `_opt_thisOnly` is an optional `boolean`. If true, code should be generated for this block but no subsequent blocks.
+- `opt_thisOnly` is an optional `boolean`. If true, code should be generated for this block but no subsequent blocks.
 
 By default, `scrub_` simply returns the passed-in code. A common pattern is to override the function to also generate code for any blocks that follow the current block in a stack. In this case, we will add commas and newlines between object members:
 

--- a/codelabs/custom_toolbox/custom_toolbox.md
+++ b/codelabs/custom_toolbox/custom_toolbox.md
@@ -520,5 +520,5 @@ The toolbox can be customized in a variety of ways to make it work for your appl
 * How to add an icon by adding a custom CSS class to the icon div.
 * How to change what HTML Elements are used for different parts of a category.
 * How to create a custom toolbox item.
-You can find the code for the [completed custom](https://github.com/google/blockly-samples/tree/master/codelabs/custom_toolbox/final_src) on GitHub, in both ES5 and ES6 syntax.
+You can find the code for the [completed custom toolbox](https://github.com/google/blockly-samples/tree/master/examples/custom-toolbox-codelab/complete-code) on GitHub, in both ES5 and ES6 syntax.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,7 @@ The [Blockly Codelabs](https://blocklycodelabs.dev/) refer to this example code.
 - [``custom-toolbox-codelab``](custom-toolbox-codelab/): Starter code and completed code for the [codelab](https://blocklycodelabs.dev/codelabs/custom_toolbox/index.html) on how to customize your toolbox.
 - [``getting-started-codelab``](getting-started-codelab/): Code for the [Blockly getting started codelab](https://blocklycodelabs.dev/codelabs/getting-started/index.html).
 - [``theme-extension-codelab``](theme-extension-codelab/): Starter code and completed code for the [codelab](https://blocklycodelabs.dev/codelabs/theme-extension-identifier/index.html) on applying themes.
+- [``validation-and-warnings-codelab``](validation-and-warnings-codelab/): Starter code and completed code for the [codelab](https://blocklycodelabs.dev/codelabs/validation-and-warnings/index.html) on validating blocks and displaying warnings.
 
 ### Integrating Blockly
 

--- a/examples/context-menu-codelab/complete-code/index.html
+++ b/examples/context-menu-codelab/complete-code/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>Context Menu Codelab</title>
   <script src="https://unpkg.com/blockly/blockly.min.js"></script>
-  <script src="https://unpkg.com/@blockly/dev-tools@2.0.0/dist/index.js"></script>
+  <script src="https://unpkg.com/@blockly/dev-tools"></script>
   <script src="./index.js"></script>
 
   <style>

--- a/examples/context-menu-codelab/starter-code/index.html
+++ b/examples/context-menu-codelab/starter-code/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>Context Menu Codelab</title>
   <script src="https://unpkg.com/blockly/blockly.min.js"></script>
-  <script src="https://unpkg.com/@blockly/dev-tools@2.0.0/dist/index.js"></script>
+  <script src="https://unpkg.com/@blockly/dev-tools"></script>
   <script src="./index.js"></script>
 
   <style>

--- a/examples/custom-toolbox-codelab/README.md
+++ b/examples/custom-toolbox-codelab/README.md
@@ -1,4 +1,4 @@
-Starter code and completed code for the [codelab](https://blocklycodelabs.dev/codelabs/custom_toolbox/index.html) on how to customize your toolbox.
+Starter code and completed code for the [codelab](https://blocklycodelabs.dev/codelabs/custom-toolbox/index.html) on how to customize your toolbox.
 
 The completed code overrides various methods on the default category class to
 change the look of the toolbox. It also adds a new toolbox item class that creates

--- a/examples/custom-toolbox-codelab/complete-code/index.html
+++ b/examples/custom-toolbox-codelab/complete-code/index.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <title>Toolbox Customization Codelab</title>
   <script src="https://unpkg.com/blockly/blockly.min.js"></script>
-  <script src="https://unpkg.com/@blockly/dev-tools@2.0.0/dist/index.js"></script>
   <script src="index.js"></script>
   <script src="custom_category_es6.js"></script>
   <script src="toolbox_label_es6.js"></script>

--- a/examples/custom-toolbox-codelab/starter-code/index.html
+++ b/examples/custom-toolbox-codelab/starter-code/index.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <title>Toolbox Customization Codelab</title>
   <script src="https://unpkg.com/blockly/blockly.min.js"></script>
-  <script src="https://unpkg.com/@blockly/dev-tools@2.0.0/dist/index.js"></script>
   <script src="index.js"></script>
 
   <style>

--- a/examples/theme-extension-codelab/complete-code/index.html
+++ b/examples/theme-extension-codelab/complete-code/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>Theme Extension Codelab</title>
   <script src="https://unpkg.com/blockly/blockly.min.js"></script>
-  <script src="https://unpkg.com/@blockly/dev-tools@2.0.0/dist/index.js"></script>
+  <script src="https://unpkg.com/@blockly/dev-tools"></script>
   <script src="./index.js"></script>
 
   <style>

--- a/examples/theme-extension-codelab/starter-code/index.html
+++ b/examples/theme-extension-codelab/starter-code/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>Theme Extension Codelab</title>
   <script src="https://unpkg.com/blockly/blockly.min.js"></script>
-  <script src="https://unpkg.com/@blockly/dev-tools@2.0.0/dist/index.js"></script>
+  <script src="https://unpkg.com/@blockly/dev-tools"></script>
   <script src="./index.js"></script>
 
   <style>

--- a/examples/turtle-field-demo/index.html
+++ b/examples/turtle-field-demo/index.html
@@ -38,7 +38,7 @@
       is used to define a turtle.
     </p>
 
-    <p>&rarr; More info on <a href="https://developers.google.com/blockly/guides/create-custom-blocks/fields/customizing-field/creating">creating a custom field</a>&hellip;</p>
+    <p>&rarr; More info on <a href="https://developers.google.com/blockly/guides/create-custom-blocks/fields/customizing-fields/creating">creating a custom field</a>&hellip;</p>
 
     <p>Click on the blocks' comment icons to learn what they are demonstrating.
       Use the buttons below to see how the fields react to changes.


### PR DESCRIPTION
* In codelabs/README.md I fixed links to use proper relative paths.
* In codelabs/custom_generator/custom_generator.md I removed underscores from parameters... I see that the canonical names of these parameters in https://developers.google.com/blockly/reference/js/Blockly.Generator#scrub_ contain underscores, but the following example in the codelab does not and I don't see why a user would choose to include the underscores unless it helped avoid shadowing some other symbol in their code. Alternatively, if you think it makes more sense, we could add the underscores back to the codelab but then we should add them to the other example in the codelab as well.
* In codelabs/custom_toolbox/custom_toolbox.md I fixed a broken link to the complete code for the custom toolbox codelab.
* In examples/custom-toolbox-codelab/README.md I fixed a broken link to the codelab.
* In examples/README.md I added a link to my new validation and warnings codelab (which hasn't been deployed to https://blocklycodelabs.dev/ yet).
* In examples/turtle-field-demo/index.html I fixed a broken link to documentation on customizing fields.
* In several codelab starter and complete index.html files, I either deleted a link to https://unpkg.com/@blockly/dev-tools@2.0.0/dist/index.js if it was unused, or I removed the (outdated) version number, so that it would use the latest version which would be more likely to be compatible with the latest version of blockly that was loaded.