### PR TITLE
fix: Remove double entry of 'kind' in toolbox-demo

### DIFF
--- a/examples/toolbox-demo/index.html
+++ b/examples/toolbox-demo/index.html
@@ -250,7 +250,6 @@
               {
                 "kind":"block",
                 "type":"math_random_int",
-                "kind":"block",
                 "inputs":{
                   "FROM":{
                     "block":{


### PR DESCRIPTION
### Description

Remove double entry of 'kind' key in toolbox-demo for the math_random_int block.