### PR TITLE
chore: update readme to point to dev docs

### DIFF
--- a/plugins/block-sharable-procedures/README.md
+++ b/plugins/block-sharable-procedures/README.md
@@ -17,24 +17,12 @@ yarn add @blockly/block-sharable-procedures
 
 ### npm
 ```
-npm install @blockly/block-sharable-procedures --save
+npm install @blockly/block-sharable-procedures
 ```
 
 ## Usage
 
-### Import
-
-The blocks in this plugin must be explicitly defined after they are imported.
-This is so that importing the plugin doesn't have side effects (i.e. defining
-the blocks itself) which might be unexpected.
-
-```js
-import * as Blockly from 'blockly';
-import {blocks} from '@blockly/block-sharable-procedures';
-
-// Blocks must be explicitly defined after importing.
-Blockly.common.defineBlocks(blocks);
-```
+See developers.google.com/blockly/guides/create-custom-blocks/procedures/using-procedures for more information about using this plugin.
 
 ## License
 Apache 2.0

--- a/plugins/block-sharable-procedures/README.md
+++ b/plugins/block-sharable-procedures/README.md
@@ -22,7 +22,8 @@ npm install @blockly/block-sharable-procedures
 
 ## Usage
 
-See developers.google.com/blockly/guides/create-custom-blocks/procedures/using-procedures for more information about using this plugin.
+See [developers.google.com/blockly/guides/create-custom-blocks/procedures/using-procedures](https://developers.google.com/blockly/guides/create-custom-blocks/procedures/using-procedures)
+for more information about using this plugin.
 
 ## License
 Apache 2.0


### PR DESCRIPTION
### Description

Updated the readme to point to the upcoming dev docs related to procedures. That way we only have to maintain information in one place (the prettier place!).

I kept everything that should be static (i.e. the project description and how to install).