### PR TITLE
chore: properly export events and event types

### DIFF
--- a/plugins/block-shareable-procedures/src/events_procedure_base.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_base.ts
@@ -10,10 +10,12 @@ import * as Blockly from 'blockly/core';
  * The base event for an event associated with a procedure.
  */
 export abstract class ProcedureBase extends Blockly.Events.Abstract {
-  isBlank = false;
-
   static readonly TYPE: string = 'procedure_base';
+
+  /** A string used to check the type of the event. */
   type = ProcedureBase.TYPE;
+
+  isBlank = false;
 
   /**
    * Constructs the base procedure event.

--- a/plugins/block-shareable-procedures/src/events_procedure_base.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_base.ts
@@ -12,6 +12,9 @@ import * as Blockly from 'blockly/core';
 export abstract class ProcedureBase extends Blockly.Events.Abstract {
   isBlank = false;
 
+  static readonly TYPE: string = 'procedure_base';
+  type = ProcedureBase.TYPE;
+
   /**
    * Constructs the base procedure event.
    * @param workspace The workspace the procedure model exists in.

--- a/plugins/block-shareable-procedures/src/events_procedure_change_return.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_change_return.ts
@@ -9,14 +9,14 @@ import * as Blockly from 'blockly/core';
 import {ProcedureBase, ProcedureBaseJson} from './events_procedure_base';
 
 
-const TYPE = 'procedure_change';
-
 /**
  * Notifies listeners that a procedure's return type/status has changed.
  */
 export class ProcedureChangeReturn extends ProcedureBase {
+  static readonly TYPE = 'procedure_change';
+
   /** A string used to check the type of the event. */
-  type = TYPE;
+  type = ProcedureChangeReturn.TYPE;
 
   /** The new type(s) the procedure's return has been set to. */
   private newTypes: string[]|null;
@@ -92,4 +92,6 @@ export interface ProcedureChangeReturnJson extends ProcedureBaseJson {
 }
 
 Blockly.registry.register(
-    Blockly.registry.Type.EVENT, TYPE, ProcedureChangeReturn);
+    Blockly.registry.Type.EVENT,
+    ProcedureChangeReturn.TYPE,
+    ProcedureChangeReturn);

--- a/plugins/block-shareable-procedures/src/events_procedure_create.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_create.ts
@@ -10,14 +10,14 @@ import {ObservableParameterModel} from './observable_parameter_model';
 import {ObservableProcedureModel} from './observable_procedure_model';
 
 
-const TYPE = 'procedure_create';
-
 /**
  * Notifies listeners that a procedure data model has been created.
  */
 export class ProcedureCreate extends ProcedureBase {
+  static readonly TYPE = 'procedure_create';
+
   /** A string used to check the type of the event. */
-  type = TYPE;
+  type = ProcedureCreate.TYPE;
 
   /**
    * Replays the event in the workspace.
@@ -69,4 +69,4 @@ export interface ProcedureCreateJson extends ProcedureBaseJson {
 }
 
 Blockly.registry.register(
-    Blockly.registry.Type.EVENT, TYPE, ProcedureCreate);
+    Blockly.registry.Type.EVENT, ProcedureCreate.TYPE, ProcedureCreate);

--- a/plugins/block-shareable-procedures/src/events_procedure_delete.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_delete.ts
@@ -9,14 +9,14 @@ import * as Blockly from 'blockly/core';
 import {ProcedureBase, ProcedureBaseJson} from './events_procedure_base';
 
 
-const TYPE = 'procedure_delete';
-
 /**
  * Notifies listeners that a procedure data model has been deleted.
  */
 export class ProcedureDelete extends ProcedureBase {
+  static readonly TYPE = 'procedure_delete';
+
   /** A string used to check the type of the event. */
-  type = TYPE;
+  type = ProcedureDelete.TYPE;
 
   /**
    * Replays the event in the workspace.
@@ -63,4 +63,4 @@ export class ProcedureDelete extends ProcedureBase {
 export type ProcedureDeleteJson = ProcedureBaseJson;
 
 Blockly.registry.register(
-    Blockly.registry.Type.EVENT, TYPE, ProcedureDelete);
+    Blockly.registry.Type.EVENT, ProcedureDelete.TYPE, ProcedureDelete);

--- a/plugins/block-shareable-procedures/src/events_procedure_enable.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_enable.ts
@@ -9,15 +9,15 @@ import * as Blockly from 'blockly/core';
 import {ProcedureBase, ProcedureBaseJson} from './events_procedure_base';
 
 
-const TYPE = 'procedure_enable';
-
 /**
  * Notifies listeners that the procedure data model has been enabled or
  * disabled.
  */
 export class ProcedureEnable extends ProcedureBase {
+  static readonly TYPE = 'procedure_enable';
+
   /** A string used to check the type of the event. */
-  type = TYPE;
+  type = ProcedureEnable.TYPE;
 
   private oldState: boolean;
   private newState: boolean;
@@ -99,4 +99,4 @@ export interface ProcedureEnableJson extends ProcedureBaseJson {
 }
 
 Blockly.registry.register(
-    Blockly.registry.Type.EVENT, TYPE, ProcedureEnable);
+    Blockly.registry.Type.EVENT, ProcedureEnable.TYPE, ProcedureEnable);

--- a/plugins/block-shareable-procedures/src/events_procedure_parameter_base.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_parameter_base.ts
@@ -14,6 +14,8 @@ import {ProcedureBase, ProcedureBaseJson} from './events_procedure_base';
  */
 export abstract class ProcedureParameterBase extends ProcedureBase {
   static readonly TYPE: string = 'procedure_parameter_base';
+
+  /** A string used to check the type of the event. */
   type = ProcedureParameterBase.TYPE;
 
   /**

--- a/plugins/block-shareable-procedures/src/events_procedure_parameter_base.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_parameter_base.ts
@@ -13,6 +13,9 @@ import {ProcedureBase, ProcedureBaseJson} from './events_procedure_base';
  * The base event for an event associated with a procedure parameter.
  */
 export abstract class ProcedureParameterBase extends ProcedureBase {
+  static readonly TYPE: string = 'procedure_parameter_base';
+  type = ProcedureParameterBase.TYPE;
+
   /**
    * Constructs the procedure parameter base event.
    * @param workspace The workspace the parameter model exists in.

--- a/plugins/block-shareable-procedures/src/events_procedure_parameter_create.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_parameter_create.ts
@@ -9,14 +9,14 @@ import {ProcedureParameterBase, ProcedureParameterBaseJson} from './events_proce
 import {ObservableParameterModel} from './observable_parameter_model';
 
 
-const TYPE = 'procedure_parameter_create';
-
 /**
  * Notifies listeners that a parameter has been added to a procedure model.
  */
 export class ProcedureParameterCreate extends ProcedureParameterBase {
+  static readonly TYPE = 'procedure_parameter_create';
+
   /** A string used to check the type of the event. */
-  type = TYPE;
+  type = ProcedureParameterCreate.TYPE;
 
   parameter: ObservableParameterModel;
 
@@ -102,4 +102,6 @@ export interface ProcedureParameterCreateJson extends
 }
 
 Blockly.registry.register(
-    Blockly.registry.Type.EVENT, TYPE, ProcedureParameterCreate);
+    Blockly.registry.Type.EVENT,
+    ProcedureParameterCreate.TYPE,
+    ProcedureParameterCreate);

--- a/plugins/block-shareable-procedures/src/events_procedure_parameter_delete.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_parameter_delete.ts
@@ -8,14 +8,14 @@ import * as Blockly from 'blockly/core';
 import {ProcedureParameterBase, ProcedureParameterBaseJson} from './events_procedure_parameter_base';
 
 
-const TYPE = 'procedure_parameter_delete';
-
 /**
  * Notifies listeners that a parameter has been removed from a procedure.
  */
 export class ProcedureParameterDelete extends ProcedureParameterBase {
+  static readonly TYPE = 'procedure_parameter_delete';
+
   /** A string used to check the type of the event. */
-  type = TYPE;
+  type = ProcedureParameterDelete.TYPE;
 
   /**
    * Constructs the procedure parameter delete event.
@@ -91,4 +91,6 @@ export interface ProcedureParameterDeleteJson extends
 }
 
 Blockly.registry.register(
-    Blockly.registry.Type.EVENT, TYPE, ProcedureParameterDelete);
+    Blockly.registry.Type.EVENT,
+    ProcedureParameterDelete.TYPE,
+    ProcedureParameterDelete);

--- a/plugins/block-shareable-procedures/src/events_procedure_parameter_rename.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_parameter_rename.ts
@@ -8,14 +8,14 @@ import * as Blockly from 'blockly/core';
 import {ProcedureParameterBase, ProcedureParameterBaseJson} from './events_procedure_parameter_base';
 
 
-const TYPE = 'procedure_parameter_rename';
-
 /**
  * Notifies listeners that a procedure parameter was renamed.
  */
 export class ProcedureParameterRename extends ProcedureParameterBase {
+  static readonly TYPE = 'procedure_parameter_rename';
+
   /** A string used to check the type of the event. */
-  type = TYPE;
+  type = ProcedureParameterRename.TYPE;
 
   /** The new name of the procedure parameter. */
   private readonly newName: string;
@@ -98,4 +98,6 @@ export interface ProcedureParameterRenameJson extends
 }
 
 Blockly.registry.register(
-    Blockly.registry.Type.EVENT, TYPE, ProcedureParameterRename);
+    Blockly.registry.Type.EVENT,
+    ProcedureParameterRename.TYPE,
+    ProcedureParameterRename);

--- a/plugins/block-shareable-procedures/src/events_procedure_rename.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_rename.ts
@@ -8,12 +8,12 @@ import * as Blockly from 'blockly/core';
 import {ProcedureBase, ProcedureBaseJson} from './events_procedure_base';
 
 
-const TYPE = 'procedure_rename';
-
 /** Notifies listeners that a procedure model has been renamed. */
 export class ProcedureRename extends ProcedureBase {
+  static readonly TYPE = 'procedure_rename';
+
   /** A string used to check the type of the event. */
-  type = TYPE;
+  type = ProcedureRename.TYPE;
 
   private newName: string;
 
@@ -93,4 +93,4 @@ export interface ProcedureRenameJson extends ProcedureBaseJson {
 }
 
 Blockly.registry.register(
-    Blockly.registry.Type.EVENT, TYPE, ProcedureRename);
+    Blockly.registry.Type.EVENT, ProcedureRename.TYPE, ProcedureRename);

--- a/plugins/block-shareable-procedures/src/index.ts
+++ b/plugins/block-shareable-procedures/src/index.ts
@@ -10,28 +10,13 @@ export {IProcedureBlock, isProcedureBlock} from './i_procedure_block';
 export {ObservableParameterModel} from './observable_parameter_model';
 export {ObservableProcedureModel} from './observable_procedure_model';
 export {ProcedureBase, ProcedureBaseJson} from './events_procedure_base';
-export {
-  ProcedureChangeReturn,
-  ProcedureChangeReturnJson,
-} from './events_procedure_change_return';
+export {ProcedureChangeReturn, ProcedureChangeReturnJson} from './events_procedure_change_return';
 export {ProcedureCreate, ProcedureCreateJson} from './events_procedure_create';
 export {ProcedureDelete, ProcedureDeleteJson} from './events_procedure_delete';
-export {
-  ProcedureParameterBase,
-  ProcedureParameterBaseJson,
-} from './events_procedure_parameter_base';
-export {
-  ProcedureParameterCreate,
-  ProcedureParameterCreateJson,
-} from './events_procedure_parameter_create';
-export {
-  ProcedureParameterDelete,
-  ProcedureParameterDeleteJson,
-} from './events_procedure_parameter_delete';
-export {
-  ProcedureParameterRename,
-  ProcedureParameterRenameJson,
-} from './events_procedure_parameter_rename';
+export {ProcedureParameterBase, ProcedureParameterBaseJson} from './events_procedure_parameter_base';
+export {ProcedureParameterCreate, ProcedureParameterCreateJson} from './events_procedure_parameter_create';
+export {ProcedureParameterDelete, ProcedureParameterDeleteJson} from './events_procedure_parameter_delete';
+export {ProcedureParameterRename, ProcedureParameterRenameJson} from './events_procedure_parameter_rename';
 export {ProcedureRename, ProcedureRenameJson} from './events_procedure_rename';
 export {triggerProceduresUpdate} from './update_procedures';
 

--- a/plugins/block-shareable-procedures/src/index.ts
+++ b/plugins/block-shareable-procedures/src/index.ts
@@ -9,6 +9,15 @@ import {blocks} from './blocks';
 import {IProcedureBlock, isProcedureBlock} from './i_procedure_block';
 import {ObservableParameterModel} from './observable_parameter_model';
 import {ObservableProcedureModel} from './observable_procedure_model';
+import {ProcedureBase, ProcedureBaseJson} from './events_procedure_base';
+import {ProcedureChangeReturn, ProcedureChangeReturnJson} from './events_procedure_change_return';
+import {ProcedureCreate, ProcedureCreateJson} from './events_procedure_create';
+import {ProcedureDelete, ProcedureDeleteJson} from './events_procedure_delete';
+import {ProcedureParameterBase, ProcedureParameterBaseJson} from './events_procedure_parameter_base';
+import {ProcedureParameterCreate, ProcedureParameterCreateJson} from './events_procedure_parameter_create';
+import {ProcedureParameterDelete, ProcedureParameterDeleteJson} from './events_procedure_parameter_delete';
+import {ProcedureParameterRename, ProcedureParameterRenameJson} from './events_procedure_parameter_rename';
+import {ProcedureRename, ProcedureRenameJson} from './events_procedure_rename';
 import {triggerProceduresUpdate} from './update_procedures';
 
 export {
@@ -17,6 +26,24 @@ export {
   isProcedureBlock,
   ObservableParameterModel,
   ObservableProcedureModel,
+  ProcedureBase,
+  ProcedureBaseJson,
+  ProcedureChangeReturn,
+  ProcedureChangeReturnJson,
+  ProcedureCreate,
+  ProcedureCreateJson,
+  ProcedureDelete,
+  ProcedureDeleteJson,
+  ProcedureParameterBase,
+  ProcedureParameterBaseJson,
+  ProcedureParameterCreate,
+  ProcedureParameterCreateJson,
+  ProcedureParameterDelete,
+  ProcedureParameterDeleteJson,
+  ProcedureParameterRename,
+  ProcedureParameterRenameJson,
+  ProcedureRename,
+  ProcedureRenameJson,
   triggerProceduresUpdate,
 };
 

--- a/plugins/block-shareable-procedures/src/index.ts
+++ b/plugins/block-shareable-procedures/src/index.ts
@@ -5,47 +5,35 @@
  */
 
 import * as Blockly from 'blockly/core';
-import {blocks} from './blocks';
-import {IProcedureBlock, isProcedureBlock} from './i_procedure_block';
-import {ObservableParameterModel} from './observable_parameter_model';
-import {ObservableProcedureModel} from './observable_procedure_model';
-import {ProcedureBase, ProcedureBaseJson} from './events_procedure_base';
-import {ProcedureChangeReturn, ProcedureChangeReturnJson} from './events_procedure_change_return';
-import {ProcedureCreate, ProcedureCreateJson} from './events_procedure_create';
-import {ProcedureDelete, ProcedureDeleteJson} from './events_procedure_delete';
-import {ProcedureParameterBase, ProcedureParameterBaseJson} from './events_procedure_parameter_base';
-import {ProcedureParameterCreate, ProcedureParameterCreateJson} from './events_procedure_parameter_create';
-import {ProcedureParameterDelete, ProcedureParameterDeleteJson} from './events_procedure_parameter_delete';
-import {ProcedureParameterRename, ProcedureParameterRenameJson} from './events_procedure_parameter_rename';
-import {ProcedureRename, ProcedureRenameJson} from './events_procedure_rename';
-import {triggerProceduresUpdate} from './update_procedures';
-
+export {blocks} from './blocks';
+export {IProcedureBlock, isProcedureBlock} from './i_procedure_block';
+export {ObservableParameterModel} from './observable_parameter_model';
+export {ObservableProcedureModel} from './observable_procedure_model';
+export {ProcedureBase, ProcedureBaseJson} from './events_procedure_base';
 export {
-  blocks,
-  IProcedureBlock,
-  isProcedureBlock,
-  ObservableParameterModel,
-  ObservableProcedureModel,
-  ProcedureBase,
-  ProcedureBaseJson,
   ProcedureChangeReturn,
   ProcedureChangeReturnJson,
-  ProcedureCreate,
-  ProcedureCreateJson,
-  ProcedureDelete,
-  ProcedureDeleteJson,
+} from './events_procedure_change_return';
+export {ProcedureCreate, ProcedureCreateJson} from './events_procedure_create';
+export {ProcedureDelete, ProcedureDeleteJson} from './events_procedure_delete';
+export {
   ProcedureParameterBase,
   ProcedureParameterBaseJson,
+} from './events_procedure_parameter_base';
+export {
   ProcedureParameterCreate,
   ProcedureParameterCreateJson,
+} from './events_procedure_parameter_create';
+export {
   ProcedureParameterDelete,
   ProcedureParameterDeleteJson,
+} from './events_procedure_parameter_delete';
+export {
   ProcedureParameterRename,
   ProcedureParameterRenameJson,
-  ProcedureRename,
-  ProcedureRenameJson,
-  triggerProceduresUpdate,
-};
+} from './events_procedure_parameter_rename';
+export {ProcedureRename, ProcedureRenameJson} from './events_procedure_rename';
+export {triggerProceduresUpdate} from './update_procedures';
 
 /**
  * Unregisters all of the procedure blocks.

--- a/plugins/eslint-config/index.js
+++ b/plugins/eslint-config/index.js
@@ -54,7 +54,13 @@ module.exports = {
     // Allow TODO comments.
     'no-warning-comments': 'off',
     // Allow long import lines.
-    'max-len': ['error', {'ignorePattern': '^import', 'ignoreUrls': true}],
+    'max-len': [
+      'error',
+      {
+        'ignorePattern': '^(import|export)',
+        'ignoreUrls': true,
+      },
+    ],
     'no-invalid-this': 'off',
     // valid-jsdoc does not work properly for interface methods.
     // https://github.com/eslint/eslint/issues/9978


### PR DESCRIPTION
### Description

Firstly events were not being exported from the index file, which meant they weren't accessible to external developers. This is fixed.

Secondly, we weren't exporting the static `TYPE` values for the events, so external developers wouldn't be able to use the `type` properties for event filtering. Now they can :D

### Additional information

Dependent on #1551 because I didn't want to run into merge conflicts.