### PR TITLE
feat: add ability to choose a branch to publish gh-pages from

### DIFF
--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -4,6 +4,12 @@ name: Update GitHub Pages
 
 on:
   workflow_dispatch:  # Manually trigger. Colon is required.
+    inputs:
+      branch:
+        description: 'Branch to publish from'
+        required: true
+        default: 'master'
+        type: string
   workflow_call: # Allow this workflow to be called from publish workflow.
 
 permissions:
@@ -17,7 +23,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        ref: master
+        ref: ${{ inputs.branch || 'master' }}
 
     - name: Setup Node
       uses: actions/setup-node@v3


### PR DESCRIPTION
When running the "Update GitHub Pages" Action manually, it offers you a text box in which to type the name of a branch which gh-pages will be based on. This is useful when you want to test the site with a branch other than main. I used it to test #1568 so I know that part works.

In theory, when called from another workflow (e.g. the publish workflow) it should just use the master branch like before. No way to test until that happens though.