### PR TITLE
chore: small changes for consistency between renderer/generator codelabs

### DIFF
--- a/codelabs/custom_generator/custom_generator.md
+++ b/codelabs/custom_generator/custom_generator.md
@@ -10,6 +10,7 @@ Feedback Link: https://github.com/google/blockly-samples/issues/new/choose
 ## Codelab overview
 
 ### What you'll learn
+
 - How to create a custom language generator.
 - How to create block generator definitions for existing blocks.
 - How to create block generator definitions for new blocks.
@@ -23,8 +24,9 @@ You will build a JSON generator that implements the [JSON language spec](https:/
 
 ### What you'll need
 
+- Comfort with the Blockly playground.
 - Familiarity with JSON and the JSON specification.
-- Comfort with defining blocks and toolboxes in Blockly.
+- Basic understanding of blocks and toolboxes in Blockly.
 - NPM installed ([instructions](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
 - Comfort using the command line/terminal.
 

--- a/codelabs/custom_renderer/custom_renderer.md
+++ b/codelabs/custom_renderer/custom_renderer.md
@@ -10,6 +10,7 @@ Feedback Link: https://github.com/google/blockly-samples/issues/new/choose
 ## Codelab overview
 
 ### What you'll learn
+
 - How to define and register a custom renderer.
 - How to override renderer constants.
 - How to change the shape of connection notches.
@@ -31,6 +32,7 @@ You will build and use four renderers:
 ### What you'll need
 
 - Comfort with the Blockly playground.
+- Basic understanding of renderers and toolboxes in Blockly.
 - NPM installed ([instructions](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
 - Comfort using the command line/terminal.
 

--- a/codelabs/custom_renderer/custom_renderer.md
+++ b/codelabs/custom_renderer/custom_renderer.md
@@ -43,10 +43,10 @@ In this codelab you will add code to the Blockly playground to create and use a 
 ### The application
 
 You will use the (`npx @blockly/create-package app`)[https://www.npmjs.com/package/@blockly/create-package) command to create a standalone application that contains a sample setup of Blockly, including custom blocks and a display of the generated code and output.
-  1) Run `npx @blockly/create-package app custom-renderer-codelab`.  This will create your blockly application in the folder `custom-renderer-codelab`.
-  2) `cd` into your new directory: `cd custom-renderer-codelab`.
-  3) Run `npm start` to start the server and run the sample application.
-  4) The sample app will automatically run in the browser window that opens.
+  1. Run `npx @blockly/create-package app custom-renderer-codelab`.  This will create your blockly application in the folder `custom-renderer-codelab`.
+  1. `cd` into your new directory: `cd custom-renderer-codelab`.
+  1. Run `npm start` to start the server and run the sample application.
+  1. The sample app will automatically run in the browser window that opens.
 
 The initial application uses the default renderer and contains no code or definitions for a custom renderer.
 

--- a/examples/custom-renderer-codelab/src/index.js
+++ b/examples/custom-renderer-codelab/src/index.js
@@ -10,7 +10,7 @@ import {generator} from './generators/javascript';
 import {javascriptGenerator} from 'blockly/javascript';
 import {save, load} from './serialization';
 import {toolbox} from './toolbox';
-import './renderers/javascript';
+import './renderers/custom';
 import './index.css';
 
 // Register the blocks and generator with Blockly


### PR DESCRIPTION
Just breaking these out while working on the keyboard-navigation codelab.

- Add a space after the ### What you'll learn section so that it's consistent that all `###` entries have a newline spacer.
- Add the `Comfort with Blockly playground` need to both.
- Change `comfort with` to `basic understanding of`.  Comfort is really what you should have AFTER the codelab, but not necessary beforehand, IMO.  
- Also fixed a syntax error that crept in when i changed the imported file from javascript.js to custom.js but didn't change it in the example code. 