### PR TITLE
fix(blockly-react): Update generator import for blockly-react demo

### DIFF
--- a/examples/blockly-react/src/generator/generator.js
+++ b/examples/blockly-react/src/generator/generator.js
@@ -24,13 +24,12 @@
 // More on generating code:
 // https://developers.google.com/blockly/guides/create-custom-blocks/generating-code
 
-import * as Blockly from 'blockly/core';
-import 'blockly/javascript';
+import {javascriptGenerator} from 'blockly/javascript';
 
-Blockly.JavaScript['test_react_field'] = function (block) {
+javascriptGenerator['test_react_field'] = function (block) {
     return 'console.log(\'custom block\');\n';
 };
 
-Blockly.JavaScript['test_react_date_field'] = function (block) {
+javascriptGenerator['test_react_date_field'] = function (block) {
     return 'console.log(' + block.getField('DATE').getText() + ');\n';
 };


### PR DESCRIPTION
Update import of the JavaScript generator in the blockly-react demo.

Creating this as a draft so it can be referred to in issue #1269.

Leaving this as draft because this PR will need to happen after (or as part of) updating blockly-samples to Blockly v9.