### PR TITLE
fix: update templates to use JSON

### DIFF
--- a/plugins/dev-create/templates/block/template/test/index.js
+++ b/plugins/dev-create/templates/block/template/test/index.js
@@ -29,9 +29,15 @@ function createWorkspace(blocklyDiv, options) {
 
 document.addEventListener('DOMContentLoaded', function() {
   const defaultOptions = {
-    toolbox: `<xml xmlns="https://developers.google.com/blockly/xml">
-      ${allBlocks.map((b) => `<block type="${b}"></block>`)}
-    </xml>`,
+    toolbox: {
+      'kind': 'flyoutToolbox',
+      'contents': allBlocks.map((b) => {
+        return {
+          'kind': 'block',
+          'type': b,
+        };
+      }),
+    },
   };
   createPlayground(document.getElementById('root'), createWorkspace,
       defaultOptions);

--- a/plugins/dev-create/templates/typescript-block/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-block/template/test/index.ts
@@ -30,9 +30,15 @@ function createWorkspace(blocklyDiv: HTMLElement,
 
 document.addEventListener('DOMContentLoaded', function() {
   const defaultOptions = {
-    toolbox: `<xml xmlns="https://developers.google.com/blockly/xml">
-      ${allBlocks.map((b) => `<block type="${b}"></block>`)}
-    </xml>`,
+    toolbox: {
+      'kind': 'flyoutToolbox',
+      'contents': allBlocks.map((b) => {
+        return {
+          'kind': 'block',
+          'type': b,
+        };
+      }),
+    },
   };
   createPlayground(document.getElementById('root'), createWorkspace,
       defaultOptions);


### PR DESCRIPTION
### Description

Updates the dev-create templates for blocks to use JSON (all the other ones are already using JSON.

Discovered: https://github.com/google/blockly-samples/pull/1523#discussion_r1088343022