### PR TITLE
chore: update eslint to allow returns for ts and omit redundant descriptions

### DIFF
--- a/plugins/eslint-config/index.js
+++ b/plugins/eslint-config/index.js
@@ -71,7 +71,13 @@ module.exports = {
         'forceRequireReturn': false,
       },
     ],
-    'jsdoc/require-description': 'warn',
+    'jsdoc/require-description': [
+      'warn',
+      {
+        // Don't require descriptions if these tags are present.
+        'exemptedBy': ['inheritdoc', 'param', 'return', 'returns', 'type'],
+      },
+    ],
     'jsdoc/check-tag-names': 'off',
     'jsdoc/check-access': 'warn',
     'jsdoc/check-types': 'off',
@@ -107,6 +113,9 @@ module.exports = {
       plugins: ['@typescript-eslint'],
       settings: {
         jsdoc: {
+          tagNamePreference: {
+            'returns': 'returns',
+          },
           mode: 'typescript',
         },
       },

--- a/plugins/field-colour-hsv-sliders/src/field_colour_hsv_sliders.ts
+++ b/plugins/field-colour-hsv-sliders/src/field_colour_hsv_sliders.ts
@@ -51,7 +51,7 @@ class RgbColour {
    * Given a number from 0 to 1, returns a two-digit hexadecimal string from
    * '00' to 'ff'.
    * @param x The amount of light in a component from 0 to 1.
-   * @return A hexadecimal representation from '00' to 'ff'.
+   * @returns A hexadecimal representation from '00' to 'ff'.
    */
   static componentToHex(x: number): string {
     if (x <= 0) return '00';
@@ -61,7 +61,7 @@ class RgbColour {
 
   /**
    * Returns a hexadecimal string in the format #rrggbb representing the colour.
-   * @return A hexadecimal representation of this colour.
+   * @returns A hexadecimal representation of this colour.
    */
   toHex(): string {
     return '#' +
@@ -74,7 +74,7 @@ class RgbColour {
    * Updates the properties of this instance to represent the same colour as the
    * provided string in the hexadecimal format #rrggbb.
    * @param hex A hexadecimal string in the format '#rrggbb'.
-   * @return This instance after updating it.
+   * @returns This instance after updating it.
    */
   loadFromHex(hex: string): RgbColour {
     this.r = parseInt(hex.slice(1, 3), 16) / 255;
@@ -87,7 +87,7 @@ class RgbColour {
    * Updates the properties of this instance to represent the same colour as the
    * provided HsvColour but in the sRGB colour space.
    * @param hsv An HSV representation of a colour to copy.
-   * @return This instance after updating it.
+   * @returns This instance after updating it.
    */
   loadFromHsv(hsv: HsvColour): RgbColour {
     const hue: number = (hsv.h - Math.floor(hsv.h)) * 6;
@@ -132,7 +132,7 @@ class HsvColour {
    * Updates the properties of this instance to represent the same colour as the
    * provided RgbColour but in the HSV colour space.
    * @param rgb An RGB representation of a colour to copy.
-   * @return This instance after updating it.
+   * @returns This instance after updating it.
    */
   loadFromRgb(rgb: RgbColour): HsvColour {
     const max: number = Math.max(Math.max(rgb.r, rgb.g), rgb.b);
@@ -163,7 +163,7 @@ class HsvColour {
   /**
    * Updates the properties of this instance to copy the provided HsvColour.
    * @param other An HSV representation of a colour to copy.
-   * @return This instance after updating it.
+   * @returns This instance after updating it.
    */
   copy(other: HsvColour): HsvColour {
     this.h = other.h;
@@ -252,7 +252,7 @@ export class FieldColourHsvSliders extends Blockly.FieldColour {
    * value, appends it to the provided container, and returns the readout.
    * @param name The display name of the slider.
    * @param container Where the row will be inserted.
-   * @return The readout, so that it can be updated.
+   * @returns The readout, so that it can be updated.
    */
   private static createLabelInContainer(
       name: string, container: HTMLElement): HTMLSpanElement {
@@ -272,7 +272,7 @@ export class FieldColourHsvSliders extends Blockly.FieldColour {
    * @param max The maximum value of the slider.
    * @param step The minimum step size of the slider.
    * @param container Where the row slider be inserted.
-   * @return The slider.
+   * @returns The slider.
    */
   private static createSliderInContainer(
       max: number, step: number, container: HTMLElement): HTMLInputElement {
@@ -352,7 +352,7 @@ export class FieldColourHsvSliders extends Blockly.FieldColour {
    * @param hue The hue of the colour.
    * @param saturation The saturation of the colour.
    * @param brightness The brightness of the colour.
-   * @return A hexadecimal representation of the colour in the format "#rrggbb"
+   * @returns A hexadecimal representation of the colour in the format "#rrggbb"
    */
   private static hsvToHex(
       hue: number, saturation: number, brightness: number): string {

--- a/plugins/field-colour-hsv-sliders/test/index.ts
+++ b/plugins/field-colour-hsv-sliders/test/index.ts
@@ -25,7 +25,7 @@ const toolbox = generateFieldTestBlocks('field_colour_hsv_sliders', [
  * Create a workspace.
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
- * @return The created workspace.
+ * @returns The created workspace.
  */
 function createWorkspace(
     blocklyDiv: HTMLElement, options: Blockly.BlocklyOptions):

--- a/plugins/field-slider/src/field_slider.ts
+++ b/plugins/field-slider/src/field_slider.ts
@@ -67,7 +67,7 @@ export class FieldSlider extends Blockly.FieldNumber {
    * Constructs a FieldSlider from a JSON arg object.
    * @param options A JSON object with options (value, min, max, and
    *                          precision).
-   * @return The new field instance.
+   * @returns The new field instance.
    * @package
    * @nocollapse
    */
@@ -122,7 +122,7 @@ export class FieldSlider extends Blockly.FieldNumber {
 
   /**
    * Creates the slider editor and add event listeners.
-   * @return The newly created slider.
+   * @returns The newly created slider.
    */
   private dropdownCreate_(): HTMLElement {
     const wrapper = document.createElement('div') as HTMLElement;

--- a/plugins/field-slider/test/index.ts
+++ b/plugins/field-slider/test/index.ts
@@ -48,7 +48,7 @@ const toolbox = generateFieldTestBlocks('field_slider', [
  * Create a workspace.
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
- * @return The created workspace.
+ * @returns The created workspace.
  */
 function createWorkspace(blocklyDiv: HTMLElement,
     options: Blockly.BlocklyOptions): Blockly.WorkspaceSvg {

--- a/plugins/renderer-inline-row-separators/src/inline_row_separators_renderer.ts
+++ b/plugins/renderer-inline-row-separators/src/inline_row_separators_renderer.ts
@@ -26,7 +26,7 @@ type RenderInfoConstructor = new (...args: any[]) =>
  *     the new renderer will be derived from.
  * @param renderInfoBase A class extending Blockly.blockRendering.RenderInfo
  *     that should be compatible with the provided rendererBase.
- * @return The new renderer class. It's up to you to register it with Blockly.
+ * @returns The new renderer class. It's up to you to register it with Blockly.
  */
 export function addInlineRowSeparators<
     RendererBase extends RendererConstructor,
@@ -45,7 +45,7 @@ export function addInlineRowSeparators<
      *
      * @param input The first input to consider
      * @param lastInput The input that follows.
-     * @return True if the next input should be rendered on a new row.
+     * @returns True if the next input should be rendered on a new row.
      */
     protected shouldStartNewRow_(
         input: Blockly.Input, lastInput?: Blockly.Input): boolean {
@@ -66,7 +66,7 @@ export function addInlineRowSeparators<
      * Create a new instance of the renderer's render info object.
      *
      * @param block The block to measure.
-     * @return The render info object.
+     * @returns The render info object.
      */
     protected makeRenderInfo_(block: Blockly.BlockSvg):
         InlineRenderInfo {

--- a/plugins/renderer-inline-row-separators/test/index.ts
+++ b/plugins/renderer-inline-row-separators/test/index.ts
@@ -93,7 +93,7 @@ const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
  * Create a workspace.
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
- * @return The created workspace.
+ * @returns The created workspace.
  */
 function createWorkspace(blocklyDiv: HTMLElement,
     options: Blockly.BlocklyOptions): Blockly.WorkspaceSvg {

--- a/plugins/shadow-block-converter/src/shadow_block_converter.ts
+++ b/plugins/shadow-block-converter/src/shadow_block_converter.ts
@@ -57,7 +57,7 @@ export class BlockShadowChange extends Blockly.Events.BlockBase {
 
   /**
    * Encode the event as JSON.
-   * @return JSON representation.
+   * @returns JSON representation.
    * @override
    */
   toJson(): BlockChangeJson {

--- a/plugins/shadow-block-converter/test/index.ts
+++ b/plugins/shadow-block-converter/test/index.ts
@@ -115,7 +115,7 @@ const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
  * Create a workspace.
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
- * @return The created workspace.
+ * @returns The created workspace.
  */
 function createWorkspace(blocklyDiv: HTMLElement,
     options: Blockly.BlocklyOptions): Blockly.WorkspaceSvg {


### PR DESCRIPTION
Updates eslint config:

- Prefer `@returns` instead of `@return` in TS code. This is consistent with proper TsDoc and with core. Should be easier to move code between the two.
    - Also updates TS code to comply with this rule 
- Allow not having a description in a JsDoc block if there is a returns, param, or type block present. This is consistent with JS Style Guide section 7.8 and allows us to skip writing redundant function descriptions for simple functions.