### PR TITLE
fix: slider field shouldn't show modal editor on mobile

### DIFF
--- a/plugins/field-slider/src/field_slider.ts
+++ b/plugins/field-slider/src/field_slider.ts
@@ -113,7 +113,7 @@ export class FieldSlider extends Blockly.FieldNumber {
 
     // Focus on the slider field, unless quietInput is passed.
     if (!quietInput) {
-      (editor.children[0] as HTMLInputElement).focus({
+      (editor.firstChild as HTMLInputElement).focus({
         preventScroll: true,
       });
     }

--- a/plugins/field-slider/src/field_slider.ts
+++ b/plugins/field-slider/src/field_slider.ts
@@ -89,10 +89,13 @@ export class FieldSlider extends Blockly.FieldNumber {
    *    editor.
    * @param e Optional mouse event that triggered the field to
    *     open, or undefined if triggered programmatically.
-   * @param quietInput Quiet input.
+   * @param quietInput Quiet input (prevent focusing on the editor).
    */
   protected showEditor_(e?: Event, quietInput?: boolean) {
-    super.showEditor_(e, quietInput);
+    // Always quiet the input for the super constructor, as we don't want to
+    // focus on the text field, and we don't want to display the modal
+    // editor on mobile devices.
+    super.showEditor_(e, true);
 
     // Build the DOM.
     const editor = this.dropdownCreate_();
@@ -107,6 +110,13 @@ export class FieldSlider extends Blockly.FieldNumber {
 
     Blockly.DropDownDiv.showPositionedByField(
         this, this.dropdownDispose_.bind(this));
+
+    // Focus on the slider field, unless quietInput is passed.
+    if (!quietInput) {
+      (editor.children[0] as HTMLInputElement).focus({
+        preventScroll: true,
+      });
+    }
   }
 
   /**
@@ -121,8 +131,8 @@ export class FieldSlider extends Blockly.FieldNumber {
    * Creates the slider editor and add event listeners.
    * @return The newly created slider.
    */
-  private dropdownCreate_(): Element {
-    const wrapper = document.createElement('div');
+  private dropdownCreate_(): HTMLElement {
+    const wrapper = document.createElement('div') as HTMLElement;
     wrapper.className = 'fieldSliderContainer';
     const sliderInput = document.createElement('input');
     sliderInput.setAttribute('type', 'range');
@@ -130,6 +140,7 @@ export class FieldSlider extends Blockly.FieldNumber {
     sliderInput.setAttribute('max', `${this.max_}`);
     sliderInput.setAttribute('step', `${this.precision_}`);
     sliderInput.setAttribute('value', this.getValue());
+    sliderInput.setAttribute('tabindex', '0');
     sliderInput.className = 'fieldSlider';
     wrapper.appendChild(sliderInput);
     this.sliderInput = sliderInput;


### PR DESCRIPTION
fixes #1341 

in #1217 in `showEditor_` the part that checked if we should avoid focusing the input if on a mobile browser was dropped, causing #1341 

In fixing this, I realized that the text editor part should never really be focused, even if not on mobile. Thus we should always pass true to the super constructor.

What we should do is focus on the actual range input so that keyboard input works automatically, so i added this while I was here. This part does respect the `quietInput` parameter in the constructor so that if someone ever subclassed this field and doesn't want to focus on the first element they don't have to.


Tested on mobile and desktop and the modal editor is never shown, and keyboard input (arrow keys) works as expected now