### PR TITLE
fix: scroll-options stops using is3dSupported

### DIFF
--- a/plugins/scroll-options/src/AutoScroll.js
+++ b/plugins/scroll-options/src/AutoScroll.js
@@ -6,6 +6,7 @@
 
 import * as Blockly from 'blockly/core';
 import {ScrollMetricsManager} from './ScrollMetricsManager';
+import {getTranslation} from './utils';
 
 /**
  * AutoScroll is used to scroll/pan the workspace automatically. For example,
@@ -111,8 +112,7 @@ export class AutoScroll {
    * @param {number} scrollDy Amount to scroll in vertical direction.
    */
   scrollWorkspaceWithBlock(scrollDx, scrollDy) {
-    const dragSurface = this.workspace_.getBlockDragSurface();
-    const oldLocation = dragSurface.getWsTranslation();
+    const oldLocation = getTranslation(this.workspace_);
 
     // As we scroll, we shouldn't expand past the content area that existed
     // before the block was picked up. Therefore, we use cached ContentMetrics
@@ -126,7 +126,7 @@ export class AutoScroll {
     this.workspace_.scroll(newX, newY);
     metricsManager.useCachedContentMetrics = false;
 
-    const newLocation = dragSurface.getWsTranslation();
+    const newLocation = getTranslation(this.workspace_);
 
     // How much we actually ended up scrolling.
     const deltaX = newLocation.x - oldLocation.x;

--- a/plugins/scroll-options/src/index.js
+++ b/plugins/scroll-options/src/index.js
@@ -6,6 +6,7 @@
 
 import Blockly from 'blockly/core';
 import {EdgeScrollOptions, ScrollBlockDragger} from './ScrollBlockDragger';
+import {getTranslation} from './utils';
 
 /**
  * A Blockly plugin that adds additional features related to scrolling and
@@ -78,7 +79,7 @@ export class ScrollOptions {
 
     let element;
     const dragSurface = this.workspace_.getBlockDragSurface();
-    if (Blockly.utils.svgMath.is3dSupported() && dragSurface) {
+    if (dragSurface) {
       element = dragSurface.getSvgRoot();
     } else {
       element = this.workspace_.svgGroup_;
@@ -147,14 +148,14 @@ export class ScrollOptions {
     const x = this.workspace_.scrollX - scrollDelta.x;
     const y = this.workspace_.scrollY - scrollDelta.y;
 
-    const oldLocation = this.getDragSurfaceLocation_();
+    const oldLocation = getTranslation(this.workspace_);
 
     // Try to scroll to the desired location.
     this.workspace_.getMetricsManager().useCachedContentMetrics = true;
     this.workspace_.scroll(x, y);
     this.workspace_.getMetricsManager().useCachedContentMetrics = false;
 
-    const newLocation = this.getDragSurfaceLocation_();
+    const newLocation = getTranslation(this.workspace_);
 
     // How much we actually ended up scrolling.
     const deltaX = newLocation.x - oldLocation.x;
@@ -164,16 +165,6 @@ export class ScrollOptions {
       currentGesture.getCurrentDragger().moveBlockWhileDragging(deltaX, deltaY);
       e.preventDefault();
     }
-  }
-
-  /**
-   * Gets the current location of the drag surface.
-   * @return {!Blockly.utils.Coordinate} The current coordinate.
-   * @private
-   */
-  getDragSurfaceLocation_() {
-    const dragSurface = this.workspace_.getBlockDragSurface();
-    return dragSurface.getWsTranslation();
   }
 }
 

--- a/plugins/scroll-options/src/utils.js
+++ b/plugins/scroll-options/src/utils.js
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Gets the current location of the workspace considering
+ * when there's no drag surface.
+ * @param {!Blockly.WorkspaceSvg} ws The workspace to calculate.
+ * @return {!Blockly.utils.Coordinate} The current workspace coordinate.
+ */
+export const getTranslation = (ws) => {
+  const dragSurface = ws.getBlockDragSurface();
+  if (dragSurface) {
+    return dragSurface.getWsTranslation();
+  } else {
+    const translation = ws.svgBlockCanvas_.getAttribute('transform');
+    const splitted = translation.split(',');
+    const x = Number(splitted[0].split('(')[1]);
+    const y = Number(splitted[1].split(')')[0]);
+    return new Blockly.utils.Coordinate(x, y);
+  }
+};


### PR DESCRIPTION
This is a follow up on:
- #1202
- https://github.com/google/blockly/pull/6400
- https://github.com/mit-cml/workspace-multiselect/pull/6

As `is3dSupported` has been removed in Blockly 9, the [workspace-multiselect](https://github.com/mit-cml/workspace-multiselect) plugin v0.1.3 will choose to use "`Blockly.WorkspaceSvg.getBlockDragSurface` always return `null`" to disable dragsurface, which means now it's OK to remove `is3dSupported` here in scroll-options.

Also fix the plugin to get the workspace translation when there's no getBlockDragSurface.

Signed-off-by: Hollow Man <hollowman@opensuse.org>