### PR TITLE
fix: renaming params in other workspaces creating different vars

### DIFF
--- a/plugins/block-shareable-procedures/src/observable_parameter_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_parameter_model.ts
@@ -35,13 +35,15 @@ export class ObservableParameterModel implements
   /**
    * Sets the name of this parameter to the given name.
    * @param name The string to set the name to.
+   * @param id The optional ID the backing variable should have.
    * @returns This parameter model.
    */
-  setName(name: string): this {
+  setName(name: string, id?: string): this {
     if (name === this.variable.name) return this;
     const oldName = this.variable.name;
     this.variable =
-        this.workspace.getVariable(name) ?? this.workspace.createVariable(name);
+        this.workspace.getVariable(name) ??
+        this.workspace.createVariable(name, '', id);
     triggerProceduresUpdate(this.workspace);
     if (this.shouldFireEvents) {
       Blockly.Events.fire(


### PR DESCRIPTION
### Description

When we would rename parameters via the mutator in one workspace, the rename param even would create a new variable with the same name, but a different ID in the other workspace. This means that if the variable was then renamed in one worspace, the procedure blocks in the other workspace would not update to reflect the new variable name. This fixes that by round-tripping the variable ID through serialization as well.