### PR TITLE
fix(field-bitmap): Fix crash when dismissing `FieldBitmap` dropdown

### DIFF
--- a/plugins/field-bitmap/src/field-bitmap.js
+++ b/plugins/field-bitmap/src/field-bitmap.js
@@ -354,6 +354,7 @@ export class FieldBitmap extends Blockly.Field {
     for (const event of this.boundEvents_) {
       Blockly.browserEvents.unbind(event);
     }
+    this.boundEvents_.length = 0;
     this.editorPixels_ = null;
   }
 


### PR DESCRIPTION
Have `.dropdownDispose_` clear `.boundEvents_` after `unbind`ing.

Fixes #1386.