### PR TITLE
fix: fixed size demo not being injected properly

### DIFF
--- a/examples/fixed-demo/index.html
+++ b/examples/fixed-demo/index.html
@@ -67,7 +67,7 @@
       ]
     };
 
-    var primaryWorkspace = Blockly.inject('primaryDiv',
+    var demoWorkspace = Blockly.inject('blocklyDiv',
         {media: 'https://unpkg.com/blockly/media/',
          toolbox: toolbox});
   </script>


### PR DESCRIPTION
### Description

https://github.com/google/blockly-samples/pull/1283 renamed the string in `inject` to `primaryDiv` instead of `blocklyDiv` which broke injection. This just switches it back =)