### PR TITLE
fix: updating callers in response to variable renames in other workspaces

### DIFF
--- a/plugins/block-sharable-procedures/src/blocks.ts
+++ b/plugins/block-sharable-procedures/src/blocks.ts
@@ -8,7 +8,6 @@
 import * as Blockly from 'blockly/core';
 import {ObservableProcedureModel} from './observable_procedure_model';
 import {ObservableParameterModel} from './observable_parameter_model';
-import {triggerProceduresUpdate} from './update_procedures';
 import {IProcedureBlock, isProcedureBlock} from './i_procedure_block';
 
 
@@ -78,6 +77,7 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     'helpUrl': '%{BKY_PROCEDURES_CALLNORETURN_HELPURL}',
     'extensions': [
       'procedure_caller_get_def_mixin',
+      'procedure_caller_var_mixin',
       'procedure_caller_update_shape_mixin',
       'procedure_caller_context_menu_mixin',
       'procedure_caller_onchange_mixin',
@@ -151,6 +151,7 @@ export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
     'helpUrl': '%{BKY_PROCEDURES_CALLRETURN_HELPURL}',
     'extensions': [
       'procedure_caller_get_def_mixin',
+      'procedure_caller_var_mixin',
       'procedure_caller_update_shape_mixin',
       'procedure_caller_context_menu_mixin',
       'procedure_caller_onchange_mixin',
@@ -263,7 +264,7 @@ const procedureDefVarMixin = function() {
       const containsVar = this.getProcedureModel().getParameters().some(
           (p) => p.getVariableModel() === variable);
       if (containsVar) {
-        triggerProceduresUpdate(this.workspace);
+        this.doProcedureUpdate(); // Rerender.
       }
     },
   };
@@ -767,6 +768,32 @@ const procedureCallerGetDefMixin = function() {
 // overriding built-ins.
 Blockly.Extensions.register(
     'procedure_caller_get_def_mixin', procedureCallerGetDefMixin);
+
+const procedureCallerVarMixin = function() {
+  const mixin = {
+    /**
+     * Notification that a variable is renaming but keeping the same ID.  If the
+     * variable is in use on this block, rerender to show the new name.
+     * @param variable The variable being renamed.
+     * @package
+     * @override
+     * @this {Blockly.Block}
+     */
+    updateVarName: function(variable) {
+      const containsVar = this.getProcedureModel().getParameters().some(
+          (p) => p.getVariableModel() === variable);
+      if (containsVar) {
+        this.doProcedureUpdate(); // Rerender.
+      }
+    },
+  };
+
+  this.mixin(mixin, true);
+};
+// Using register instead of registerMixin to avoid triggering warnings about
+// overriding built-ins.
+Blockly.Extensions.register(
+    'procedure_caller_var_mixin', procedureCallerVarMixin);
 
 const procedureCallerMutator = {
   previousEnabledState_: true,

--- a/plugins/block-sharable-procedures/test/procedure_test_helpers.js
+++ b/plugins/block-sharable-procedures/test/procedure_test_helpers.js
@@ -20,7 +20,7 @@ const sinon = require('sinon');
  * @param {string|!Array<string>} returnIds The return values to use for the
  *    created stub. If a single value is passed, then the stub always returns
  *    that value.
- * @return {!sinon.SinonStub} The created stub.
+ * @returns {!sinon.SinonStub} The created stub.
  */
 export function createGenUidStubWithReturns(returnIds) {
   const stub = sinon.stub(Blockly.utils.idGenerator.TEST_ONLY, 'genUid');
@@ -143,7 +143,7 @@ export function assertCallBlockStructure(
  *    return.
  * @param {Array<string>=} args An array of argument names.
  * @param {string=} name The name of the def block (defaults to 'proc name').
- * @return {Blockly.Block} The created block.
+ * @returns {Blockly.Block} The created block.
  */
 export function createProcDefBlock(
     workspace, hasReturn = false, args = [], name = 'proc name') {
@@ -165,7 +165,7 @@ export function createProcDefBlock(
  *    has return.
  * @param {string=} name The name of the caller block
  *     (defaults to 'proc name').
- * @return {Blockly.Block} The created block.
+ * @returns {Blockly.Block} The created block.
  */
 export function createProcCallBlock(
     workspace, hasReturn = false, name = 'proc name') {


### PR DESCRIPTION
### Description

Caller blocks were relying on calls to `doProcedureUpdate` triggered by procedure definition blocks setting parameter model names in response to the `updateVarName` callback. This meant that if their def block was in another workspace, they wouldn't get an update. Now they respond to the callback directly as well, so callers in other workspaces properly 
respond to variable renamings.

### Testing

Wasn't sure how to test this since it is specifically a side effect of sharing blocks between workspaces. But I might come up with something over the weekend!