### PR TITLE
fix: Fix cut shortcut in cross tab copy paste plugin.

### DIFF
--- a/plugins/cross-tab-copy-paste/src/index.js
+++ b/plugins/cross-tab-copy-paste/src/index.js
@@ -187,7 +187,7 @@ export class CrossTabCopyPaste {
           !Blockly.Gesture.inProgress() &&
           Blockly.getSelected() &&
           Blockly.getSelected().isDeletable() &&
-          Blockly.segetSelected().isMovable() &&
+          Blockly.getSelected().isMovable() &&
           !Blockly.getSelected().workspace.isFlyout;
       },
       callback: function(workspace, e) {


### PR DESCRIPTION
Fixes a typo that broke the implementation of handling the cut shortcut in the cross-tab copy paste plugin. Fixes #1698.