### PR TITLE
fix: field-bitmap now serializing correctly

### DIFF
--- a/plugins/field-bitmap/src/field-bitmap.js
+++ b/plugins/field-bitmap/src/field-bitmap.js
@@ -34,6 +34,9 @@ export class FieldBitmap extends Blockly.Field {
   constructor(value = undefined, validator = undefined, config = undefined) {
     super(value, validator, config);
 
+    this.SERIALIZABLE = true;
+
+
     // Configure value, height, and width
     if (this.getValue() !== null) {
       this.imgHeight_ = this.getValue().length;
@@ -484,8 +487,6 @@ export class FieldBitmap extends Blockly.Field {
     );
   }
 }
-
-FieldBitmap.prototype.SERIALIZABLE = true;
 
 Blockly.fieldRegistry.register('field_bitmap', FieldBitmap);
 


### PR DESCRIPTION
fix #1312 

- Serialisation issue should be sorted but unsure about changing CSS to an array of singles lines of CSS. 

- I'm not too familiar with Typescript but I the function definition for CSS.register specifies only type string. I can't supply this function with an array without it complaining. Is there a way round this?

