### PR TITLE
fix: Fix instructions and completed code for the context menu codelab.

### DIFF
--- a/codelabs/context_menu_option/context_menu_option.md
+++ b/codelabs/context_menu_option/context_menu_option.md
@@ -267,7 +267,7 @@ callback: function(scope) {
     'fields': {
       'TEXT': 'Now there is a block'
     }
-  });
+  }, scope.workspace);
 }
 ```
 

--- a/examples/context-menu-codelab/complete-code/index.js
+++ b/examples/context-menu-codelab/complete-code/index.js
@@ -61,7 +61,7 @@ function registerHelpOption() {
         'fields': {
           'TEXT': 'Now there is a block'
         }
-      });
+      }, scope.workspace);
     },
     scopeType: Blockly.ContextMenuRegistry.ScopeType.WORKSPACE,
     id: 'help_no_blocks',


### PR DESCRIPTION
The context menu codelab directed users to append a block to the workspace, but omitted the workspace argument to `Blockly.serialization.blocks.append()`. This PR adds that argument to both the codelab instructions and the completed reference code. Fixes #1408.