### PR TITLE
Fix: Correct date field test assertions

### DIFF
--- a/plugins/dev-tools/src/field_test_helpers.mocha.js
+++ b/plugins/dev-tools/src/field_test_helpers.mocha.js
@@ -14,7 +14,7 @@ import {runTestCases, TestCase} from './common_test_helpers.mocha';
  */
 export class FieldValueTestCase {
   /**
-   * Class for a a field value test case.
+   * Class for a field value test case.
    */
   constructor() {
     /**

--- a/plugins/field-date/test/field_date_test.mocha.js
+++ b/plugins/field-date/test/field_date_test.mocha.js
@@ -53,7 +53,7 @@ suite('FieldDate', function() {
    * @param {FieldValueTestCase} testCase The test case.
    */
   const validTestCaseAssertField = function(field, testCase) {
-    assertFieldValue(field, testCase.value);
+    assertFieldValue(field, testCase.expectedValue);
   };
 
   runConstructorSuiteTests(


### PR DESCRIPTION
Assert on the expected value rather than the input value.

Apparently unique to the date field.