### PR TITLE
feat: automatically release samples on a schedule

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,10 @@
 
 name: publish
 
-on: workflow_dispatch  # Manually trigger.
+on:
+  workflow_dispatch:  # Manually trigger. Colon is required.
+  schedule:
+    cron: '5 17 * * 4' # Thursdays at 17:05 UTC (09:05 PST / 10:05 PDT)
 
 permissions:
   contents: write  # For checkout and tag.


### PR DESCRIPTION
Sets up the release action to run on a schedule, specifically at 10:05 PDT (9:05 PST) on Thursdays. Also left the manual trigger so we can release on demand if needed.

The reason it's at :05 is because GH says actions that run on the hour exactly are popular and the machine resources may not be open, so waiting a few minutes decreases the chance the workflow will be delayed.