### PR TITLE
chore: Update lerna-version to use the correct form of conventional commits

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,8 @@
       "registry": "https://wombat-dressing-room.appspot.com"
     }
   },
+  "changelogPreset": {
+    "name": "conventionalcommits"
+  },
   "ignoreChanges": ["plugins/**/package-lock.json"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/eslint-config": "^2.1.7",
+        "conventional-changelog-conventionalcommits": "^5.0.0",
         "eslint": "^7.15.0",
         "gh-pages": "^3.1.0",
         "gulp": "^4.0.2",
@@ -4937,6 +4938,20 @@
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
         "q": "^1.5.1"
       },
       "engines": {
@@ -18907,6 +18922,17 @@
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
         "q": "^1.5.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@blockly/eslint-config": "^2.1.7",
+    "conventional-changelog-conventionalcommits": "^5.0.0",
     "eslint": "^7.15.0",
     "gh-pages": "^3.1.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
By default, lerna uses the "angular" preset, and apparently the angular spec does not use `!` to represent breaking changes. This can cause lerna to incorrectly set the version numbers.

This PR configures lerna to use the same conventional commit spec that we use.

See https://github.com/lerna/lerna/issues/2668#issuecomment-708632441