### PR TITLE
fix: generator imports in examples

### DIFF
--- a/examples/blockly-node/index.js
+++ b/examples/blockly-node/index.js
@@ -22,6 +22,7 @@
  */
 
 var Blockly = require('blockly');
+var {pythonGenerator} = require('blockly/python');
 
 var json = {
   "blocks": {
@@ -53,7 +54,7 @@ try {
   var workspace = new Blockly.Workspace();
   Blockly.serialization.workspaces.load(json, workspace);
   // Convert code and log output
-  var code = Blockly.Python.workspaceToCode(workspace);
+  var code = pythonGenerator.workspaceToCode(workspace);
   console.log(code);
 }
 catch (e) {

--- a/examples/blockly-node/package-lock.json
+++ b/examples/blockly-node/package-lock.json
@@ -8,7 +8,7 @@
             "name": "blockly-node-sample",
             "version": "0.0.0",
             "dependencies": {
-                "blockly": "^ 8.0.5"
+                "blockly": "^9.0.0"
             }
         },
         "node_modules/abab": {
@@ -114,9 +114,9 @@
             }
         },
         "node_modules/blockly": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/blockly/-/blockly-8.0.5.tgz",
-            "integrity": "sha512-jgr3PHImkFYSC2pNWZ74TmXP1HdajxeRd2DQaAt+9I+XLl9RCWvInqNHcS+blsKBTn6zOIxHK6nLzRATbLrDSw==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.1.1.tgz",
+            "integrity": "sha512-wgeiCC7raa/VOj/kqARHnOjUKIWHKv0ptEwPuBKa6hhvwSU1jzw3jzmsbRU6ECjIF3UoQMfmO0fDu6iduhHQZA==",
             "dependencies": {
                 "jsdom": "15.2.1"
             }
@@ -955,9 +955,9 @@
             }
         },
         "blockly": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/blockly/-/blockly-8.0.5.tgz",
-            "integrity": "sha512-jgr3PHImkFYSC2pNWZ74TmXP1HdajxeRd2DQaAt+9I+XLl9RCWvInqNHcS+blsKBTn6zOIxHK6nLzRATbLrDSw==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.1.1.tgz",
+            "integrity": "sha512-wgeiCC7raa/VOj/kqARHnOjUKIWHKv0ptEwPuBKa6hhvwSU1jzw3jzmsbRU6ECjIF3UoQMfmO0fDu6iduhHQZA==",
             "requires": {
                 "jsdom": "15.2.1"
             }

--- a/examples/blockly-node/package.json
+++ b/examples/blockly-node/package.json
@@ -8,6 +8,6 @@
         "start": "node index.js"
     },
     "dependencies": {
-        "blockly": "^ 8.0.5"
+        "blockly": "^9.0.0"
     }
 }

--- a/examples/blockly-parcel/package-lock.json
+++ b/examples/blockly-parcel/package-lock.json
@@ -8,7 +8,7 @@
       "name": "blockly-parcel-sample",
       "version": "0.0.0",
       "devDependencies": {
-        "blockly": "^8.0.5",
+        "blockly": "^9.0.0",
         "parcel": "next",
         "parcel-reporter-static-files-copy": "^1.3"
       }
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-8.0.5.tgz",
-      "integrity": "sha512-jgr3PHImkFYSC2pNWZ74TmXP1HdajxeRd2DQaAt+9I+XLl9RCWvInqNHcS+blsKBTn6zOIxHK6nLzRATbLrDSw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.1.1.tgz",
+      "integrity": "sha512-wgeiCC7raa/VOj/kqARHnOjUKIWHKv0ptEwPuBKa6hhvwSU1jzw3jzmsbRU6ECjIF3UoQMfmO0fDu6iduhHQZA==",
       "dev": true,
       "dependencies": {
         "jsdom": "15.2.1"
@@ -14689,9 +14689,9 @@
       }
     },
     "blockly": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-8.0.5.tgz",
-      "integrity": "sha512-jgr3PHImkFYSC2pNWZ74TmXP1HdajxeRd2DQaAt+9I+XLl9RCWvInqNHcS+blsKBTn6zOIxHK6nLzRATbLrDSw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.1.1.tgz",
+      "integrity": "sha512-wgeiCC7raa/VOj/kqARHnOjUKIWHKv0ptEwPuBKa6hhvwSU1jzw3jzmsbRU6ECjIF3UoQMfmO0fDu6iduhHQZA==",
       "dev": true,
       "requires": {
         "jsdom": "15.2.1"

--- a/examples/blockly-parcel/package.json
+++ b/examples/blockly-parcel/package.json
@@ -9,7 +9,7 @@
     "build": "parcel build public/index.html"
   },
   "devDependencies": {
-    "blockly": "^8.0.5",
+    "blockly": "^9.0.0",
     "parcel": "next",
     "parcel-reporter-static-files-copy": "^1.3"
   },

--- a/examples/blockly-parcel/src/generator.js
+++ b/examples/blockly-parcel/src/generator.js
@@ -12,7 +12,7 @@
 
 import * as Blockly from 'blockly/core';
 import 'blockly/blocks';
-import 'blockly/python';
+import {pythonGenerator} from 'blockly/python';
 import * as En from 'blockly/msg/en';
 
 const toolbox = {
@@ -93,11 +93,10 @@ document.addEventListener('DOMContentLoaded', function () {
       media: 'media/'
     });
 
-  const lang = 'Python';
   const button = document.getElementById('blocklyButton');
   button.addEventListener('click', function () {
     alert('Check the console for the generated output.');
-    const code = Blockly[lang].workspaceToCode(workspace);
+    const code = pythonGenerator.workspaceToCode(workspace);
     console.log(code);
   });
 });

--- a/examples/blockly-parcel/src/index.js
+++ b/examples/blockly-parcel/src/index.js
@@ -11,6 +11,7 @@
  */
 
 import * as Blockly from 'blockly';
+import {javascriptGenerator} from 'blockly/javascript';
 
 const toolbox = {
   kind: 'flyoutToolbox',
@@ -88,11 +89,10 @@ document.addEventListener('DOMContentLoaded', function () {
       media: 'media/'
     });
 
-  const lang = 'JavaScript';
   const button = document.getElementById('blocklyButton');
   button.addEventListener('click', function () {
     alert('Check the console for the generated output.');
-    const code = Blockly[lang].workspaceToCode(workspace);
+    const code = javascriptGenerator.workspaceToCode(workspace);
     console.log(code);
   });
 });

--- a/examples/blockly-parcel/src/locale.js
+++ b/examples/blockly-parcel/src/locale.js
@@ -12,7 +12,7 @@
 
 import * as Blockly from 'blockly/core';
 import 'blockly/blocks';
-import 'blockly/javascript';
+import {javascriptGenerator} from 'blockly/javascript';
 import * as Fr from 'blockly/msg/fr';
 
 Blockly.setLocale(Fr);
@@ -93,11 +93,10 @@ document.addEventListener('DOMContentLoaded', function () {
       media: 'media/'
     });
 
-  const lang = 'JavaScript';
   const button = document.getElementById('blocklyButton');
   button.addEventListener('click', function () {
     alert('Check the console for the generated output.');
-    const code = Blockly[lang].workspaceToCode(workspace);
+    const code = javascriptGenerator.workspaceToCode(workspace);
     console.log(code);
   });
 });

--- a/examples/blockly-webpack/package-lock.json
+++ b/examples/blockly-webpack/package-lock.json
@@ -8,7 +8,7 @@
       "name": "blockly-webpack-sample",
       "version": "0.0.0",
       "dependencies": {
-        "blockly": "^3.20200123.1"
+        "blockly": "^9.0.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^5.1.1",
@@ -683,11 +683,11 @@
       }
     },
     "node_modules/blockly": {
-      "version": "3.20200123.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-3.20200123.1.tgz",
-      "integrity": "sha512-7GMGpILwTkWCUuttjKhFPQzp4P/A2MeT10JaV2q9xAR4EF6G72T8RvF3HUMq0Kkx0wUDyiFGT1F1BfINFgfMng==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.1.1.tgz",
+      "integrity": "sha512-wgeiCC7raa/VOj/kqARHnOjUKIWHKv0ptEwPuBKa6hhvwSU1jzw3jzmsbRU6ECjIF3UoQMfmO0fDu6iduhHQZA==",
       "dependencies": {
-        "jsdom": "^15.1.1"
+        "jsdom": "15.2.1"
       }
     },
     "node_modules/bluebird": {
@@ -8254,11 +8254,11 @@
       }
     },
     "blockly": {
-      "version": "3.20200123.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-3.20200123.1.tgz",
-      "integrity": "sha512-7GMGpILwTkWCUuttjKhFPQzp4P/A2MeT10JaV2q9xAR4EF6G72T8RvF3HUMq0Kkx0wUDyiFGT1F1BfINFgfMng==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-9.1.1.tgz",
+      "integrity": "sha512-wgeiCC7raa/VOj/kqARHnOjUKIWHKv0ptEwPuBKa6hhvwSU1jzw3jzmsbRU6ECjIF3UoQMfmO0fDu6iduhHQZA==",
       "requires": {
-        "jsdom": "^15.1.1"
+        "jsdom": "15.2.1"
       }
     },
     "bluebird": {

--- a/examples/blockly-webpack/package.json
+++ b/examples/blockly-webpack/package.json
@@ -9,7 +9,7 @@
     "build": "webpack"
   },
   "dependencies": {
-    "blockly": "^3.20200123.1"
+    "blockly": "^9.0.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^5.1.1",

--- a/examples/blockly-webpack/src/generator.js
+++ b/examples/blockly-webpack/src/generator.js
@@ -24,7 +24,7 @@
 
 import * as Blockly from 'blockly/core';
 import 'blockly/blocks';
-import 'blockly/python';
+import {pythonGenerator} from 'blockly/python';
 
 import * as En from 'blockly/msg/en';
 Blockly.setLocale(En);
@@ -37,11 +37,10 @@ document.addEventListener("DOMContentLoaded", function () {
             media: 'media/'
         });
 
-    const lang = 'Python';
     const button = document.getElementById('blocklyButton');
     button.addEventListener('click', function () {
         alert("Check the console for the generated output.");
-        const code = Blockly[lang].workspaceToCode(workspace);
+        const code = pythonGenerator.workspaceToCode(workspace);
         console.log(code);
     })
 });

--- a/examples/blockly-webpack/src/index.js
+++ b/examples/blockly-webpack/src/index.js
@@ -23,6 +23,7 @@
  */
 
 import * as Blockly from 'blockly';
+import {javascriptGenerator} from 'blockly/javascript';
 
 document.addEventListener("DOMContentLoaded", function () {
     const workspace = Blockly.inject('blocklyDiv',
@@ -31,11 +32,10 @@ document.addEventListener("DOMContentLoaded", function () {
             media: 'media/'
         });
 
-    const lang = 'JavaScript';
     const button = document.getElementById('blocklyButton');
     button.addEventListener('click', function () {
         alert("Check the console for the generated output.");
-        const code = Blockly[lang].workspaceToCode(workspace);
+        const code = javascriptGenerator.workspaceToCode(workspace);
         console.log(code);
     })
 });

--- a/examples/blockly-webpack/src/locale.js
+++ b/examples/blockly-webpack/src/locale.js
@@ -24,7 +24,7 @@
 
 import * as Blockly from 'blockly/core';
 import 'blockly/blocks';
-import 'blockly/javascript';
+import {javascriptGenerator} from 'blockly/javascript';
 
 import * as Fr from 'blockly/msg/fr';
 Blockly.setLocale(Fr);
@@ -37,11 +37,10 @@ document.addEventListener("DOMContentLoaded", function () {
             media: 'media/'
         });
 
-    const lang = 'JavaScript';
     const button = document.getElementById('blocklyButton');
     button.addEventListener('click', function () {
         alert("Check the console for the generated output.");
-        const code = Blockly[lang].workspaceToCode(workspace);
+        const code = javascriptGenerator.workspaceToCode(workspace);
         console.log(code);
     })
 });


### PR DESCRIPTION
### Description

Fixes the generator imports in examples.

### Additional info

Sadly this could not be fixed with the migration script, because we didn't think anyone was using side effect imports to access generators off of `Blockly`, because we thought we never told them to. Apparently we did in these examples :/