### PR TITLE
fix: slider field dispose

### DIFF
--- a/plugins/field-slider/src/field_slider.js
+++ b/plugins/field-slider/src/field_slider.js
@@ -136,6 +136,7 @@ export class FieldSlider extends Blockly.FieldNumber {
     for (const event of this.boundEvents_) {
       Blockly.unbindEvent_(event);
     }
+    this.boundEvents_.length = 0;
     this.sliderInput_ = null;
   }
 


### PR DESCRIPTION
Fixes #1272 

The issue was that on dropdown dispose we unbound events but didn't clear the array containing the bind info.

I didn't fix any other issues, because https://github.com/google/blockly-samples/pull/1217 makes extensive changes to the code as it updates to TypeScript.