### PR TITLE
chore: Removed browserslist from package.json

### DIFF
--- a/examples/blockly-vue/package.json
+++ b/examples/blockly-vue/package.json
@@ -46,9 +46,5 @@
     "plugins": {
       "autoprefixer": {}
     }
-  },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions"
-  ]
+  }
 }

--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -58,10 +58,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/block-test/package.json
+++ b/plugins/block-test/package.json
@@ -54,10 +54,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -59,10 +59,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -55,10 +55,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -56,8 +56,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults"
-  ]
+  }
 }

--- a/plugins/dev-create/bin/create.js
+++ b/plugins/dev-create/bin/create.js
@@ -144,14 +144,12 @@ const packageJson = {
   homepage: isGit ? `${gitURL}/tree/master/${gitPluginPath}#readme` : '',
   bugs: isGit ? {
     url: `${gitURL}/issues`,
-  } :
-                {},
+  } : {},
   repository: isGit ? {
     'type': 'git',
     'url': `${gitURL}.git`,
     'directory': gitPluginPath,
-  } :
-                      {},
+  } : {},
   license: 'Apache-2.0',
   directories: {
     'dist': 'dist',
@@ -168,19 +166,13 @@ const packageJson = {
   publishConfig: isFirstParty ? {
     'access': 'public',
     'registry': 'https://wombat-dressing-room.appspot.com',
-  } :
-                                {},
+  } : {},
   eslintConfig: {
     'extends': '@blockly/eslint-config',
   },
   engines: {
     'node': '>=8.17.0',
   },
-  browserslist: [
-    'defaults',
-    'IE 11',
-    'IE_Mob 11',
-  ],
 };
 
 // Add dev dependencies.

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -68,10 +68,5 @@
   },
   "engines": {
     "node": ">=8.0.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -55,10 +55,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/field-bitmap/package.json
+++ b/plugins/field-bitmap/package.json
@@ -59,10 +59,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/field-colour-hsv-sliders/package.json
+++ b/plugins/field-colour-hsv-sliders/package.json
@@ -58,10 +58,5 @@
   },
   "engines": {
     "node": ">=8.0.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -59,10 +59,5 @@
   },
   "engines": {
     "node": ">=8.0.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -56,10 +56,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -58,10 +58,5 @@
   },
   "engines": {
     "node": ">=8.0.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -55,10 +55,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/keyboard-navigation/package.json
+++ b/plugins/keyboard-navigation/package.json
@@ -61,10 +61,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -60,10 +60,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/renderer-inline-row-separators/package.json
+++ b/plugins/renderer-inline-row-separators/package.json
@@ -60,8 +60,5 @@
   },
   "engines": {
     "node": ">=8.0.0"
-  },
-  "browserslist": [
-    "defaults"
-  ]
+  }
 }

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -56,10 +56,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/serialize-disabled-interactions/package.json
+++ b/plugins/serialize-disabled-interactions/package.json
@@ -54,10 +54,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/shadow-block-converter/package.json
+++ b/plugins/shadow-block-converter/package.json
@@ -59,8 +59,5 @@
   },
   "engines": {
     "node": ">=8.0.0"
-  },
-  "browserslist": [
-    "defaults"
-  ]
+  }
 }

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -59,8 +59,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults"
-  ]
+  }
 }

--- a/plugins/suggested-blocks/package.json
+++ b/plugins/suggested-blocks/package.json
@@ -59,10 +59,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -56,10 +56,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/theme-deuteranopia/package.json
+++ b/plugins/theme-deuteranopia/package.json
@@ -56,10 +56,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/theme-highcontrast/package.json
+++ b/plugins/theme-highcontrast/package.json
@@ -56,10 +56,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -56,10 +56,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/theme-tritanopia/package.json
+++ b/plugins/theme-tritanopia/package.json
@@ -56,10 +56,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -63,10 +63,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -57,10 +57,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -59,10 +59,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -55,10 +55,5 @@
   },
   "engines": {
     "node": ">=8.17.0"
-  },
-  "browserslist": [
-    "defaults",
-    "IE 11",
-    "IE_Mob 11"
-  ]
+  }
 }


### PR DESCRIPTION
Fixes #1303. Removes the browserslist data from all package.json since it is unmaintained. Also removes it from the script to create new blockly packages.