### PR TITLE
feat: Update theme-dark to use JSON toolbox definitions instead of xml

### DIFF
--- a/plugins/theme-dark/test/index.js
+++ b/plugins/theme-dark/test/index.js
@@ -11,12 +11,201 @@
 import * as Blockly from 'blockly';
 import Theme from '../src/index';
 
+const toolbox = {
+  'kind': 'categoryToolbox',
+  'contents': [
+    {
+      'kind': 'category',
+      'name': 'Logic',
+      'categorystyle': 'logic_category',
+      'contents': [
+        {
+          'kind': 'block',
+          'type': 'controls_if',
+        },
+        {
+          'kind': 'block',
+          'type': 'logic_compare',
+        },
+        {
+          'kind': 'block',
+          'type': 'logic_operation',
+        },
+        {
+          'kind': 'block',
+          'type': 'logic_negate',
+        },
+        {
+          'kind': 'block',
+          'type': 'logic_boolean',
+        },
+      ],
+    },
+    {
+      'kind': 'category',
+      'name': 'Loops',
+      'categorystyle': 'loop_category',
+      'contents': [
+        {
+          'kind': 'block',
+          'type': 'controls_repeat_ext',
+          'inputs': {
+            'TIMES': {
+              'shadow': {
+                'type': 'math_number',
+                'fields': {
+                  'NUM': 10,
+                },
+              },
+            },
+          },
+        },
+        {
+          'kind': 'block',
+          'type': 'controls_flow_statements',
+        },
+      ],
+    },
+    {
+      'kind': 'category',
+      'name': 'Math',
+      'categorystyle': 'math_category',
+      'contents': [
+        {
+          'kind': 'block',
+          'type': 'math_number',
+          'gap': 32,
+          'fields': {
+            'NUM': 123,
+          },
+        },
+        {
+          'kind': 'block',
+          'type': 'math_arithmetic',
+          'inputs': {
+            'A': {
+              'shadow': {
+                'type': 'math_number',
+                'fields': {
+                  'NUM': 1,
+                },
+              },
+            },
+            'B': {
+              'shadow': {
+                'type': 'math_number',
+                'fields': {
+                  'NUM': 1,
+                },
+              },
+            },
+
+          },
+        },
+        {
+          'kind': 'block',
+          'type': 'math_single',
+          'inputs': {
+            'NUM': {
+              'shadow': {
+                'type': 'math_number',
+                'fields': {
+                  'NUM': 9,
+                },
+              },
+            },
+          },
+        },
+        {
+          'kind': 'block',
+          'type': 'math_number_property',
+          'inputs': {
+            'NUMBER_TO_CHECK': {
+              'shadow': {
+                'type': 'math_number',
+                'fields': {
+                  'NUM': 0,
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
+      'kind': 'category',
+      'name': 'Text',
+      'categorystyle': 'text_category',
+      'contents': [
+        {
+          'kind': 'block',
+          'type': 'text',
+        },
+        {
+          'kind': 'block',
+          'type': 'text_multiline',
+        },
+        {
+          'kind': 'label',
+          'text': 'Input/Output:',
+          'web-class': 'ioLabel',
+        },
+        {
+          'kind': 'block',
+          'type': 'text_print',
+          'inputs': {
+            'TEXT': {
+              'shadow': {
+                'type': 'text',
+                'fields': {
+                  'TEXT': 'abc',
+                },
+              },
+            },
+          },
+        },
+        {
+          'kind': 'block',
+          'type': 'text_prompt_ext',
+          'inputs': {
+            'TEXT': {
+              'shadow': {
+                'type': 'text',
+                'fields': {
+                  'TEXT': 'abc',
+                },
+              },
+            },
+          },
+
+        },
+      ],
+    },
+    {
+      'kind': 'sep',
+    },
+    {
+      'kind': 'category',
+      'name': 'Variables',
+      'categorystyle': 'variable_category',
+      'custom': 'VARIABLE',
+    },
+    {
+      'kind': 'category',
+      'name': 'Functions',
+      'categorystyle': 'procedure_category',
+      'custom': 'PROCEDURE',
+    },
+  ],
+};
+
+
 // Do not use the advanced playground here because it will create a circular
 // dependency with the @blockly/dev-tools package.
 document.addEventListener('DOMContentLoaded', function() {
   Blockly.inject('root', {
     theme: Theme,
-    toolbox: document.getElementById('toolbox'),
+    toolbox: toolbox,
     grid: {
       spacing: 25,
       length: 3,


### PR DESCRIPTION
In this PR theme-dark plugin is modified to use JSON toolbox definitions instead of xml