### PR TITLE
fix: remove prepublishOnly scripts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Publish
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: npx lerna publish --conventional-commits --create-release github --yes --ignore-scripts
+      run: npx lerna publish --conventional-commits --create-release github --yes
 
   update-gh-pages:
     name: Update GitHub Pages

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,6 +126,9 @@ function publish(force) {
             `${force ? ' --force-publish=*' : ''}`,
         {cwd: releaseDir, stdio: 'inherit'});
 
+    console.log('Removing release directory.');
+    rimraf.sync(releaseDir);
+
     done();
   };
 }
@@ -166,6 +169,9 @@ function publishFromPackage(done) {
   execSync(
       `lerna publish --from-package`,
       {cwd: releaseDir, stdio: 'inherit'});
+
+  console.log('Removing release directory.');
+  rimraf.sync(releaseDir);
   done();
 }
 

--- a/plugins/dev-create/bin/plugin.js
+++ b/plugins/dev-create/bin/plugin.js
@@ -103,7 +103,6 @@ exports.createPlugin = function(pluginName, options) {
       'dist': 'blockly-scripts build prod',
       'lint': 'blockly-scripts lint',
       'predeploy': 'blockly-scripts predeploy',
-      'prepublishOnly': 'npm run clean && npm run dist',
       'start': 'blockly-scripts start',
       'test': 'blockly-scripts test',
     },

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -7,7 +7,6 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start"
   },
   "main": "dist/index.js",

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -7,7 +7,6 @@
     "build": "blockly-scripts build",
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "predeploy": "npm run build && blockly-scripts predeploy"
   },

--- a/plugins/field-bitmap/package.json
+++ b/plugins/field-bitmap/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/field-colour-hsv-sliders/package.json
+++ b/plugins/field-colour-hsv-sliders/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "npm run build && blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "npm run build && blockly-scripts start",
     "test": "npm run build && blockly-scripts test"
   },

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -7,7 +7,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "npm run build && blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",

--- a/plugins/keyboard-navigation/package.json
+++ b/plugins/keyboard-navigation/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/renderer-inline-row-separators/package.json
+++ b/plugins/renderer-inline-row-separators/package.json
@@ -9,7 +9,6 @@
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
     "postinstall": "blockly-scripts postinstall",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/serialize-disabled-interactions/package.json
+++ b/plugins/serialize-disabled-interactions/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/shadow-block-converter/package.json
+++ b/plugins/shadow-block-converter/package.json
@@ -9,7 +9,6 @@
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
     "postinstall": "blockly-scripts postinstall",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -9,7 +9,6 @@
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
     "postinstall": "blockly-scripts postinstall",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/suggested-blocks/package.json
+++ b/plugins/suggested-blocks/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-deuteranopia/package.json
+++ b/plugins/theme-deuteranopia/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-highcontrast/package.json
+++ b/plugins/theme-highcontrast/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/theme-tritanopia/package.json
+++ b/plugins/theme-tritanopia/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -8,7 +8,6 @@
     "clean": "blockly-scripts clean",
     "lint": "blockly-scripts lint",
     "predeploy": "blockly-scripts predeploy",
-    "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",

--- a/scripts.md
+++ b/scripts.md
@@ -61,18 +61,18 @@ try again.
 
 ### `npm run publish:manual`
 This script assumes that you have already run `npm run publish:prepare`. It will
-publish all of the changed plugins since the last release, using the `dist` directory. It
-runs the lerna command that uses conventional commits to determine a new version number
-for each plugin, and publishes the new versions to npm and to a github release and tag.
-Since all plugins should have the `prepublishOnly` lifecycle script configured, plugins
-will build themselves before the publish step, so that the correct files are uploaded.
+publish all of the changed plugins since the last release, using the `dist`
+directory. It runs the lerna command that uses conventional commits to determine
+a new version number for each plugin, and publishes the new versions to npm and
+to a github release and tag. Plugins do not automatically build themselves
+before publishing. You must have run `npm run publish:prepare` script ahead of
+time for this reason.
 
-If any plugin fails to build, hopefully that should have been caught by the
-`publish:prepare` script. If it fails during this step, then likely some plugins have
-already been published to npm, and some will not have due to the error. That may also
-occur if there is some other with npm while running this command. You can recover from
-this state by fixing the error, and then running `npm run publish:prepare` again followed
-by `npm run publish:unpublishedOnly` or `npm run publish:force`.
+If there is some error with npm while running this command, you may end up in a
+state where some plugins have been published to npm and not others, after lerna
+has already tagged the new releases. You can recover from this state by fixing
+the error, and then running `npm run publish:prepare` again followed by
+`npm run publish:unpublishedOnly` or `npm run publish:force`.
 
 ### `npm run publish:unpublishedOnly`
 This script assumes that you have already run `npm run publish:prepare`. It uses the `dist`


### PR DESCRIPTION
Removes the `prepublishOnly` lifecycle script from all plugins. Removes the `--no-scripts` flag from the lerna command when publishing via github actions.

- Its use was to build the plugins before publishing them, but we are already doing this in both the github action that publishes, and when publishing manually (since running `npm run publish:prepare` was already required)
- It being there means we were passing the `--no-scripts` flag to lerna when publishing via github action, which disables all the lifecycle scripts like this one
    - This is unexpected and can cause problems (e.g. #1578 didn't work because the `prepack` hook was not being run)
    - This made the behavior when publishing manually vs ci unexpectedly behave differently
- To increase the safety level when publishing manually, I added a step that removes the `dist` directory after publishing. So if you haven't run `npm run publish:prepare` then there won't be a `dist` directory so we won't move forward with publishing. You can't risk publishing an old copy or publishing without building now.
- Publishing a single plugin via `npm publish` directly is now dangerous if you don't run `npm run build` first. I'll update our developer docs to note this. But this was already going to mess everything up anyway, so it's already heavily discouraged and we haven't done this in years. 