### PR TITLE
chore: add timeouts to github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   build:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,6 +35,7 @@ jobs:
       run: npm run test -- -- -- --skip-lint
 
   lint:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Description

Adds timeouts to github workflows so that we don't have to deal with 6 hour timeouts.