### PR TITLE
feat: convert block-plus-minus toolbox definition from xml to json

### DIFF
--- a/plugins/block-plus-minus/test/index.html
+++ b/plugins/block-plus-minus/test/index.html
@@ -13,23 +13,6 @@
 <body>
     <div id="root"></div>
 
-    <xml xmlns="https://developers.google.com/blockly/xml" id="toolbox" style="display: none">
-        <category name="Others" categorystyle="logic_category">
-            <block type="controls_if"></block>
-            <block type="controls_if">
-                <mutation else="1"></mutation>
-            </block>
-            <block type="controls_ifelse"></block>
-            <block type="text_join"></block>
-            <block type="lists_create_with">
-                <mutation items="0"></mutation>
-            </block>
-            <block type="lists_create_with"></block>
-        </category>
-        <category name="Functions" categorystyle="procedure_category" custom="PROCEDURE"></category>
-        <category name="Variables" categorystyle="variable_category" custom="VARIABLE"></category>
-    </xml>
-
     <script src="../build/test_bundle.js"></script>
 </body>
 

--- a/plugins/block-plus-minus/test/index.js
+++ b/plugins/block-plus-minus/test/index.js
@@ -24,9 +24,65 @@ function createWorkspace(blocklyDiv, options) {
   return workspace;
 }
 
+const toolbox =
+{
+  'kind': 'categoryToolbox',
+  'contents': [
+    {
+      'kind': 'category',
+      'name': 'Others',
+      'categorystyle': 'logic_category',
+      'contents': [
+        {
+          'kind': 'block',
+          'type': 'controls_if',
+        },
+        {
+          'kind': 'block',
+          'type': 'controls_if',
+          'extraState': {
+            'hasElse': true,
+          },
+        },
+        {
+          'kind': 'block',
+          'type': 'controls_ifelse',
+        },
+        {
+          'kind': 'block',
+          'type': 'text_join',
+        },
+        {
+          'kind': 'block',
+          'type': 'lists_create_with',
+          'extraState': {
+            'itemCount': 0,
+          },
+        },
+        {
+          'kind': 'block',
+          'type': 'lists_create_with',
+        },
+      ],
+    },
+    {
+      'kind': 'category',
+      'name': 'Functions',
+      'categorystyle': 'procedure_category',
+      'custom': 'PROCEDURE',
+    },
+    {
+      'kind': 'category',
+      'name': 'Variables',
+      'categorystyle': 'variable_category',
+      'custom': 'VARIABLE',
+    },
+  ],
+};
+
 document.addEventListener('DOMContentLoaded', function() {
   const defaultOptions = {
-    toolbox: document.getElementById('toolbox'),
+    toolbox: toolbox,
   };
   createPlayground(document.getElementById('root'), createWorkspace,
       defaultOptions);


### PR DESCRIPTION
This pull request fixes https://github.com/google/blockly-samples/issues/1239.

#### What I Did 
Update the code in blockly-samples to use the JSON toolbox API.
(references: https://developers.google.com/blockly/guides/configure/web/toolbox#json)

#### Test Results
![image](https://user-images.githubusercontent.com/6015458/190726265-ec09314e-dbd5-414a-a348-232ef9a811a4.png)
