### PR TITLE
fix: Clean the dist directory before every build.

### DIFF
--- a/examples/blockly-rtc/webpack.config.js
+++ b/examples/blockly-rtc/webpack.config.js
@@ -34,7 +34,8 @@ module.exports = {
     },
     output: {
         path: path.resolve(__dirname, 'build'),
-        filename: '[name].js'
+        filename: '[name].js',
+        clean: true,
     },
     plugins: [
         new webpack.optimize.ModuleConcatenationPlugin(),

--- a/examples/blockly-webpack/webpack.config.js
+++ b/examples/blockly-webpack/webpack.config.js
@@ -35,7 +35,8 @@ module.exports = {
     },
     output: {
         path: path.resolve(__dirname, 'build'),
-        filename: '[name].js'
+        filename: '[name].js',
+        clean: true,
     },
     plugins: [
         new webpack.optimize.ModuleConcatenationPlugin(),

--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -78,6 +78,7 @@ module.exports = (env) => {
       filename: outputFile,
       libraryTarget: 'umd',
       globalObject: 'this',
+      clean: true,
     },
     resolve: {
       alias: {


### PR DESCRIPTION
Fixes #1675 by updating the Webpack config to clean the dist directory as part of each build, avoiding issues where files from previous runs could cause unexpected or inconsistent behavior.