### PR TITLE
fix: Have checkout action check out the master branch specifically

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ jobs:
       # fetch all tags and commits so that lerna can version appropriately
       with:
         fetch-depth: 0
+        ref: 'master'
 
     # This uses a reverse-engineered email for the github actions bot. See
     # https://github.com/actions/checkout/issues/13#issuecomment-724415212


### PR DESCRIPTION
Publishing on blockly-samples is failing with this: "lerna WARN EBEHIND Local branch 'master' is behind remote upstream origin/master, exiting"

https://github.com/google/blockly-samples/actions/runs/3438892425/jobs/5736635938



I don't actually know why this would be happening, or why this would have worked before if this will indeed fix it, but I don't know what else to try.