### PR TITLE
fix: put eslint cache files in a better spot

### DIFF
--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -20,12 +20,6 @@ const packageJson = require(resolveApp('package.json'));
 
 const ESLintPlugin = require('eslint-webpack-plugin');
 
-// Create the eslint cache directory if it doesn't exist.
-const eslintCacheLocation = path.join('node_modules', '.cache', '.eslint');
-if (!fs.existsSync(eslintCacheLocation)) {
-  fs.mkdirSync(eslintCacheLocation, {recursive: true});
-}
-
 module.exports = (env) => {
   const mode = env.mode;
   const isDevelopment = mode === 'development';
@@ -126,7 +120,7 @@ module.exports = (env) => {
       // Run the linter.
       !env.skipLint && new ESLintPlugin({
         cache: true,
-        cacheLocation: eslintCacheLocation,
+        cacheLocation: path.join('node_modules/.cache/eslint/'),
         formatter: 'stylish',
         emitWarning: isDevelopment,
         eslintPath: require.resolve('eslint'),

--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -20,6 +20,12 @@ const packageJson = require(resolveApp('package.json'));
 
 const ESLintPlugin = require('eslint-webpack-plugin');
 
+// Create the eslint cache directory if it doesn't exist.
+const eslintCacheLocation = path.join('node_modules', '.cache', '.eslint');
+if (!fs.existsSync(eslintCacheLocation)) {
+  fs.mkdirSync(eslintCacheLocation, {recursive: true});
+}
+
 module.exports = (env) => {
   const mode = env.mode;
   const isDevelopment = mode === 'development';
@@ -120,6 +126,7 @@ module.exports = (env) => {
       // Run the linter.
       !env.skipLint && new ESLintPlugin({
         cache: true,
+        cacheLocation: eslintCacheLocation,
         formatter: 'stylish',
         emitWarning: isDevelopment,
         eslintPath: require.resolve('eslint'),

--- a/plugins/dev-scripts/scripts/lint.js
+++ b/plugins/dev-scripts/scripts/lint.js
@@ -30,6 +30,12 @@ console.log(`Running lint for ${packageJson.name}`);
 // Create the eslint engine.
 const eslintConfig = require('@blockly/eslint-config');
 
+// Create the cache directory if it doesn't exist.
+const cacheLocation = path.join('node_modules', '.cache', '.eslint');
+if (!fs.existsSync(cacheLocation)) {
+  fs.mkdirSync(cacheLocation, {recursive: true});
+}
+
 const args = process.argv.slice(2);
 const shouldFix = args.includes('--fix');
 const linter = new ESLint({
@@ -38,6 +44,8 @@ const linter = new ESLint({
   useEslintrc: false,
   resolvePluginsRelativeTo: __dirname,
   fix: shouldFix,
+  cache: true,
+  cacheLocation: cacheLocation,
 });
 
 /**

--- a/plugins/dev-scripts/scripts/lint.js
+++ b/plugins/dev-scripts/scripts/lint.js
@@ -30,11 +30,7 @@ console.log(`Running lint for ${packageJson.name}`);
 // Create the eslint engine.
 const eslintConfig = require('@blockly/eslint-config');
 
-// Create the cache directory if it doesn't exist.
-const cacheLocation = path.join('node_modules', '.cache', '.eslint');
-if (!fs.existsSync(cacheLocation)) {
-  fs.mkdirSync(cacheLocation, {recursive: true});
-}
+const cacheLocation = path.join('node_modules/.cache/.eslint/');
 
 const args = process.argv.slice(2);
 const shouldFix = args.includes('--fix');


### PR DESCRIPTION
Lately when you run `npm run test` there's a bunch of `.eslintcache` files that appear.

They appear now because in #1672 we updated from eslint-loader to eslint-webpack-plugin. eslint-loader was nice enough to put the cache in a [fairly standard](https://github.com/eslint/eslint/issues/11757#issuecomment-496945984) location, hidden away in `node_modules`. Unfortunately eslint itself doesn't do that and just puts them in the main directory, which is pretty unfortunate :/

so this PR updates to use a `node_modules/.cache/eslint` directory (which is already ignored by gitignore) so we don't have to look at the thing

also enables caching when running `npm run lint` because I tried that first before I realized the problem was in the webpack config.

The alternative is to just gitignore the `.eslintcache` file, but I'm really tired of seeing them tbh so I didn't want to keep them in each plugin's root level. 

(in the second commit I realized I don't need to create the directory, just need to pass a location that ends in the OS-specific path separator)

