### PR TITLE
fix: assorted gh-pages issues

### DIFF
--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -46,4 +46,4 @@ jobs:
       run: |
         npm run deploy:prepare
         git remote set-url origin https://git:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-        npx gh-pages -d gh-pages -u "github-actions-bot <support+actions@github.com>"
+        npx gh-pages -d gh-pages -t -u "github-actions-bot <support+actions@github.com>"

--- a/gh-pages/README.md
+++ b/gh-pages/README.md
@@ -2,64 +2,18 @@
 
 
 ## Serving Locally
+To test locally, go to the root of blockly-samples and run:
 
-### Setup
-
-Install Ruby
-
-Install bundler:
-
-```bash
-gem install jekyll bundler
-```
-
-From the gh-pages directory, run:
-
-```
-bundle install
-```
-
-### Install and build blockly-samples
-
-From the root directory, run:
-
-```
-npm install
-cd examples && npm install
-cd ..
-# This copies necessary files to gh-pages folder. This is necessary to run gh-pages locally.
-npm run deploy:prepare
-```
-
-This runs `install` for all of the plugins and all of the examples, then runs the `deploy:prepare` script to copy over built files into the gh-pages directory.
-
-### Test locally with beta
-
-From the root directory run:
-
-```
-npm install
-cd examples && npm install
-cd ..
-# This copies necessary files to gh-pages folder. This is necessary to run gh-pages locally.
-npm run test:ghpages
-```
-
-This runs `install` for all of the plugins and all of the examples, then directly installs the current beta release of Blockly, then runs the `deploy:prepare` script to copy over built files into the gh-pages directory.
-
-### Serve
-
-From the gh-pages directory, start the jekyll server by running:
-
-```
-bundle exec jekyll serve
-```
-
-Jekyll will watch files and regenerate on changes, except if you change
-_config.yml, at which point you will need to restart the server.
+    ```
+    npm run test:ghpages
+    ```
 
 
-Browse to http://127.0.0.1:4000
+To test locally with a beta version of Blockly, go to the root of blockly-samples and run:
+
+    ```
+    npm run test:ghpages:beta
+    ```
 
 ## Deploying
 

--- a/gh-pages/css/custom.css
+++ b/gh-pages/css/custom.css
@@ -26,6 +26,10 @@ main .article-container {
   padding: 24px 0;
 }
 
+div.article img  {
+  max-width: 100%;
+}
+
 main .article {
   background-color: #fff;
   color: #202124;

--- a/scripts.md
+++ b/scripts.md
@@ -49,6 +49,12 @@ this repo.
 ### `npm run test`
 This script runs `npm run test` on each of the Blockly plugins in this repo.
 
+### `npm run test:ghpages`
+This script builds all files needed to deploy plugins and examples to Github Pages, then starts a local server with that content.
+
+### `npm run test:ghpages:beta`
+This script installs a beta version of Blockly, builds all files needed to deploy plugins and examples to Github Pages, then starts a local server with that content.
+
 ### `npm run publish:prepare`
 This script will clone a copy of blockly-samples to a directory called `dist`,
 run `npm ci`, build and test all plugins, and then log in to the npm publishing

--- a/scripts.md
+++ b/scripts.md
@@ -50,10 +50,10 @@ this repo.
 This script runs `npm run test` on each of the Blockly plugins in this repo.
 
 ### `npm run test:ghpages`
-This script builds all files needed to deploy plugins and examples to Github Pages, then starts a local server with that content.
+This script builds all files needed to deploy plugins and examples to GitHub Pages, then starts a local server with that content.
 
 ### `npm run test:ghpages:beta`
-This script installs a beta version of Blockly, builds all files needed to deploy plugins and examples to Github Pages, then starts a local server with that content.
+This script installs a beta version of Blockly, builds all files needed to deploy plugins and examples to GitHub Pages, then starts a local server with that content.
 
 ### `npm run publish:prepare`
 This script will clone a copy of blockly-samples to a directory called `dist`,

--- a/scripts/gh-predeploy.js
+++ b/scripts/gh-predeploy.js
@@ -368,8 +368,7 @@ function injectExampleNavBar(inputString, demoConfig, pageRoot, isLocal) {
     
     <a href="${codeLink}" class="button" target="_blank">View code</a>
   </nav>
-  <!-- END NAV BAR -->
-  ${tabString}`
+  <!-- END NAV BAR -->`;
 
   // Find the start of the body and inject the nav bar just after the opening
   // <body> tag, preserving anything else in the tag (such as onload).
@@ -377,7 +376,11 @@ function injectExampleNavBar(inputString, demoConfig, pageRoot, isLocal) {
   let modifiedContent = inputString.replace(
       /<body([^>]*)>/,
       `<body$1 class="root">
-      <main id="main" class="has-tabs">${navBar}`
+      ${navBar}
+      <main id="main" class="has-tabs">
+        <div class="drop-shadow"></div>
+        ${tabString}
+        `
       );
   modifiedContent = modifiedContent.replace(/<\/body>/, `</main>\n  </body>`);
   return modifiedContent;

--- a/scripts/gh-predeploy.js
+++ b/scripts/gh-predeploy.js
@@ -123,7 +123,9 @@ function injectPluginNavBar(inputString, packageJson, pluginDir, isLocal) {
     <a href="${codeLink}" class="button" target="_blank">View code</a>
     <a href="${npmLink}" class="button" target="_blank">View on npm</a>
   </nav>
-  <!-- END NAV BAR -->
+  <!-- END NAV BAR -->`;
+
+  let tabs = `
   <!-- PAGE TABS -->
   <ul id="tabs">
     <li>
@@ -137,8 +139,7 @@ function injectPluginNavBar(inputString, packageJson, pluginDir, isLocal) {
       </a>
     </li>
   </ul>
-  <!-- END PAGE TABS -->
-`
+  <!-- END PAGE TABS -->`;
 
   // Find the start of the body and inject the nav bar just after the opening <body> tag,
   // preserving anything else in the tag (such as onload).
@@ -146,7 +147,11 @@ function injectPluginNavBar(inputString, packageJson, pluginDir, isLocal) {
   let modifiedContent = inputString.replace(
     /<body([^>]*)>/,
     `<body$1 class="root">
-    <main id="main" class="has-tabs">${navBar}`
+    ${navBar}
+    <main id="main" class="has-tabs">
+      <div class="drop-shadow"></div>
+      ${tabs}
+      `
     );
   modifiedContent = modifiedContent.replace(/(<\/body>)/, `</main>$1`);
   return modifiedContent;
@@ -224,11 +229,12 @@ function createReadmePage(pluginDir, isLocal) {
   const initialContents = 
       fs.readFileSync(`./plugins/${pluginDir}/README.md`).toString();
 
-  // TODO: Remove spurious line breaks. 
-  // By default, showdown preserves line breaks from the README file that are 
-  // just there to stay under 80 characters per line. 
   const converter = new showdown.Converter();
   converter.setFlavor('github');
+  // By default, showdown preserves line breaks from the README file that are 
+  // just there to stay under 80 characters per line. Turn that off.
+  converter.setOption('simpleLineBreaks', false);
+  converter.setOption('ghMentions', false);
   const text = initialContents;
   const html = converter.makeHtml(text);
 
@@ -237,13 +243,11 @@ function createReadmePage(pluginDir, isLocal) {
     <title></title>
   </head>
   <body class="root">
-    <main id="main" class="has-tabs">
     <article class="article-container site-width">
       <div class="article">
       ${html}
       </div>
     </article>
-    </main>
   </body>
  </html>
   `;

--- a/scripts/gh-predeploy.js
+++ b/scripts/gh-predeploy.js
@@ -409,6 +409,7 @@ function createExamplePage(pageRoot, pagePath, demoConfig, isLocal) {
   contents = injectFooter(contents);
 
   const outputPath = path.join('gh-pages', pageRoot, pagePath);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   fs.writeFileSync(outputPath, contents, 'utf-8');
 }
 


### PR DESCRIPTION
- Fix visual issues in generated files
- Fix oversized images in readme pages
- Add dotfiles to gh-pages deploy action
- Create directory for example page if it didn't already exist
- Update documentation in `scripts.md` and `gh-pages/readme.md`

Part of https://github.com/google/blockly-samples/issues/1549

Tested locally and by pushing to rachel-fenichel.github.io/blockly-samples

Sample action run: https://github.com/rachel-fenichel/blockly-samples/actions/runs/4886382082

Once this is merged, I can open a PR to actually merge `remove_jekyll` back into `master.