### PR TITLE
fix: create events not fired

### DIFF
--- a/plugins/block-sharable-procedures/src/blocks.ts
+++ b/plugins/block-sharable-procedures/src/blocks.ts
@@ -218,7 +218,7 @@ const procedureDefGetDefMixin = function() {
       Blockly.Procedures.findLegalName(this.getFieldValue('NAME'), this));
 
   // Events cannot be fired from instantiation when deserializing or dragging
-  // from the flyout. So make this consistant and never fire from instantiation.
+  // from the flyout. So make this consistent and never fire from instantiation.
   Blockly.Events.disable();
   this.workspace.getProcedureMap().add(mixin.getProcedureModel());
   Blockly.Events.enable();

--- a/plugins/block-sharable-procedures/test/data_models.mocha.js
+++ b/plugins/block-sharable-procedures/test/data_models.mocha.js
@@ -7,19 +7,36 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const assert = chai.assert;
+const eventTestHelpers = require('./event_test_helpers');
 const Blockly = require('blockly/node');
 const {ObservableProcedureModel} = require('../src/observable_procedure_model');
 const {ObservableParameterModel} = require('../src/observable_parameter_model');
+const {ProcedureCreate} = require('../src/events_procedure_create');
+const {ProcedureDelete} = require('../src/events_procedure_delete');
+const {ProcedureRename} = require('../src/events_procedure_rename');
+const {ProcedureChangeReturn} =
+    require('../src/events_procedure_change_return');
+const {ProcedureEnable} = require('../src/events_procedure_enable');
+const {ProcedureParameterCreate} =
+    require('../src/events_procedure_parameter_create');
+const {ProcedureParameterDelete} =
+    require('../src/events_procedure_parameter_delete');
+const {ProcedureParameterRename} =
+    require('../src/events_procedure_parameter_rename');
 
 
 suite('Procedure data models', function() {
   setup(function() {
     this.workspace = new Blockly.Workspace();
     this.procedureMap = this.workspace.getProcedureMap();
+    this.sandbox = sinon.createSandbox();
+    this.clock = this.sandbox.useFakeTimers();
   });
 
   teardown(function() {
     this.workspace.dispose();
+    this.clock.runAll();
+    this.sandbox.restore();
   });
 
   suite('triggering block updates', function() {
@@ -33,7 +50,8 @@ suite('Procedure data models', function() {
 
       this.procedureBlock = this.workspace.newBlock('procedure_mock');
 
-      this.updateSpy = sinon.spy(this.procedureBlock, 'doProcedureUpdate');
+      this.updateSpy =
+          this.sandbox.spy(this.procedureBlock, 'doProcedureUpdate');
     });
 
     teardown(function() {
@@ -190,6 +208,230 @@ suite('Procedure data models', function() {
             chai.assert.isFalse(
                 this.updateSpy.called, 'Expected no update to be triggered');
           });
+    });
+  });
+
+  suite('firing events', function() {
+    setup(function() {
+      this.eventSpy = this.sandbox.spy();
+      this.spyData = this.workspace.addChangeListener(this.eventSpy);
+    });
+
+    teardown(function() {
+      this.workspace.removeChangeListener(this.spyData);
+    });
+
+    suite('procedure model creation and destruction', function() {
+      test('inserting a procedure model fires a create event', function() {
+        const procedure = new ObservableProcedureModel(this.workspace, 'proc');
+        this.procedureMap.add(procedure);
+        this.clock.runAll();
+
+        eventTestHelpers.assertEventFiredShallow(
+            this.eventSpy,
+            ProcedureCreate,
+            {procedure},
+            this.workspace.id);
+      });
+
+      test('removing a procedure model fires a delete event', function() {
+        const procedure = new ObservableProcedureModel(this.workspace, 'proc');
+        this.procedureMap.add(procedure);
+        this.clock.runAll();
+
+        this.eventSpy.resetHistory();
+        this.procedureMap.delete(procedure.getId());
+        this.clock.runAll();
+
+        eventTestHelpers.assertEventFiredShallow(
+            this.eventSpy,
+            ProcedureDelete,
+            {procedure},
+            this.workspace.id);
+      });
+    });
+
+    suite('procedure model changes', function() {
+      test('setting the name fires a rename event', function() {
+        const procedure =
+            new ObservableProcedureModel(this.workspace, 'old name');
+        this.procedureMap.add(procedure);
+        this.clock.runAll();
+
+        this.eventSpy.resetHistory();
+        procedure.setName('new name');
+        this.clock.runAll();
+
+        eventTestHelpers.assertEventFiredShallow(
+            this.eventSpy,
+            ProcedureRename,
+            {
+              procedure,
+              oldName: 'old name',
+              newName: 'new name',
+            },
+            this.workspace.id);
+      });
+
+      test('setting the return type fires a change return event', function() {
+        const procedure =
+          new ObservableProcedureModel(this.workspace, 'old name')
+              .setReturnTypes(null);
+        this.procedureMap.add(procedure);
+        this.clock.runAll();
+
+        this.eventSpy.resetHistory();
+        const newTypes = [];
+        procedure.setReturnTypes(newTypes);
+        this.clock.runAll();
+
+        eventTestHelpers.assertEventFiredShallow(
+            this.eventSpy,
+            ProcedureChangeReturn,
+            {
+              procedure,
+              oldTypes: null,
+              newTypes,
+            },
+            this.workspace.id);
+      });
+
+      test('removing the return type fires a change return event', function() {
+        const oldTypes = [];
+        const procedure =
+          new ObservableProcedureModel(this.workspace, 'old name')
+              .setReturnTypes(oldTypes);
+        this.procedureMap.add(procedure);
+        this.clock.runAll();
+
+        this.eventSpy.resetHistory();
+        procedure.setReturnTypes(null);
+        this.clock.runAll();
+
+        eventTestHelpers.assertEventFiredShallow(
+            this.eventSpy,
+            ProcedureChangeReturn,
+            {
+              procedure,
+              oldTypes,
+              newTypes: null,
+            },
+            this.workspace.id);
+      });
+
+      test('disabling the procedure fires an enable event', function() {
+        const procedure =
+            new ObservableProcedureModel(this.workspace, 'old name')
+                .setEnabled(true);
+        this.procedureMap.add(procedure);
+        this.clock.runAll();
+
+        this.eventSpy.resetHistory();
+        procedure.setEnabled(false);
+        this.clock.runAll();
+
+        eventTestHelpers.assertEventFiredShallow(
+            this.eventSpy,
+            ProcedureEnable,
+            {
+              procedure,
+              oldState: true,
+              newState: false,
+            },
+            this.workspace.id);
+      });
+
+      test('enabling the procedure fires an enable event', function() {
+        const procedure =
+            new ObservableProcedureModel(this.workspace, 'old name')
+                .setEnabled(false);
+        this.procedureMap.add(procedure);
+        this.clock.runAll();
+
+        this.eventSpy.resetHistory();
+        procedure.setEnabled(true);
+        this.clock.runAll();
+
+        eventTestHelpers.assertEventFiredShallow(
+            this.eventSpy,
+            ProcedureEnable,
+            {
+              procedure,
+              oldState: false,
+              newState: true,
+            },
+            this.workspace.id);
+      });
+
+      test('inserting a parameter fires a parameter create event', function() {
+        const procedure =
+            new ObservableProcedureModel(this.workspace, 'old name');
+        this.procedureMap.add(procedure);
+        this.clock.runAll();
+        const parameter = new ObservableParameterModel(this.workspace, 'param');
+
+        this.eventSpy.resetHistory();
+        procedure.insertParameter(parameter, 0);
+        this.clock.runAll();
+
+        eventTestHelpers.assertEventFiredShallow(
+            this.eventSpy,
+            ProcedureParameterCreate,
+            {
+              procedure,
+              parameter,
+              index: 0,
+            },
+            this.workspace.id);
+      });
+
+      test('deleting a parameter fires a parameter delete event', function() {
+        const parameter = new ObservableParameterModel(this.workspace, 'param');
+        const procedure =
+            new ObservableProcedureModel(this.workspace, 'old name')
+                .insertParameter(parameter, 0);
+        this.procedureMap.add(procedure);
+        this.clock.runAll();
+
+        this.eventSpy.resetHistory();
+        procedure.deleteParameter(0);
+        this.clock.runAll();
+
+        eventTestHelpers.assertEventFiredShallow(
+            this.eventSpy,
+            ProcedureParameterDelete,
+            {
+              procedure,
+              parameter,
+              index: 0,
+            },
+            this.workspace.id);
+      });
+    });
+
+    suite('parameter model changes', function() {
+      test('setting the name fires a procedure rename event', function() {
+        const parameter =
+            new ObservableParameterModel(this.workspace, 'old name');
+        this.procedureMap.add(
+            new ObservableProcedureModel(this.workspace, 'proc')
+                .insertParameter(parameter, 0));
+        this.clock.runAll();
+
+        this.eventSpy.resetHistory();
+        parameter.setName('new name');
+        this.clock.runAll();
+
+        eventTestHelpers.assertEventFiredShallow(
+            this.eventSpy,
+            ProcedureParameterRename,
+            {
+              parameter,
+              oldName: 'old name',
+              newName: 'new name',
+            },
+            this.workspace.id);
+      });
     });
   });
 

--- a/plugins/block-sharable-procedures/test/procedure_test_helpers.js
+++ b/plugins/block-sharable-procedures/test/procedure_test_helpers.js
@@ -20,7 +20,7 @@ const sinon = require('sinon');
  * @param {string|!Array<string>} returnIds The return values to use for the
  *    created stub. If a single value is passed, then the stub always returns
  *    that value.
- * @return {!sinon.SinonStub} The created stub.
+ * @returns {!sinon.SinonStub} The created stub.
  */
 export function createGenUidStubWithReturns(returnIds) {
   const stub = sinon.stub(Blockly.utils.idGenerator.TEST_ONLY, 'genUid');
@@ -143,7 +143,7 @@ export function assertCallBlockStructure(
  *    return.
  * @param {Array<string>=} args An array of argument names.
  * @param {string=} name The name of the def block (defaults to 'proc name').
- * @return {Blockly.Block} The created block.
+ * @returns {Blockly.Block} The created block.
  */
 export function createProcDefBlock(
     workspace, hasReturn = false, args = [], name = 'proc name') {
@@ -165,7 +165,7 @@ export function createProcDefBlock(
  *    has return.
  * @param {string=} name The name of the caller block
  *     (defaults to 'proc name').
- * @return {Blockly.Block} The created block.
+ * @returns {Blockly.Block} The created block.
  */
 export function createProcCallBlock(
     workspace, hasReturn = false, name = 'proc name') {


### PR DESCRIPTION
### Description

Fixed create events not being fired when dragging blocks from the flyout or deserializing.

This doesn't properly order events. Ideally the procedure create event would happen before the block create event so that it would work properly with real time collaboration. But this is not possible due to https://github.com/google/blockly/issues/6840

### Testing

Added unit tests that check that events are properly fired when they are supposed to be. Surprised I didn't have this before but 🤷 