### PR TITLE
fix: do not include dist script in template

### DIFF
--- a/plugins/dev-create/bin/plugin.js
+++ b/plugins/dev-create/bin/plugin.js
@@ -100,7 +100,6 @@ exports.createPlugin = function(pluginName, options) {
       'audit:fix': 'blockly-scripts auditFix',
       'build': 'blockly-scripts build',
       'clean': 'blockly-scripts clean',
-      'dist': 'blockly-scripts build prod',
       'lint': 'blockly-scripts lint',
       'predeploy': 'blockly-scripts predeploy',
       'start': 'blockly-scripts start',


### PR DESCRIPTION
Remove the `dist` script from the new plugin template. It's not used in our other plugins. The build script always runs in production mode currently, so this script isn't doing anything.