### PR TITLE
chore: update package-locks

### DIFF
--- a/plugins/dev-tools/package-lock.json
+++ b/plugins/dev-tools/package-lock.json
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.1.tgz",
-      "integrity": "sha512-bi1gRgOptc8tcRMLT4escitvZTF45HgSxP4KKCEuVRQpn1OH5yVQOk/kMnkTwsTySvpoU6SoTYORrZpekmaLoQ==",
+      "version": "9.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.2.tgz",
+      "integrity": "sha512-0lzLxIF+hjKEkfE7cWCZgUqfibtGaq9QS5bE0jAYpjWr1A53Eq8HsLScPtOiprMKz1ofJg65oga9D75RaYxhjg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1389,9 +1389,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.1.tgz",
-      "integrity": "sha512-bi1gRgOptc8tcRMLT4escitvZTF45HgSxP4KKCEuVRQpn1OH5yVQOk/kMnkTwsTySvpoU6SoTYORrZpekmaLoQ==",
+      "version": "9.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.2.tgz",
+      "integrity": "sha512-0lzLxIF+hjKEkfE7cWCZgUqfibtGaq9QS5bE0jAYpjWr1A53Eq8HsLScPtOiprMKz1ofJg65oga9D75RaYxhjg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/field-bitmap/package-lock.json
+++ b/plugins/field-bitmap/package-lock.json
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.1.tgz",
-      "integrity": "sha512-bi1gRgOptc8tcRMLT4escitvZTF45HgSxP4KKCEuVRQpn1OH5yVQOk/kMnkTwsTySvpoU6SoTYORrZpekmaLoQ==",
+      "version": "9.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.2.tgz",
+      "integrity": "sha512-0lzLxIF+hjKEkfE7cWCZgUqfibtGaq9QS5bE0jAYpjWr1A53Eq8HsLScPtOiprMKz1ofJg65oga9D75RaYxhjg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -2184,9 +2184,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "9.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.1.tgz",
-      "integrity": "sha512-bi1gRgOptc8tcRMLT4escitvZTF45HgSxP4KKCEuVRQpn1OH5yVQOk/kMnkTwsTySvpoU6SoTYORrZpekmaLoQ==",
+      "version": "9.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.2.tgz",
+      "integrity": "sha512-0lzLxIF+hjKEkfE7cWCZgUqfibtGaq9QS5bE0jAYpjWr1A53Eq8HsLScPtOiprMKz1ofJg65oga9D75RaYxhjg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/workspace-backpack/package-lock.json
+++ b/plugins/workspace-backpack/package-lock.json
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.1.tgz",
-      "integrity": "sha512-bi1gRgOptc8tcRMLT4escitvZTF45HgSxP4KKCEuVRQpn1OH5yVQOk/kMnkTwsTySvpoU6SoTYORrZpekmaLoQ==",
+      "version": "9.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.2.tgz",
+      "integrity": "sha512-0lzLxIF+hjKEkfE7cWCZgUqfibtGaq9QS5bE0jAYpjWr1A53Eq8HsLScPtOiprMKz1ofJg65oga9D75RaYxhjg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.1.tgz",
-      "integrity": "sha512-bi1gRgOptc8tcRMLT4escitvZTF45HgSxP4KKCEuVRQpn1OH5yVQOk/kMnkTwsTySvpoU6SoTYORrZpekmaLoQ==",
+      "version": "9.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.2.tgz",
+      "integrity": "sha512-0lzLxIF+hjKEkfE7cWCZgUqfibtGaq9QS5bE0jAYpjWr1A53Eq8HsLScPtOiprMKz1ofJg65oga9D75RaYxhjg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"


### PR DESCRIPTION
After this the `blocky-9-beta` branch should be able to run lint, but tests will still fail on the keyboard navigation plugin.

Created by running 
`npm run clean:node`
`npm install`
at the root of the repository.