### PR TITLE
fix: undoing renames

### DIFF
--- a/plugins/block-shareable-procedures/src/events_procedure_parameter_rename.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_parameter_rename.ts
@@ -61,9 +61,11 @@ export class ProcedureParameterRename extends ProcedureParameterBase {
         this.procedure.getId(),
         this.parameter.getId());
     if (forward) {
+      if (parameter.getName() !== this.oldName) return;
       (parameter as ObservableParameterModel)
           .setName(this.newName, this.newVarId);
     } else {
+      if (parameter.getName() !== this.newName) return;
       parameter.setName(this.oldName);
     }
   }

--- a/plugins/block-shareable-procedures/src/events_procedure_rename.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_rename.ts
@@ -50,8 +50,10 @@ export class ProcedureRename extends ProcedureBase {
           'in the procedure map');
     }
     if (forward) {
+      if (procedureModel.getName() !== this.oldName) return;
       procedureModel.setName(this.newName);
     } else {
+      if (procedureModel.getName() !== this.newName) return;
       procedureModel.setName(this.oldName);
     }
   }

--- a/plugins/block-shareable-procedures/test/event_procedure_parameter_rename.mocha.js
+++ b/plugins/block-shareable-procedures/test/event_procedure_parameter_rename.mocha.js
@@ -134,6 +134,29 @@ suite('Procedure Parameter Rename Event', function() {
           });
 
       test(
+          'attempting to rename a procedure with a different old name ' +
+          'does not work',
+          function() {
+            const otherNonDefaultName = 'other non-default name';
+            const {param: finalParam, proc: finalProc} =
+                this.createProcedureAndParameter('test procId', 'test paramId');
+            finalParam.setName(NON_DEFAULT_NAME);
+            const event = this.createEventToState(finalProc, finalParam);
+            const {param: testParam, proc: testProc} =
+                this.createProcedureAndParameter('test procId', 'test paramId');
+            testParam.setName(otherNonDefaultName);
+            this.procedureMap.add(testProc);
+
+            event.run(/* forward= */ true);
+            this.clock.runAll();
+
+            assert.equal(
+                testParam.getName(),
+                otherNonDefaultName,
+                'Expected the parameter\'s name to be unchanged');
+          });
+
+      test(
           'deserializing the event and running it triggers the effect',
           function() {
             const {param: initialParam, proc: initialProc} =
@@ -238,6 +261,29 @@ suite('Procedure Parameter Rename Event', function() {
             assert.throws(() => {
               event.run(/* forward= */ false);
             });
+          });
+
+      test(
+          'attempting to rename a procedure with a different old name ' +
+          'does not work',
+          function() {
+            const otherNonDefaultName = 'other non-default name';
+            const {param: undoableParam, proc: undoableProc} =
+                this.createProcedureAndParameter('test procId', 'test paramId');
+            undoableParam.setName(NON_DEFAULT_NAME);
+            const event = this.createEventToState(undoableProc, undoableParam);
+            const {param: testParam, proc: testProc} =
+                this.createProcedureAndParameter('test procId', 'test paramId');
+            testParam.setName(otherNonDefaultName);
+            this.procedureMap.add(testProc);
+
+            event.run(/* forward= */ false);
+            this.clock.runAll();
+
+            assert.equal(
+                testParam.getName(),
+                otherNonDefaultName,
+                'Expected the parameter\'s name to be unchanged');
           });
     });
   });

--- a/plugins/block-shareable-procedures/test/event_procedure_rename.mocha.js
+++ b/plugins/block-shareable-procedures/test/event_procedure_rename.mocha.js
@@ -111,6 +111,27 @@ suite('Procedure Rename Event', function() {
           });
 
       test(
+          'attempting to rename a procedure with a different old name ' +
+          'does not work',
+          function() {
+            const otherNonDefaultName = 'other non-default name';
+            const final = this.createProcedureModel('test id')
+                .setName(NON_DEFAULT_NAME);
+            const event = this.createEventToState(final);
+            const testModel = this.createProcedureModel('test id')
+                .setName(otherNonDefaultName);
+            this.procedureMap.add(testModel);
+
+            event.run(/* forward= */ true);
+            this.clock.runAll();
+
+            assert.equal(
+                testModel.getName(),
+                otherNonDefaultName,
+                'Expected the procedure\'s name to be unchanged');
+          });
+
+      test(
           'deserializing the event and running it triggers the effect',
           function() {
             const initial = this.createProcedureModel('test id');
@@ -187,15 +208,33 @@ suite('Procedure Rename Event', function() {
       test(
           'attempting to rename a procedure that does not exist throws',
           function() {
-            const initial = this.createProcedureModel('test id');
             const undoable = this.createProcedureModel('test id');
-            initial.setName(NON_DEFAULT_NAME);
             undoable.setName(NON_DEFAULT_NAME);
             const event = this.createEventToState(undoable);
 
             assert.throws(() => {
               event.run(/* forward= */ false);
             });
+          });
+
+      test(
+          'attempting to rename a procedure with a different new name ' +
+          'does not work',
+          function() {
+            const otherNonDefaultName = 'other non-default name';
+            const undoable = this.createProcedureModel('test id');
+            const event = this.createEventToState(undoable);
+            const testModel = this.createProcedureModel('test id')
+                .setName(otherNonDefaultName);
+            this.procedureMap.add(testModel);
+
+            event.run(/* forward= */ false);
+            this.clock.runAll();
+
+            assert.equal(
+                testModel.getName(),
+                otherNonDefaultName,
+                'Expected the procedure\'s name to be unchanged');
           });
     });
   });


### PR DESCRIPTION
### Description

Undoing renames with more than 1 character changed were causing event loops similar to #1552 This adds a check that the previous name of the procedure / parameter matches the previous name of the event before triggering a rename to kill those loops.