### PR TITLE
chore: Make custom generator example code match user experience.

### DIFF
--- a/examples/custom-generator-codelab/package.json
+++ b/examples/custom-generator-codelab/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "generator-sample-app",
+  "name": "sample-app",
   "version": "1.0.0",
-  "description": "A sample app using Blockly and custom generators",
+  "description": "A sample app using Blockly",
   "main": "index.js",
   "private": true,
   "scripts": {
@@ -12,6 +12,7 @@
   "keywords": [
     "blockly"
   ],
+  "author": "Blockly team",
   "license": "Apache-2.0",
   "devDependencies": {
     "css-loader": "^6.7.1",

--- a/examples/custom-generator-codelab/package.json
+++ b/examples/custom-generator-codelab/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generator-sample-app",
   "version": "1.0.0",
-  "description": "A sample app using Blockly",
+  "description": "A sample app using Blockly and custom generators",
   "main": "index.js",
   "private": true,
   "scripts": {
@@ -12,7 +12,6 @@
   "keywords": [
     "blockly"
   ],
-  "author": "Blockly team",
   "license": "Apache-2.0",
   "devDependencies": {
     "css-loader": "^6.7.1",

--- a/examples/custom-generator-codelab/package.json
+++ b/examples/custom-generator-codelab/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sample-app",
+  "name": "generator-sample-app",
   "version": "1.0.0",
   "description": "A sample app using Blockly",
   "main": "index.js",

--- a/examples/custom-generator-codelab/src/index.html
+++ b/examples/custom-generator-codelab/src/index.html
@@ -2,7 +2,7 @@
  <html>
    <head>
      <meta charset="utf-8" />
-     <title>Custom Generator Example</title>
+     <title>Blockly Sample App</title>
    </head>
    <body>
     <div id="pageContainer">


### PR DESCRIPTION
This reverts custom values in the custom generator codelab that never actually get set during the tutorial.

without this, the user experience (as i had it), is to wonder why my end result doesn't match the example code and then go back looking for what steps i missed.