### PR TITLE
chore: Migrate custom-renderer-codelab to using npx @blockly/create-package app

### DIFF
--- a/codelabs/custom_renderer/custom_renderer.md
+++ b/codelabs/custom_renderer/custom_renderer.md
@@ -40,18 +40,17 @@ In this codelab you will add code to the Blockly playground to create and use a 
 
 ### The application
 
-You will make all of your changes in a sample Blockly app, which you can find in blockly-samples at [`examples/sample-app`](https://github.com/google/blockly-samples/tree/master/examples/sample-app). This application contains a sample setup of Blockly, including custom blocks and a display of the generated code and output.
-  1) Clone or download the blockly-samples repository if you haven't already.
-  2) Navigate to the `examples/sample-app` directory (or a copy of it) via the command line.
-  3) Run `npm install` to install the required dependencies.
-  4) Run `npm run start` to start the server and run the sample application.
-  5) The sample app will automatically run in the browser window that opens.
+You will use the (`npx @blockly/create-package app`)[https://www.npmjs.com/package/@blockly/create-package) command to create a standalone application that contains a sample setup of Blockly, including custom blocks and a display of the generated code and output.
+  1) Run `npx @blockly/create-package app custom-renderer-codelab`.  This will create your blockly application in the folder `custom-renderer-codelab`.
+  2) `cd` into your new directory: `cd custom-renderer-codelab`.
+  3) Run `npm start` to start the server and run the sample application.
+  4) The sample app will automatically run in the browser window that opens.
 
 The initial application uses the default renderer and contains no code or definitions for a custom renderer.
 
 You can view the complete code used in this codelab in blockly-samples under [`examples/custom-renderer-codelab`](https://github.com/google/blockly-samples/tree/master/examples/custom-renderer-codelab).
 
-Before setting up the rest of the application, let's change the storage key used for this codelab application. This will ensure that the workspace is saved in its own storage, separate from the regular sample app, so that we don't interfere with other demos. In `serialization.js`, change the value of `storageKey` to some unique string:
+Before setting up the rest of the application, let's change the storage key used for this codelab application. This will ensure that the workspace is saved in its own storage, separate from the regular sample app, so that we don't interfere with other demos. In `serialization.js`, change the value of `storageKey` to some unique string.  `customRenderersWorkspace` will work:
 
 ```js
 // Use a unique storage key for this codelab
@@ -109,7 +108,7 @@ const ws = Blockly.inject(blocklyDiv, {
 
 ### The result
 
-If the server is already running, you can refresh the page to see your changes. Otherwise, run `npm run start` to start the server. Once the server is running, click on the `Loops` entry in your browser and drag out a repeat block. The resulting block will use the same values already defined in the base `Blockly.blockRendering.Renderer`.
+If the server is already running, you can refresh the page to see your changes. Otherwise, run `npm start` to start the server. Once the server is running, click on the `Loops` entry in your browser and drag out a repeat block. The resulting block will use the same values already defined in the base `Blockly.blockRendering.Renderer`.
 
 ![Screenshot of a renderer with an appearance matching the base renderer.](./custom_renderer.png)
 

--- a/examples/custom-renderer-codelab/README.md
+++ b/examples/custom-renderer-codelab/README.md
@@ -1,0 +1,50 @@
+# Blockly Sample App
+
+## Purpose
+
+This app illustrates how to use Blockly together with common programming tools like node/npm, webpack, typescript, eslint, and others. You can use it as the starting point for your own application and modify it as much as you'd like. It contains basic infrastructure for running, building, testing, etc. that you can use even if you don't understand how to configure the related tool yet. When your needs outgrow the functionality provided here, you can replace the provided configuration or tool with your own.
+
+## Quick Start
+
+1. [Install](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) npm if you haven't before.
+2. Run [`npx @blockly/create-package app <application-name>`](https://www.npmjs.com/package/@blockly/create-package) to clone this application to your own machine.
+3. Run `npm install` to install the required dependencies.
+4. Run `npm run start` to run the development server and see the app in action.
+5. If you make any changes to the source code, just refresh the browser while the server is running to see them.
+
+## Tooling
+
+The application uses many of the same tools that the Blockly team uses to develop Blockly itself. Following is a brief overview, and you can read more about them on our [developer site](https://developers.google.com/blockly/guides/contribute/get-started/development_tools).
+
+- Structure: The application is built as an npm package. You can use npm to manage the dependencies of the application.
+- Modules: ES6 modules to handle imports to/exports from other files.
+- Building/bundling: Webpack to build the source code and bundle it into one file for serving.
+- Development server: webpack-dev-server to run locally while in development.
+- Testing: Mocha to run unit tests.
+- Linting: Eslint to lint the code and ensure it conforms with a standard style.
+- UI Framework: Does not use a framework. For more complex applications, you may wish to integrate a UI framework like React or Angular.
+
+You can disable, reconfigure, or replace any of these tools at any time, but they are preconfigured to get you started developing your Blockly application quickly.
+
+## Structure
+
+- `package.json` contains basic information about the app. This is where the scripts to run, build, etc. are listed.
+- `package-lock.json` is used by npm to manage dependencies
+- `webpack.config.js` is the configuration for webpack. This handles bundling the application and running our development server.
+- `src/` contains the rest of the source code.
+- `dist/` contains the packaged output (that you could host on a server, for example). This is ignored by git and will only appear after you run `npm run build` or `npm run start`.
+
+### Source Code
+
+- `index.html` contains the skeleton HTML for the page. This file is modified during the build to import the bundled source code output by webpack.
+- `index.js` is the entry point of the app. It configures Blockly and sets up the page to show the blocks, the generated code, and the output of running the code in JavaScript.
+- `serialization.js` has code to save and load the workspace using the browser's local storage. This is how your workspace is saved even after refreshing or leaving the page. You could replace this with code that saves the user's data to a cloud database instead.
+- `toolbox.js` contains the toolbox definition for the app. The current toolbox contains nearly every block that Blockly provides out of the box. You probably want to replace this definition with your own toolbox that uses your custom blocks and only includes the default blocks that are relevant to your application.
+- `blocks/text.js` has code for a custom text block, just as an example of creating your own blocks. You probably want to delete this block, and add your own blocks in this directory.
+- `generators/javascript.js` contains the JavaScript generator for the custom text block. You'll need to include block generators for any custom blocks you create, in whatever programming language(s) your application will use.
+
+## Serving
+
+To run your app locally, run `npm run start` to run the development server. This mode generates source maps and ingests the source maps created by Blockly, so that you can debug using unminified code.
+
+To deploy your app so that others can use it, run `npm run build` to run a production build. This will bundle your code and minify it to reduce its size. You can then host the contents of the `dist` directory on a web server of your choosing. If you're just getting started, try using [GitHub Pages](https://pages.github.com/).

--- a/examples/custom-renderer-codelab/package.json
+++ b/examples/custom-renderer-codelab/package.json
@@ -1,21 +1,23 @@
 {
-  "name": "renderer-sample-app",
+  "name": "custom-renderer-codelab",
   "version": "1.0.0",
-  "description": "A sample app using Blockly and custom renderers",
+  "description": "A sample app using Blockly",
   "main": "index.js",
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack",
-    "start": "webpack serve --open"
+    "build": "webpack --mode production",
+    "start": "webpack serve --open --mode development"
   },
   "keywords": [
     "blockly"
   ],
+  "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
     "css-loader": "^6.7.1",
     "html-webpack-plugin": "^5.5.0",
+    "source-map-loader": "^4.0.1",
     "style-loader": "^3.3.1",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0",

--- a/examples/custom-renderer-codelab/package.json
+++ b/examples/custom-renderer-codelab/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "custom-renderer-codelab",
+  "name": "renderer-sample-app",
   "version": "1.0.0",
-  "description": "A sample app using Blockly",
+  "description": "A sample app using Blockly and custom renderers",
   "main": "index.js",
   "private": true,
   "scripts": {

--- a/examples/custom-renderer-codelab/src/index.js
+++ b/examples/custom-renderer-codelab/src/index.js
@@ -10,6 +10,7 @@ import {generator} from './generators/javascript';
 import {javascriptGenerator} from 'blockly/javascript';
 import {save, load} from './serialization';
 import {toolbox} from './toolbox';
+import './renderers/javascript';
 import './index.css';
 
 // Register the blocks and generator with Blockly
@@ -20,7 +21,10 @@ Object.assign(javascriptGenerator, generator);
 const codeDiv = document.getElementById('generatedCode').firstChild;
 const outputDiv = document.getElementById('output');
 const blocklyDiv = document.getElementById('blocklyDiv');
-const ws = Blockly.inject(blocklyDiv, {toolbox});
+const ws = Blockly.inject(blocklyDiv, {
+  renderer: 'custom_renderer',
+  toolbox,
+});
 
 // This function resets the code and output divs, shows the
 // generated code from the workspace, and evals the code.
@@ -58,5 +62,3 @@ ws.addChangeListener((e) => {
   }
   runCode();
 });
-
-

--- a/examples/custom-renderer-codelab/src/index.js
+++ b/examples/custom-renderer-codelab/src/index.js
@@ -10,7 +10,6 @@ import {generator} from './generators/javascript';
 import {javascriptGenerator} from 'blockly/javascript';
 import {save, load} from './serialization';
 import {toolbox} from './toolbox';
-import './renderers/javascript';
 import './index.css';
 
 // Register the blocks and generator with Blockly
@@ -21,10 +20,7 @@ Object.assign(javascriptGenerator, generator);
 const codeDiv = document.getElementById('generatedCode').firstChild;
 const outputDiv = document.getElementById('output');
 const blocklyDiv = document.getElementById('blocklyDiv');
-const ws = Blockly.inject(blocklyDiv, {
-  renderer: 'custom_renderer',
-  toolbox,
-});
+const ws = Blockly.inject(blocklyDiv, {toolbox});
 
 // This function resets the code and output divs, shows the
 // generated code from the workspace, and evals the code.
@@ -62,3 +58,5 @@ ws.addChangeListener((e) => {
   }
   runCode();
 });
+
+

--- a/examples/custom-renderer-codelab/webpack.config.js
+++ b/examples/custom-renderer-codelab/webpack.config.js
@@ -1,8 +1,8 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-module.exports = {
-  mode: 'development',
+// Base config that applies to either development or production mode.
+const config = {
   entry: './src/index.js',
   output: {
     // Compile the source files into a bundle.
@@ -12,7 +12,7 @@ module.exports = {
   },
   // Enable webpack-dev-server to get hot refresh of the app.
   devServer: {
-    static: './dist',
+    static: './build',
   },
   module: {
     rules: [
@@ -31,4 +31,29 @@ module.exports = {
       template: 'src/index.html',
     }),
   ],
+};
+
+module.exports = (env, argv) => {
+  if (argv.mode === 'development') {
+    // Set the output path to the `build` directory
+    // so we don't clobber production builds.
+    config.output.path = path.resolve(__dirname, 'build');
+
+    // Generate source maps for our code for easier debugging.
+    // Not suitable for production builds. If you want source maps in
+    // production, choose a different one from https://webpack.js.org/configuration/devtool
+    config.devtool = 'eval-cheap-module-source-map';
+
+    // Include the source maps for Blockly for easier debugging Blockly code.
+    config.module.rules.push({
+      test: /(blockly\/.*\.js)$/,
+      use: [require.resolve('source-map-loader')],
+      enforce: 'pre',
+    });
+
+    // Ignore spurious warnings from source-map-loader
+    // It can't find source maps for some Closure modules and that is expected
+    config.ignoreWarnings = [/Failed to parse source map/];
+  }
+  return config;
 };


### PR DESCRIPTION
- Follow patterns laid down in and discussed in PR #1635
- Not much more to say.  Very straightforward migration.  