### PR TITLE
feat: add built-on-blockly badge as a static file in the gh-pages directory

### DIFF
--- a/gh-pages/built-on-blockly.svg
+++ b/gh-pages/built-on-blockly.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="125" height="20" role="img" aria-label="Built on: Blockly">
+  <title>Built on: Blockly</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+    <stop offset="1" stop-opacity=".1" />
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="125" height="20" rx="3" fill="#fff" />
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="76" height="20" fill="#5f6368" />
+    <rect x="76" width="49" height="20" fill="#4285f4" />
+    <rect width="125" height="20" fill="url(#s)" />
+  </g>
+  <g text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+    <g transform="translate(10 2.5) scale(0.073)">
+      <path fill="#4285f4" d="M20.1 32C13.4 32 8 37.4 8 44.1V149c0 6.7 5.4 12.1 12.1 12.1H25a20 20 0 0 0 38.5 0H84a8 8 0 0 0 8-8V40l-8-8z"/>
+      <path fill="#c8d1db" d="M80 32V85l-16.6-9.4a3.6 3.6 0 0 0-5.4 3.1v40.7c0 2.7 3 4.4 5.4 3l16.6-9.3V161h45.4c6.4 0 11.6-5.2 11.6-11.5v-106c0-6.4-5.2-11.5-11.5-11.5z"/>
+    </g>
+    <text aria-hidden="true" x="505" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="430">Built on</text>
+    <text x="505" y="140" transform="scale(.1)" fill="#fff" textLength="430">Built on</text>
+    <text aria-hidden="true" x="995" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="390">Blockly</text>
+    <text x="995" y="140" transform="scale(.1)" fill="#fff" textLength="390">Blockly</text>
+  </g>
+</svg>


### PR DESCRIPTION
This is a static version of the badge that you get if you use our "built on blockly" badge through tinyurl and shields.io.

[![Built on Blockly](https://tinyurl.com/built-on-blockly)](https://github.com/google/blockly)

The other image is built in a very roundabout way: there's a tinyurl link, which redirects to a [shields.io link](https://img.shields.io/badge/Built%20on-Blockly-4285F4?style=flat&cacheSeconds=3600&logoWidth=20&labelColor=5F6368&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJMYXllcl82IiBkYXRhLW5hbWU9IkxheWVyIDYiIHZpZXdCb3g9IjAgMCAxOTIgMTkyIj4KICA8ZGVmcyBpZD0iZGVmczkwMiIvPgogIDxnIGlkPSJnMTAxMyIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMjMuNSAtOCkiPgogICAgPHBhdGggaWQ9InBhdGg5MDYiIGZpbGw9IiM0Mjg1ZjQiIGQ9Ik0yMC4xIDMyQzEzLjQgMzIgOCAzNy40IDggNDQuMVYxNDljMCA2LjcgNS40IDEyLjEgMTIuMSAxMi4xSDI1YTIwIDIwIDAgMCAwIDM4LjUgMEg4NGE4IDggMCAwIDAgOC04VjQwbC04LTh6Ii8+CiAgICA8cGF0aCBpZD0icGF0aDkwOCIgZmlsbD0iI2M4ZDFkYiIgZD0iTTgwIDMyVjg1bC0xNi42LTkuNGEzLjYgMy42IDAgMCAwLTUuNCAzLjF2NDAuN2MwIDIuNyAzIDQuNCA1LjQgM2wxNi42LTkuM1YxNjFoNDUuNGM2LjQgMCAxMS42LTUuMiAxMS42LTExLjV2LTEwNmMwLTYuNC01LjItMTEuNS0xMS41LTExLjV6Ii8+CiAgPC9nPgo8L3N2Zz4K)

That link tells shields.io to build a badge with a few specific parameters (text, color) and then includes the blockly logo SVG as base64 encoded SVG. This is pretty roundabout, considering that we already know how to make SVG images here.

Neil unpacked it all into a single file. I'm adding it to our hosted gh-pages site, and we can later change references to point here instead of to tinyurl.

