### PR TITLE
docs: Generator demo uses eval, not JS-Interpreter.

### DIFF
--- a/examples/generator-demo/index.html
+++ b/examples/generator-demo/index.html
@@ -21,7 +21,7 @@
 </head>
 <body>
   <p>This is a simple demo of generating code from blocks and running
-  the code in a sandboxed JavaScript interpreter.</p>
+  the code using eval.</p>
 
   <p>&rarr; More info on <a href="https://developers.google.com/blockly/guides/configure/web/code-generators">Code Generators</a> and <a href="https://developers.google.com/blockly/guides/app-integration/running-javascript">Running JavaScript</a>.</p>
 


### PR DESCRIPTION
Andrew added false info to the description 4 years ago.