### PR TITLE
fix:  resizing for slider field to fit contents (Zelos)

### DIFF
--- a/plugins/field-slider/src/field_slider.js
+++ b/plugins/field-slider/src/field_slider.js
@@ -145,6 +145,7 @@ export class FieldSlider extends Blockly.FieldNumber {
    */
   onSliderChange_() {
     this.setEditorValue_(this.sliderInput_.value);
+    this.resizeEditor_();
   }
 
   /**


### PR DESCRIPTION
Fixes [#1177](https://github.com/google/blockly-samples/issues/1177)

This PR fixes a bug found in a Zelos theme. After the fix Field-slider component is  properly resizing to match the width of the content.

Before:
<img width="323" alt="image" src="https://user-images.githubusercontent.com/21177635/190709701-ef593d4c-b6cf-4d89-b786-886b9cb5a061.png">

After:
<img width="323" alt="image" src="https://user-images.githubusercontent.com/21177635/190709922-71ecc7c3-2f1d-471d-b8a2-0b616f8c4947.png">

