### PR TITLE
feat!: Added a custom serializer to the backpack plugin so that its state is saved (when using JSON serialization):

### DIFF
--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -445,13 +445,15 @@ export class Backpack extends Blockly.DragTarget {
    * Converts the provided block into a JSON string.
    * @param {!Blockly.Block} block The block to convert.
    * @returns {string} The JSON object as a string
+   * @private
    */
-  blockToJSONString_(block) {
+  blockToJsonString(block) {
     const json = Blockly.serialization.blocks.save(block);
     // Add a BLOCK parameter so that the flyout can categorize it
     json.kind = 'BLOCK';
-    const jsonString = JSON.stringify(json);
-    return jsonString;
+    // Does not allow the same block to be added to the backpack
+    delete json['id'];
+    return JSON.stringify(json);
   }
 
   /**
@@ -461,8 +463,7 @@ export class Backpack extends Blockly.DragTarget {
    *     provided block.
    */
   containsBlock(block) {
-    const blockJSONString = this.blockToJSONString_(block);
-    return this.contents_.indexOf(blockJSONString) !== -1;
+    return this.contents_.indexOf(this.blockToJsonString(block)) !== -1;
   }
 
   /**
@@ -470,7 +471,7 @@ export class Backpack extends Blockly.DragTarget {
    * @param {!Blockly.Block} block The block to be added to the backpack.
    */
   addBlock(block) {
-    this.addItem(this.blockToJSONString_(block));
+    this.addItem(this.blockToJsonString(block));
   }
 
 
@@ -480,8 +481,7 @@ export class Backpack extends Blockly.DragTarget {
    *     backpack.
    */
   addBlocks(blocks) {
-    const jsonStrings = blocks.map(this.blockToJSONString_);
-    this.addItems(jsonStrings);
+    this.addItems(blocks.map(this.blockToJsonString));
   }
 
 
@@ -490,7 +490,7 @@ export class Backpack extends Blockly.DragTarget {
    * @param {!Blockly.Block} block The block to be removed from the backpack.
    */
   removeBlock(block) {
-    this.removeItem(this.blockToJSONString_(block));
+    this.removeItem(this.blockToJsonString(block));
   }
 
   /**
@@ -835,7 +835,7 @@ class BackpackSerializer {
      * Should be after blocks, procedures, and variables.
      * @type {number}
      */
-    this.priority = Blockly.serialization.priorities.VARIABLES - 10;
+    this.priority = Blockly.serialization.priorities.BLOCKS - 10;
   }
 
   /**
@@ -844,7 +844,6 @@ class BackpackSerializer {
    * @returns {object|undefined} the serialized JSON if present
    */
   save(workspace) {
-    console.trace();
     const componentManager = workspace.getComponentManager();
     const backpack = componentManager.getComponent('backpack');
     return backpack.getContents().map((text) => JSON.parse(text));
@@ -856,7 +855,6 @@ class BackpackSerializer {
    * @param {Blockly.Workspace} workspace the workspace to load into
    */
   load(state, workspace) {
-    console.trace();
     const jsonStrings = state.map((j) => JSON.stringify(j));
     const componentManager = workspace.getComponentManager();
     const backpack = componentManager.getComponent('backpack');

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -442,17 +442,36 @@ export class Backpack extends Blockly.DragTarget {
   }
 
   /**
-   * Converts the provided block into a JSON string.
+   * Converts the provided block into a JSON string and
+   * cleans the JSON of any unnecessary attributes
    * @param {!Blockly.Block} block The block to convert.
    * @returns {string} The JSON object as a string
    * @private
    */
   blockToJsonString(block) {
     const json = Blockly.serialization.blocks.save(block);
-    // Add a BLOCK parameter so that the flyout can categorize it
-    json.kind = 'BLOCK';
-    // Does not allow the same block to be added to the backpack
-    delete json['id'];
+
+    // The keys to remove
+    const keys = ['id', 'height', 'width', 'pinned', 'enabled'];
+
+    // Traverse the JSON recursively
+    const traverseJson = function(json, keys) {
+      for (const key in json) {
+        if (key) {
+          const val = json[key];
+          if (keys.includes(key)) delete json[key];
+
+          // Add a 'kind' key so the flyout can recognize it as a block
+          else if (key == 'type') json.kind = 'BLOCK';
+
+          if (val != null && typeof val == 'object') {
+            traverseJson(json[key], keys);
+          }
+        }
+      }
+    };
+
+    traverseJson(json, keys);
     return JSON.stringify(json);
   }
 

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -445,26 +445,26 @@ export class Backpack extends Blockly.DragTarget {
    * Converts the provided block into a JSON string and
    * cleans the JSON of any unnecessary attributes
    * @param {!Blockly.Block} block The block to convert.
-   * @returns {string} The JSON object as a string
+   * @returns {string} The JSON object as a string.
    * @private
    */
   blockToJsonString(block) {
     const json = Blockly.serialization.blocks.save(block);
 
-    // The keys to remove
+    // Add a 'kind' key so the flyout can recognize it as a block.
+    json.kind = 'BLOCK';
+
+    // The keys to remove.
     const keys = ['id', 'height', 'width', 'pinned', 'enabled'];
 
-    // Traverse the JSON recursively
+    // Traverse the JSON recursively.
     const traverseJson = function(json, keys) {
       for (const key in json) {
         if (key) {
-          const val = json[key];
-          if (keys.includes(key)) delete json[key];
-
-          // Add a 'kind' key so the flyout can recognize it as a block
-          else if (key == 'type') json.kind = 'BLOCK';
-
-          if (val != null && typeof val == 'object') {
+          if (keys.includes(key)) {
+            delete json[key];
+          }
+          if (json[key] && typeof json[key] == 'object') {
             traverseJson(json[key], keys);
           }
         }

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -464,7 +464,7 @@ export class Backpack extends Blockly.DragTarget {
           if (keys.includes(key)) {
             delete json[key];
           }
-          if (json[key] && typeof json[key] == 'object') {
+          if (json[key] && typeof json[key] === 'object') {
             traverseJson(json[key], keys);
           }
         }

--- a/plugins/workspace-backpack/src/backpack_helpers.js
+++ b/plugins/workspace-backpack/src/backpack_helpers.js
@@ -194,7 +194,7 @@ function registerPasteAllBackpack() {
       const contents = backpack.getContents();
       contents.forEach((blockText) => {
         const block =
-            Blockly.Xml.domToBlock(Blockly.Xml.textToDom(blockText), ws);
+          Blockly.serialization.blocks.append(JSON.parse(blockText), ws);
         block.scheduleSnapAndBump();
       });
     },
@@ -230,52 +230,4 @@ export function registerContextMenus(contextMenuOptions, workspace) {
   if (contextMenuOptions.pasteAllToBackpack) {
     registerPasteAllBackpack();
   }
-}
-
-/**
- * Converts XML representing a block into text that can be stored in the
- * content array.
- * @param {!Element} xml An XML tree defining the block and any
- *    connected child blocks.
- * @returns {string} Text representing the XML tree, cleaned of all unnecessary
- * attributes.
- */
-export function cleanBlockXML(xml) {
-  const xmlBlock = xml.cloneNode(true);
-  let node = xmlBlock;
-  while (node) {
-    // Things like text inside tags are still treated as nodes, but they
-    // don't have attributes (or the removeAttribute function) so we can
-    // skip removing attributes from them.
-    if (node.removeAttribute) {
-      node.removeAttribute('x');
-      node.removeAttribute('y');
-      node.removeAttribute('id');
-      node.removeAttribute('disabled');
-      if (node.nodeName == 'comment') {
-        node.removeAttribute('h');
-        node.removeAttribute('w');
-        node.removeAttribute('pinned');
-      }
-    }
-
-    // Try to go down the tree
-    let nextNode = node.firstChild || node.nextSibling;
-    // If we can't go down, try to go back up the tree.
-    if (!nextNode) {
-      nextNode = node.parentNode;
-      while (nextNode) {
-        // We are valid again!
-        if (nextNode.nextSibling) {
-          nextNode = nextNode.nextSibling;
-          break;
-        }
-        // Try going up again. If parentNode is null that means we have
-        // reached the top, and we will break out of both loops.
-        nextNode = nextNode.parentNode;
-      }
-    }
-    node = nextNode;
-  }
-  return Blockly.Xml.domToText(xmlBlock);
 }


### PR DESCRIPTION
**Issue**
Fixes #1662 

**Solution**
Converted the state of the backpack from XML to JSON and added a custom serializer to save a backpack between sessions

**Breaking changes**
The functions that previously had XML strings as parameters now only support JSON strings. The functions are addItem and addItems.

**Tests**
I tested the serializer by checking to see if the workspace state saved any time I made changes to the backpack. The advanced playground had the issue of loading a session based off of the XML (which is a separate issue to be addressed), so when reloading the page the backpack would not load the backpack contents from the previous session. To test around this, I copied the state of a full backpack and pasted it onto an empty one to see if it would load, and it did.