### PR TITLE
fix: undoing moving params

### DIFF
--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -464,7 +464,7 @@ const procedureDefMutator = {
       this.model_ = map.get(procedureId);
     }
 
-    if (state['params']) {
+    if (state['params'] && !this.getProcedureModel().getParameters().length) {
       for (let i = 0; i < state['params'].length; i++) {
         const {name, id, paramId} = state['params'][i];
         this.getProcedureModel().insertParameter(


### PR DESCRIPTION
### Description

Previously when we would undo moving a param, the block change event would get undone first, which would actually add parameters to the model. So our undo was ineffective :/ This change makes it so that block change events are essentially ignored, so then the parameter delete + create events work properly.