### PR TITLE
fix!: make scroll options work without drag surfaces

### DIFF
--- a/plugins/scroll-options/src/index.js
+++ b/plugins/scroll-options/src/index.js
@@ -77,7 +77,7 @@ export class ScrollOptions {
       return;
     }
 
-    // TODO: We should maybe add an accessor for the svgGroup_?
+    // TODO(blockly/#7157): We should maybe add an accessor for the svgGroup_?
     this.wheelEvent_ = Blockly.browserEvents.conditionalBind(
         this.workspace_.svgGroup_, 'wheel', this, this.onMouseWheel_);
   }

--- a/plugins/scroll-options/src/index.js
+++ b/plugins/scroll-options/src/index.js
@@ -77,16 +77,9 @@ export class ScrollOptions {
       return;
     }
 
-    let element;
-    const dragSurface = this.workspace_.getBlockDragSurface();
-    if (dragSurface) {
-      element = dragSurface.getSvgRoot();
-    } else {
-      element = this.workspace_.svgGroup_;
-    }
-
+    // TODO: We should maybe add an accessor for the svgGroup_?
     this.wheelEvent_ = Blockly.browserEvents.conditionalBind(
-        element, 'wheel', this, this.onMouseWheel_);
+        this.workspace_.svgGroup_, 'wheel', this, this.onMouseWheel_);
   }
 
   /**

--- a/plugins/scroll-options/src/utils.js
+++ b/plugins/scroll-options/src/utils.js
@@ -11,8 +11,10 @@
  * @returns {!Blockly.utils.Coordinate} The current workspace coordinate.
  */
 export const getTranslation = (ws) => {
-  // TODO: We should maybe make getBlockCanvas public?
+  // TODO(blockly/#7157): We should maybe make getBlockCanvas public?
   const translation = ws.svgBlockCanvas_.getAttribute('transform');
+
+  // Translation has the format 'translate(x, y)'.
   const splitted = translation.split(',');
   const x = Number(splitted[0].split('(')[1]);
   const y = Number(splitted[1].split(')')[0]);

--- a/plugins/scroll-options/src/utils.js
+++ b/plugins/scroll-options/src/utils.js
@@ -11,14 +11,10 @@
  * @returns {!Blockly.utils.Coordinate} The current workspace coordinate.
  */
 export const getTranslation = (ws) => {
-  const dragSurface = ws.getBlockDragSurface();
-  if (dragSurface) {
-    return dragSurface.getWsTranslation();
-  } else {
-    const translation = ws.svgBlockCanvas_.getAttribute('transform');
-    const splitted = translation.split(',');
-    const x = Number(splitted[0].split('(')[1]);
-    const y = Number(splitted[1].split(')')[0]);
-    return new Blockly.utils.Coordinate(x, y);
-  }
+  // TODO: We should maybe make getBlockCanvas public?
+  const translation = ws.svgBlockCanvas_.getAttribute('transform');
+  const splitted = translation.split(',');
+  const x = Number(splitted[0].split('(')[1]);
+  const y = Number(splitted[1].split(')')[0]);
+  return new Blockly.utils.Coordinate(x, y);
 };


### PR DESCRIPTION
### Description

Fixes #1664 

Tested against https://github.com/google/blockly/pull/6758

### Additional information

Not mergable until after v10 release.

TODO: Need to bump minimum version of Blockly & master version of plugin.