### PR TITLE
fix: add missing removeGenerator function in Playground API type (#1224)

### DIFF
--- a/plugins/dev-tools/src/index.d.ts
+++ b/plugins/dev-tools/src/index.d.ts
@@ -24,6 +24,7 @@ interface PlaygroundAPI {
   getCurrentTab: () => PlaygroundTab;
   getGUI: () => DevTools.GUI;
   getWorkspace: () => Blockly.WorkspaceSvg;
+  removeGenerator: (label: string) => void;
 }
 
 declare namespace DevTools {


### PR DESCRIPTION
Fixes #1224 

Adds the missing removeGenerator function to the PlaygroundAPI interface.  Now, you can use removeGenerator() without the scary error suggesting that it does not exist. I tested using the helpful steps to reproduce in the issue. 

Attached is an example of the message before this fix.
![Example of missing type error](https://user-images.githubusercontent.com/17906628/190703224-9d20c2d7-5350-4b75-b227-64a21c85188f.png)
