### PR TITLE
fix: don't publish from forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Don't try to publish from a fork of google/blockly-samples.
+    if: ${{ github.repository_owner == 'google' }}
 
     # Environment specific to releasing so we can isolate the npm token.
     environment: release  


### PR DESCRIPTION
Add a check to the publish workflow that will skip the job if the repository owner isn't google.

Tested by manually running the workflow on my fork from this branch and the result is "job was skipped" https://github.com/maribethb/blockly-samples/actions/runs/3292583164/jobs/5428112646