### PR TITLE
fix: keyboard navigation tests

### DIFF
--- a/plugins/keyboard-navigation/src/navigation_controller.js
+++ b/plugins/keyboard-navigation/src/navigation_controller.js
@@ -113,7 +113,8 @@ export class NavigationController {
           return false;
       }
     }
-    return Blockly.FieldColour.superClass_.onShortcut.call(this, shortcut);
+    // Field is the superclass of FieldColour.
+    return Blockly.Field.prototype.onShortcut.call(this, shortcut);
   }
 
   /**
@@ -139,7 +140,8 @@ export class NavigationController {
           return false;
       }
     }
-    return Blockly.FieldDropdown.superClass_.onShortcut.call(this, shortcut);
+    // Field is the superclass of FieldDropdown.
+    return Blockly.Field.prototype.onShortcut.call(this, shortcut);
   }
 
   /**

--- a/plugins/keyboard-navigation/src/navigation_controller.js
+++ b/plugins/keyboard-navigation/src/navigation_controller.js
@@ -113,7 +113,8 @@ export class NavigationController {
           return false;
       }
     }
-    // Field is the superclass of FieldColour.
+    // If we haven't already handled the shortcut, let the default Field
+    // handler try.
     return Blockly.Field.prototype.onShortcut.call(this, shortcut);
   }
 
@@ -140,7 +141,8 @@ export class NavigationController {
           return false;
       }
     }
-    // Field is the superclass of FieldDropdown.
+    // If we haven't already handled the shortcut, let the default Field
+    // handler try.
     return Blockly.Field.prototype.onShortcut.call(this, shortcut);
   }
 

--- a/plugins/keyboard-navigation/test/navigation_test.mocha.js
+++ b/plugins/keyboard-navigation/test/navigation_test.mocha.js
@@ -23,9 +23,6 @@ suite('Navigation', function() {
   setup(function() {
     this.jsdomCleanup =
         require('jsdom-global')('<!DOCTYPE html><div id="blocklyDiv"></div>');
-    Blockly.utils.dom.getFastTextWidthWithSizeString = function() {
-      return 10;
-    };
     this.controller = new NavigationController();
     this.controller.init();
     this.navigation = this.controller.navigation;
@@ -45,9 +42,9 @@ suite('Navigation', function() {
         'message0': '%1',
         'args0': [
           {
-            'type': 'field_input',
-            'name': 'TEXT',
-            'text': 'default',
+            'type': 'field_colour',
+            'name': 'COLOURFIELD',
+            'colour': '#ff4040',
           },
         ],
       }]);
@@ -56,6 +53,7 @@ suite('Navigation', function() {
     });
 
     teardown(function() {
+      this.navigation.removeWorkspace(this.workspace);
       this.workspace.dispose();
       sinon.restore();
       delete Blockly.Blocks['basic_block'];
@@ -111,9 +109,10 @@ suite('Navigation', function() {
           navigation.getState(this.workspace), Constants.STATE.FLYOUT);
 
       const flyoutCursor = navigation.getFlyoutCursor(this.workspace);
+      // See test_helper.js for hardcoded field values.
       chai.assert.equal(
-          flyoutCursor.getCurNode().getLocation().getFieldValue('TEXT'),
-          'FirstCategory-FirstBlock');
+          flyoutCursor.getCurNode().getLocation().getFieldValue('COLOURFIELD'),
+          '#ff0000');
     });
 
     test('Focuses workspace from toolbox (e)', function() {
@@ -155,9 +154,9 @@ suite('Navigation', function() {
         'message0': '%1',
         'args0': [
           {
-            'type': 'field_input',
-            'name': 'TEXT',
-            'text': 'default',
+            'type': 'field_colour',
+            'name': 'COLOURFIELD',
+            'colour': '#ff4040',
           },
         ],
       }]);
@@ -167,6 +166,7 @@ suite('Navigation', function() {
     });
 
     teardown(function() {
+      this.navigation.removeWorkspace(this.workspace);
       this.workspace.dispose();
       sinon.restore();
       delete Blockly.Blocks['basic_block'];
@@ -183,12 +183,13 @@ suite('Navigation', function() {
       chai.assert.isTrue(keyDownSpy.returned(true));
       chai.assert.equal(
           this.navigation.getState(this.workspace), Constants.STATE.FLYOUT);
+      // See test_helper.js for hardcoded field values.
       chai.assert.equal(
           this.navigation.getFlyoutCursor(this.workspace)
               .getCurNode()
               .getLocation()
-              .getFieldValue('TEXT'),
-          'FirstCategory-FirstBlock');
+              .getFieldValue('COLOURFIELD'),
+          '#ff0000');
     });
     test('Previous', function() {
       const flyoutBlocks =
@@ -198,8 +199,9 @@ suite('Navigation', function() {
       let flyoutBlock = this.navigation.getFlyoutCursor(this.workspace)
           .getCurNode()
           .getLocation();
+      // See test_helper.js for hardcoded field values.
       chai.assert.equal(
-          flyoutBlock.getFieldValue('TEXT'), 'FirstCategory-SecondBlock');
+          flyoutBlock.getFieldValue('COLOURFIELD'), '#00ff00');
 
       const mockEvent =
           createKeyDownEvent(Blockly.utils.KeyCodes.W, 'NotAField');
@@ -214,8 +216,9 @@ suite('Navigation', function() {
       flyoutBlock = this.navigation.getFlyoutCursor(this.workspace)
           .getCurNode()
           .getLocation();
+      // See test_helper.js for hardcoded field values.
       chai.assert.equal(
-          flyoutBlock.getFieldValue('TEXT'), 'FirstCategory-FirstBlock');
+          flyoutBlock.getFieldValue('COLOURFIELD'), '#ff0000');
     });
 
     test('Next', function() {
@@ -232,8 +235,9 @@ suite('Navigation', function() {
       const flyoutBlock = this.navigation.getFlyoutCursor(this.workspace)
           .getCurNode()
           .getLocation();
+      // See test_helper.js for hardcoded field values.
       chai.assert.equal(
-          flyoutBlock.getFieldValue('TEXT'), 'FirstCategory-SecondBlock');
+          flyoutBlock.getFieldValue('COLOURFIELD'), '#00ff00');
     });
 
     test('Out', function() {
@@ -306,9 +310,9 @@ suite('Navigation', function() {
         'message0': '%1',
         'args0': [
           {
-            'type': 'field_input',
-            'name': 'TEXT',
-            'text': 'default',
+            'type': 'field_colour',
+            'name': 'COLOURFIELD',
+            'colour': '#ff4040',
           },
         ],
         'previousStatement': null,
@@ -319,6 +323,7 @@ suite('Navigation', function() {
     });
 
     teardown(function() {
+      this.navigation.removeWorkspace(this.workspace);
       this.workspace.dispose();
       sinon.restore();
       delete Blockly.Blocks['basic_block'];
@@ -442,15 +447,9 @@ suite('Navigation', function() {
         'message0': '%1',
         'args0': [
           {
-            'type': 'field_dropdown',
-            'name': 'OP',
-            'options': [
-              ['%{BKY_MATH_ADDITION_SYMBOL}', 'ADD'],
-              ['%{BKY_MATH_SUBTRACTION_SYMBOL}', 'MINUS'],
-              ['%{BKY_MATH_MULTIPLICATION_SYMBOL}', 'MULTIPLY'],
-              ['%{BKY_MATH_DIVISION_SYMBOL}', 'DIVIDE'],
-              ['%{BKY_MATH_POWER_SYMBOL}', 'POWER'],
-            ],
+            'type': 'field_colour',
+            'name': 'COLOURFIELD',
+            'colour': '#ff4040',
           },
         ],
       }]);
@@ -460,11 +459,11 @@ suite('Navigation', function() {
       this.basicBlock = this.workspace.newBlock('basic_block');
     });
     teardown(function() {
+      this.navigation.removeWorkspace(this.workspace);
       this.workspace.dispose();
       sinon.restore();
       delete Blockly.Blocks['basic_block'];
     });
-
 
     test('Action does not exist', function() {
       const block = this.workspace.getTopBlocks()[0];
@@ -549,14 +548,9 @@ suite('Navigation', function() {
           'message0': '%1 %2',
           'args0': [
             {
-              'type': 'field_dropdown',
-              'name': 'NAME',
-              'options': [
-                [
-                  'a',
-                  'optionA',
-                ],
-              ],
+              'type': 'field_colour',
+              'name': 'COLOURFIELD',
+              'colour': '#ff4040',
             },
             {
               'type': 'input_value',
@@ -577,6 +571,7 @@ suite('Navigation', function() {
       });
 
       teardown(function() {
+        this.navigation.removeWorkspace(this.workspace);
         this.workspace.dispose();
         sinon.restore();
         delete Blockly.Blocks['field_block'];
@@ -627,9 +622,9 @@ suite('Navigation', function() {
         'message0': '%1',
         'args0': [
           {
-            'type': 'field_input',
-            'name': 'TEXT',
-            'text': 'default',
+            'type': 'field_colour',
+            'name': 'COLOURFIELD',
+            'colour': '#ff4040',
           },
         ],
         'previousStatement': null,
@@ -646,6 +641,7 @@ suite('Navigation', function() {
     });
 
     teardown(function() {
+      this.navigation.removeWorkspace(this.workspace);
       this.workspace.dispose();
       sinon.restore();
       delete Blockly.Blocks['basic_block'];
@@ -759,6 +755,7 @@ suite('Navigation', function() {
     });
 
     teardown(function() {
+      this.navigation.removeWorkspace(this.workspace);
       this.workspace.dispose();
       sinon.restore();
       delete Blockly.Blocks['basic_block'];
@@ -851,6 +848,7 @@ suite('Navigation', function() {
     });
 
     teardown(function() {
+      this.navigation.removeWorkspace(this.workspace);
       this.workspace.dispose();
       sinon.restore();
       delete Blockly.Blocks['basic_block'];
@@ -945,9 +943,9 @@ suite('Navigation', function() {
         'message0': '%1',
         'args0': [
           {
-            'type': 'field_input',
-            'name': 'TEXT',
-            'text': 'default',
+            'type': 'field_colour',
+            'name': 'COLOURFIELD',
+            'colour': '#ff4040',
           },
         ],
         'previousStatement': null,
@@ -959,6 +957,8 @@ suite('Navigation', function() {
     });
 
     teardown(function() {
+      this.navigation.removeWorkspace(this.workspace);
+      this.workspace.dispose();
       delete Blockly.Blocks['basic_block'];
       sinon.restore();
     });
@@ -1049,13 +1049,11 @@ suite('Navigation', function() {
         'message0': '%1',
         'args0': [
           {
-            'type': 'field_input',
-            'name': 'TEXT',
-            'text': 'default',
+            'type': 'field_colour',
+            'name': 'COLOURFIELD',
+            'colour': '#ff4040',
           },
         ],
-        'previousStatement': null,
-        'nextStatement': null,
       }]);
       this.workspace = createNavigationWorkspace(this.navigation, true);
       this.flyoutChangeListener = this.navigation.flyoutChangeWrapper;
@@ -1067,6 +1065,8 @@ suite('Navigation', function() {
 
     teardown(function() {
       delete Blockly.Blocks['basic_block'];
+      this.navigation.removeWorkspace(this.workspace);
+      this.workspace.dispose();
       sinon.restore();
     });
     test('Handle block click in flyout - click event', function() {
@@ -1120,8 +1120,8 @@ suite('Navigation', function() {
       this.navigation.removeWorkspace(this.workspace);
       chai.assert.equal(this.workspace.listeners_.length, numListeners - 1);
 
-      const marker = this.workspace.getMarkerManager().markers_[markerName];
-      chai.assert.isUndefined(marker);
+      const marker = this.workspace.getMarkerManager().getMarker(markerName);
+      chai.assert.isNull(marker);
     });
     test('Keyboard accessibility mode can not be enabled', function() {
       this.navigation.removeWorkspace(this.workspace);

--- a/plugins/keyboard-navigation/test/test_helper.js
+++ b/plugins/keyboard-navigation/test/test_helper.js
@@ -24,15 +24,15 @@ export function createNavigationWorkspace(
           id="toolbox-categories" style="display: none">
         <category colour="#FFFFFF" name="First" css-container="something">
           <block type="basic_block">
-            <field name="TEXT">FirstCategory-FirstBlock</field>
+            <field name="COLOURFIELD">#ff0000</field>
           </block>
           <block type="basic_block">
-            <field name="TEXT">FirstCategory-SecondBlock</field>
+            <field name="COLOURFIELD">#00ff00</field>
           </block>
         </category>
         <category colour="#FFFFFF" name="Second">
           <block type="basic_block">
-            <field name="TEXT">SecondCategory-FirstBlock</field>
+            <field name="COLOURFIELD">#0000ff</field>
           </block>
         </category>
       </xml>
@@ -53,7 +53,7 @@ export function createNavigationWorkspace(
  *     enum.
  * @param {string} type The type of the target. This only matters for the
  *     Blockly.utils.isTargetInput method.
- * @param {Array<number>} modifiers A list of modifiers. Use
+ * @param {?Array<number>} modifiers A list of modifiers. Use
  *     Blockly.utils.KeyCodes enum.
  * @return {Object} The mocked keydown
  * event.


### PR DESCRIPTION
## The changes

Actual keyboard nav implementation: Adjust how it's calling a superclass function in a strange bit of monkeypatching code. This change is necessary because of the switch to ES6 classes.

Test code:
- Stop overriding `Blockly.utils.dom.getFastTextWidthWithSizeString`. 
  - This is no longer accessible for replacement. Unfortunately, without this monkeypatch, the tests fail any time they try to render a field with text that has to be measured.
- Replace text fields with colour fields in test blocks.
  - Colour fields can render just fine, because they don't need text width measurement. The fields are mostly used to test that the correct block has been selected after a series of key presses. That happens by looking at the value of the field, which is set in the hardcoded toolbox definition. I updated the block definitions, toolbox definitions, and test assertions to all be for my colour fields.
- Don't access a private field in `MarkerManager` for a test assert. Particularly since that field's name has changed. Use the getter instead.
- Call `this.navigation.removeWorkspace(this.workspace)` in the test teardown for each suite. Otherwise the workspace is disposed before being removed from `this.navigation`, which means that the `navigation` object is manipulating an already-disposed `WorkspaceSvg` object. 
  - **I'm not sure why this worked before.**


## Tested
In the keyboard nav playground and with automated tests.