### PR TITLE
chore(deps): Allow `typescript` v5 as peer dep of `dev-scripts`

### DIFF
--- a/plugins/dev-scripts/package.json
+++ b/plugins/dev-scripts/package.json
@@ -43,7 +43,7 @@
     "webpack-dev-server": "^4.0.0"
   },
   "peerDependencies": {
-    "typescript": "^4.3.2"
+    "typescript": "^4.3.2 || ^5"
   },
   "peerDependenciesMeta": {
     "typescript": {


### PR DESCRIPTION
This should allow plugins to pull in a sufficiently recent version of typescript that eslint will allow them to use the `override` keyword.