### PR TITLE
chore: fix generator imports in dev tools

### DIFF
--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -11,11 +11,11 @@
 
 import {toolboxTestBlocks, toolboxTestBlocksInit} from '@blockly/block-test';
 import * as Blockly from 'blockly/core';
-import * as BlocklyDart from 'blockly/dart';
-import * as BlocklyJS from 'blockly/javascript';
-import * as BlocklyLua from 'blockly/lua';
-import * as BlocklyPHP from 'blockly/php';
-import * as BlocklyPython from 'blockly/python';
+import {dartGenerator} from 'blockly/dart';
+import {javascriptGenerator} from 'blockly/javascript';
+import {luaGenerator} from 'blockly/lua';
+import {phpGenerator} from 'blockly/php';
+import {pythonGenerator} from 'blockly/python';
 
 import {downloadWorkspaceScreenshot} from '../screenshot';
 import toolboxCategories from '../toolboxCategories';
@@ -265,27 +265,28 @@ export function createPlayground(
           'JavaScript': registerGenerator(
               'JavaScript',
               'javascript',
-              (ws) => (BlocklyJS || Blockly.JavaScript).workspaceToCode(ws),
+              (ws) =>
+                (javascriptGenerator || Blockly.JavaScript).workspaceToCode(ws),
               true),
           'Python': registerGenerator(
               'Python',
               'python',
-              (ws) => (BlocklyPython || Blockly.Python).workspaceToCode(ws),
+              (ws) => (pythonGenerator || Blockly.Python).workspaceToCode(ws),
               true),
           'Dart': registerGenerator(
               'Dart',
               'dart',
-              (ws) => (BlocklyDart || Blockly.Dart).workspaceToCode(ws),
+              (ws) => (dartGenerator || Blockly.Dart).workspaceToCode(ws),
               true),
           'Lua': registerGenerator(
               'Lua',
               'lua',
-              (ws) => (BlocklyLua || Blockly.Lua).workspaceToCode(ws),
+              (ws) => (luaGenerator || Blockly.Lua).workspaceToCode(ws),
               true),
           'PHP': registerGenerator(
               'PHP',
               'php',
-              (ws) => (BlocklyPHP || Blockly.PHP).workspaceToCode(ws),
+              (ws) => (phpGenerator || Blockly.PHP).workspaceToCode(ws),
               true),
         };
 


### PR DESCRIPTION
### Description

Updates dev tools to use the new generator imports for the 9.0 release of Blockly. That needs to be released first.

### Testing

Tested with the beta release of Blockly, and it works. Although I think the Blockly generator type definitions may need some updating.