### PR TITLE
fix: running procedure events in other workspaces

### DIFF
--- a/plugins/block-sharable-procedures/src/events_procedure_create.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_create.ts
@@ -27,12 +27,9 @@ export class ProcedureCreate extends ProcedureBase {
   run(forward: boolean) {
     const workspace = this.getEventWorkspace_();
     const procedureMap = workspace.getProcedureMap();
-    const procedureModel = procedureMap.get(this.procedure.getId());
     if (forward) {
-      if (procedureModel) return;
       procedureMap.add(this.procedure);
     } else {
-      if (!procedureModel) return;
       procedureMap.delete(this.procedure.getId());
     }
   }

--- a/plugins/block-sharable-procedures/src/events_procedure_delete.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_delete.ts
@@ -7,7 +7,6 @@
 
 import * as Blockly from 'blockly/core';
 import {ProcedureBase, ProcedureBaseJson} from './events_procedure_base';
-import {ObservableProcedureModel} from './observable_procedure_model';
 
 
 const TYPE = 'procedure_delete';
@@ -27,14 +26,10 @@ export class ProcedureDelete extends ProcedureBase {
   run(forward: boolean) {
     const workspace = this.getEventWorkspace_();
     const procedureMap = workspace.getProcedureMap();
-    const procedureModel = procedureMap.get(this.procedure.getId());
     if (forward) {
-      if (!procedureModel) return;
       procedureMap.delete(this.procedure.getId());
     } else {
-      if (procedureModel) return;
-      procedureMap.add(new ObservableProcedureModel(
-          workspace, this.procedure.getName(), this.procedure.getId()));
+      procedureMap.add(this.procedure);
     }
   }
 

--- a/plugins/block-sharable-procedures/src/events_procedure_enable.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_enable.ts
@@ -26,14 +26,23 @@ export class ProcedureEnable extends ProcedureBase {
    * Constructs the procedure enable event.
    * @param workspace The workspace this event is associated with.
    * @param procedure The model this event is associated with.
+   * @param newState The (optional) new enabled state of the procedure model.
+   *     If not provided, the procedure model will be inspected to determine
+   *     its current state.
    */
   constructor(
       workspace: Blockly.Workspace,
-      procedure: Blockly.procedures.IProcedureModel) {
+      procedure: Blockly.procedures.IProcedureModel,
+      newState?: boolean) {
     super(workspace, procedure);
 
-    this.oldState = !procedure.getEnabled();
-    this.newState = procedure.getEnabled();
+    if (newState === undefined) {
+      this.oldState = !procedure.getEnabled();
+      this.newState = procedure.getEnabled();
+    } else {
+      this.oldState = !newState;
+      this.newState = newState;
+    }
   }
 
   /**
@@ -61,7 +70,9 @@ export class ProcedureEnable extends ProcedureBase {
    * @returns JSON representation.
    */
   toJson(): ProcedureEnableJson {
-    return super.toJson() as ProcedureEnableJson;
+    const json = super.toJson() as ProcedureEnableJson;
+    json['newState'] = this.newState;
+    return json;
   }
 
   /**
@@ -79,11 +90,13 @@ export class ProcedureEnable extends ProcedureBase {
           'Cannot deserialize procedure enable event because the ' +
           'target procedure does not exist');
     }
-    return new ProcedureEnable(workspace, model);
+    return new ProcedureEnable(workspace, model, json['newState']);
   }
 }
 
-export type ProcedureEnableJson = ProcedureBaseJson;
+export interface ProcedureEnableJson extends ProcedureBaseJson {
+  newState: boolean;
+}
 
 Blockly.registry.register(
     Blockly.registry.Type.EVENT, TYPE, ProcedureEnable);

--- a/plugins/block-sharable-procedures/src/events_procedure_parameter_base.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_parameter_base.ts
@@ -30,10 +30,41 @@ export abstract class ProcedureParameterBase extends ProcedureBase {
    * Returns true if the given parameter is identical to this parameter.
    * @param param The parameter to check for equivalence.
    * @returns True if the parameter matches, false if it does not.
+   * @internal
    */
   protected parameterMatches(
       param?: Blockly.procedures.IParameterModel): boolean {
     return param && param.getId() === this.parameter.getId();
+  }
+
+  /**
+   * Finds the parameter with the given ID in the procedure model with the given
+   * ID, if both things exist.
+   * @param workspace The workspace to search for the parameter.
+   * @param modelId The ID of the model to search for the parameter.
+   * @param paramId The ID of the parameter to search for.
+   * @returns The parameter model that was found.
+   * @internal
+   */
+  static findMatchingParameter(
+      workspace: Blockly.Workspace,
+      modelId: string,
+      paramId: string
+  ): ProcedureParameterPair {
+    const procedure = workspace.getProcedureMap().get(modelId);
+    if (!procedure) {
+      throw new Error(
+          'Cannot find the parameter of a procedure that does not exist ' +
+          'in the procedure map');
+    }
+    const parameter = procedure.getParameters()
+        .find((p) => p.getId() === paramId);
+    if (!parameter) {
+      throw new Error(
+          'Cannot find a parameter that does not exist in ' +
+          'its associated procedure');
+    }
+    return {procedure, parameter};
   }
 
   /**
@@ -45,6 +76,11 @@ export abstract class ProcedureParameterBase extends ProcedureBase {
     json['parameterId'] = this.parameter.getId();
     return json;
   }
+}
+
+export interface ProcedureParameterPair {
+  procedure: Blockly.procedures.IProcedureModel;
+  parameter: Blockly.procedures.IParameterModel;
 }
 
 export interface ProcedureParameterBaseJson extends ProcedureBaseJson {

--- a/plugins/block-sharable-procedures/src/events_procedure_parameter_base.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_parameter_base.ts
@@ -27,17 +27,6 @@ export abstract class ProcedureParameterBase extends ProcedureBase {
   }
 
   /**
-   * Returns true if the given parameter is identical to this parameter.
-   * @param param The parameter to check for equivalence.
-   * @returns True if the parameter matches, false if it does not.
-   * @internal
-   */
-  protected parameterMatches(
-      param?: Blockly.procedures.IParameterModel): boolean {
-    return param && param.getId() === this.parameter.getId();
-  }
-
-  /**
    * Finds the parameter with the given ID in the procedure model with the given
    * ID, if both things exist.
    * @param workspace The workspace to search for the parameter.
@@ -52,18 +41,10 @@ export abstract class ProcedureParameterBase extends ProcedureBase {
       paramId: string
   ): ProcedureParameterPair {
     const procedure = workspace.getProcedureMap().get(modelId);
-    if (!procedure) {
-      throw new Error(
-          'Cannot find the parameter of a procedure that does not exist ' +
-          'in the procedure map');
-    }
+    if (!procedure) return {procedure: undefined, parameter: undefined};
     const parameter = procedure.getParameters()
         .find((p) => p.getId() === paramId);
-    if (!parameter) {
-      throw new Error(
-          'Cannot find a parameter that does not exist in ' +
-          'its associated procedure');
-    }
+    if (!parameter) return {procedure, parameter: undefined};
     return {procedure, parameter};
   }
 
@@ -79,8 +60,8 @@ export abstract class ProcedureParameterBase extends ProcedureBase {
 }
 
 export interface ProcedureParameterPair {
-  procedure: Blockly.procedures.IProcedureModel;
-  parameter: Blockly.procedures.IParameterModel;
+  procedure?: Blockly.procedures.IProcedureModel;
+  parameter?: Blockly.procedures.IParameterModel;
 }
 
 export interface ProcedureParameterBaseJson extends ProcedureBaseJson {

--- a/plugins/block-sharable-procedures/src/events_procedure_parameter_base.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_parameter_base.ts
@@ -30,17 +30,18 @@ export abstract class ProcedureParameterBase extends ProcedureBase {
    * Finds the parameter with the given ID in the procedure model with the given
    * ID, if both things exist.
    * @param workspace The workspace to search for the parameter.
-   * @param modelId The ID of the model to search for the parameter.
+   * @param procedureId The ID of the procedure model to search for
+   *     the parameter.
    * @param paramId The ID of the parameter to search for.
    * @returns The parameter model that was found.
    * @internal
    */
   static findMatchingParameter(
       workspace: Blockly.Workspace,
-      modelId: string,
+      procedureId: string,
       paramId: string
   ): ProcedureParameterPair {
-    const procedure = workspace.getProcedureMap().get(modelId);
+    const procedure = workspace.getProcedureMap().get(procedureId);
     if (!procedure) return {procedure: undefined, parameter: undefined};
     const parameter = procedure.getParameters()
         .find((p) => p.getId() === paramId);

--- a/plugins/block-sharable-procedures/src/events_procedure_parameter_create.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_parameter_create.ts
@@ -49,12 +49,9 @@ export class ProcedureParameterCreate extends ProcedureParameterBase {
           'Cannot add a parameter to a procedure that does not exist ' +
           'in the procedure map');
     }
-    const parameterModel = procedureModel.getParameter(this.index);
     if (forward) {
-      if (this.parameterMatches(parameterModel)) return;
       procedureModel.insertParameter(this.parameter, this.index);
     } else {
-      if (!this.parameterMatches(parameterModel)) return;
       procedureModel.deleteParameter(this.index);
     }
   }

--- a/plugins/block-sharable-procedures/src/events_procedure_parameter_create.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_parameter_create.ts
@@ -18,6 +18,8 @@ export class ProcedureParameterCreate extends ProcedureParameterBase {
   /** A string used to check the type of the event. */
   type = TYPE;
 
+  parameter: ObservableParameterModel;
+
   /**
    * Constructs the procedure parameter create event.js.
    * @param workspace The workspace this event is associated with.
@@ -28,7 +30,7 @@ export class ProcedureParameterCreate extends ProcedureParameterBase {
   constructor(
       workspace: Blockly.Workspace,
       procedure: Blockly.procedures.IProcedureModel,
-      parameter: Blockly.procedures.IParameterModel,
+      parameter: ObservableParameterModel,
       readonly index: number) {
     super(workspace, procedure, parameter);
   }
@@ -63,8 +65,9 @@ export class ProcedureParameterCreate extends ProcedureParameterBase {
    */
   toJson(): ProcedureParameterCreateJson {
     const json = super.toJson() as ProcedureParameterCreateJson;
-    json['parameter'] =
-        Blockly.serialization.procedures.saveParameter(this.parameter);
+    json['name'] = this.parameter.getName();
+    json['id'] = this.parameter.getId();
+    json['varId'] = this.parameter.getVariableModel().getId();
     json['index'] = this.index;
     return json;
   }
@@ -87,9 +90,10 @@ export class ProcedureParameterCreate extends ProcedureParameterBase {
           'target procedure does not exist');
     }
     return new ProcedureParameterCreate(
-        workspace, procedure,
-        Blockly.serialization.procedures.loadParameter(
-            ObservableParameterModel, json['parameter'], workspace),
+        workspace,
+        procedure,
+        new ObservableParameterModel(
+            workspace, json['name'], json['id'], json['varId']),
         json['index']);
   }
 }

--- a/plugins/block-sharable-procedures/src/events_procedure_parameter_delete.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_parameter_delete.ts
@@ -47,12 +47,9 @@ export class ProcedureParameterDelete extends ProcedureParameterBase {
           'Cannot add a parameter to a procedure that does not exist ' +
           'in the procedure map');
     }
-    const parameterModel = procedureModel.getParameter(this.index);
     if (forward) {
-      if (!this.parameterMatches(parameterModel)) return;
       procedureModel.deleteParameter(this.index);
     } else {
-      if (this.parameterMatches(parameterModel)) return;
       procedureModel.insertParameter(this.parameter, this.index);
     }
   }
@@ -80,6 +77,9 @@ export class ProcedureParameterDelete extends ProcedureParameterBase {
   ): ProcedureParameterDelete {
     const {procedure, parameter} = ProcedureParameterBase.findMatchingParameter(
         workspace, json['procedureId'], json['parameterId']);
+    if (!parameter) {
+      throw new Error('Cannot delete a non existant parameter');
+    }
     return new ProcedureParameterDelete(
         workspace, procedure, parameter, json['index']);
   }

--- a/plugins/block-sharable-procedures/src/events_procedure_parameter_delete.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_parameter_delete.ts
@@ -78,14 +78,10 @@ export class ProcedureParameterDelete extends ProcedureParameterBase {
       json: ProcedureParameterDeleteJson,
       workspace: Blockly.Workspace
   ): ProcedureParameterDelete {
-    const model = workspace.getProcedureMap().get(json['procedureId']);
-    if (!model) {
-      throw new Error(
-          'Cannot deserialize procedure delete event because the ' +
-          'target procedure does not exist');
-    }
-    const param = model.getParameter(json['index']);
-    return new ProcedureParameterDelete(workspace, model, param, json['index']);
+    const {procedure, parameter} = ProcedureParameterBase.findMatchingParameter(
+        workspace, json['procedureId'], json['parameterId']);
+    return new ProcedureParameterDelete(
+        workspace, procedure, parameter, json['index']);
   }
 }
 

--- a/plugins/block-sharable-procedures/src/events_procedure_parameter_rename.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_parameter_rename.ts
@@ -43,14 +43,14 @@ export class ProcedureParameterRename extends ProcedureParameterBase {
    *     backward (undo).
    */
   run(forward: boolean) {
-    const parameterModel = findMatchingParameter(
+    const {parameter} = ProcedureParameterBase.findMatchingParameter(
         this.getEventWorkspace_(),
         this.procedure.getId(),
         this.parameter.getId());
     if (forward) {
-      parameterModel.setName(this.newName);
+      parameter.setName(this.newName);
     } else {
-      parameterModel.setName(this.oldName);
+      parameter.setName(this.oldName);
     }
   }
 
@@ -75,41 +75,12 @@ export class ProcedureParameterRename extends ProcedureParameterBase {
       json: ProcedureParameterRenameJson,
       workspace: Blockly.Workspace
   ): ProcedureParameterRename {
-    const model = workspace.getProcedureMap().get(json['procedureId']);
-    const param = findMatchingParameter(
-        workspace, json['procedureId'], json['parameterId']);
+    const {procedure, parameter} =
+        ProcedureParameterBase.findMatchingParameter(
+            workspace, json['procedureId'], json['parameterId']);
     return new ProcedureParameterRename(
-        workspace, model, param, json['oldName']);
+        workspace, procedure, parameter, json['oldName']);
   }
-}
-
-/**
- * Finds the parameter with the given ID in the procedure model with the given
- * ID, if both things exist.
- * @param workspace The workspace to search for the parameter.
- * @param modelId The ID of the model to search for the parameter.
- * @param paramId The ID of the parameter to search for.
- * @returns The parameter model that was found.
- */
-function findMatchingParameter(
-    workspace: Blockly.Workspace,
-    modelId: string,
-    paramId: string
-): Blockly.procedures.IParameterModel {
-  const procedureModel = workspace.getProcedureMap().get(modelId);
-  if (!procedureModel) {
-    throw new Error(
-        'Cannot rename the parameter of a procedure that does not exist ' +
-        'in the procedure map');
-  }
-  const param = procedureModel.getParameters()
-      .find((p) => p.getId() === paramId);
-  if (!param) {
-    throw new Error(
-        'Cannot rename a parameter that does not exist in ' +
-        'its associated procedure');
-  }
-  return param;
 }
 
 export interface ProcedureParameterRenameJson extends

--- a/plugins/block-sharable-procedures/src/events_procedure_parameter_rename.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_parameter_rename.ts
@@ -83,6 +83,9 @@ export class ProcedureParameterRename extends ProcedureParameterBase {
     const {procedure, parameter} =
         ProcedureParameterBase.findMatchingParameter(
             workspace, json['procedureId'], json['parameterId']);
+    if (!parameter) {
+      throw new Error('Cannot delete a non existant parameter');
+    }
     return new ProcedureParameterRename(
         workspace, procedure, parameter, json['oldName'], json['newName']);
   }

--- a/plugins/block-sharable-procedures/src/events_procedure_parameter_rename.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_parameter_rename.ts
@@ -26,15 +26,19 @@ export class ProcedureParameterRename extends ProcedureParameterBase {
    * @param procedure The procedure model this event is associated with.
    * @param parameter The parameter model this event is associated with.
    * @param oldName The old name of the procedure parameter.
+   * @param newName The (optional) new name of the procedure parameter. If not
+   *     provided, the parameter model will be inspected to see what its current
+   *     name is.
    */
   constructor(
       workspace: Blockly.Workspace,
       procedure: Blockly.procedures.IProcedureModel,
       parameter: Blockly.procedures.IParameterModel,
-      readonly oldName: string) {
+      readonly oldName: string,
+      newName?: string) {
     super(workspace, procedure, parameter);
 
-    this.newName = parameter.getName();
+    this.newName = newName ?? parameter.getName();
   }
 
   /**
@@ -60,6 +64,7 @@ export class ProcedureParameterRename extends ProcedureParameterBase {
    */
   toJson(): ProcedureParameterRenameJson {
     const json = super.toJson() as ProcedureParameterRenameJson;
+    json['newName'] = this.newName;
     json['oldName'] = this.oldName;
     return json;
   }
@@ -79,13 +84,14 @@ export class ProcedureParameterRename extends ProcedureParameterBase {
         ProcedureParameterBase.findMatchingParameter(
             workspace, json['procedureId'], json['parameterId']);
     return new ProcedureParameterRename(
-        workspace, procedure, parameter, json['oldName']);
+        workspace, procedure, parameter, json['oldName'], json['newName']);
   }
 }
 
 export interface ProcedureParameterRenameJson extends
     ProcedureParameterBaseJson {
   oldName: string;
+  newName: string;
 }
 
 Blockly.registry.register(

--- a/plugins/block-sharable-procedures/src/events_procedure_rename.ts
+++ b/plugins/block-sharable-procedures/src/events_procedure_rename.ts
@@ -22,14 +22,18 @@ export class ProcedureRename extends ProcedureBase {
    * @param workspace The workspace this event is associated with.
    * @param procedure The model this event is associated with.
    * @param oldName The old name of the procedure model.
+   * @param newName The (optional) new name of the procedure. If not provided,
+   *     the procedure model will be inspected to see what its current
+   *     name is.
    */
   constructor(
       workspace: Blockly.Workspace,
       procedure: Blockly.procedures.IProcedureModel,
-      readonly oldName: string) {
+      readonly oldName: string,
+      newName?: string) {
     super(workspace, procedure);
 
-    this.newName = procedure.getName();
+    this.newName = newName ?? procedure.getName();
   }
 
   /**
@@ -58,6 +62,7 @@ export class ProcedureRename extends ProcedureBase {
    */
   toJson(): ProcedureRenameJson {
     const json = super.toJson() as ProcedureRenameJson;
+    json['newName'] = this.newName;
     json['oldName'] = this.oldName;
     return json;
   }
@@ -77,12 +82,14 @@ export class ProcedureRename extends ProcedureBase {
           'Cannot deserialize procedure rename event because the ' +
           'target procedure does not exist');
     }
-    return new ProcedureRename(workspace, model, json['oldName']);
+    return new ProcedureRename(
+        workspace, model, json['oldName'], json['newName']);
   }
 }
 
 export interface ProcedureRenameJson extends ProcedureBaseJson {
   oldName: string;
+  newName: string;
 }
 
 Blockly.registry.register(

--- a/plugins/block-sharable-procedures/src/observable_procedure_model.ts
+++ b/plugins/block-sharable-procedures/src/observable_procedure_model.ts
@@ -5,6 +5,7 @@
  */
 
 import * as Blockly from 'blockly/core';
+import {ObservableParameterModel} from './observable_parameter_model';
 import {ProcedureChangeReturn} from './events_procedure_change_return';
 import {ProcedureCreate} from './events_procedure_create';
 import {ProcedureDelete} from './events_procedure_delete';
@@ -19,7 +20,7 @@ export class ObservableProcedureModel
 implements Blockly.procedures.IProcedureModel {
   private id: string;
   private name: string;
-  private parameters: Blockly.procedures.IParameterModel[] = [];
+  private parameters: ObservableParameterModel[] = [];
   private returnTypes: string[]|null = null;
   private enabled = true;
   private shouldFireEvents = false;
@@ -64,7 +65,7 @@ implements Blockly.procedures.IProcedureModel {
    * @returns This procedure model.
    */
   insertParameter(
-      parameterModel: Blockly.procedures.IParameterModel, index: number): this {
+      parameterModel: ObservableParameterModel, index: number): this {
     if (this.parameters[index] &&
         this.parameters[index].getId() === parameterModel.getId()) {
       return this;

--- a/plugins/block-sharable-procedures/test/event_procedure_enable.mocha.js
+++ b/plugins/block-sharable-procedures/test/event_procedure_enable.mocha.js
@@ -102,6 +102,26 @@ suite('Procedure Enable Event', function() {
               event.run(/* forward= */ true);
             });
           });
+
+      test(
+          'deserializing the event and running it triggers the effect',
+          function() {
+            const initial = this.createProcedureModel('test id');
+            const final = this.createProcedureModel('test id');
+            final.setEnabled(!final.getEnabled()); // Set it to the non-default.
+            const event = this.createEventToState(final);
+            this.procedureMap.add(initial);
+
+            const newEvent = Blockly.Events.fromJson(
+                event.toJson(), this.workspace);
+            newEvent.run(/* forward= */ true);
+            this.clock.runAll();
+
+            assert.equal(
+                initial.getEnabled(),
+                final.getEnabled(),
+                'Expected the procedure\'s enabled state to be flipped');
+          });
     });
 
     suite('backward', function() {

--- a/plugins/block-sharable-procedures/test/event_procedure_parameter_rename.mocha.js
+++ b/plugins/block-sharable-procedures/test/event_procedure_parameter_rename.mocha.js
@@ -132,6 +132,28 @@ suite('Procedure Parameter Rename Event', function() {
               event.run(/* forward= */ true);
             });
           });
+
+      test(
+          'deserializing the event and running it triggers the effect',
+          function() {
+            const {param: initialParam, proc: initialProc} =
+                this.createProcedureAndParameter('test procId', 'test paramId');
+            const {param: finalParam, proc: finalProc} =
+                this.createProcedureAndParameter('test procId', 'test paramId');
+            finalParam.setName(NON_DEFAULT_NAME);
+            const event = this.createEventToState(finalProc, finalParam);
+            this.procedureMap.add(initialProc);
+
+            const newEvent = Blockly.Events.fromJson(
+                event.toJson(), this.workspace);
+            newEvent.run(/* forward= */ true);
+            this.clock.runAll();
+
+            assert.equal(
+                initialParam.getName(),
+                finalParam.getName(),
+                'Expected the procedure parameter\'s name to be changed');
+          });
     });
 
     suite('backward', function() {

--- a/plugins/block-sharable-procedures/test/event_procedure_rename.mocha.js
+++ b/plugins/block-sharable-procedures/test/event_procedure_rename.mocha.js
@@ -109,6 +109,26 @@ suite('Procedure Rename Event', function() {
               event.run(/* forward= */ true);
             });
           });
+
+      test(
+          'deserializing the event and running it triggers the effect',
+          function() {
+            const initial = this.createProcedureModel('test id');
+            const final = this.createProcedureModel('test id');
+            final.setName(NON_DEFAULT_NAME);
+            const event = this.createEventToState(final);
+            this.procedureMap.add(initial);
+
+            const newEvent = Blockly.Events.fromJson(
+                event.toJson(), this.workspace);
+            newEvent.run(/* forward= */ true);
+            this.clock.runAll();
+
+            assert.equal(
+                initial.getName(),
+                final.getName(),
+                'Expected the procedure\'s name to be changed');
+          });
     });
 
     suite('backward', function() {

--- a/plugins/block-sharable-procedures/test/procedure_test_helpers.js
+++ b/plugins/block-sharable-procedures/test/procedure_test_helpers.js
@@ -20,7 +20,7 @@ const sinon = require('sinon');
  * @param {string|!Array<string>} returnIds The return values to use for the
  *    created stub. If a single value is passed, then the stub always returns
  *    that value.
- * @return {!sinon.SinonStub} The created stub.
+ * @returns {!sinon.SinonStub} The created stub.
  */
 export function createGenUidStubWithReturns(returnIds) {
   const stub = sinon.stub(Blockly.utils.idGenerator.TEST_ONLY, 'genUid');
@@ -143,7 +143,7 @@ export function assertCallBlockStructure(
  *    return.
  * @param {Array<string>=} args An array of argument names.
  * @param {string=} name The name of the def block (defaults to 'proc name').
- * @return {Blockly.Block} The created block.
+ * @returns {Blockly.Block} The created block.
  */
 export function createProcDefBlock(
     workspace, hasReturn = false, args = [], name = 'proc name') {
@@ -165,7 +165,7 @@ export function createProcDefBlock(
  *    has return.
  * @param {string=} name The name of the caller block
  *     (defaults to 'proc name').
- * @return {Blockly.Block} The created block.
+ * @returns {Blockly.Block} The created block.
  */
 export function createProcCallBlock(
     workspace, hasReturn = false, name = 'proc name') {


### PR DESCRIPTION
### Description

When I hooked up the sharing procedures test page, I found some bugs with running the events in other workspaces.

Namely:
  * Some of the events didn't work because we weren't round-tripping the new value (it was basing the new value on inspection, which doesn't work when instantiating into a different worksapce)
  * The parameter create events weren't round-tripping the variable ID, so then if you renamed the variable in another workspace after instantiating it, the rename wouldn't properly propogate.

And I also made it consistent that events will throw when they run into erroneous situtations when deserializing /and/ when running.

Work on https://github.com/google/blockly/issues/6834

### Additional Info

Dependent on #1544 