### PR TITLE
chore!: update peer and devDependencies of all plugins to require Blockly v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "blockly": "^9.0.0-beta.4"
-      },
       "devDependencies": {
         "@blockly/eslint-config": "^2.1.7",
         "eslint": "^7.15.0",
@@ -3319,11 +3316,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
-    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -3346,26 +3338,7 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-globals": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-      "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
-      "dependencies": {
-        "acorn": "^6.0.1",
-        "acorn-walk": "^6.0.1"
-      }
-    },
-    "node_modules/acorn-globals/node_modules/acorn": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3380,14 +3353,6 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/add-stream": {
@@ -3439,6 +3404,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3788,11 +3754,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/array-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha512-H3LU5RLiSsGXPhN+Nipar0iR0IofH+8r89G2y1tBKxQ/agagKyAjhkAFDRBfodP2caPrNKHpAWNIM/c9yeL7uA=="
-    },
     "node_modules/array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -3916,22 +3877,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -3992,11 +3937,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -4017,19 +3957,6 @@
       "engines": {
         "node": ">= 4.5.0"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "node_modules/babel-eslint": {
       "version": "10.1.0",
@@ -4184,14 +4111,6 @@
         }
       ]
     },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "node_modules/before-after-hook": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
@@ -4259,14 +4178,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
-      "dependencies": {
-        "jsdom": "15.2.1"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4297,11 +4208,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/browser-process-hrtime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -4554,11 +4460,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -4917,17 +4818,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -5336,27 +5226,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/cssom": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
-    },
-    "node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "dependencies": {
-        "cssom": "~0.3.6"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-    },
     "node_modules/d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -5374,50 +5243,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/data-urls": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-      "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
-      "dependencies": {
-        "abab": "^2.0.0",
-        "whatwg-mimetype": "^2.2.0",
-        "whatwg-url": "^7.0.0"
-      }
-    },
-    "node_modules/data-urls/node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/data-urls/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-    },
-    "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/dateformat": {
@@ -5525,7 +5350,8 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/default-compare": {
       "version": "1.0.0",
@@ -5605,14 +5431,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -5686,19 +5504,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/domexception": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-      "dependencies": {
-        "webidl-conversions": "^4.0.2"
-      }
-    },
-    "node_modules/domexception/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-    },
     "node_modules/dot-prop": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
@@ -5767,15 +5572,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/email-addresses": {
@@ -5930,83 +5726,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -6321,6 +6040,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -6375,6 +6095,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -6383,6 +6104,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6488,7 +6210,8 @@
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
@@ -6594,14 +6317,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
     "node_modules/fancy-log": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
@@ -6620,7 +6335,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -6641,12 +6357,14 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -6994,27 +6712,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -7310,14 +7007,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
       }
     },
     "node_modules/gh-pages": {
@@ -7838,27 +7527,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -7970,14 +7638,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/html-encoding-sniffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-      "dependencies": {
-        "whatwg-encoding": "^1.0.1"
-      }
-    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -7996,20 +7656,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -8047,6 +7693,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -8409,14 +8056,6 @@
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
     },
-    "node_modules/ip-regex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -8717,7 +8356,8 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true
     },
     "node_modules/is-unc-path": {
       "version": "1.0.0",
@@ -8800,11 +8440,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
-    },
     "node_modules/js-green-licenses": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-1.1.0.tgz",
@@ -8845,11 +8480,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
-    },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.2.tgz",
@@ -8857,73 +8487,6 @@
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/jsdom": {
-      "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
-      "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
-      "dependencies": {
-        "abab": "^2.0.0",
-        "acorn": "^7.1.0",
-        "acorn-globals": "^4.3.2",
-        "array-equal": "^1.0.0",
-        "cssom": "^0.4.1",
-        "cssstyle": "^2.0.0",
-        "data-urls": "^1.1.0",
-        "domexception": "^1.0.1",
-        "escodegen": "^1.11.1",
-        "html-encoding-sniffer": "^1.0.2",
-        "nwsapi": "^2.2.0",
-        "parse5": "5.1.0",
-        "pn": "^1.1.0",
-        "request": "^2.88.0",
-        "request-promise-native": "^1.0.7",
-        "saxes": "^3.1.9",
-        "symbol-tree": "^3.2.2",
-        "tough-cookie": "^3.0.1",
-        "w3c-hr-time": "^1.0.1",
-        "w3c-xmlserializer": "^1.1.2",
-        "webidl-conversions": "^4.0.2",
-        "whatwg-encoding": "^1.0.5",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^7.0.0",
-        "ws": "^7.0.0",
-        "xml-name-validator": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jsdom/node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/jsdom/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-    },
-    "node_modules/jsdom/node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/jsesc": {
@@ -8956,15 +8519,11 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -8984,7 +8543,8 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
     },
     "node_modules/json-to-pretty-yaml": {
       "version": "1.2.2",
@@ -9049,20 +8609,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/just-debounce": {
@@ -9447,7 +8993,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -9466,11 +9013,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
@@ -10072,25 +9614,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -10973,11 +10496,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/nwsapi": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw=="
-    },
     "node_modules/nx": {
       "version": "14.5.8",
       "resolved": "https://registry.npmjs.org/nx/-/nx-14.5.8.tgz",
@@ -11436,14 +10954,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/object-assign": {
@@ -12140,11 +11650,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse5": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
-    },
     "node_modules/pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -12223,11 +11728,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
-    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -12284,11 +11784,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/pn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
     },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
@@ -12408,11 +11903,6 @@
       "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
       "dev": true
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-    },
     "node_modules/pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -12438,6 +11928,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -12450,14 +11941,6 @@
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/queue-microtask": {
@@ -13188,101 +12671,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/request/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -13501,7 +12889,8 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -13515,18 +12904,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/saxes": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
-      "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
-      "dependencies": {
-        "xmlchars": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "7.3.5",
@@ -14077,30 +13456,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "node_modules/sshpk": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ssri": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
@@ -14131,14 +13486,6 @@
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14294,11 +13641,6 @@
         "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
       }
-    },
-    "node_modules/symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/table": {
       "version": "6.8.0",
@@ -14648,19 +13990,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-      "dependencies": {
-        "ip-regex": "^2.1.0",
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tr46": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
@@ -14729,22 +14058,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/type": {
       "version": "1.2.0",
@@ -14983,6 +14296,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -15076,24 +14390,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
-    },
     "node_modules/vinyl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
@@ -15169,29 +14465,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/w3c-hr-time": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-      "dependencies": {
-        "browser-process-hrtime": "^1.0.0"
-      }
-    },
-    "node_modules/w3c-xmlserializer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
-      "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
-      "dependencies": {
-        "domexception": "^1.0.1",
-        "webidl-conversions": "^4.0.2",
-        "xml-name-validator": "^3.0.0"
-      }
-    },
-    "node_modules/w3c-xmlserializer/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-    },
     "node_modules/walk-up-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-1.0.0.tgz",
@@ -15215,19 +14488,6 @@
       "engines": {
         "node": ">=10.4"
       }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-      "dependencies": {
-        "iconv-lite": "0.4.24"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
     },
     "node_modules/whatwg-url": {
       "version": "8.7.0",
@@ -15277,6 +14537,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15509,36 +14770,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/xml-name-validator": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
-    },
-    "node_modules/xmlchars": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -18393,11 +17624,6 @@
         "eslint-visitor-keys": "^3.0.0"
       }
     },
-    "abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
-    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -18416,23 +17642,8 @@
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
-    },
-    "acorn-globals": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-      "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
-      "requires": {
-        "acorn": "^6.0.1",
-        "acorn-walk": "^6.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.4.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
-        }
-      }
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -18440,11 +17651,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
-    },
-    "acorn-walk": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
     },
     "add-stream": {
       "version": "1.0.0",
@@ -18486,6 +17692,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18754,11 +17961,6 @@
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
       "dev": true
     },
-    "array-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha512-H3LU5RLiSsGXPhN+Nipar0iR0IofH+8r89G2y1tBKxQ/agagKyAjhkAFDRBfodP2caPrNKHpAWNIM/c9yeL7uA=="
-    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -18853,19 +18055,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
-    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -18914,11 +18103,6 @@
         "async-done": "^1.2.2"
       }
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -18930,16 +18114,6 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
-    },
-    "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -19053,14 +18227,6 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "before-after-hook": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
@@ -19121,14 +18287,6 @@
         }
       }
     },
-    "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
-      "requires": {
-        "jsdom": "15.2.1"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -19156,11 +18314,6 @@
         "split-string": "^3.0.2",
         "to-regex": "^3.0.1"
       }
-    },
-    "browser-process-hrtime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "buffer": {
       "version": "5.7.1",
@@ -19352,11 +18505,6 @@
         "map-obj": "^4.0.0",
         "quick-lru": "^4.0.1"
       }
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -19648,14 +18796,6 @@
       "requires": {
         "strip-ansi": "^6.0.1",
         "wcwidth": "^1.0.0"
-      }
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -20007,26 +19147,6 @@
         "which": "^2.0.1"
       }
     },
-    "cssom": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
-    },
-    "cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "requires": {
-        "cssom": "~0.3.6"
-      },
-      "dependencies": {
-        "cssom": {
-          "version": "0.3.8",
-          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
-        }
-      }
-    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -20042,49 +19162,6 @@
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
       "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
       "dev": true
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "data-urls": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-      "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
-      "requires": {
-        "abab": "^2.0.0",
-        "whatwg-mimetype": "^2.2.0",
-        "whatwg-url": "^7.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-          "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-        },
-        "whatwg-url": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-          "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
-          }
-        }
-      }
     },
     "dateformat": {
       "version": "3.0.3",
@@ -20161,7 +19238,8 @@
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "default-compare": {
       "version": "1.0.0",
@@ -20225,11 +19303,6 @@
         "is-descriptor": "^0.1.0"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -20286,21 +19359,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "domexception": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-      "requires": {
-        "webidl-conversions": "^4.0.2"
-      },
-      "dependencies": {
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-        }
       }
     },
     "dot-prop": {
@@ -20361,15 +19419,6 @@
             "isobject": "^3.0.1"
           }
         }
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "email-addresses": {
@@ -20506,61 +19555,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
-    },
-    "escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
-          }
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
-        }
-      }
     },
     "eslint": {
       "version": "7.32.0",
@@ -20789,7 +19783,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.4.0",
@@ -20828,12 +19823,14 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "event-target-shim": {
       "version": "5.0.1",
@@ -20925,7 +19922,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "2.0.1",
@@ -21009,11 +20007,6 @@
         }
       }
     },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
-    },
     "fancy-log": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
@@ -21029,7 +20022,8 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.11",
@@ -21047,12 +20041,14 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fastq": {
       "version": "1.13.0",
@@ -21323,21 +20319,6 @@
         "for-in": "^1.0.1"
       }
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -21562,14 +20543,6 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "gh-pages": {
       "version": "3.2.3",
@@ -21993,20 +20966,6 @@
         }
       }
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
-    },
     "hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -22090,14 +21049,6 @@
         "lru-cache": "^6.0.0"
       }
     },
-    "html-encoding-sniffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-      "requires": {
-        "whatwg-encoding": "^1.0.1"
-      }
-    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -22113,16 +21064,6 @@
         "@tootallnate/once": "2",
         "agent-base": "6",
         "debug": "4"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -22154,6 +21095,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -22424,11 +21366,6 @@
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
     },
-    "ip-regex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw=="
-    },
     "is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -22654,7 +21591,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true
     },
     "is-unc-path": {
       "version": "1.0.0",
@@ -22716,11 +21654,6 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
-    },
     "js-green-licenses": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-1.1.0.tgz",
@@ -22752,74 +21685,11 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
-    },
     "jsdoc-type-pratt-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.2.tgz",
       "integrity": "sha512-zRokSWcPLSWkoNzsWn9pq7YYSwDhKyEe+cJYT2qaPqLOOJb5sFSi46BPj81vP+e8chvCNdQL9RG86Bi9EI6MDw==",
       "dev": true
-    },
-    "jsdom": {
-      "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
-      "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
-      "requires": {
-        "abab": "^2.0.0",
-        "acorn": "^7.1.0",
-        "acorn-globals": "^4.3.2",
-        "array-equal": "^1.0.0",
-        "cssom": "^0.4.1",
-        "cssstyle": "^2.0.0",
-        "data-urls": "^1.1.0",
-        "domexception": "^1.0.1",
-        "escodegen": "^1.11.1",
-        "html-encoding-sniffer": "^1.0.2",
-        "nwsapi": "^2.2.0",
-        "parse5": "5.1.0",
-        "pn": "^1.1.0",
-        "request": "^2.88.0",
-        "request-promise-native": "^1.0.7",
-        "saxes": "^3.1.9",
-        "symbol-tree": "^3.2.2",
-        "tough-cookie": "^3.0.1",
-        "w3c-hr-time": "^1.0.1",
-        "w3c-xmlserializer": "^1.1.2",
-        "webidl-conversions": "^4.0.2",
-        "whatwg-encoding": "^1.0.5",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^7.0.0",
-        "ws": "^7.0.0",
-        "xml-name-validator": "^3.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-          "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-        },
-        "whatwg-url": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-          "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
-          }
-        }
-      }
     },
     "jsesc": {
       "version": "2.5.2",
@@ -22845,15 +21715,11 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -22870,7 +21736,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
     },
     "json-to-pretty-yaml": {
       "version": "1.2.2",
@@ -22920,17 +21787,6 @@
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
-      }
-    },
-    "jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
       }
     },
     "just-debounce": {
@@ -23247,7 +22103,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -23266,11 +22123,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -23740,19 +22592,6 @@
             "is-number": "^7.0.0"
           }
         }
-      }
-    },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "requires": {
-        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {
@@ -24449,11 +23288,6 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "nwsapi": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw=="
-    },
     "nx": {
       "version": "14.5.8",
       "resolved": "https://registry.npmjs.org/nx/-/nx-14.5.8.tgz",
@@ -24789,11 +23623,6 @@
           "dev": true
         }
       }
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -25313,11 +24142,6 @@
         }
       }
     },
-    "parse5": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
-    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -25375,11 +24199,6 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
-    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -25415,11 +24234,6 @@
       "requires": {
         "find-up": "^4.0.0"
       }
-    },
-    "pn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -25512,11 +24326,6 @@
       "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
       "dev": true
     },
-    "psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-    },
     "pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -25541,18 +24350,14 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
       "dev": true
-    },
-    "qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -26115,78 +24920,6 @@
         "remove-trailing-separator": "^1.1.0"
       }
     },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "requires": {
-        "lodash": "^4.17.19"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "requires": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "dependencies": {
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        }
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -26345,7 +25078,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -26359,15 +25093,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "saxes": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
-      "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
-      "requires": {
-        "xmlchars": "^2.1.1"
-      }
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "semver": {
       "version": "7.3.5",
@@ -26818,22 +25545,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sshpk": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "ssri": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
@@ -26858,11 +25569,6 @@
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
       }
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g=="
     },
     "stream-exhaust": {
       "version": "1.0.2",
@@ -26976,11 +25682,6 @@
         "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
       }
-    },
-    "symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "table": {
       "version": "6.8.0",
@@ -27262,16 +25963,6 @@
         "through2": "^2.0.3"
       }
     },
-    "tough-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
-      "requires": {
-        "ip-regex": "^2.1.0",
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
     "tr46": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
@@ -27327,19 +26018,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "type": {
       "version": "1.2.0",
@@ -27531,6 +26209,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -27608,23 +26287,6 @@
       "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
       "dev": true
     },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      },
-      "dependencies": {
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
-        }
-      }
-    },
     "vinyl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
@@ -27690,31 +26352,6 @@
         }
       }
     },
-    "w3c-hr-time": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-      "requires": {
-        "browser-process-hrtime": "^1.0.0"
-      }
-    },
-    "w3c-xmlserializer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
-      "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
-      "requires": {
-        "domexception": "^1.0.1",
-        "webidl-conversions": "^4.0.2",
-        "xml-name-validator": "^3.0.0"
-      },
-      "dependencies": {
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-        }
-      }
-    },
     "walk-up-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-1.0.0.tgz",
@@ -27735,19 +26372,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
       "dev": true
-    },
-    "whatwg-encoding": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-      "requires": {
-        "iconv-lite": "0.4.24"
-      }
-    },
-    "whatwg-mimetype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
     },
     "whatwg-url": {
       "version": "8.7.0",
@@ -27787,7 +26411,8 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -27972,22 +26597,6 @@
           }
         }
       }
-    },
-    "ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "requires": {}
-    },
-    "xml-name-validator": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
-    },
-    "xmlchars": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,5 @@
   },
   "eslintConfig": {
     "extends": "@blockly/eslint-config"
-  },
-  "dependencies": {
-    "blockly": "^9.0.0-beta.4"
   }
 }

--- a/plugins/block-dynamic-connection/package-lock.json
+++ b/plugins/block-dynamic-connection/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.36",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4",
+        "blockly": "^9.0.0",
         "chai": "^4.2.0",
         "mocha": "^7.1.0"
       },
@@ -216,9 +216,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -2693,9 +2693,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -47,7 +47,7 @@
     "mocha": "^7.1.0"
   },
   "peerDependencies": {
-    "blockly": ">=3 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4",
+    "blockly": "^9.0.0",
     "chai": "^4.2.0",
     "mocha": "^7.1.0"
   },

--- a/plugins/block-plus-minus/package-lock.json
+++ b/plugins/block-plus-minus/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.22",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4",
+        "blockly": "^9.0.0",
         "chai": "^4.2.0",
         "mocha": "^7.1.0",
         "sinon": "^9.0.1"
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -2693,9 +2693,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/block-plus-minus/package.json
+++ b/plugins/block-plus-minus/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4",
+    "blockly": "^9.0.0",
     "chai": "^4.2.0",
     "mocha": "^7.1.0",
     "sinon": "^9.0.1"

--- a/plugins/block-plus-minus/package.json
+++ b/plugins/block-plus-minus/package.json
@@ -47,7 +47,7 @@
     "sinon": "^9.0.1"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/block-test/package-lock.json
+++ b/plugins/block-test/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.18",
       "license": "Apache 2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/block-test/package.json
+++ b/plugins/block-test/package.json
@@ -43,7 +43,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/block-test/package.json
+++ b/plugins/block-test/package.json
@@ -40,7 +40,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=7 <10"

--- a/plugins/content-highlight/package-lock.json
+++ b/plugins/content-highlight/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.31",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=5.20210325.0 <10"

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -48,7 +48,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=5.20210325.0 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/continuous-toolbox/package-lock.json
+++ b/plugins/continuous-toolbox/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.40",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=7 <10"

--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -44,7 +44,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/cross-tab-copy-paste/package-lock.json
+++ b/plugins/cross-tab-copy-paste/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1112,9 +1112,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=7 <10"

--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -45,7 +45,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/dev-tools/package-lock.json
+++ b/plugins/dev-tools/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@types/dat.gui": "^0.7.5",
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1389,9 +1389,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@types/dat.gui": "^0.7.5",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=8 <10"

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -57,7 +57,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=8 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/disable-top-blocks/package-lock.json
+++ b/plugins/disable-top-blocks/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.42",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -44,7 +44,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=3.20200924.3 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=3.20200924.3 <10"

--- a/plugins/field-bitmap/package-lock.json
+++ b/plugins/field-bitmap/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.7",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4",
+        "blockly": "^9.0.0",
         "chai": "^4.3.6",
         "mocha": "^9.2.1"
       },
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -2184,9 +2184,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/field-bitmap/package.json
+++ b/plugins/field-bitmap/package.json
@@ -48,7 +48,7 @@
     "mocha": "^9.2.1"
   },
   "peerDependencies": {
-    "blockly": ">=7.20211209.2 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-bitmap/package.json
+++ b/plugins/field-bitmap/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4",
+    "blockly": "^9.0.0",
     "chai": "^4.3.6",
     "mocha": "^9.2.1"
   },

--- a/plugins/field-colour-hsv-sliders/package-lock.json
+++ b/plugins/field-colour-hsv-sliders/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1112,9 +1112,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/field-colour-hsv-sliders/package.json
+++ b/plugins/field-colour-hsv-sliders/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=7 <10"

--- a/plugins/field-colour-hsv-sliders/package.json
+++ b/plugins/field-colour-hsv-sliders/package.json
@@ -47,7 +47,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-date/package-lock.json
+++ b/plugins/field-date/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.22",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4",
+        "blockly": "^9.0.0",
         "google-closure-compiler": "^20200920.0.0",
         "google-closure-library": "^20200830.0.0",
         "gulp": "^4.0.2",
@@ -553,9 +553,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -5803,9 +5803,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -48,7 +48,7 @@
     "gulp-sourcemaps": "^2.6.5"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4",
+    "blockly": "^9.0.0",
     "google-closure-compiler": "^20200920.0.0",
     "google-closure-library": "^20200830.0.0",
     "gulp": "^4.0.2",

--- a/plugins/field-grid-dropdown/package-lock.json
+++ b/plugins/field-grid-dropdown/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.47",
       "license": "Apache 2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=7 <10"

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -45,7 +45,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-slider/package-lock.json
+++ b/plugins/field-slider/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.22",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4",
+        "blockly": "^9.0.0",
         "chai": "^4.2.0",
         "sinon": "^9.0.1"
       },
@@ -184,9 +184,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1376,9 +1376,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4",
+    "blockly": "^9.0.0",
     "chai": "^4.2.0",
     "sinon": "^9.0.1"
   },

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -47,7 +47,7 @@
     "sinon": "^9.0.1"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/fixed-edges/package-lock.json
+++ b/plugins/fixed-edges/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.40",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=5.20210325.0 <10"

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -44,7 +44,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=5.20210325.0 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/keyboard-navigation/package-lock.json
+++ b/plugins/keyboard-navigation/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.22",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4",
+        "blockly": "^9.0.0",
         "chai": "^4.2.0",
         "jsdom": "^16.4.0",
         "jsdom-global": "^3.0.2",
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -3230,9 +3230,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/keyboard-navigation/package.json
+++ b/plugins/keyboard-navigation/package.json
@@ -50,7 +50,7 @@
     "sinon": "^9.0.1"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/keyboard-navigation/package.json
+++ b/plugins/keyboard-navigation/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4",
+    "blockly": "^9.0.0",
     "chai": "^4.2.0",
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",

--- a/plugins/modal/package-lock.json
+++ b/plugins/modal/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.22",
       "license": "Apache 2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4",
+        "blockly": "^9.0.0",
         "jsdom": "^19.0.0",
         "jsdom-global": "3.0.2",
         "mocha": "^7.1.0",
@@ -272,9 +272,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -3209,9 +3209,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -49,7 +49,7 @@
     "sinon": "7.5.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4",
+    "blockly": "^9.0.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",
     "mocha": "^7.1.0",

--- a/plugins/scroll-options/package-lock.json
+++ b/plugins/scroll-options/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.23",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=7 <10"

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -45,7 +45,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/serialize-disabled-interactions/package-lock.json
+++ b/plugins/serialize-disabled-interactions/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.18",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4",
+        "blockly": "^9.0.0",
         "chai": "^4.3.4"
       },
       "engines": {
@@ -148,9 +148,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1217,9 +1217,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/serialize-disabled-interactions/package.json
+++ b/plugins/serialize-disabled-interactions/package.json
@@ -46,7 +46,7 @@
     "chai": "^4.3.4"
   },
   "peerDependencies": {
-    "blockly": ">=6.20210701.0 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/serialize-disabled-interactions/package.json
+++ b/plugins/serialize-disabled-interactions/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4",
+    "blockly": "^9.0.0",
     "chai": "^4.3.4"
   },
   "peerDependencies": {

--- a/plugins/strict-connection-checker/package-lock.json
+++ b/plugins/strict-connection-checker/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.47",
       "license": "Apache 2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4",
+        "blockly": "^9.0.0",
         "chai": "^4.2.0"
       },
       "engines": {
@@ -148,9 +148,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1217,9 +1217,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4",
+    "blockly": "^9.0.0",
     "chai": "^4.2.0"
   },
   "peerDependencies": {

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -48,7 +48,7 @@
     "chai": "^4.2.0"
   },
   "peerDependencies": {
-    "blockly": ">=3.20200924.1 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/suggested-blocks/package-lock.json
+++ b/plugins/suggested-blocks/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4",
+        "blockly": "^9.0.0",
         "chai": "^4.3.6",
         "sinon": "^14.0.0"
       },
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1370,9 +1370,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/suggested-blocks/package.json
+++ b/plugins/suggested-blocks/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4",
+    "blockly": "^9.0.0",
     "chai": "^4.3.6",
     "sinon": "^14.0.0"
   },

--- a/plugins/suggested-blocks/package.json
+++ b/plugins/suggested-blocks/package.json
@@ -48,7 +48,7 @@
     "sinon": "^14.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=8.0.2 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/theme-dark/package-lock.json
+++ b/plugins/theme-dark/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.17",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -45,7 +45,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -42,7 +42,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=7 <10"

--- a/plugins/theme-deuteranopia/package-lock.json
+++ b/plugins/theme-deuteranopia/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.17",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/theme-deuteranopia/package.json
+++ b/plugins/theme-deuteranopia/package.json
@@ -45,7 +45,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/theme-deuteranopia/package.json
+++ b/plugins/theme-deuteranopia/package.json
@@ -42,7 +42,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=7 <10"

--- a/plugins/theme-highcontrast/package-lock.json
+++ b/plugins/theme-highcontrast/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.17",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/theme-highcontrast/package.json
+++ b/plugins/theme-highcontrast/package.json
@@ -45,7 +45,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/theme-highcontrast/package.json
+++ b/plugins/theme-highcontrast/package.json
@@ -42,7 +42,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=7 <10"

--- a/plugins/theme-modern/package-lock.json
+++ b/plugins/theme-modern/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.42",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -42,7 +42,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=3.20200123.0 <10"

--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -45,7 +45,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=3.20200123.0 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/theme-tritanopia/package-lock.json
+++ b/plugins/theme-tritanopia/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.17",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/theme-tritanopia/package.json
+++ b/plugins/theme-tritanopia/package.json
@@ -45,7 +45,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/theme-tritanopia/package.json
+++ b/plugins/theme-tritanopia/package.json
@@ -42,7 +42,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=7 <10"

--- a/plugins/typed-variable-modal/package-lock.json
+++ b/plugins/typed-variable-modal/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.22",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4",
+        "blockly": "^9.0.0",
         "jsdom": "^19.0.0",
         "jsdom-global": "3.0.2",
         "mocha": "^7.1.0",
@@ -272,9 +272,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -3209,9 +3209,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4",
+    "blockly": "^9.0.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",
     "mocha": "^7.1.0",

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -49,7 +49,7 @@
     "sinon": "7.5.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "dependencies": {
     "@blockly/plugin-modal": "^3.0.22"

--- a/plugins/workspace-backpack/package-lock.json
+++ b/plugins/workspace-backpack/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.16",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=7 <10"

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -46,7 +46,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/workspace-search/package-lock.json
+++ b/plugins/workspace-search/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.22",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4",
+        "blockly": "^9.0.0",
         "jsdom": "^19.0.0",
         "jsdom-global": "3.0.2",
         "sinon": "^9.0.1"
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1731,9 +1731,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -48,7 +48,7 @@
     "sinon": "^9.0.1"
   },
   "peerDependencies": {
-    "blockly": ">=7 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4",
+    "blockly": "^9.0.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",
     "sinon": "^9.0.1"

--- a/plugins/zoom-to-fit/package-lock.json
+++ b/plugins/zoom-to-fit/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.31",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^9.0.0-beta.4"
+        "blockly": "^9.0.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -1126,9 +1126,9 @@
       }
     },
     "blockly": {
-      "version": "9.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0-beta.4.tgz",
-      "integrity": "sha512-+Hfme05eture5TWpLYHDOJuENLqkPEzv00LtXcYgfKWoTHN/5lgDRnCCm0wKVke6ZKkcjYL9FU5R4uBqjFUWMw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -44,7 +44,7 @@
     "blockly": "^9.0.0"
   },
   "peerDependencies": {
-    "blockly": ">=6.20210701.0 <10"
+    "blockly": "^9.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.27",
     "@blockly/dev-tools": "^4.0.3",
-    "blockly": "^9.0.0-beta.4"
+    "blockly": "^9.0.0"
   },
   "peerDependencies": {
     "blockly": ">=6.20210701.0 <10"


### PR DESCRIPTION
1. Updates devDependencies from beta to the main release.
2. (breaking change) Updates peerDependencies to require v9 of Blockly. The reason we are doing this unilaterally for all plugins is that we don't test plugins with older releases of Blockly. Some of the plugins had to be changed to be compatible with v9, and some of them may already be broken on older releases that they claim to be compatible with, because when we change the plugins we don't check which version of Blockly an API was added in, etc. 
3. Remove the dependency on blockly from root of blockly-samples. It's not needed and was probably erroneously added when someone was linking or unlinking to test the beta.

If you're seeing this PR from release notes about breaking changes, know that if you've upgraded to Blockly v9 and are using any plugins, you should also update the plugin to the next major version. There are no other breaking changes in this release of any plugins. If you haven't yet upgraded to Blockly v9 but are using plugins, don't upgrade to the next major version of the plugin until you've updated Blockly.

~~Note that because of the way lerna handles package dependencies within the monorepo, this PR must not be released using the standard release process. Do not click the auto-release button until the release including this change has already been handled manually.~~ This concern seems not to apply anymore after careful testing with `lerna version`.