### PR TITLE
feat: Add third-party plugins section to site

### DIFF
--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -42,7 +42,7 @@ layout: index
 * [Theme Tritanopia](plugins/theme-tritanopia/test/index.html)
 * [Theme Deuteranopia](plugins/theme-deuteranopia/test/index.html)
 
-## Third Party Plugins
+# Third Party Plugins
 These plugins are not published by the Blockly team. They are linked here for your convenience.
 * [Lexical Variables](https://www.npmjs.com/package/@mit-app-inventor/blockly-block-lexical-variables)
 

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -42,6 +42,10 @@ layout: index
 * [Theme Tritanopia](plugins/theme-tritanopia/test/index.html)
 * [Theme Deuteranopia](plugins/theme-deuteranopia/test/index.html)
 
+## Third Party Plugins
+These plugins are not published by the Blockly team. They are linked here for your convenience.
+* [Lexical Variables](https://www.npmjs.com/package/@mit-app-inventor/blockly-block-lexical-variables)
+
 # Examples
 
 ## Blockly in React


### PR DESCRIPTION
Add a third-party plugins section to the samples site.

Didn't add any fancy css. If we are ripping out Jekyll soon then there is not a good way to add css classes using showdown, other than using straight html inside the markdown. Open to follow up PRs enhancing the style.

@mark-friedman are you ok with this? Using your plugin as the first example. We'd then accept PRs from folks wanting to add their own plugins.


Preview: https://maribethb.github.io/blockly-samples/ (note this is currently updating, if you view this within 10 min of me opening this PR)