### PR TITLE
fix: grammar, consistency, and functionality in getting started codelab.

### DIFF
--- a/codelabs/getting_started/getting_started.md
+++ b/codelabs/getting_started/getting_started.md
@@ -196,7 +196,7 @@ Blockly.inject('blocklyDiv', {
 
 Let's look at the options we used to initialize your blockly editor:
 
-- `toolbox`: An JavaScript object which defines the toolbox for the editor.
+- `toolbox`: A JavaScript object which defines the toolbox for the editor.
 - `scrollbars`: Whether to show scrollbars in the workspace.
 - `horizontalLayout`: Whether to display the toolbox horizontally or vertically in the workspace.
 - `toolboxPosition`: Whether to show the toolbox at the top or bottom of the workspace.

--- a/codelabs/getting_started/getting_started.md
+++ b/codelabs/getting_started/getting_started.md
@@ -98,7 +98,7 @@ Open `starter-code/index.html` in a text editor and scroll to the end. You can s
 <script src="scripts/main.js"></script>
 ```
 
-Add Blockly just before these two scripts. The order is important, because you will use Blockly objects later in `main.js`.
+Add Blockly just before these two scripts. The order is important, because you will use Blockly objects later in `main.js`.  Your imports should now look like this:
 
 ```html
 <script src="https://unpkg.com/blockly"></script>
@@ -141,7 +141,7 @@ For more information on this JSON format and toolbox configuration, including ca
 
 ### Define the toolbox
 
-Open up `scripts/main.js` and scroll down to the end of the file. Then add the code for your toolbox definition just after the call to `enableMakerMode()`.
+Open up `scripts/main.js` and scroll down to the end of the file. Then add the code for your `toolbox` definition just after the call to `enableMakerMode()`:
 
 ```js
 const toolbox = {
@@ -188,16 +188,20 @@ Now add code to inject the Blockly editor just afer the code you used to define 
 ```js
 Blockly.inject('blocklyDiv', {
   toolbox: toolbox,
-  scrollbars: false
+  scrollbars: false,
+  horizontalLayout: true,
+  toolboxPosition: "end"
 });
 ```
 
 Let's look at the options we used to initialize your blockly editor:
 
 - `toolbox`: An JavaScript object which defines the toolbox for the editor.
-- `scrollbars`: whether to show scrollbars in the workspace.
+- `scrollbars`: Whether to show scrollbars in the workspace.
+- `horizontalLayout`: Whether to display the toolbox horizontally or vertically in the workspace.
+- `toolboxPosition`: Whether to show the toolbox at the top or bottom of the workspace.
 
-The options struct gives you significant control over your Blockly instance. You can pass options to set Blockly's theme, modify scrolling behaviour, set the renderer, and more. For more information, head over to Blockly's developer site and check out the [configuration](https://developers.google.com/blockly/guides/get-started/web#configuration) section.
+The `options` struct gives you significant control over your Blockly instance. You can pass options to set Blockly's theme, modify scrolling behaviour, set the renderer, and more. For more information, head over to Blockly's developer site and check out the [configuration](https://developers.google.com/blockly/guides/get-started/web#configuration) section.
 
 ### Check your work
 
@@ -257,12 +261,18 @@ Add a script tag to `index.html` to include your new block definition:
 <script src="scripts/sound_blocks.js"></script>
 ```
 
-Your block definitions must come after importing Blockly and before the other imports, since you will use Blockly functions in this file, and you will be using functions from this file in later files.
+Your sound block definitions must come after importing Blockly and before the other imports, since you will use Blockly functions in this file, and you will be using functions from this file in later files.  Your imports should now look like this:
 
+```html
+<script src="https://unpkg.com/blockly"></script>
+<script src="scripts/sound_blocks.js"></script>
+<script src="scripts/music_maker.js"></script>
+<script src="scripts/main.js"></script>
+```
 
 ### Add the sound block to the toolbox
 
-Now we can update the toolbox to include the new sound block, by adding `{'kind': 'block', 'type': 'play_sound'}`.
+Now we can update the toolbox to include the new sound block, by adding `{'kind': 'block', 'type': 'play_sound'}` to our `toolbox` definition:
 
 ```js
 const toolbox = {
@@ -309,7 +319,8 @@ Once the button behavior is defined by the user, it needs to be saved for later 
 Open `scripts/main.js`. Add the following code to the `save()` method:
 
 ```js
-button.blocklySave = Blockly.serialization.workspaces.save(Blockly.common.getMainWorkspace());
+button.blocklySave = Blockly.serialization.workspaces.save(
+    Blockly.getMainWorkspace());
 ```
 
 `workspaces.save` takes the Blockly workspace, exports its state to a JavaScript object and stores it in a `blocklySave` property on the button. This way the exported state for the block sequence gets associated with a particular button.
@@ -322,16 +333,18 @@ In the `scripts/main.js `file, add `loadWorkspace` function:
 
 ```
 function loadWorkspace(button) {
-  const workspace = Blockly.common.getMainWorkspace();
+  const workspace = Blockly.getMainWorkspace();
   if (button.blocklySave) {
     Blockly.serialization.workspaces.load(button.blocklySave, workspace);
+  } else {
+    workspace.clear();
   }
 }
 ```
 
 This loads the blocks stored on the button that was clicked back into the workspace.
 
-Call this function from `enableBlocklyMode`:
+Call this function from the end of the function `enableBlocklyMode`:
 
 ```
 function enableBlocklyMode(e) {
@@ -360,7 +373,7 @@ As previously mentioned, you can define your imports more carefully to get a [di
 
 When Blockly generates JavaScript code for blocks in a workspace, it translates each block into code. By default, it knows how to translate all library-provided default blocks into JavaScript code. However, for any custom blocks, we need to specify our own translation functions. These are called *block generators*.
 
-Add the following code in `scripts/sound_blocks.js`:
+Add the following code to the bottom of `scripts/sound_blocks.js`:
 
 ```js
 Blockly.JavaScript['play_sound'] = function(block) {
@@ -373,7 +386,11 @@ With this translation function, the following `play_sound` block:
 
 ![image](play_sound_block.png)
 
-translates into the JavaScript code "`MusicMaker.queueSound('Sounds/c4.m4a');`".
+translates into the JavaScript code:
+
+```javascript
+MusicMaker.queueSound('Sounds/c4.m4a');
+```
 
 For more information on generators, read the [generating code](https://developers.google.com/blockly/guides/create-custom-blocks/generating-code) page on the developer site.
 
@@ -389,10 +406,10 @@ loadWorkspace(event.target);
 
 Next, you need to generate the code out of that workspace, which you can do with a call to `Blockly.JavaScript.workspaceToCode`.
 
-The user's code will consist of many `MusicMaker.queueSound` calls. At the end of our generated script, add `MusicMaker.play `call to play all the sounds added to the queue.
+The user's code will consist of many `MusicMaker.queueSound` calls. At the end of our generated script, add a call to `MusicMaker.play` to play all the sounds added to the queue:
 
 ```js
-let code = Blockly.JavaScript.workspaceToCode(Blockly.common.getMainWorkspace());
+let code = Blockly.JavaScript.workspaceToCode(Blockly.getMainWorkspace());
 code += 'MusicMaker.play();';
 ```
 
@@ -413,7 +430,7 @@ The end result should look like this:
 ```js
 function handlePlay(event) {
   loadWorkspace(event.target);
-  let code = Blockly.JavaScript.workspaceToCode(Blockly.common.getMainWorkspace());
+  let code = Blockly.JavaScript.workspaceToCode(Blockly.getMainWorkspace());
   code += 'MusicMaker.play();';
   try {
     eval(code);

--- a/codelabs/getting_started/getting_started.md
+++ b/codelabs/getting_started/getting_started.md
@@ -190,7 +190,7 @@ Blockly.inject('blocklyDiv', {
   toolbox: toolbox,
   scrollbars: false,
   horizontalLayout: true,
-  toolboxPosition: "end"
+  toolboxPosition: "end",
 });
 ```
 

--- a/examples/getting-started-codelab/complete-code/index.html
+++ b/examples/getting-started-codelab/complete-code/index.html
@@ -43,22 +43,12 @@
 
     <div class="blockly-editor">
       <div id="blocklyDiv" style="height: 480px; width: 400px;"></div>
-      <xml id="toolbox" style="display: none">
-        <block type="controls_repeat_ext">
-          <value name="TIMES">
-            <shadow type="math_number">
-              <field name="NUM">5</field>
-            </shadow>
-          </value>
-        </block>
-        <block type="play_sound"></block>
-      </xml>
     </div>
   </main>
 
   <script src="https://unpkg.com/blockly"></script>
-  <script src="scripts/music_maker.js"></script>
   <script src="scripts/sound_blocks.js"></script>
+  <script src="scripts/music_maker.js"></script>
   <script src="scripts/main.js"></script>
 
 </body>

--- a/examples/getting-started-codelab/complete-code/scripts/main.js
+++ b/examples/getting-started-codelab/complete-code/scripts/main.js
@@ -24,6 +24,8 @@
     const workspace = Blockly.getMainWorkspace();
     if (button.blocklySave) {
       Blockly.serialization.workspaces.load(button.blocklySave, workspace);
+    } else {
+      workspace.clear();
     }
   }
 
@@ -92,5 +94,7 @@
   Blockly.inject('blocklyDiv', {
     toolbox: toolbox,
     scrollbars: false,
+    horizontalLayout: true,
+    toolboxPosition: 'end',
   });
 })();


### PR DESCRIPTION
- Always end each statement that precedes a code block with ":".  Most already did this, but some just ended in
period.  Now they are all consistent.
- Additional clarifiers in several places about exactly where code should be added, like "the end of a function",
etc.
- Added `horizontalLayout: true` and `toolboxPosition: "end"` so the screenshots would be accurate.  Also explained
what those options do.
- Some places weren't wrapping words that referred to code constructs in back-ticks while most places did.  Added
back-ticks for consistency.
- When adding javascript imports in the steps, sometimes it wasn't absolutely clear what order the imports should
be, so added additional code block making it clear what it should now look like.
- Some code examples intended to be pasted into the files were longer than 80 chars.  I changed them to have them
wrap properly.
- Some of the examples and starter code was using `Blockly.common.getMainWorkspace()`, whereas the complete-code/
was just using `Blockly.getMainWorkspace()`.  The latter seems to work fine, so I changed them all to this,
removing the `common` portion.
- The complete-code/index.html had an additional `xml` tag for the toolbox that isn't mentioned in the codelab and
doesn't seem necessary.  I'm guessing it was replaced by the javascript `toolbox` struct but was just overlooked
from being removed from the complete-code/index.html file.  I've removed it.
- Fixed #1521 by adding a call to `workspace.clear()` in the `else` block of `loadWorkspace`.  This has been added
both to the `complete-code` example and to the code snippet in the markdown codelab text.

Fixes: #1521