### PR TITLE
fix: update pitch field to es6 class

### DIFF
--- a/examples/pitch-field-demo/field_pitch.js
+++ b/examples/pitch-field-demo/field_pitch.js
@@ -27,6 +27,11 @@ var CustomFields = CustomFields || {};
  * @constructor
  */
 class FieldPitch extends Blockly.FieldTextInput {
+  /**
+   * All notes available for the picker.
+   */
+  static NOTES = 'C3 D3 E3 F3 G3 A3 B3 C4 D4 E4 F4 G4 A4'.split(/ /);
+
   constructor(text) {
     super(text);
 
@@ -64,13 +69,13 @@ class FieldPitch extends Blockly.FieldTextInput {
   showEditor_() {
     super.showEditor_();
 
-    var div = Blockly.WidgetDiv.DIV;
+    const div = Blockly.WidgetDiv.DIV;
     if (!div.firstChild) {
       // Mobile interface uses Blockly.dialog.setPrompt().
       return;
     }
     // Build the DOM.
-    var editor = this.dropdownCreate_();
+    const editor = this.dropdownCreate_();
     Blockly.DropDownDiv.getContentDiv().appendChild(editor);
 
     Blockly.DropDownDiv.setColour(this.sourceBlock_.style.colourPrimary,
@@ -131,9 +136,9 @@ class FieldPitch extends Blockly.FieldTextInput {
    * @param {!Event} e Mouse move event.
    */
   onMouseMove(e) {
-    var bBox = this.imageElement_.getBoundingClientRect();
-    var dy = e.clientY - bBox.top;
-    var note = Blockly.utils.math.clamp(Math.round(13.5 - dy / 7.5), 0, 12);
+    const bBox = this.imageElement_.getBoundingClientRect();
+    const dy = e.clientY - bBox.top;
+    const note = Blockly.utils.math.clamp(Math.round(13.5 - dy / 7.5), 0, 12);
     this.imageElement_.style.backgroundPosition = (-note * 37) + 'px 0';
     this.setEditorValue_(note);
   }
@@ -151,8 +156,8 @@ class FieldPitch extends Blockly.FieldTextInput {
    * @return {number|undefined} The respective value, or undefined if invalid.
    */
   noteToValue(text) {
-    var normalizedText = text.trim().toUpperCase();
-    var i = FieldPitch.NOTES.indexOf(normalizedText);
+    const normalizedText = text.trim().toUpperCase();
+    const i = FieldPitch.NOTES.indexOf(normalizedText);
     return i > -1 ? i : undefined;
   }
   /**
@@ -201,7 +206,7 @@ class FieldPitch extends Blockly.FieldTextInput {
     if (!this.imageElement_) {
       return;
     }
-    var i = this.getValue();
+    const i = this.getValue();
     this.imageElement_.style.backgroundPosition = (-i * 37) + 'px 0';
   }
   /**
@@ -213,32 +218,13 @@ class FieldPitch extends Blockly.FieldTextInput {
     if (opt_newValue === null || opt_newValue === undefined) {
       return null;
     }
-    var note = this.valueToNote(opt_newValue);
+    const note = this.valueToNote(opt_newValue);
     if (note) {
       return opt_newValue;
     }
     return null;
   }
 }
-
-
-/**
- * All notes available for the picker.
- */
-FieldPitch.NOTES = 'C3 D3 E3 F3 G3 A3 B3 C4 D4 E4 F4 G4 A4'.split(/ /);
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 Blockly.fieldRegistry.register('field_pitch', FieldPitch);
 

--- a/examples/pitch-field-demo/field_pitch.js
+++ b/examples/pitch-field-demo/field_pitch.js
@@ -26,217 +26,220 @@ var CustomFields = CustomFields || {};
  * @extends {Blockly.FieldTextInput}
  * @constructor
  */
-CustomFields.FieldPitch = function(text) {
-  CustomFields.FieldPitch.superClass_.constructor.call(this, text);
+class FieldPitch extends Blockly.FieldTextInput {
+  constructor(text) {
+    super(text);
 
-  // Disable spellcheck.
-  this.setSpellcheck(false);
+    // Disable spellcheck.
+    this.setSpellcheck(false);
 
+    /**
+     * Click event data.
+     * @type {?Blockly.browserEvents.Data}
+     * @private
+     */
+    this.clickWrapper_ = null;
+
+    /**
+     * Move event data.
+     * @type {?Blockly.browserEvents.Data}
+     * @private
+     */
+    this.moveWrapper_ = null;
+  }
   /**
-   * Click event data.
-   * @type {?Blockly.browserEvents.Data}
+   * Construct a FieldPitch from a JSON arg object.
+   * @param {!Object} options A JSON object with options (pitch).
+   * @return {!FieldPitch} The new field instance.
+   * @package
+   * @nocollapse
+   */
+  static fromJson(options) {
+    return new FieldPitch(options['pitch']);
+  }
+  /**
+   * Show the inline free-text editor on top of the text and the note picker.
+   * @protected
+   */
+  showEditor_() {
+    super.showEditor_();
+
+    var div = Blockly.WidgetDiv.DIV;
+    if (!div.firstChild) {
+      // Mobile interface uses Blockly.dialog.setPrompt().
+      return;
+    }
+    // Build the DOM.
+    var editor = this.dropdownCreate_();
+    Blockly.DropDownDiv.getContentDiv().appendChild(editor);
+
+    Blockly.DropDownDiv.setColour(this.sourceBlock_.style.colourPrimary,
+      this.sourceBlock_.style.colourTertiary);
+
+    Blockly.DropDownDiv.showPositionedByField(
+      this, this.dropdownDispose_.bind(this));
+
+    // The note picker is different from other fields in that it updates on
+    // mousemove even if it's not in the middle of a drag.  In future we may
+    // change this behaviour.  For now, using bindEvent_ instead of
+    // bindEventWithChecks_ allows it to work without a mousedown/touchstart.
+    this.clickWrapper_ =
+      Blockly.browserEvents.bind(this.imageElement_, 'click', this,
+        this.hide_);
+    this.moveWrapper_ =
+      Blockly.browserEvents.bind(this.imageElement_, 'mousemove', this,
+        this.onMouseMove);
+
+    this.updateGraph_();
+  }
+  /**
+   * Create the pitch editor.
+   * @return {!Element} The newly created pitch picker.
    * @private
    */
-  this.clickWrapper_ = null;
+  dropdownCreate_() {
+    this.imageElement_ = document.createElement('div');
+    this.imageElement_.id = 'notePicker';
 
+    return this.imageElement_;
+  }
   /**
-   * Move event data.
-   * @type {?Blockly.browserEvents.Data}
+   * Dispose of events belonging to the pitch editor.
    * @private
    */
-  this.moveWrapper_ = null;
-};
-Blockly.utils.object.inherits(CustomFields.FieldPitch, Blockly.FieldTextInput);
+  dropdownDispose_() {
+    if (this.clickWrapper_) {
+      Blockly.browserEvents.unbind(this.clickWrapper_);
+      this.clickWrapper_ = null;
+    }
+    if (this.moveWrapper_) {
+      Blockly.browserEvents.unbind(this.moveWrapper_);
+      this.moveWrapper_ = null;
+    }
+    this.imageElement_ = null;
+  }
+  /**
+   * Hide the editor.
+   * @private
+   */
+  hide_() {
+    Blockly.WidgetDiv.hide();
+    Blockly.DropDownDiv.hideWithoutAnimation();
+  }
+  /**
+   * Set the note to match the mouse's position.
+   * @param {!Event} e Mouse move event.
+   */
+  onMouseMove(e) {
+    var bBox = this.imageElement_.getBoundingClientRect();
+    var dy = e.clientY - bBox.top;
+    var note = Blockly.utils.math.clamp(Math.round(13.5 - dy / 7.5), 0, 12);
+    this.imageElement_.style.backgroundPosition = (-note * 37) + 'px 0';
+    this.setEditorValue_(note);
+  }
+  /**
+   * Convert the machine-readable value (0-12) to human-readable text (C3-A4).
+   * @param {number|string} value The provided value.
+   * @return {string|undefined} The respective note, or undefined if invalid.
+   */
+  valueToNote(value) {
+    return FieldPitch.NOTES[Number(value)];
+  }
+  /**
+   * Convert the human-readable text (C3-A4) to machine-readable value (0-12).
+   * @param {string} text The provided note.
+   * @return {number|undefined} The respective value, or undefined if invalid.
+   */
+  noteToValue(text) {
+    var normalizedText = text.trim().toUpperCase();
+    var i = FieldPitch.NOTES.indexOf(normalizedText);
+    return i > -1 ? i : undefined;
+  }
+  /**
+   * Get the text to be displayed on the field node.
+   * @return {?string} The HTML value if we're editing, otherwise null. Null means
+   *   the super class will handle it, likely a string cast of value.
+   * @protected
+   */
+  getText_() {
+    if (this.isBeingEdited_) {
+      return super.getText_();
+    }
+    return this.valueToNote(this.getValue()) || null;
+  }
+  /**
+   * Transform the provided value into a text to show in the HTML input.
+   * @param {*} value The value stored in this field.
+   * @return {string} The text to show on the HTML input.
+   */
+  getEditorText_(value) {
+    return this.valueToNote(value);
+  }
+  /**
+   * Transform the text received from the HTML input (note) into a value
+   * to store in this field.
+   * @param {string} text Text received from the HTML input.
+   * @return {*} The value to store.
+   */
+  getValueFromEditorText_(text) {
+    return this.noteToValue(text);
+  }
+  /**
+   * Updates the graph when the field rerenders.
+   * @private
+   * @override
+   */
+  render_() {
+    super.render_();
+    this.updateGraph_();
+  }
+  /**
+   * Redraw the note picker with the current note.
+   * @private
+   */
+  updateGraph_() {
+    if (!this.imageElement_) {
+      return;
+    }
+    var i = this.getValue();
+    this.imageElement_.style.backgroundPosition = (-i * 37) + 'px 0';
+  }
+  /**
+   * Ensure that only a valid value may be entered.
+   * @param {*} opt_newValue The input value.
+   * @return {*} A valid value, or null if invalid.
+   */
+  doClassValidation_(opt_newValue) {
+    if (opt_newValue === null || opt_newValue === undefined) {
+      return null;
+    }
+    var note = this.valueToNote(opt_newValue);
+    if (note) {
+      return opt_newValue;
+    }
+    return null;
+  }
+}
 
-/**
- * Construct a FieldPitch from a JSON arg object.
- * @param {!Object} options A JSON object with options (pitch).
- * @return {!CustomFields.FieldPitch} The new field instance.
- * @package
- * @nocollapse
- */
-CustomFields.FieldPitch.fromJson = function(options) {
-  return new CustomFields.FieldPitch(options['pitch']);
-};
 
 /**
  * All notes available for the picker.
  */
-CustomFields.FieldPitch.NOTES = 'C3 D3 E3 F3 G3 A3 B3 C4 D4 E4 F4 G4 A4'.split(/ /);
+FieldPitch.NOTES = 'C3 D3 E3 F3 G3 A3 B3 C4 D4 E4 F4 G4 A4'.split(/ /);
 
-/**
- * Show the inline free-text editor on top of the text and the note picker.
- * @protected
- */
-CustomFields.FieldPitch.prototype.showEditor_ = function() {
-  CustomFields.FieldPitch.superClass_.showEditor_.call(this);
 
-  var div = Blockly.WidgetDiv.DIV;
-  if (!div.firstChild) {
-    // Mobile interface uses Blockly.dialog.setPrompt().
-    return;
-  }
-  // Build the DOM.
-  var editor = this.dropdownCreate_();
-  Blockly.DropDownDiv.getContentDiv().appendChild(editor);
 
-  Blockly.DropDownDiv.setColour(this.sourceBlock_.style.colourPrimary,
-      this.sourceBlock_.style.colourTertiary);
 
-  Blockly.DropDownDiv.showPositionedByField(
-      this, this.dropdownDispose_.bind(this));
 
-  // The note picker is different from other fields in that it updates on
-  // mousemove even if it's not in the middle of a drag.  In future we may
-  // change this behaviour.  For now, using bindEvent_ instead of
-  // bindEventWithChecks_ allows it to work without a mousedown/touchstart.
-  this.clickWrapper_ =
-      Blockly.browserEvents.bind(this.imageElement_, 'click', this,
-          this.hide_);
-  this.moveWrapper_ =
-      Blockly.browserEvents.bind(this.imageElement_, 'mousemove', this,
-          this.onMouseMove);
 
-  this.updateGraph_();
-};
 
-/**
- * Create the pitch editor.
- * @return {!Element} The newly created pitch picker.
- * @private
- */
-CustomFields.FieldPitch.prototype.dropdownCreate_ = function() {
-  this.imageElement_ = document.createElement('div');
-  this.imageElement_.id = 'notePicker';
 
-  return this.imageElement_;
-};
 
-/**
- * Dispose of events belonging to the pitch editor.
- * @private
- */
-CustomFields.FieldPitch.prototype.dropdownDispose_ = function() {
-  if (this.clickWrapper_) {
-    Blockly.browserEvents.unbind(this.clickWrapper_);
-    this.clickWrapper_ = null;
-  }
-  if (this.moveWrapper_) {
-    Blockly.browserEvents.unbind(this.moveWrapper_);
-    this.moveWrapper_ = null;
-  }
-  this.imageElement_ = null;
-};
 
-/**
- * Hide the editor.
- * @private
- */
-CustomFields.FieldPitch.prototype.hide_ = function() {
-  Blockly.WidgetDiv.hide();
-  Blockly.DropDownDiv.hideWithoutAnimation();
-};
 
-/**
- * Set the note to match the mouse's position.
- * @param {!Event} e Mouse move event.
- */
-CustomFields.FieldPitch.prototype.onMouseMove = function(e) {
-  var bBox = this.imageElement_.getBoundingClientRect();
-  var dy = e.clientY - bBox.top;
-  var note = Blockly.utils.math.clamp(Math.round(13.5 - dy / 7.5), 0, 12);
-  this.imageElement_.style.backgroundPosition = (-note * 37) + 'px 0';
-  this.setEditorValue_(note);
-};
 
-/**
- * Convert the machine-readable value (0-12) to human-readable text (C3-A4).
- * @param {number|string} value The provided value.
- * @return {string|undefined} The respective note, or undefined if invalid.
- */
-CustomFields.FieldPitch.prototype.valueToNote = function(value) {
-  return CustomFields.FieldPitch.NOTES[Number(value)];
-};
 
-/**
- * Convert the human-readable text (C3-A4) to machine-readable value (0-12).
- * @param {string} text The provided note.
- * @return {number|undefined} The respective value, or undefined if invalid.
- */
-CustomFields.FieldPitch.prototype.noteToValue = function(text) {
-  var normalizedText = text.trim().toUpperCase();
-  var i = CustomFields.FieldPitch.NOTES.indexOf(normalizedText);
-  return i > -1 ? i : undefined;
-};
 
-/**
- * Get the text to be displayed on the field node.
- * @return {?string} The HTML value if we're editing, otherwise null. Null means
- *   the super class will handle it, likely a string cast of value.
- * @protected
- */
-CustomFields.FieldPitch.prototype.getText_ = function() {
-  if (this.isBeingEdited_) {
-    return CustomFields.FieldPitch.superClass_.getText_.call(this);
-  }
-  return this.valueToNote(this.getValue()) || null;
-};
+Blockly.fieldRegistry.register('field_pitch', FieldPitch);
 
-/**
- * Transform the provided value into a text to show in the HTML input.
- * @param {*} value The value stored in this field.
- * @return {string} The text to show on the HTML input.
- */
-CustomFields.FieldPitch.prototype.getEditorText_ = function(value) {
-  return this.valueToNote(value);
-};
-
-/**
- * Transform the text received from the HTML input (note) into a value
- * to store in this field.
- * @param {string} text Text received from the HTML input.
- * @return {*} The value to store.
- */
-CustomFields.FieldPitch.prototype.getValueFromEditorText_ = function(text) {
-  return this.noteToValue(text);
-};
-
-/**
- * Updates the graph when the field rerenders.
- * @private
- * @override
- */
-CustomFields.FieldPitch.prototype.render_ = function() {
-  CustomFields.FieldPitch.superClass_.render_.call(this);
-  this.updateGraph_();
-};
-
-/**
- * Redraw the note picker with the current note.
- * @private
- */
-CustomFields.FieldPitch.prototype.updateGraph_ = function() {
-  if (!this.imageElement_) {
-    return;
-  }
-  var i = this.getValue();
-  this.imageElement_.style.backgroundPosition = (-i * 37) + 'px 0';
-};
-
-/**
- * Ensure that only a valid value may be entered.
- * @param {*} opt_newValue The input value.
- * @return {*} A valid value, or null if invalid.
- */
-CustomFields.FieldPitch.prototype.doClassValidation_ = function(opt_newValue) {
-  if (opt_newValue === null || opt_newValue === undefined) {
-    return null;
-  }
-  var note = this.valueToNote(opt_newValue);
-  if (note) {
-    return opt_newValue;
-  }
-  return null;
-};
-
-Blockly.fieldRegistry.register('field_pitch', CustomFields.FieldPitch);
+CustomFields.FieldPitch = FieldPitch;

--- a/examples/pitch-field-demo/field_pitch.js
+++ b/examples/pitch-field-demo/field_pitch.js
@@ -52,6 +52,7 @@ class FieldPitch extends Blockly.FieldTextInput {
      */
     this.moveWrapper_ = null;
   }
+  
   /**
    * Construct a FieldPitch from a JSON arg object.
    * @param {!Object} options A JSON object with options (pitch).
@@ -62,6 +63,7 @@ class FieldPitch extends Blockly.FieldTextInput {
   static fromJson(options) {
     return new FieldPitch(options['pitch']);
   }
+
   /**
    * Show the inline free-text editor on top of the text and the note picker.
    * @protected
@@ -97,6 +99,7 @@ class FieldPitch extends Blockly.FieldTextInput {
 
     this.updateGraph_();
   }
+
   /**
    * Create the pitch editor.
    * @return {!Element} The newly created pitch picker.
@@ -108,6 +111,7 @@ class FieldPitch extends Blockly.FieldTextInput {
 
     return this.imageElement_;
   }
+
   /**
    * Dispose of events belonging to the pitch editor.
    * @private
@@ -123,6 +127,7 @@ class FieldPitch extends Blockly.FieldTextInput {
     }
     this.imageElement_ = null;
   }
+
   /**
    * Hide the editor.
    * @private
@@ -131,6 +136,7 @@ class FieldPitch extends Blockly.FieldTextInput {
     Blockly.WidgetDiv.hide();
     Blockly.DropDownDiv.hideWithoutAnimation();
   }
+
   /**
    * Set the note to match the mouse's position.
    * @param {!Event} e Mouse move event.
@@ -142,6 +148,7 @@ class FieldPitch extends Blockly.FieldTextInput {
     this.imageElement_.style.backgroundPosition = (-note * 37) + 'px 0';
     this.setEditorValue_(note);
   }
+
   /**
    * Convert the machine-readable value (0-12) to human-readable text (C3-A4).
    * @param {number|string} value The provided value.
@@ -150,6 +157,7 @@ class FieldPitch extends Blockly.FieldTextInput {
   valueToNote(value) {
     return FieldPitch.NOTES[Number(value)];
   }
+
   /**
    * Convert the human-readable text (C3-A4) to machine-readable value (0-12).
    * @param {string} text The provided note.
@@ -160,6 +168,7 @@ class FieldPitch extends Blockly.FieldTextInput {
     const i = FieldPitch.NOTES.indexOf(normalizedText);
     return i > -1 ? i : undefined;
   }
+
   /**
    * Get the text to be displayed on the field node.
    * @return {?string} The HTML value if we're editing, otherwise null. Null means
@@ -172,6 +181,7 @@ class FieldPitch extends Blockly.FieldTextInput {
     }
     return this.valueToNote(this.getValue()) || null;
   }
+
   /**
    * Transform the provided value into a text to show in the HTML input.
    * @param {*} value The value stored in this field.
@@ -180,6 +190,7 @@ class FieldPitch extends Blockly.FieldTextInput {
   getEditorText_(value) {
     return this.valueToNote(value);
   }
+
   /**
    * Transform the text received from the HTML input (note) into a value
    * to store in this field.
@@ -189,6 +200,7 @@ class FieldPitch extends Blockly.FieldTextInput {
   getValueFromEditorText_(text) {
     return this.noteToValue(text);
   }
+
   /**
    * Updates the graph when the field rerenders.
    * @private
@@ -198,6 +210,7 @@ class FieldPitch extends Blockly.FieldTextInput {
     super.render_();
     this.updateGraph_();
   }
+
   /**
    * Redraw the note picker with the current note.
    * @private
@@ -209,6 +222,7 @@ class FieldPitch extends Blockly.FieldTextInput {
     const i = this.getValue();
     this.imageElement_.style.backgroundPosition = (-i * 37) + 'px 0';
   }
+
   /**
    * Ensure that only a valid value may be entered.
    * @param {*} opt_newValue The input value.


### PR DESCRIPTION
Part of https://github.com/google/blockly-samples/issues/1267

Converts the pitch field example to an ES6 class with const and let. Mostly leaves the rest of the code in place.