### PR TITLE
fix: disable copy for immovable and undeletable blocks

### DIFF
--- a/plugins/cross-tab-copy-paste/src/index.js
+++ b/plugins/cross-tab-copy-paste/src/index.js
@@ -66,7 +66,12 @@ export class CrossTabCopyPaste {
       },
       preconditionFn: function(
           /** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
-        return 'enabled';
+        if (
+          Blockly.selected.isDeletable() &&
+          Blockly.selected.isMovable()) {
+          return 'enabled';
+        }
+        return 'disabled';
       },
       callback: function(
           /** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {


### PR DESCRIPTION
The context menu option for "Copy" was set to always be enabled. To match core Blockly behavior, and to align to this plugin's behavior for the copy shortcut (below), the precondition function should be modified. 
Compare to copy shortcut:
https://github.com/google/blockly-samples/blob/4a5f0368e21ea90784041e4daafe5a43ebba3b39/plugins/cross-tab-copy-paste/src/index.js#L136-L143

New behavior:

https://user-images.githubusercontent.com/43474485/200906473-09a7264c-81c4-49bb-87f5-3f1c62562ceb.mp4

