### PR TITLE
feat: call the update gh-pages workflow after publishing succeeds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,3 +59,9 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: npx lerna publish --conventional-commits --create-release github --yes --ignore-scripts
+
+  update-gh-pages:
+    name: Update GitHub Pages
+    # Call the Update gh-pages workflow only if publishing succeeds
+    needs: [publish]
+    uses: ./.github/workflows/update_gh_pages.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,4 +64,6 @@ jobs:
     name: Update GitHub Pages
     # Call the Update gh-pages workflow only if publishing succeeds
     needs: [publish]
+    # Don't try to auto-update if on a fork of google/blockly-samples.
+    if: ${{ github.repository_owner == 'google' }}
     uses: ./.github/workflows/update_gh_pages.yml

--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -4,6 +4,7 @@ name: Update GitHub Pages
 
 on:
   workflow_dispatch:  # Manually trigger. Colon is required.
+  workflow_call: # Allow this workflow to be called from publish workflow.
 
 permissions:
   contents: write  # For checkout and push.


### PR DESCRIPTION
Calls the update gh-pages workflow from the publish workflow

Due to the way calling other workflows works, it has to be a separate job within the publish workflow, not just a step. Should only happen when publishing succeeds. Since skipping a job causes it to report "success", I have to repeat the if conditional to also skip the second job so that forks aren't updated every thursday