### PR TITLE
chore: mark backpack plugin as private

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Publish
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: npx lerna publish --conventional-commits --create-release github --yes
+      run: npx lerna publish --no-private --conventional-commits --create-release github --yes
 
   update-gh-pages:
     name: Update GitHub Pages

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -119,7 +119,7 @@ function publish(force) {
     // creates the release on GitHub.
     console.log(`Publishing ${force ? 'all' : 'changed'} plugins.`);
     execSync(
-        `lerna publish --conventional-commits --create-release github` +
+        `lerna publish --no-private --conventional-commits --create-release github` +
             `${force ? ' --force-publish=*' : ''}`,
         {cwd: releaseDir, stdio: 'inherit'});
 
@@ -164,7 +164,7 @@ function publishFromPackage(done) {
   // Run lerna publish. Will not update versions.
   console.log(`Publishing plugins from package.json versions.`);
   execSync(
-      `lerna publish --from-package`,
+      `lerna publish --no-private --from-package`,
       {cwd: releaseDir, stdio: 'inherit'});
 
   console.log('Removing release directory.');
@@ -187,7 +187,7 @@ function checkVersions(done) {
       'These version numbers will not be pushed and no tags will be created,',
       'even if you answer yes to the prompt.');
   execSync(
-      `lerna version --conventional-commits --no-git-tag-version --no-push`,
+      `lerna version --no-private --conventional-commits --no-git-tag-version --no-push`,
       {cwd: releaseDir, stdio: 'inherit'});
 
   done();

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -11,6 +11,7 @@
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },
+  "private": true,
   "main": "./dist/index.js",
   "types": "./src/index.d.ts",
   "module": "./src/index.js",


### PR DESCRIPTION
Temporarily mark the backpack plugin as private and add flags to commands to make sure it doesnt get published.

Changing this because we just did a breaking change, and we're also planning to do a breaking change in two weeks, so we're just going to hold the first breakage until we can do them both at once at the end of the month.