### PR TITLE
chore: remove wrapper from devsite demo

### DIFF
--- a/gh-pages/_config.yml
+++ b/gh-pages/_config.yml
@@ -20,3 +20,9 @@ defaults:
       type: "pages"
     values:
       layout: "default"
+  -
+    scope:
+      path: "examples/devsite-demo/index.html"
+      type: "pages"
+    values:
+      layout: "devsite-demo"

--- a/gh-pages/_layouts/devsite-demo.html
+++ b/gh-pages/_layouts/devsite-demo.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<html lang="en">
+  {{ content }}
+</html>


### PR DESCRIPTION
Remove the wrapper from the devsite demo so it can be embedded directly into devsite.

Staged at https://rachel-fenichel.github.io/blockly-samples/examples/devsite-demo/

![image](https://user-images.githubusercontent.com/13686399/214685514-e74fcdd4-d982-4c51-903a-bd110c9f7f3b.png)

This adds a new jekyll layout that is very basic, and configures it to apply to only the devsite demo.