### PR TITLE
fix: react demo not loading or generating code

### DIFF
--- a/examples/blockly-react/package-lock.json
+++ b/examples/blockly-react/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@blockly/field-date": "^5.0.16",
-        "blockly": "^8.0.3",
+        "@blockly/field-date": "^6.0.0",
+        "blockly": "^9.0.0",
         "react": "^17.0.1",
         "react-datepicker": "^3.3.0",
         "react-dom": "^17.0.1",
@@ -1183,14 +1183,14 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@blockly/field-date": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/@blockly/field-date/-/field-date-5.0.16.tgz",
-      "integrity": "sha512-sXoe0rPrHaN5RK0Vpc0U4QbPXy+HUiOrOS0HGXQyMaGZGvaBi4vigTIGEW4UHqY8ut8kpqnakgKkPDJkRF3bhg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@blockly/field-date/-/field-date-6.0.0.tgz",
+      "integrity": "sha512-7Ggphysvk7ItCjDmoWLHSVa2vwLDi6HwFQ9m3GjJpqTDTrUxS+MRu1n81+kywNnTQD0lJUBoBGbgIBOoRKOj9Q==",
       "engines": {
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": ">=7 <9"
+        "blockly": "^9.0.0"
       }
     },
     "node_modules/@cnakazawa/watch": {
@@ -4011,9 +4011,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-8.0.3.tgz",
-      "integrity": "sha512-6sufD+HiKjLk8BtF/mAZagnwr41TQqcj74W1m+qB4pFttXrSWiSsWRsBnJYRMxuAO7iuLcehaQhBbCs3LkoLVw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "dependencies": {
         "jsdom": "15.2.1"
       }
@@ -21283,9 +21283,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@blockly/field-date": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/@blockly/field-date/-/field-date-5.0.16.tgz",
-      "integrity": "sha512-sXoe0rPrHaN5RK0Vpc0U4QbPXy+HUiOrOS0HGXQyMaGZGvaBi4vigTIGEW4UHqY8ut8kpqnakgKkPDJkRF3bhg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@blockly/field-date/-/field-date-6.0.0.tgz",
+      "integrity": "sha512-7Ggphysvk7ItCjDmoWLHSVa2vwLDi6HwFQ9m3GjJpqTDTrUxS+MRu1n81+kywNnTQD0lJUBoBGbgIBOoRKOj9Q==",
       "requires": {}
     },
     "@cnakazawa/watch": {
@@ -23663,9 +23663,9 @@
       "optional": true
     },
     "blockly": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-8.0.3.tgz",
-      "integrity": "sha512-6sufD+HiKjLk8BtF/mAZagnwr41TQqcj74W1m+qB4pFttXrSWiSsWRsBnJYRMxuAO7iuLcehaQhBbCs3LkoLVw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.0.0.tgz",
+      "integrity": "sha512-V8rAT3N4QJ5r2emMGAf8D/yhwmAEfMnu/JVXmcvmS6dFcWR8g8aVlYpjTjW3CH8FyAPTrav2JalLqSfdc8TPpg==",
       "requires": {
         "jsdom": "15.2.1"
       }

--- a/examples/blockly-react/package.json
+++ b/examples/blockly-react/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@blockly/field-date": "^5.0.16",
-    "blockly": "^8.0.3",
+    "@blockly/field-date": "^6.0.0",
+    "blockly": "^9.0.0",
     "react": "^17.0.1",
     "react-datepicker": "^3.3.0",
     "react-dom": "^17.0.1",

--- a/examples/blockly-react/src/Blockly/BlocklyComponent.jsx
+++ b/examples/blockly-react/src/Blockly/BlocklyComponent.jsx
@@ -26,7 +26,7 @@
  import {useEffect, useRef} from 'react';
 
  import Blockly from 'blockly/core';
- import BlocklyJS from 'blockly/javascript';
+ import {javascriptGenerator} from 'blockly/javascript';
  import locale from 'blockly/msg/en';
  import 'blockly/blocks';
  
@@ -38,7 +38,7 @@
     let primaryWorkspace = useRef();
 
     const generateCode = () => {
-        var code = BlocklyJS.workspaceToCode(
+        var code = javascriptGenerator.workspaceToCode(
           primaryWorkspace.current
         );
         console.log(code);


### PR DESCRIPTION
### Description

The react demo had been *partially* updated to use the new generator imports (the generator.js file, which adds the block-code generators was updated) but not fully updated. This finihes updating it, and also bumps the blockly dependency so that the fixes actually work.