### PR TITLE
fix: block-test unregister warning

### DIFF
--- a/plugins/block-test/src/mutators.js
+++ b/plugins/block-test/src/mutators.js
@@ -108,7 +108,9 @@ const MANY_BLOCKS_MUTATOR = {
   },
 };
 
-Blockly.Extensions.unregister('test_many_blocks_mutator');
+if (Blockly.Extensions.isRegistered('test_many_blocks_mutator')) {
+  Blockly.Extensions.unregister('test_many_blocks_mutator');
+};
 
 /**
  * Register custom mutator used by the test_mutators_many block.

--- a/plugins/block-test/src/mutators.js
+++ b/plugins/block-test/src/mutators.js
@@ -110,7 +110,7 @@ const MANY_BLOCKS_MUTATOR = {
 
 if (Blockly.Extensions.isRegistered('test_many_blocks_mutator')) {
   Blockly.Extensions.unregister('test_many_blocks_mutator');
-};
+}
 
 /**
  * Register custom mutator used by the test_mutators_many block.


### PR DESCRIPTION
Fixes #770 

Changes made
- Add `isRegistered` check to `block-test` plugin before calling unregister