### PR TITLE
chore: add a test/demo playground for shareable procedures

### DIFF
--- a/plugins/block-shareable-procedures/src/events_procedure_create.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_create.ts
@@ -28,8 +28,10 @@ export class ProcedureCreate extends ProcedureBase {
     const workspace = this.getEventWorkspace_();
     const procedureMap = workspace.getProcedureMap();
     if (forward) {
+      if (procedureMap.get(this.procedure.getId())) return;
       procedureMap.add(this.procedure);
     } else {
+      if (!procedureMap.get(this.procedure.getId())) return;
       procedureMap.delete(this.procedure.getId());
     }
   }

--- a/plugins/block-shareable-procedures/src/events_procedure_delete.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_delete.ts
@@ -27,8 +27,10 @@ export class ProcedureDelete extends ProcedureBase {
     const workspace = this.getEventWorkspace_();
     const procedureMap = workspace.getProcedureMap();
     if (forward) {
+      if (!procedureMap.get(this.procedure.getId())) return;
       procedureMap.delete(this.procedure.getId());
     } else {
+      if (procedureMap.get(this.procedure.getId())) return;
       procedureMap.add(this.procedure);
     }
   }

--- a/plugins/block-shareable-procedures/src/index.ts
+++ b/plugins/block-shareable-procedures/src/index.ts
@@ -5,10 +5,11 @@
  */
 
 import * as Blockly from 'blockly/core';
+import {ObservableParameterModel} from './observable_parameter_model';
+import {ObservableProcedureModel} from './observable_procedure_model';
+
 export {blocks} from './blocks';
 export {IProcedureBlock, isProcedureBlock} from './i_procedure_block';
-export {ObservableParameterModel} from './observable_parameter_model';
-export {ObservableProcedureModel} from './observable_procedure_model';
 export {ProcedureBase, ProcedureBaseJson} from './events_procedure_base';
 export {ProcedureChangeReturn, ProcedureChangeReturnJson} from './events_procedure_change_return';
 export {ProcedureCreate, ProcedureCreateJson} from './events_procedure_create';
@@ -19,6 +20,11 @@ export {ProcedureParameterDelete, ProcedureParameterDeleteJson} from './events_p
 export {ProcedureParameterRename, ProcedureParameterRenameJson} from './events_procedure_parameter_rename';
 export {ProcedureRename, ProcedureRenameJson} from './events_procedure_rename';
 export {triggerProceduresUpdate} from './update_procedures';
+
+export {
+  ObservableParameterModel,
+  ObservableProcedureModel,
+};
 
 /**
  * Unregisters all of the procedure blocks.
@@ -31,4 +37,16 @@ export function unregisterProcedureBlocks() {
   delete Blockly.Blocks['procedures_callnoreturn'];
   delete Blockly.Blocks['procedures_defreturn'];
   delete Blockly.Blocks['procedures_callreturn'];
+}
+
+/**
+ * Unregisters any existing procedure serializer, and registers a new one
+ * parameterized with the shareable procedure backing data models.
+ */
+export function registerProcedureSerializer() {
+  Blockly.serialization.registry.unregister('procedures');
+  Blockly.serialization.registry.register(
+      'procedures',
+      new Blockly.serialization.procedures.ProcedureSerializer(
+          ObservableProcedureModel, ObservableParameterModel));
 }

--- a/plugins/block-shareable-procedures/test/index.html
+++ b/plugins/block-shareable-procedures/test/index.html
@@ -3,16 +3,58 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Blockly Sharable Procedures</title>
+  <title>Blockly Shareable Procedures</title>
   <style>
     html, body {
       margin: 0;
+    }
+
+    h2, h3 {
+      padding: 1em;
+      margin: 0;
+      background-color: black;
+      color: white;
+      font-family: monospace;
+    }
+
+    #root {
+      display: flex;
+    }
+
+    #saveArea {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+      height: 100vh;
+    }
+
+    .save {
+      flex-grow: 1;
+      background-color: black;
+      color: white;
+      resize: none;
+    }
+
+    .blockly {
+      flex-grow: 4;
+      height: 100vh;
     }
   </style>
 </head>
 
 <body>
-  <div id="root"></div>
+  <div id="root">
+    <div class="blockly" id="blockly1"></div>
+    <div class="blockly" id="blockly2"></div>
+    <div id="saveArea">
+      <h2>Saved State</h2>
+      <input id="load" type="button" value="Reload"/>
+      <h3>Workspace 1</h3>
+      <textarea class="save" id="save1"></textarea>
+      <h3>Workspace 2</h3>
+      <textarea class="save" id="save2"></textarea>
+    </div>
+  </div>
   <script src="../build/test_bundle.js"></script>
 </body>
 

--- a/plugins/block-shareable-procedures/test/index.js
+++ b/plugins/block-shareable-procedures/test/index.js
@@ -3,34 +3,105 @@
  * Copyright 2022 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 /**
  * @fileoverview Block test.
  */
 
 import * as Blockly from 'blockly';
-import {createPlayground, toolboxCategories} from '@blockly/dev-tools';
-import {blocks, unregisterProcedureBlocks} from '../src/index';
+import {toolboxCategories} from '@blockly/dev-tools';
+import {blocks, unregisterProcedureBlocks, ObservableProcedureModel, ObservableParameterModel} from '../src/index';
+import {ProcedureBase} from '../src/events_procedure_base';
 
 
 unregisterProcedureBlocks();
 Blockly.common.defineBlocks(blocks);
 
-/**
- * Create a workspace.
- * @param {HTMLElement} blocklyDiv The blockly container div.
- * @param {!Blockly.BlocklyOptions} options The Blockly options.
- * @returns {!Blockly.WorkspaceSvg} The created workspace.
- */
-function createWorkspace(blocklyDiv, options) {
-  const workspace = Blockly.inject(blocklyDiv, options);
-  return workspace;
-}
+Blockly.serialization.registry.unregister('procedures');
+Blockly.serialization.registry.register(
+    'procedures',
+    new Blockly.serialization.procedures.ProcedureSerializer(
+        ObservableProcedureModel, ObservableParameterModel));
+
+export let workspace1;
+export let eventSharer1;
+export let workspace2;
+export let eventSharer2;
 
 document.addEventListener('DOMContentLoaded', function() {
-  const defaultOptions = {
+  const options = {
     toolbox: toolboxCategories,
   };
-  createPlayground(document.getElementById('root'), createWorkspace,
-      defaultOptions);
+  workspace1 = Blockly.inject('blockly1', options);
+  workspace2 = Blockly.inject('blockly2', options);
+  eventSharer1 = workspace1.addChangeListener(createEventSharer(workspace2));
+  eventSharer2 = workspace2.addChangeListener(createEventSharer(workspace1));
+
+  workspace1.addChangeListener(
+      createSerializationListener(workspace1, 'save1'));
+  workspace2.addChangeListener(
+      createSerializationListener(workspace2, 'save2'));
+
+  document.getElementById('load')
+      .addEventListener('click', () => reloadWorkspaces());
 });
+
+/**
+ * Returns an event listener that shares procedure and var events from the
+ * connected workspace to the other workspace.
+ * @param {!Blockly.Workspace} otherWorkspace The workspace to share events to.
+ * @returns {function(Blockly.Events.Abstract)} The listener.
+ */
+function createEventSharer(otherWorkspace) {
+  return (e) => {
+    if (!(e instanceof ProcedureBase) &&
+        !(e instanceof Blockly.Events.VarBase)) {
+      return;
+    }
+    let event;
+    try {
+      event = Blockly.Events.fromJson(e.toJson(), otherWorkspace);
+    } catch (e) {
+      console.log(
+          'Could not deserialize event. This is expected to happen. E.g. ' +
+          'when round-tripping parameter deletes, the delete in the ' +
+          'secondary workspace cannot be deserialized into the original ' +
+          'workspace.');
+      return;
+    }
+    console.log('running', event);
+    event.run(true);
+  };
+}
+
+/**
+ * Returns an event listener that serializes the given workspace to JSON and
+ * outputs it to the text area with the given ID.
+ * @param {!Blockly.Workspace} workspace The workspace to serialize.
+ * @param {string} textAreaId The ID of the text area to output to.
+ * @returns {function(Blockly.Events.Abstract)} The listener.
+ */
+function createSerializationListener(workspace, textAreaId) {
+  const textArea = document.getElementById(textAreaId);
+  return (e) => {
+    if (workspace.isDragging()) return;
+    textArea.value =
+        JSON.stringify(
+            Blockly.serialization.workspaces.save(workspace),
+            undefined,
+            2);
+  };
+}
+
+/**
+ * Reloads both workspaces to showcase serialization working.
+ */
+async function reloadWorkspaces() {
+  const save1 = Blockly.serialization.workspaces.save(workspace1);
+  const save2 = Blockly.serialization.workspaces.save(workspace2);
+  workspace1.clear();
+  workspace2.clear();
+  // Show people the cleared workspace so they know the reload did something.
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  Blockly.serialization.workspaces.load(save1, workspace1);
+  Blockly.serialization.workspaces.load(save2, workspace2);
+}

--- a/plugins/block-shareable-procedures/test/index.js
+++ b/plugins/block-shareable-procedures/test/index.js
@@ -33,6 +33,8 @@ document.addEventListener('DOMContentLoaded', function() {
   };
   workspace1 = Blockly.inject('blockly1', options);
   workspace2 = Blockly.inject('blockly2', options);
+  // If we allow undoing operations, it can create event loops when sharing
+  // events between workspaces.
   workspace1.MAX_UNDO = 0;
   workspace2.MAX_UNDO = 0;
   eventSharer1 = workspace1.addChangeListener(createEventSharer(workspace2));

--- a/plugins/block-shareable-procedures/test/index.js
+++ b/plugins/block-shareable-procedures/test/index.js
@@ -33,6 +33,8 @@ document.addEventListener('DOMContentLoaded', function() {
   };
   workspace1 = Blockly.inject('blockly1', options);
   workspace2 = Blockly.inject('blockly2', options);
+  workspace1.MAX_UNDO = 0;
+  workspace2.MAX_UNDO = 0;
   eventSharer1 = workspace1.addChangeListener(createEventSharer(workspace2));
   eventSharer2 = workspace2.addChangeListener(createEventSharer(workspace1));
 


### PR DESCRIPTION
### Description

Adds a test/demo page for shareable procedures. Procedure and variable events are shared between two workspaces to allow you to instantiate procedure definition blocks in one workspaces, and their caller blocks in another.

The JSON serialized state of both worksapces is made visible to the user, and a reload button is provided to showcase serialization working.

![image](https://user-images.githubusercontent.com/25440652/222015693-d3be0e97-574e-4891-a13f-cb0836db8521.png)


### Additional Info

Dependent on #1552 