### PR TITLE
fix: Copy the sample-app files before publishing

### DIFF
--- a/plugins/dev-create/.gitignore
+++ b/plugins/dev-create/.gitignore
@@ -1,0 +1,2 @@
+# Don't commit the copy of sample-app to Git
+templates/sample-app

--- a/plugins/dev-create/bin/app.js
+++ b/plugins/dev-create/bin/app.js
@@ -20,7 +20,7 @@ exports.createApp = function(name, options) {
       `Creating a new Blockly application called ${name} in ${appPath}`);
 
   // Copy over files from sample-app directory.
-  const sampleDir = '../../../examples/sample-app';
+  const sampleDir = '../templates/sample-app';
   const excludes =
       ['node_modules', 'dist', 'package-lock.json', 'package.json']
           .map((file) => {

--- a/plugins/dev-create/package.json
+++ b/plugins/dev-create/package.json
@@ -12,6 +12,13 @@
     "plugin",
     "template"
   ],
+  "files": [
+    "*",
+    "templates/sample-app/*"
+  ],
+  "scripts": {
+    "prepack": "cp -r ../../examples/sample-app ./templates"
+  },
   "homepage": "https://github.com/google/blockly-samples/tree/master/plugins/dev-create#readme",
   "bugs": {
     "url": "https://github.com/google/blockly-samples/issues"


### PR DESCRIPTION
A new version of dev-create was just published with the changes from #1553 but it doesn't work :/ This is because if you run it outside of blockly-samples, it can't find the sample-app files because they are not included in the npm package.

To fix this, I added a script that is run before the plugin is packaged, which copies the files from `examples/sample-app` into the templates directory of the plugin. I am open to better ways of dealing with this, but for now I would like to publish this so that the published script works, and if we find a better solution later, we can change it.

Tested via `npm pack --dry-run` and inspecting the contents.

## Details
- In order to exclude the copied directory from git, I created a `.gitignore` file
- However, by default, npm will ignore files that are ignored by git (if there is no `.npmignore` file, which there isn't)
- Therefore I also had to explicitly specify in `package.json` that the new directory should also be included in the package.

## Alternatives Considered
- Specifying in `files` to include files from outside the current directory, i.e. the original sample-app files. This didn't work for unknown reasons
- A local file dependency on the examples/sample-app... I don't think this would work when publishing though
- Publishing the sample-app as a plugin and relying on it as a dependency... but the sample-app shouldn't really be published on its own and this isn't a good enough reason to do so
- (from Beka) have the plugin get the files from github
    - this is how the renamings script works (it gets the renamings file from blockly core)
    - introduces an online dependency / if github goes down the script effectively goes down
- Just hosting the files in the templates directory to begin with
    - This is the most compelling alternative
    - The reason I didn't do this to begin with is because I want the sample-app to be published on the plugins site and I plan to do that soon
    - Beka points out we could run a script whenever we update the site, that runs the dev-create script and generates a new sample app then, which I think would work
    - I thought it would be difficult to test changes to the sample-app itself, run it, etc. but it would probably work, you would just have to run it from inside the create-package directory, which is kinda weird
    - Conceptually the code does belong in examples, I want people to be able to browse the code there, and not point them at a really weird location inside the dev-create plugin
    - Regardless, I couldn't do this right this second because the generator codelab currently instructs people to look in the examples directory for the sample code, and I don't want to break that codelab again. So we can explore this in the future if we want (once this plugin works and we can update the codelab to say to use this script instead) 