### PR TITLE
fix: Change from Blockly.selected to Blockly.getSelected

### DIFF
--- a/plugins/cross-tab-copy-paste/src/index.js
+++ b/plugins/cross-tab-copy-paste/src/index.js
@@ -67,8 +67,8 @@ export class CrossTabCopyPaste {
       preconditionFn: function(
           /** @type {!Blockly.ContextMenuRegistry.Scope} */ scope) {
         if (
-          Blockly.selected.isDeletable() &&
-          Blockly.selected.isMovable()) {
+          Blockly.getSelected().isDeletable() &&
+          Blockly.getSelected().isMovable()) {
           return 'enabled';
         }
         return 'disabled';


### PR DESCRIPTION
Blockly.selected is deprecated, changed to Blockly.getSelected