### PR TITLE
fix: update suggested-blocks to work if events are disabled during initial load

### DIFF
--- a/plugins/suggested-blocks/README.md
+++ b/plugins/suggested-blocks/README.md
@@ -43,7 +43,19 @@ SuggestedBlocks.init(workspace);
 
 ## API
 
-- `init`: Initializes the suggested blocks categories in the toolbox
+- `init`: Initializes the suggested blocks categories in the toolbox. Takes several arguments:
+  - `workspace`: The workspace to use the plugin with. If you have multiple
+    workspaces, you need to register the plugin for each workspace separately,
+    and the stats will be tracked separately.
+  - `numBlocksPerCategory` (optional): The maximum number of blocks to show in
+    each category. Defaults to 10.
+  - `waitForFinishedLoading` (optional): Whether to wait for the
+    [`Blockly.Events.FinishedLoading` event](https://developers.google.com/blockly/reference/js/blockly.events_namespace.finishedloading_class.md)
+    before taking action on any new `BlockCreate` events. If you disable event
+    firing while you load the initial state of the workspace, you'll need to set
+    this to `false`, or the plugin will never place blocks in either category.
+    By default, this value is `true`, so that events fired while loading initial
+    serialized state do not affect the statistics.
 
 ## License
 Apache 2.0

--- a/plugins/suggested-blocks/test/index.js
+++ b/plugins/suggested-blocks/test/index.js
@@ -25,6 +25,7 @@ function createWorkspace(blocklyDiv, options) {
 }
 
 const customTheme = Blockly.Theme.defineTheme('classic_with_suggestions', {
+  'name': 'classic_with_suggestions',
   'base': Blockly.Themes.Classic,
   'blockStyles': {},
   'categoryStyles': {


### PR DESCRIPTION
Fixes #1624 

- Previously, this plugin would throw errors during serialization for non-initialized workspaces. This could happen if you import the plugin, but don't initialize it for every workspace that is serialized, because serializers are registered globally but this plugin may not have data for every workspace. I fixed this by making the making the serialized methods return early if a workspace is not found.
- Added an option to skip waiting for the `FINISHED_LOADING` event. Previously, the plugin waited to hear that event before adding the blocks to either category, but that doesn't work if you disable events during initial load (like I do in the sample app).
- Updated readme with this information.
- Added type information to `init`.
- Added `name` to theme info object as `name` is a required property of `ITheme` (even though name is also the first argument passed to `defineTheme`?)

Tested the plugin itself and installed it in a standalone app.

Notes:
- When testing in the advanced playground, the serialized state is not saved between refreshes because the advanced playground uses xml, not json #1049 this has always been true. By testing in a standalone app I've confirmed serialization works as expected.
- I did not update the toolbox example in the README because another contributor is currently working on that task.