### PR TITLE
fix: Add the --in-place flag to the migration script README.

### DIFF
--- a/plugins/migration/README.md
+++ b/plugins/migration/README.md
@@ -5,8 +5,8 @@ A collection of tools that help with migrating apps built on [Blockly](https://w
 ## Example Usage
 
 ```
-npx @blockly/migrate rename --from 6 ./path/to/my/files*
-npx @blockly/migrate rename --from 6 --to 7 ./path/to/my/files*
+npx @blockly/migrate rename --from 6 --in-place ./path/to/my/files*
+npx @blockly/migrate rename --from 6 --to 7 --in-place ./path/to/my/files*
 ```
 
 Use `help` subcommand for more info.


### PR DESCRIPTION
By default, the migration script just dumps the changes to stdout. The docs made no reference to the `--in-place` flag, which causes the script to actually update the files, which is presumably the behavior most people would want and expect.