### PR TITLE
feat: add workspace-backpack plugin type declarations

### DIFF
--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -13,6 +13,7 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
+  "types": "./src/index.d.ts",
   "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",

--- a/plugins/workspace-backpack/src/backpack.d.ts
+++ b/plugins/workspace-backpack/src/backpack.d.ts
@@ -62,7 +62,7 @@ export declare class Backpack extends Blockly.DragTarget {
      * @param {!Array<!Blockly.utils.Rect>} savedPositions List of rectangles that
      *     are already on the workspace.
      */
-    position(metrics: Blockly.MetricsManager.UiMetrics, savedPositions: Array<Blockly.utils.Rect>): void;
+    position(metrics: Blockly.MetricsManager.UiMetrics, savedPositions: Blockly.utils.Rect[]): void;
     /**
      * Returns the count of items in the backpack.
      * @return {number} The count of items.
@@ -72,7 +72,7 @@ export declare class Backpack extends Blockly.DragTarget {
      * Returns backpack contents.
      * @return {!Array<string>} The backpack contents.
      */
-    getContents(): Array<string>;
+    getContents(): string[];
     /**
      * Handles when a block or bubble is dropped on this component.
      * Should not handle delete here.
@@ -97,7 +97,7 @@ export declare class Backpack extends Blockly.DragTarget {
      * @param {!Array<!Blockly.Block>} blocks The blocks to be added to the
      *     backpack.
      */
-    addBlocks(blocks: Array<Blockly.Block>): void;
+    addBlocks(blocks: Blockly.Block[]): void;
     /**
      * Removes the specified block from the backpack.
      * @param {!Blockly.Block} block The block to be removed from the backpack.
@@ -113,7 +113,7 @@ export declare class Backpack extends Blockly.DragTarget {
      * Adds multiple items to the backpack.
      * @param {!Array<string>} items The backpack contents to add.
      */
-    addItems(items: Array<string>): void;
+    addItems(items: string[]): void;
     /**
      * Removes item from the backpack.
      * @param {string} item Text representing the XML tree of a block to remove,
@@ -124,7 +124,7 @@ export declare class Backpack extends Blockly.DragTarget {
      * Sets backpack contents.
      * @param {!Array<string>} contents The new backpack contents.
      */
-    setContents(contents: Array<string>): void;
+    setContents(contents: string[]): void;
     /**
      * Empties the backpack's contents. If the contents-flyout is currently open
      * it will be closed.

--- a/plugins/workspace-backpack/src/backpack.d.ts
+++ b/plugins/workspace-backpack/src/backpack.d.ts
@@ -8,7 +8,7 @@
  * @author kozbial@google.com (Monica Kozbial)
  */
 import * as Blockly from 'blockly/core';
-import { BackpackOptions } from './options';
+import {BackpackOptions} from './options';
 /**
  * Class for backpack that can be used save blocks from the workspace for
  * future use.
@@ -18,157 +18,163 @@ import { BackpackOptions } from './options';
  * @extends {Blockly.DragTarget}
  */
 export declare class Backpack extends Blockly.DragTarget {
-    /**
-     * Constructor for a backpack.
-     * @param {!Blockly.WorkspaceSvg} targetWorkspace The target workspace that
-     *     the backpack will be added to.
-     * @param {!BackpackOptions=} backpackOptions The backpack options to use.
-     */
-    constructor(targetWorkspace: Blockly.WorkspaceSvg, backpackOptions?: BackpackOptions);
-    /**
-     * Initializes the backpack.
-     */
-    init(): void;
-    /**
-     * Disposes of workspace search.
-     * Unlink from all DOM elements and remove all event listeners
-     * to prevent memory leaks.
-     */
-    dispose(): void;
-    /**
-     * Returns the backpack flyout.
-     * @return {?Blockly.IFlyout} The backpack flyout.
-     * @public
-     */
-    getFlyout(): Blockly.IFlyout | null;
-    /**
-     * Returns the bounding rectangle of the drag target area in pixel units
-     * relative to viewport.
-     * @return {?Blockly.utils.Rect} The component's bounding box. Null if drag
-     *   target area should be ignored.
-     */
-    getClientRect(): Blockly.utils.Rect | null;
-    /**
-     * Returns the bounding rectangle of the UI element in pixel units relative to
-     * the Blockly injection div.
-     * @return {!Blockly.utils.Rect} The component’s bounding box.
-     */
-    getBoundingRectangle(): Blockly.utils.Rect;
-    /**
-     * Positions the backpack.
-     * It is positioned in the opposite corner to the corner the
-     * categories/toolbox starts at.
-     * @param {!Blockly.MetricsManager.UiMetrics} metrics The workspace metrics.
-     * @param {!Array<!Blockly.utils.Rect>} savedPositions List of rectangles that
-     *     are already on the workspace.
-     */
-    position(metrics: Blockly.MetricsManager.UiMetrics, savedPositions: Blockly.utils.Rect[]): void;
-    /**
-     * Returns the count of items in the backpack.
-     * @return {number} The count of items.
-     */
-    getCount(): number;
-    /**
-     * Returns backpack contents.
-     * @return {!Array<string>} The backpack contents.
-     */
-    getContents(): string[];
-    /**
-     * Handles when a block or bubble is dropped on this component.
-     * Should not handle delete here.
-     * @param {!Blockly.IDraggable} dragElement The block or bubble currently
-     *   being dragged.
-     */
-    onDrop(dragElement: Blockly.IDraggable): void;
-    /**
-     * Returns whether the backpack contains a duplicate of the provided Block.
-     * @param {!Blockly.Block} block The block to check.
-     * @return {boolean} Whether the backpack contains a duplicate of the provided
-     *     block.
-     */
-    containsBlock(block: Blockly.Block): boolean;
-    /**
-     * Adds the specified block to backpack.
-     * @param {!Blockly.Block} block The block to be added to the backpack.
-     */
-    addBlock(block: Blockly.Block): void;
-    /**
-     * Adds the provided blocks to backpack.
-     * @param {!Array<!Blockly.Block>} blocks The blocks to be added to the
-     *     backpack.
-     */
-    addBlocks(blocks: Blockly.Block[]): void;
-    /**
-     * Removes the specified block from the backpack.
-     * @param {!Blockly.Block} block The block to be removed from the backpack.
-     */
-    removeBlock(block: Blockly.Block): void;
-    /**
-     * Adds item to backpack.
-     * @param {string} item Text representing the XML tree of a block to add,
-     *     cleaned of all unnecessary attributes.
-     */
-    addItem(item: string): void;
-    /**
-     * Adds multiple items to the backpack.
-     * @param {!Array<string>} items The backpack contents to add.
-     */
-    addItems(items: string[]): void;
-    /**
-     * Removes item from the backpack.
-     * @param {string} item Text representing the XML tree of a block to remove,
-     * cleaned of all unnecessary attributes.
-     */
-    removeItem(item: string): void;
-    /**
-     * Sets backpack contents.
-     * @param {!Array<string>} contents The new backpack contents.
-     */
-    setContents(contents: string[]): void;
-    /**
-     * Empties the backpack's contents. If the contents-flyout is currently open
-     * it will be closed.
-     */
-    empty(): void;
-    /**
-     * Returns whether the backpack is open.
-     * @return {boolean} Whether the backpack is open.
-     */
-    isOpen(): boolean;
-    /**
-     * Opens the backpack flyout.
-     */
-    open(): void;
-    /**
-     * Closes the backpack flyout.
-     */
-    close(): void;
-    /**
-     * Hides the component. Called in Blockly.hideChaff.
-     * @param {boolean} onlyClosePopups Whether only popups should be closed.
-     *     Flyouts should not be closed if this is true.
-     */
-    autoHide(onlyClosePopups: boolean): void;
-    /**
-     * Handles when a cursor with a block or bubble enters this drag target.
-     * @param {!Blockly.IDraggable} dragElement The block or bubble currently
-     *   being dragged.
-     */
-    onDragEnter(dragElement: Blockly.IDraggable): void;
-    /**
-     * Handles when a cursor with a block or bubble exits this drag target.
-     * @param {!Blockly.IDraggable} _dragElement The block or bubble currently
-     *   being dragged.
-     */
-    onDragExit(_dragElement: Blockly.IDraggable): void;
-    /**
-     * Returns whether the provided block or bubble should not be moved after
-     * being dropped on this component. If true, the element will return to where
-     * it was when the drag started.
-     * @param {!Blockly.IDraggable} dragElement The block or bubble currently
-     *   being dragged.
-     * @return {boolean} Whether the block or bubble provided should be returned
-     *   to drag start.
-     */
-    shouldPreventMove(dragElement: Blockly.IDraggable): boolean;
+  /**
+   * Constructor for a backpack.
+   * @param {!Blockly.WorkspaceSvg} targetWorkspace The target workspace that
+   *     the backpack will be added to.
+   * @param {!BackpackOptions=} backpackOptions The backpack options to use.
+   */
+  constructor(
+    targetWorkspace: Blockly.WorkspaceSvg,
+    backpackOptions?: BackpackOptions,
+  );
+  /**
+   * Initializes the backpack.
+   */
+  init(): void;
+  /**
+   * Disposes of workspace search.
+   * Unlink from all DOM elements and remove all event listeners
+   * to prevent memory leaks.
+   */
+  dispose(): void;
+  /**
+   * Returns the backpack flyout.
+   * @return {?Blockly.IFlyout} The backpack flyout.
+   * @public
+   */
+  getFlyout(): Blockly.IFlyout | null;
+  /**
+   * Returns the bounding rectangle of the drag target area in pixel units
+   * relative to viewport.
+   * @return {?Blockly.utils.Rect} The component's bounding box. Null if drag
+   *   target area should be ignored.
+   */
+  getClientRect(): Blockly.utils.Rect | null;
+  /**
+   * Returns the bounding rectangle of the UI element in pixel units relative to
+   * the Blockly injection div.
+   * @return {!Blockly.utils.Rect} The component’s bounding box.
+   */
+  getBoundingRectangle(): Blockly.utils.Rect;
+  /**
+   * Positions the backpack.
+   * It is positioned in the opposite corner to the corner the
+   * categories/toolbox starts at.
+   * @param {!Blockly.MetricsManager.UiMetrics} metrics The workspace metrics.
+   * @param {!Array<!Blockly.utils.Rect>} savedPositions List of rectangles that
+   *     are already on the workspace.
+   */
+  position(
+    metrics: Blockly.MetricsManager.UiMetrics,
+    savedPositions: Blockly.utils.Rect[],
+  ): void;
+  /**
+   * Returns the count of items in the backpack.
+   * @return {number} The count of items.
+   */
+  getCount(): number;
+  /**
+   * Returns backpack contents.
+   * @return {!Array<string>} The backpack contents.
+   */
+  getContents(): string[];
+  /**
+   * Handles when a block or bubble is dropped on this component.
+   * Should not handle delete here.
+   * @param {!Blockly.IDraggable} dragElement The block or bubble currently
+   *   being dragged.
+   */
+  onDrop(dragElement: Blockly.IDraggable): void;
+  /**
+   * Returns whether the backpack contains a duplicate of the provided Block.
+   * @param {!Blockly.Block} block The block to check.
+   * @return {boolean} Whether the backpack contains a duplicate of the provided
+   *     block.
+   */
+  containsBlock(block: Blockly.Block): boolean;
+  /**
+   * Adds the specified block to backpack.
+   * @param {!Blockly.Block} block The block to be added to the backpack.
+   */
+  addBlock(block: Blockly.Block): void;
+  /**
+   * Adds the provided blocks to backpack.
+   * @param {!Array<!Blockly.Block>} blocks The blocks to be added to the
+   *     backpack.
+   */
+  addBlocks(blocks: Blockly.Block[]): void;
+  /**
+   * Removes the specified block from the backpack.
+   * @param {!Blockly.Block} block The block to be removed from the backpack.
+   */
+  removeBlock(block: Blockly.Block): void;
+  /**
+   * Adds item to backpack.
+   * @param {string} item Text representing the XML tree of a block to add,
+   *     cleaned of all unnecessary attributes.
+   */
+  addItem(item: string): void;
+  /**
+   * Adds multiple items to the backpack.
+   * @param {!Array<string>} items The backpack contents to add.
+   */
+  addItems(items: string[]): void;
+  /**
+   * Removes item from the backpack.
+   * @param {string} item Text representing the XML tree of a block to remove,
+   * cleaned of all unnecessary attributes.
+   */
+  removeItem(item: string): void;
+  /**
+   * Sets backpack contents.
+   * @param {!Array<string>} contents The new backpack contents.
+   */
+  setContents(contents: string[]): void;
+  /**
+   * Empties the backpack's contents. If the contents-flyout is currently open
+   * it will be closed.
+   */
+  empty(): void;
+  /**
+   * Returns whether the backpack is open.
+   * @return {boolean} Whether the backpack is open.
+   */
+  isOpen(): boolean;
+  /**
+   * Opens the backpack flyout.
+   */
+  open(): void;
+  /**
+   * Closes the backpack flyout.
+   */
+  close(): void;
+  /**
+   * Hides the component. Called in Blockly.hideChaff.
+   * @param {boolean} onlyClosePopups Whether only popups should be closed.
+   *     Flyouts should not be closed if this is true.
+   */
+  autoHide(onlyClosePopups: boolean): void;
+  /**
+   * Handles when a cursor with a block or bubble enters this drag target.
+   * @param {!Blockly.IDraggable} dragElement The block or bubble currently
+   *   being dragged.
+   */
+  onDragEnter(dragElement: Blockly.IDraggable): void;
+  /**
+   * Handles when a cursor with a block or bubble exits this drag target.
+   * @param {!Blockly.IDraggable} dragElement The block or bubble currently
+   *   being dragged.
+   */
+  onDragExit(dragElement: Blockly.IDraggable): void;
+  /**
+   * Returns whether the provided block or bubble should not be moved after
+   * being dropped on this component. If true, the element will return to where
+   * it was when the drag started.
+   * @param {!Blockly.IDraggable} dragElement The block or bubble currently
+   *   being dragged.
+   * @return {boolean} Whether the block or bubble provided should be returned
+   *   to drag start.
+   */
+  shouldPreventMove(dragElement: Blockly.IDraggable): boolean;
 }

--- a/plugins/workspace-backpack/src/backpack.d.ts
+++ b/plugins/workspace-backpack/src/backpack.d.ts
@@ -1,0 +1,174 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * @fileoverview A backpack that lives on top of the workspace.
+ * @author kozbial@google.com (Monica Kozbial)
+ */
+import * as Blockly from 'blockly/core';
+import { BackpackOptions } from './options';
+/**
+ * Class for backpack that can be used save blocks from the workspace for
+ * future use.
+ * @param {!Blockly.WorkspaceSvg} workspace The workspace to sit in.
+ * @implements {Blockly.IAutoHideable}
+ * @implements {Blockly.IPositionable}
+ * @extends {Blockly.DragTarget}
+ */
+export declare class Backpack extends Blockly.DragTarget {
+    /**
+     * Constructor for a backpack.
+     * @param {!Blockly.WorkspaceSvg} targetWorkspace The target workspace that
+     *     the backpack will be added to.
+     * @param {!BackpackOptions=} backpackOptions The backpack options to use.
+     */
+    constructor(targetWorkspace: Blockly.WorkspaceSvg, backpackOptions?: BackpackOptions);
+    /**
+     * Initializes the backpack.
+     */
+    init(): void;
+    /**
+     * Disposes of workspace search.
+     * Unlink from all DOM elements and remove all event listeners
+     * to prevent memory leaks.
+     */
+    dispose(): void;
+    /**
+     * Returns the backpack flyout.
+     * @return {?Blockly.IFlyout} The backpack flyout.
+     * @public
+     */
+    getFlyout(): Blockly.IFlyout | null;
+    /**
+     * Returns the bounding rectangle of the drag target area in pixel units
+     * relative to viewport.
+     * @return {?Blockly.utils.Rect} The component's bounding box. Null if drag
+     *   target area should be ignored.
+     */
+    getClientRect(): Blockly.utils.Rect | null;
+    /**
+     * Returns the bounding rectangle of the UI element in pixel units relative to
+     * the Blockly injection div.
+     * @return {!Blockly.utils.Rect} The component’s bounding box.
+     */
+    getBoundingRectangle(): Blockly.utils.Rect;
+    /**
+     * Positions the backpack.
+     * It is positioned in the opposite corner to the corner the
+     * categories/toolbox starts at.
+     * @param {!Blockly.MetricsManager.UiMetrics} metrics The workspace metrics.
+     * @param {!Array<!Blockly.utils.Rect>} savedPositions List of rectangles that
+     *     are already on the workspace.
+     */
+    position(metrics: Blockly.MetricsManager.UiMetrics, savedPositions: Array<Blockly.utils.Rect>): void;
+    /**
+     * Returns the count of items in the backpack.
+     * @return {number} The count of items.
+     */
+    getCount(): number;
+    /**
+     * Returns backpack contents.
+     * @return {!Array<string>} The backpack contents.
+     */
+    getContents(): Array<string>;
+    /**
+     * Handles when a block or bubble is dropped on this component.
+     * Should not handle delete here.
+     * @param {!Blockly.IDraggable} dragElement The block or bubble currently
+     *   being dragged.
+     */
+    onDrop(dragElement: Blockly.IDraggable): void;
+    /**
+     * Returns whether the backpack contains a duplicate of the provided Block.
+     * @param {!Blockly.Block} block The block to check.
+     * @return {boolean} Whether the backpack contains a duplicate of the provided
+     *     block.
+     */
+    containsBlock(block: Blockly.Block): boolean;
+    /**
+     * Adds the specified block to backpack.
+     * @param {!Blockly.Block} block The block to be added to the backpack.
+     */
+    addBlock(block: Blockly.Block): void;
+    /**
+     * Adds the provided blocks to backpack.
+     * @param {!Array<!Blockly.Block>} blocks The blocks to be added to the
+     *     backpack.
+     */
+    addBlocks(blocks: Array<Blockly.Block>): void;
+    /**
+     * Removes the specified block from the backpack.
+     * @param {!Blockly.Block} block The block to be removed from the backpack.
+     */
+    removeBlock(block: Blockly.Block): void;
+    /**
+     * Adds item to backpack.
+     * @param {string} item Text representing the XML tree of a block to add,
+     *     cleaned of all unnecessary attributes.
+     */
+    addItem(item: string): void;
+    /**
+     * Adds multiple items to the backpack.
+     * @param {!Array<string>} items The backpack contents to add.
+     */
+    addItems(items: Array<string>): void;
+    /**
+     * Removes item from the backpack.
+     * @param {string} item Text representing the XML tree of a block to remove,
+     * cleaned of all unnecessary attributes.
+     */
+    removeItem(item: string): void;
+    /**
+     * Sets backpack contents.
+     * @param {!Array<string>} contents The new backpack contents.
+     */
+    setContents(contents: Array<string>): void;
+    /**
+     * Empties the backpack's contents. If the contents-flyout is currently open
+     * it will be closed.
+     */
+    empty(): void;
+    /**
+     * Returns whether the backpack is open.
+     * @return {boolean} Whether the backpack is open.
+     */
+    isOpen(): boolean;
+    /**
+     * Opens the backpack flyout.
+     */
+    open(): void;
+    /**
+     * Closes the backpack flyout.
+     */
+    close(): void;
+    /**
+     * Hides the component. Called in Blockly.hideChaff.
+     * @param {boolean} onlyClosePopups Whether only popups should be closed.
+     *     Flyouts should not be closed if this is true.
+     */
+    autoHide(onlyClosePopups: boolean): void;
+    /**
+     * Handles when a cursor with a block or bubble enters this drag target.
+     * @param {!Blockly.IDraggable} dragElement The block or bubble currently
+     *   being dragged.
+     */
+    onDragEnter(dragElement: Blockly.IDraggable): void;
+    /**
+     * Handles when a cursor with a block or bubble exits this drag target.
+     * @param {!Blockly.IDraggable} _dragElement The block or bubble currently
+     *   being dragged.
+     */
+    onDragExit(_dragElement: Blockly.IDraggable): void;
+    /**
+     * Returns whether the provided block or bubble should not be moved after
+     * being dropped on this component. If true, the element will return to where
+     * it was when the drag started.
+     * @param {!Blockly.IDraggable} dragElement The block or bubble currently
+     *   being dragged.
+     * @return {boolean} Whether the block or bubble provided should be returned
+     *   to drag start.
+     */
+    shouldPreventMove(dragElement: Blockly.IDraggable): boolean;
+}

--- a/plugins/workspace-backpack/src/index.d.ts
+++ b/plugins/workspace-backpack/src/index.d.ts
@@ -1,2 +1,5 @@
-export { Backpack } from './backpack';
-export { BackpackOptions, BackpackContextMenuOptions, } from './options';
+export {Backpack} from './backpack';
+export {
+  BackpackOptions,
+  BackpackContextMenuOptions,
+} from './options';

--- a/plugins/workspace-backpack/src/index.d.ts
+++ b/plugins/workspace-backpack/src/index.d.ts
@@ -1,0 +1,2 @@
+export { Backpack } from './backpack';
+export { BackpackOptions, BackpackContextMenuOptions, } from './options';

--- a/plugins/workspace-backpack/src/options.d.ts
+++ b/plugins/workspace-backpack/src/options.d.ts
@@ -8,23 +8,25 @@
  * backpack plugin.
  * @author kozbial@google.com (Monica Kozbial)
  */
-export type BackpackContextMenuOptions = {
-    emptyBackpack?: boolean;
-    removeFromBackpack?: boolean;
-    copyToBackpack?: boolean;
-    copyAllToBackpack?: boolean;
-    pasteAllToBackpack?: boolean;
-    disablePreconditionChecks?: boolean;
-};
-export type BackpackOptions = {
-    allowEmptyBackpackOpen?: boolean;
-    useFilledBackpackImage?: boolean;
-    contextMenu?: BackpackContextMenuOptions;
-};
+export interface BackpackContextMenuOptions {
+  emptyBackpack?: boolean;
+  removeFromBackpack?: boolean;
+  copyToBackpack?: boolean;
+  copyAllToBackpack?: boolean;
+  pasteAllToBackpack?: boolean;
+  disablePreconditionChecks?: boolean;
+}
+export interface BackpackOptions {
+  allowEmptyBackpackOpen?: boolean;
+  useFilledBackpackImage?: boolean;
+  contextMenu?: BackpackContextMenuOptions;
+}
 /**
  * Returns a new options object with all properties set, using default values
  * if not specified in the optional options that were passed in.
  * @param {BackpackOptions=} options The options to use.
  * @return {!BackpackOptions} The created options object.
  */
-export declare function parseOptions(options?: BackpackOptions): BackpackOptions;
+export declare function parseOptions(
+  options?: BackpackOptions,
+): BackpackOptions;

--- a/plugins/workspace-backpack/src/options.d.ts
+++ b/plugins/workspace-backpack/src/options.d.ts
@@ -8,19 +8,17 @@
  * backpack plugin.
  * @author kozbial@google.com (Monica Kozbial)
  */
-export type BackpackOptions = {
-    allowEmptyBackpackOpen: boolean;
-    contextMenu: {
-        emptyBackpack: boolean;
-        removeFromBackpack: boolean;
-        copyToBackpack: boolean;
-        copyAllToBackpack: boolean;
-        pasteAllToBackpack: boolean;
-        disablePreconditionChecks: boolean;
-    };
-};
 export type BackpackContextMenuOptions = {
+    emptyBackpack?: boolean;
+    removeFromBackpack?: boolean;
+    copyToBackpack?: boolean;
+    copyAllToBackpack?: boolean;
+    pasteAllToBackpack?: boolean;
+    disablePreconditionChecks?: boolean;
+};
+export type BackpackOptions = {
     allowEmptyBackpackOpen?: boolean;
+    useFilledBackpackImage?: boolean;
     contextMenu?: BackpackContextMenuOptions;
 };
 /**

--- a/plugins/workspace-backpack/src/options.d.ts
+++ b/plugins/workspace-backpack/src/options.d.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * @fileoverview Typedefs and utility methods for parsing options for the
+ * backpack plugin.
+ * @author kozbial@google.com (Monica Kozbial)
+ */
+export type BackpackOptions = {
+    allowEmptyBackpackOpen: boolean;
+    contextMenu: {
+        emptyBackpack: boolean;
+        removeFromBackpack: boolean;
+        copyToBackpack: boolean;
+        copyAllToBackpack: boolean;
+        pasteAllToBackpack: boolean;
+        disablePreconditionChecks: boolean;
+    };
+};
+export type BackpackContextMenuOptions = {
+    allowEmptyBackpackOpen?: boolean;
+    contextMenu?: BackpackContextMenuOptions;
+};
+/**
+ * Returns a new options object with all properties set, using default values
+ * if not specified in the optional options that were passed in.
+ * @param {BackpackOptions=} options The options to use.
+ * @return {!BackpackOptions} The created options object.
+ */
+export declare function parseOptions(options?: BackpackOptions): BackpackOptions;


### PR DESCRIPTION
## Problem

The `workspace-backpack` plugin is missing type declarations, which makes it difficult to add to TypeScript projects. Searching on [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) yields no results.

## PR Summary:

* Adds the following type declaration files:
  * index.d.ts
  * backpack.d.ts
  * options.d.ts
* Adds `"types": "./src/index.d.ts"` to `workspace-backpack`'s package.json, as these type declarations aren't copied to `dist` during build, but the `src` folder is published along with `dist`

This PR is similar to https://github.com/google/blockly-samples/pull/1143