### PR TITLE
fix: local testing for github pages site

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,8 +19,6 @@ const predeployTasks = require('./scripts/gh-predeploy');
 
 gulp.header = require('gulp-header');
 
-const appDirectory = fs.realpathSync(process.cwd());
-
 /**
  * Run the license checker for all packages.
  * @returns {Promise} A promise.
@@ -210,7 +208,7 @@ function deployToGhPages(repo) {
           repo,
           // Include .nojekyll file to tell GitHub to publish without building.
           // By default, dotfiles are excluded.
-          // TODO: make the github action do the build step before publishing.
+          // TODO: make the github action include .nojekyll.
           src: ['**/*', '.nojekyll']
         },
         done);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -266,11 +266,11 @@ function testGhPagesLocally(isBeta) {
   return gulp.series(
       gulp.parallel(
           preparePluginsForLocal(isBeta), prepareExamplesForLocal(isBeta)),
-      gulp.parallel(predeployTasks.predeployPlugins, predeployTasks.predeployExamples),
+      predeployTasks.predeployAllLocal,
       function(done) {
-        console.log('Starting server using "bundle exec jekyll serve"');
+        console.log('Starting server using http-server');
         execSync(
-            `bundle exec jekyll serve`, {cwd: 'gh-pages', stdio: 'inherit'});
+            `npx http-server`, {cwd: 'gh-pages', stdio: 'inherit'});
         done();
       });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "gh-pages": "^3.1.0",
         "gulp": "^4.0.2",
         "gulp-header": "^2.0.9",
+        "http-server": "^14.1.1",
         "js-green-licenses": "^1.1.0",
         "json-to-pretty-yaml": "^1.2.2",
         "lerna": "^6.5.1",
@@ -2460,6 +2461,18 @@
         }
       ]
     },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
@@ -3569,6 +3582,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.0",
@@ -6068,6 +6090,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -6092,11 +6123,37 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -6110,6 +6167,103 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-server/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/http-server/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/http-server/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/http-server/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/http-server/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/http-server/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -8505,6 +8659,18 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -9792,6 +9958,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -9923,6 +10098,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -10577,6 +10761,41 @@
         "node": ">=8"
       }
     },
+    "node_modules/portfinder": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/portfinder/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -10739,6 +10958,21 @@
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+      "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -11494,6 +11728,12 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -11706,6 +11946,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true
+    },
     "node_modules/semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -11831,6 +12077,20 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -12968,6 +13228,18 @@
       "integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk=",
       "dev": true
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -13104,6 +13376,12 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "deprecated": "Please see https://github.com/lydell/urix#deprecated",
+      "dev": true
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
     },
     "node_modules/url-parse-lax": {
@@ -13276,6 +13554,30 @@
       "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {
@@ -15568,6 +15870,15 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "before-after-hook": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
@@ -16480,6 +16791,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
       "dev": true
     },
     "cosmiconfig": {
@@ -18444,6 +18761,12 @@
         }
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -18462,11 +18785,31 @@
         "lru-cache": "^6.0.0"
       }
     },
+    "html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^2.0.0"
+      }
+    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
+    },
+    "http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
     },
     "http-proxy-agent": {
       "version": "5.0.0",
@@ -18477,6 +18820,78 @@
         "@tootallnate/once": "2",
         "agent-base": "6",
         "debug": "4"
+      }
+    },
+    "http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "https-proxy-agent": {
@@ -20345,6 +20760,12 @@
         }
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -21347,6 +21768,12 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -21443,6 +21870,12 @@
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
       }
+    },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
     },
     "optionator": {
       "version": "0.9.1",
@@ -21927,6 +22360,37 @@
         "find-up": "^4.0.0"
       }
     },
+    "portfinder": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        }
+      }
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -22056,6 +22520,15 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
       "dev": true
+    },
+    "qs": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+      "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
+      "dev": true,
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -22636,6 +23109,12 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -22794,6 +23273,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true
+    },
     "semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -22888,6 +23373,17 @@
           "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
           "dev": true
         }
+      }
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
       }
     },
     "signal-exit": {
@@ -23794,6 +24290,15 @@
       "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
       "dev": true
     },
+    "union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "requires": {
+        "qs": "^6.4.0"
+      }
+    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -23905,6 +24410,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
     },
     "url-parse-lax": {
@@ -24052,6 +24563,26 @@
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
+      }
+    },
+    "whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.6.3"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
     },
     "which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "gulp-header": "^2.0.9",
         "http-server": "^14.1.1",
         "js-green-licenses": "^1.1.0",
-        "json-to-pretty-yaml": "^1.2.2",
         "lerna": "^6.5.1",
         "rimraf": "^3.0.2",
         "showdown": "^2.1.0"
@@ -7242,19 +7241,6 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
-    "node_modules/json-to-pretty-yaml": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
-      "integrity": "sha1-9M0L0KXo/h3yWq9boRiwmf2ZLVs=",
-      "dev": true,
-      "dependencies": {
-        "remedial": "^1.0.7",
-        "remove-trailing-spaces": "^1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.2.0"
-      }
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -11615,15 +11601,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/remedial": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
-      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/remove-bom-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
@@ -11655,12 +11632,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
-    },
-    "node_modules/remove-trailing-spaces": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.8.tgz",
-      "integrity": "sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA==",
       "dev": true
     },
     "node_modules/repeat-element": {
@@ -19630,16 +19601,6 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
-    "json-to-pretty-yaml": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
-      "integrity": "sha1-9M0L0KXo/h3yWq9boRiwmf2ZLVs=",
-      "dev": true,
-      "requires": {
-        "remedial": "^1.0.7",
-        "remove-trailing-spaces": "^1.0.6"
-      }
-    },
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -23023,12 +22984,6 @@
         "rc": "^1.2.8"
       }
     },
-    "remedial": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
-      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
-      "dev": true
-    },
     "remove-bom-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
@@ -23054,12 +23009,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
-    },
-    "remove-trailing-spaces": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.8.tgz",
-      "integrity": "sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA==",
       "dev": true
     },
     "repeat-element": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gh-pages": "^3.1.0",
     "gulp": "^4.0.2",
     "gulp-header": "^2.0.9",
+    "http-server": "^14.1.1",
     "js-green-licenses": "^1.1.0",
     "json-to-pretty-yaml": "^1.2.2",
     "lerna": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "gulp-header": "^2.0.9",
     "http-server": "^14.1.1",
     "js-green-licenses": "^1.1.0",
-    "json-to-pretty-yaml": "^1.2.2",
     "lerna": "^6.5.1",
     "rimraf": "^3.0.2",
     "showdown": "^2.1.0"

--- a/scripts/gh-predeploy.js
+++ b/scripts/gh-predeploy.js
@@ -19,37 +19,37 @@ const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
 
 /**
  * Inject head HTML for a plugin or example page on gh-pages.
- * This finds the existing head tag and inserts a few additional lines of CSS,
- * as well as updating the title to match the plugin or example's name.
  * @param {string} initialContents The initial page HTML, as a string.
- * @param {string} title The title to use for the page, which may be generated from the package
- *    name or specified explicitly.
- * @param {boolean} isLocal True if building for a local test. False if building for gh-pages.
+ * @param {string} title The title to use for the page, which may be
+ *     generated from the package name or specified explicitly.
+ * @param {boolean} isLocal True if building for a local test. False
+ *     if building for gh-pages.
  * @returns {string} The modified contents of the page, as a string.
  */
 function injectHeader(initialContents, title, isLocal) {
-  let baseurl = isLocal ? '' : '/blockly-samples';
+  let baseURL = isLocal ? '/' : '/blockly-samples/';
 
   let headerAdditions = `
   <!-- INJECTED HEADER -->
   <meta name="viewport" content="width=device-width,maximum-scale=2">
-  <link rel="icon" type="image/x-icon" href="${baseurl}/favicon.ico" />
+  <link rel="icon" type="image/x-icon" href="${baseURL}favicon.ico" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,300,300italic,400italic,500,500italic,700,700italic" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="${baseurl}/css/custom.css"/>
+  <link rel="stylesheet" href="${baseURL}css/custom.css"/>
   <!-- END INJECTED HEADER -->`;
 
   // Replace the title with a more descriptive title.
-  let modifiedContents = initialContents.replace(/<title>.*<\/title>/,
-      `<title>${title}</title>`);
-  // Add some CSS at the beginning of the header. Any CSS the page already had will be higher priority.
-  modifiedContents = modifiedContents.replace(/<\s*head\s*>/,
-      `<head>${headerAdditions}`);
+  let modifiedContents = initialContents.replace(
+      /<title>.*<\/title>/, `<title>${title}</title>`);
+  // Add some CSS at the beginning of the header. Any CSS the page already
+  // had will be higher priority.
+  modifiedContents = modifiedContents.replace(
+      /<\s*head\s*>/, `<head>${headerAdditions}`);
   return modifiedContents;
 }
 
 /**
- * Create footer HTML for a plugin demo page on gh-pages.
+ * Inject footer HTML into a page at the end of the body.
  * @param {string} initialContents The initial page HTML, as a string.
  * @returns {string} The modified contents of the page, as a string.
  */
@@ -94,42 +94,51 @@ function injectFooter(initialContents) {
  * Inject nav bar HTML for a specific plugin at the beginning of the body.
  * @param {string} initialContents The initial page HTML, as a string.
  * @param {!Object} packageJson The contents of the plugin's package.json.
- * @param {string} pluginDir The directory of the plugin that is currently being prepared.
- * @param {boolean} isLocal True if building for a local test. False if building for gh-pages.
+ * @param {string} pluginDir The directory of the plugin that is currently
+ *     being prepared.
+ * @param {boolean} isLocal True if building for a local test. False if
+ *     building for gh-pages.
  * @returns {string} The modified contents of the page, as a string.
  */
 function injectPluginNavBar(inputString, packageJson, pluginDir, isLocal) {
-  // Build up information from package.json.
-  let title = `${packageJson.name} Demo`;
-  let description = packageJson.description;
-  let version = packageJson.version;
   let codeLink = `https://github.com/google/blockly-samples/blob/master/plugins/${pluginDir}`;
-
   let npmLink = `https://www.npmjs.com/package/${packageJson.name}`;
-  let baseurl = isLocal ? '/' : '/blockly-samples';
+  let baseURL = isLocal ? '/' : '/blockly-samples/';
 
-  // Assemble that information into a nav bar and tabs for getting to the
-  // playground and README pages.
   let navBar = `
   <!-- NAV BAR -->
   <nav id="toolbar">
-    <a href="${baseurl}" id="arrow-back">
+    <a href="${baseURL}" id="arrow-back">
       <i class="material-icons">close</i>
       <img src="https://blocklycodelabs.dev/images/logo_knockout.png" class="logo-devs"
         alt="Blockly logo" />
     </a>
 
     <div class="title-grow">
-      <div class="title">${title}</div>
-      <div class="subtitle">${description}</div>
+      <div class="title">${packageJson.name} Demo</div>
+      <div class="subtitle">${packageJson.description}</div>
     </div>
-    ${version}
+    ${packageJson.version}
     
     <a href="${codeLink}" class="button" target="_blank">View code</a>
     <a href="${npmLink}" class="button" target="_blank">View on npm</a>
   </nav>
   <!-- END NAV BAR -->
-  ${createPluginTabs(pluginDir, isLocal)}`
+  <!-- PAGE TABS -->
+  <ul id="tabs">
+    <li>
+      <a href="${baseURL}plugins/${pluginDir}/test/index">
+        Playground
+      </a>
+    </li>
+    <li>
+      <a href="${baseURL}plugins/${pluginDir}/README">
+        README
+      </a>
+    </li>
+  </ul>
+  <!-- END PAGE TABS -->
+`
 
   // Find the start of the body and inject the nav bar just after the opening <body> tag,
   // preserving anything else in the tag (such as onload).
@@ -144,54 +153,27 @@ function injectPluginNavBar(inputString, packageJson, pluginDir, isLocal) {
 }
 
 /**
- * Create the tabs for switching between playground and README pages.
- * @param {string} pluginDir The directory of the plugin that is currently being prepared.
- * @param {boolean} isLocal True if building for a local test. False if building for gh-pages.
- * @returns {string} The HTML for the page tabs, as a string.
- */
-function createPluginTabs(pluginDir, isLocal) {
-  let baseurl = isLocal ? '' : '/blockly-samples';
-  return `
-  <!-- PAGE TABS -->
-  <ul id="tabs">
-    <li>
-      <a href="${baseurl}/plugins/${pluginDir}/test/index">
-        Playground
-      </a>
-    </li>
-    <li>
-      <a href="${baseurl}/plugins/${pluginDir}/README">
-        README
-      </a>
-    </li>
-  </ul>
-  <!-- END PAGE TABS -->
-  `;
-}
-
-/**
  * Create the tabs for switching between pages in an example.
  * The pages to include are specified in the example's package.json.
  * Unlike plugins, examples may have as many tabs as they want.
- * @param {string} pageRoot The directory of the example that is currently being prepared.
- * @param {boolean} isLocal True if building for a local test. False if building for gh-pages.
+ * @param {string} pageRoot The directory of the example that is currently 
+ *     being prepared.
+ * @param {boolean} isLocal True if building for a local test. False if 
+ *     building for gh-pages.
  * @returns {string} The HTML for the page tabs, as a string.
  */
 function createExampleTabs(pageRoot, pages, isLocal) {
-  let baseurl = isLocal ? '' : '/blockly-samples';
-  function createTab(page) {
-    return `
-      <li>
-        <a href="${baseurl}/${pageRoot}/${page.link}">
-          ${page.label}
-        </a>
-      </li>
-      `;
-  }
+  let baseURL = isLocal ? '/' : '/blockly-samples/';
 
   let tabsString = ``;
   for (const page of pages) {
-    tabsString += createTab(page); 
+    tabsString += `
+    <li>
+      <a href="${baseURL}${pageRoot}/${page.link}">
+        ${page.label}
+      </a>
+    </li>
+    `;
   }
 
   return `
@@ -207,35 +189,44 @@ function createExampleTabs(pageRoot, pages, isLocal) {
  * This page has the plugin's test playground, but wraps it in a 
  * devsite-style header and footer, and includes the plugin's readme and 
  * links to the plugin source files on GitHub and published package on npm.
- * @param {string} pluginDir The directory of the plugin that is currently being prepared.
- * @param {boolean} isLocal True if building for a local test. False if building for gh-pages.
+ * @param {string} pluginDir The directory of the plugin that is currently
+ *     being prepared.
+ * @param {boolean} isLocal True if building for a local test. False if
+ *     building for gh-pages.
  */
 function createPluginPage(pluginDir, isLocal) {
   const packageJson = require(resolveApp(`plugins/${pluginDir}/package.json`));
-  const initialContents = fs.readFileSync(path.join('plugins', pluginDir, 'test', 'index.html')).toString();
-  let title = `${packageJson.name} Demo`;
-  let contents = injectHeader(initialContents, title, isLocal);
+  const initialPath = path.join('plugins', pluginDir, 'test', 'index.html');
+  const initialContents = fs.readFileSync(initialPath).toString();
+
+  let contents = injectHeader(
+      initialContents, `${packageJson.name} Demo`, isLocal);
   contents = injectPluginNavBar(contents, packageJson, pluginDir, isLocal);
   contents = injectFooter(contents);
   
   const dirPath = path.join('gh-pages', 'plugins', pluginDir, 'test');
   fs.mkdirSync(dirPath, { recursive: true });
-
   fs.writeFileSync(path.join(dirPath, 'index.html'), contents, 'utf-8');
 }
 
 /**
  * Create the README page (in HTML) from the plugin's README.md file.
- * This includes the same header, nav bar, and footer as the playground page for a
- * given package.
+ * This includes the same header, nav bar, and footer as the playground page
+ * for a given package.
  * 
- * @param {string} pluginDir The directory of the plugin that is currently being prepared.
- * @param {boolean} isLocal True if building for a local test. False if building for gh-pages.
+ * @param {string} pluginDir The directory of the plugin that is currently
+ *     being prepared.
+ * @param {boolean} isLocal True if building for a local test. False if 
+ *     building for gh-pages.
  */
 function createReadmePage(pluginDir, isLocal) {
   const packageJson = require(resolveApp(`plugins/${pluginDir}/package.json`));
-  const initialContents = fs.readFileSync(`./plugins/${pluginDir}/README.md`).toString();
+  const initialContents = 
+      fs.readFileSync(`./plugins/${pluginDir}/README.md`).toString();
 
+  // TODO: Remove spurious line breaks. 
+  // By default, showdown preserves line breaks from the README file that are 
+  // just there to stay under 80 characters per line. 
   const converter = new showdown.Converter();
   converter.setFlavor('github');
   const text = initialContents;
@@ -258,24 +249,24 @@ function createReadmePage(pluginDir, isLocal) {
   `;
 
   // Add the same header, nav bar, and footer as we used for the playground.
-  let title = `${packageJson.name} Demo`;
-  let modifiedContents = injectHeader(initialPage, title, isLocal);
-  modifiedContents = injectPluginNavBar(modifiedContents, packageJson, pluginDir, isLocal);
+  let modifiedContents = injectHeader(
+      initialPage, `${packageJson.name} Demo`, isLocal);
+  modifiedContents = injectPluginNavBar(
+      modifiedContents, packageJson, pluginDir, isLocal);
   modifiedContents = injectFooter(modifiedContents);
 
   // Make sure the directory exists, then write to it.
   const dirString = `./gh-pages/plugins/${pluginDir}/`;
   fs.mkdirSync(dirString, { recursive: true });
-  const outputPath = `${dirString}/README.html`;
-
-  fs.writeFileSync(outputPath, modifiedContents, 'utf-8');
+  fs.writeFileSync(`${dirString}/README.html`, modifiedContents, 'utf-8');
 }
 
 /**
  * Copy over files needed to deploy this plugin and its test page to 
  * github pages.
  * @param {string} pluginDir The directory with the plugin source files.
- * @param {boolean} isLocal True if building for a local test. False if building for gh-pages.
+ * @param {boolean} isLocal True if building for a local test. False if
+ *     building for gh-pages.
  */
 function preparePlugin(pluginDir, isLocal) {
   console.log(`Preparing ${pluginDir} plugin for deployment.`);
@@ -338,36 +329,37 @@ function prepareLocalPlugins(done) {
 /**
  * Inject nav bar HTML for a specific example at the beginning of the body.
  * @param {string} inputString The initial page HTML, as a string.
- * @param {!Object} packageJson The contents of the example's package.json.
- * @param {string} pageRoot The location of the example's files relative to the root of
- *     the repository.
- * @param {string} title The title to display in the nav bar.
- * @param {boolean} isLocal True if building for a local test. False if building for gh-pages.
+ * @param {!Object} demoConfig The contents of the blocklyDemoConfig object
+ *     in the example's package.json.
+ * @param {string} pageRoot The location of the example's files relative to
+ *     the root of the repository.
+ * @param {boolean} isLocal True if building for a local test. False if
+ *     building for gh-pages.
  * @returns {string} The modified contents of the page, as a string.
  */
-function injectExampleNavBar(inputString, packageJson, pageRoot, title, isLocal) {
+function injectExampleNavBar(inputString, demoConfig, pageRoot, isLocal) {
   // Build up information from package.json.
-  let description = packageJson.blocklyDemoConfig.description ?
-      `<div class="subtitle">${ packageJson.blocklyDemoConfig.description}</div>` : ``;
+  let descriptionString = demoConfig.description ?
+      `<div class="subtitle">${demoConfig.description}</div>` : ``;
   let codeLink = `https://github.com/google/blockly-samples/blob/master/${pageRoot}`;
 
-  const pages = packageJson.blocklyDemoConfig.pages;
+  const pages = demoConfig.pages;
   const tabString = pages ? createExampleTabs(pageRoot, pages, isLocal) : '';
-  let baseurl = isLocal ? '/' : '/blockly-samples';
+  let indexURL = isLocal ? '/' : '/blockly-samples';
   // Assemble that information into a nav bar and tabs for getting to linked
   // example pages.
   let navBar = `
   <!-- NAV BAR -->
   <nav id="toolbar">
-    <a href="${baseurl}" id="arrow-back">
+    <a href="${indexURL}" id="arrow-back">
       <i class="material-icons">close</i>
       <img src="https://blocklycodelabs.dev/images/logo_knockout.png" class="logo-devs"
         alt="Blockly sample" />
     </a>
 
     <div class="title-grow">
-      <div class="title">${title}</div>
-      ${description}
+      <div class="title">${demoConfig.title}</div>
+      ${descriptionString}
     </div>
     
     <a href="${codeLink}" class="button" target="_blank">View code</a>
@@ -375,8 +367,8 @@ function injectExampleNavBar(inputString, packageJson, pageRoot, title, isLocal)
   <!-- END NAV BAR -->
   ${tabString}`
 
-  // Find the start of the body and inject the nav bar just after the opening <body> tag,
-  // preserving anything else in the tag (such as onload).
+  // Find the start of the body and inject the nav bar just after the opening
+  // <body> tag, preserving anything else in the tag (such as onload).
   // Also wrap all page content in a <main></main> tag.
   let modifiedContent = inputString.replace(
       /<body([^>]*)>/,
@@ -392,24 +384,24 @@ function injectExampleNavBar(inputString, packageJson, pageRoot, title, isLocal)
  * that it will display nicely on gh-pages. This includes a
  * devsite-style header and footer, links to the source files, and links
  * to other files within the same demo package.
- * @param {string} pageRoot The directory of the example that is currently being
- *     prepared (e.g. examples/interpreter-demo).
- * @param {string} pagePath The page of the page to create within the example's directory
- *     (e.g. index.html).
- * @param {boolean} isLocal True if building for a local test. False if building for gh-pages.
+ * @param {string} pageRoot The directory of the example that is currently
+ *     being prepared (e.g. examples/interpreter-demo).
+ * @param {string} pagePath The path of the page to create within the example's
+ *     directory (e.g. index.html).
+ * @param {!Object} demoConfig The contents of the blocklyDemoConfig object
+ *     in the example's package.json.
+ * @param {boolean} isLocal True if building for a local test. False if
+ *     building for gh-pages.
  */
-function createExamplePage(pageRoot, pagePath, isLocal) {
-  const packageJson = require(resolveApp(`${pageRoot}/package.json`));
-  const initialContents = fs.readFileSync(path.join(pageRoot, pagePath)).toString();
+function createExamplePage(pageRoot, pagePath, demoConfig, isLocal) {
+  const initialContents = 
+      fs.readFileSync(path.join(pageRoot, pagePath)).toString();
 
-  const { blocklyDemoConfig } = packageJson;
-
-  let contents = injectHeader(initialContents, blocklyDemoConfig.title, isLocal);
-  contents = injectExampleNavBar(contents, packageJson, pageRoot, blocklyDemoConfig.title, isLocal);
+  let contents = injectHeader(initialContents, demoConfig.title, isLocal);
+  contents = injectExampleNavBar(contents, demoConfig, pageRoot, isLocal);
   contents = injectFooter(contents);
 
   const outputPath = path.join('gh-pages', pageRoot, pagePath);
-
   fs.writeFileSync(outputPath, contents, 'utf-8');
 }
 
@@ -419,7 +411,8 @@ function createExamplePage(pageRoot, pagePath, isLocal) {
  * The resulting code lives in gh-pages/examples/<exampleName>.
  * @param {string} exampleDir The subdirectory (inside examples/) for this
  *     example.
- * @param {boolean} isLocal True if building for a local test. False if building for gh-pages.
+ * @param {boolean} isLocal True if building for a local test. False if
+ *     building for gh-pages.
  * @param {Function} done Completed callback.
  * @return {Function} Gulp task.
  */
@@ -429,14 +422,14 @@ function prepareExample(exampleDir, isLocal, done) {
     require(resolveApp(path.join(baseDir, exampleDir, 'package.json')));
   
   // Cancel early if the package.json says this is not a demo.
-  const { blocklyDemoConfig } = packageJson;
-  if (!blocklyDemoConfig) {
+  const { blocklyDemoConfig: demoConfig } = packageJson;
+  if (!demoConfig) {
     done();
     return;
   }
   console.log(`Preparing ${exampleDir} example for deployment.`);
 
-  const fileList = blocklyDemoConfig.files;
+  const fileList = demoConfig.files;
 
   // Create target folder, if it doesn't exist.
   fs.mkdirSync(path.join('gh-pages', baseDir, exampleDir), { recursive: true });
@@ -453,9 +446,12 @@ function prepareExample(exampleDir, isLocal, done) {
   const pageRegex = /.*\.(html|htm)$/i;
   const pages = fileList.filter((f) => pageRegex.test(f));
   // Add headers and footers to HTML pages.
-  pages.forEach(page => createExamplePage(`${baseDir}/${exampleDir}`, page, isLocal));
+  pages.forEach(page => 
+      createExamplePage(`${baseDir}/${exampleDir}`, page, demoConfig, isLocal)
+  );
   
-  // Copy over all other files mentioned in the demoConfig to the correct directory.
+  // Copy over all other files mentioned in the demoConfig to the
+  // correct directory.
   const assets = fileList.filter((f) => !pageRegex.test(f));
   let stream;
   if (assets.length) {
@@ -509,13 +505,13 @@ function prepareLocalExamples(done) {
   }))(done);
 }
 
-
 /**
  * Create the index page for the blockly-samples GitHub Pages site.
- * This page has some nice wrappers, a search bar, and a link to every plugin or example
- * specified in in `index.md`.
+ * This page has some nice wrappers, a search bar, and a link to every
+ * plugin or example specified in in `index.md`.
  * 
- * @param {boolean} isLocal True if building for a local test. False if building for gh-pages.
+ * @param {boolean} isLocal True if building for a local test. False if 
+ *   building for gh-pages.
  */
 function createIndexPage(isLocal) {
   const initialContents = fs.readFileSync(`./gh-pages/index.md`).toString();
@@ -579,9 +575,7 @@ function createIndexPage(isLocal) {
 
   let contents = injectHeader(indexBase, 'Plugins | blockly-samples', isLocal);
   contents = injectFooter(contents);
-
   const outputPath = path.join('gh-pages', 'index.html');
-
   fs.writeFileSync(outputPath, contents, 'utf-8');
 }
 
@@ -594,6 +588,10 @@ function predeployForGitHub(done) {
   return gulp.parallel(prepareToDeployPlugins, prepareToDeployExamples)(done);
 }
 
+/**
+ * Create pages for examples, plugins, and the index page for
+ * local testing of the GitHub Pages site.
+ */
 function predeployForLocal(done) {
   createIndexPage(true);
   return gulp.parallel(prepareLocalPlugins, prepareLocalExamples)(done);


### PR DESCRIPTION
Part of https://github.com/google/blockly-samples/issues/1549

This change stops using `bundle exec jekyll serve` for local testing by just building the site locally and using `http-server` to serve it. To make that work I had to pipe an `isLocal` flag around and use it to set the base URL for all of the links.

Also removes an unused dependency (`json-to-pretty-yaml`) and cleans up some code, including inlining some portions of the template strings where I thought it made the resulting HTML easier to read.

I suggest reviewing one commit at a time.

You can test it by pulling the code down and running `npm ci && npm test:ghpages` to see a local version of all of the pages. The remote version is live at https://rachel-fenichel.github.io/blockly-samples/ and you can also test it by running `npm deploy`.