### PR TITLE
fix: Fixed the typed variable modal plugin demo

### DIFF
--- a/plugins/typed-variable-modal/test/index.js
+++ b/plugins/typed-variable-modal/test/index.js
@@ -52,13 +52,15 @@ function createWorkspace(blocklyDiv, options) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-  let toolboxString = toolboxCategories.replace('</xml>',
-      '<category name="Typed Variables" categorystyle="variable_category" ' +
-      'custom="CREATE_TYPED_VARIABLE"></category>');
-  toolboxString = toolboxString + '</xml>';
+  toolboxCategories['contents'].push({
+    'kind': 'category',
+    'name': 'Typed Variables',
+    'custom': 'CREATE_TYPED_VARIABLE',
+    'categorystyle': 'variable_category',
+  });
 
   const defaultOptions = {
-    toolbox: toolboxString,
+    toolbox: toolboxCategories,
   };
   createPlayground(document.getElementById('root'), createWorkspace,
       defaultOptions);


### PR DESCRIPTION
In line with #1570, updated the demo of the typed variable modal plugin to add a new toolbox category using JSON. Fixes #1565.