### PR TITLE
fix: remove types from ts templates for lint

### DIFF
--- a/plugins/dev-create/templates/plugin/template/src/index.js
+++ b/plugins/dev-create/templates/plugin/template/src/index.js
@@ -25,7 +25,7 @@ export class Plugin {
      * @type {!Blockly.WorkspaceSvg}
      * @protected
      */
-    this.workspace_ = workspace;
+    this.workspace = workspace;
   }
 
   /**

--- a/plugins/dev-create/templates/typescript-block/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-block/template/test/index.ts
@@ -18,9 +18,9 @@ const allBlocks = ['block_template'];
 
 /**
  * Create a workspace.
- * @param {HTMLElement} blocklyDiv The blockly container div.
- * @param {!Blockly.BlocklyOptions} options The Blockly options.
- * @returns {!Blockly.WorkspaceSvg} The created workspace.
+ * @param blocklyDiv The blockly container div.
+ * @param options The Blockly options.
+ * @returns The created workspace.
  */
 function createWorkspace(blocklyDiv: HTMLElement,
     options: Blockly.BlocklyOptions): Blockly.WorkspaceSvg {

--- a/plugins/dev-create/templates/typescript-field/template/src/index.ts
+++ b/plugins/dev-create/templates/typescript-field/template/src/index.ts
@@ -18,8 +18,8 @@ import * as Blockly from 'blockly/core';
 export class FieldTemplate extends Blockly.Field {
   /**
    * Constructs a FieldTemplate from a JSON arg object.
-   * @param {!Object} options A JSON object with options.
-   * @returns {!FieldTemplate} The new field instance.
+   * @param options A JSON object with options.
+   * @returns The new field instance.
    * @package
    * @nocollapse
    */

--- a/plugins/dev-create/templates/typescript-field/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-field/template/test/index.ts
@@ -22,9 +22,9 @@ const toolbox = generateFieldTestBlocks('field_template', [
 
 /**
  * Create a workspace.
- * @param {HTMLElement} blocklyDiv The blockly container div.
- * @param {!Blockly.BlocklyOptions} options The Blockly options.
- * @returns {!Blockly.WorkspaceSvg} The created workspace.
+ * @param blocklyDiv The blockly container div.
+ * @param options The Blockly options.
+ * @returns The created workspace.
  */
 function createWorkspace(blocklyDiv: HTMLElement,
     options: Blockly.BlocklyOptions): Blockly.WorkspaceSvg {

--- a/plugins/dev-create/templates/typescript-plugin/template/src/index.ts
+++ b/plugins/dev-create/templates/typescript-plugin/template/src/index.ts
@@ -16,14 +16,14 @@ import * as Blockly from 'blockly/core';
  */
 export class Plugin {
   /** The workspace. */
-  protected workspace_: Blockly.WorkspaceSvg;
+  protected workspace: Blockly.WorkspaceSvg;
   /**
    * Constructor for ...
-   * @param {!Blockly.WorkspaceSvg} workspace The workspace that the plugin will
+   * @param workspace The workspace that the plugin will
    *     be added to.
    */
   constructor(workspace: Blockly.WorkspaceSvg) {
-    this.workspace_ = workspace;
+    this.workspace = workspace;
   }
 
   /**

--- a/plugins/dev-create/templates/typescript-plugin/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-plugin/template/test/index.ts
@@ -14,9 +14,9 @@ import {Plugin} from '../src/index';
 
 /**
  * Create a workspace.
- * @param {HTMLElement} blocklyDiv The blockly container div.
- * @param {!Blockly.BlocklyOptions} options The Blockly options.
- * @returns {!Blockly.WorkspaceSvg} The created workspace.
+ * @param blocklyDiv The blockly container div.
+ * @param options The Blockly options.
+ * @returns The created workspace.
  */
 function createWorkspace(blocklyDiv: HTMLElement,
     options: Blockly.BlocklyOptions): Blockly.WorkspaceSvg {

--- a/plugins/dev-create/templates/typescript-theme/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-theme/template/test/index.ts
@@ -15,9 +15,9 @@ import Theme from '../src/index';
 
 /**
  * Create a workspace.
- * @param {HTMLElement} blocklyDiv The blockly container div.
- * @param {!Blockly.BlocklyOptions} options The Blockly options.
- * @returns {!Blockly.WorkspaceSvg} The created workspace.
+ * @param blocklyDiv The blockly container div.
+ * @param options The Blockly options.
+ * @returns The created workspace.
  */
 function createWorkspace(blocklyDiv: HTMLElement,
     options: Blockly.BlocklyOptions): Blockly.WorkspaceSvg {


### PR DESCRIPTION
fix #1670 

- remove types from tsdoc since we have typescript for that
- change `workspace_` to `workspace` -- I changed this in the js files as well, but now existing plugins won't be consistent with new plugins, and I don't know how we feel about that. I don't think it's a big deal since this is a protected variable so it's not part of the public API.
