### PR TITLE
chore(tests): drop build/test support for node.js v12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
### Description

npm is no longer compatible with node.js v12, which is causing CI to fail.