### PR TITLE
fix: event cycles caused by deleting and adding parameters to models

### DIFF
--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -251,11 +251,7 @@ const procedureDefVarMixin = function() {
       if (index === -1) return; // Not found.
       const newVar = this.workspace.getVariableById(newId);
       const oldParam = model.getParameter(index);
-      model.deleteParameter(index);
-      model.insertParameter(
-          new ObservableParameterModel(
-              this.workspace, newVar.name, oldParam.getId()),
-          index);
+      oldParam.setName(newVar.name);
     },
 
     /**

--- a/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
+++ b/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
@@ -1032,6 +1032,7 @@ suite('Procedures', function() {
           // Reorder the parameters.
           paramBlock2.previousConnection.disconnect();
           paramBlock1.previousConnection.disconnect();
+          defBlock.compose(containerBlock);
           containerBlock.getInput('STACK').connection
               .connect(paramBlock2.previousConnection);
           paramBlock2.nextConnection.connect(paramBlock1.previousConnection);


### PR DESCRIPTION
### Description

Blockly's event system has a 1ms timeout built into it, which means that events get "batched" and then fired. This was causing problems when attempting to share procedures between workspaces & modify their parameters.

Previously whenever we were composing a definition block, we would delete all of the parameters of the procedure model, and then add them back based on the blocks in the mutator. So when adding a parameter we would get an event cycle like:

```
Start with [x], and [x]

- Remove [x] |
- Add [x]    |
- Add [y]    |

Run in the next workspace
             |  - Remove [x]
             |  - Add [x]
             |  - Add [y]

Run in the original workspace
- Remove [x] |
- Add [x]    |
- Add [y]    |

etc...
```

Now we just have two events that run
```
Start with [x], and [x]

- Add [y]        |
                 | - Add [y]
- Add [y] noops, |
  so cycle stops |
```

Similar thing was occuring for the renaming of parameters based on var rename events (i.e. `renameVarById`).

### Testing

I don't think there's really a way to test this besides manually testing, because the bug was occuring as a side effect of the 1 ms delay in our events system :/

### Additional Info

Dependent on #1544 