### PR TITLE
fix: update graph demo for blockly v10

### DIFF
--- a/examples/graph-demo/index.html
+++ b/examples/graph-demo/index.html
@@ -388,9 +388,9 @@ Blockly.defineBlocksWithJsonArray([{
   "helpUrl": Blockly.Msg['VARIABLES_GET_HELPURL']
 }]);
 
-Blockly.JavaScript['graph_get_x'] = function(block) {
+javascript.javascriptGenerator.forBlock['graph_get_x'] = function(block) {
   // x variable getter.
-  return ['x', Blockly.JavaScript.ORDER_ATOMIC];
+  return ['x', javascript.Order.ATOMIC];
 };
 
 Blockly.defineBlocksWithJsonArray([{
@@ -408,13 +408,13 @@ Blockly.defineBlocksWithJsonArray([{
   "helpUrl": Blockly.Msg['VARIABLES_SET_HELPURL']
 }]);
 
-Blockly.JavaScript['graph_set_y'] = function(block) {
+javascript.javascriptGenerator.forBlock['graph_set_y'] = function(block) {
   // block.setDeletable cannot be set from json
   block.setDeletable(false);
 
   // y variable setter.
-  var argument0 = Blockly.JavaScript.valueToCode(block, 'VALUE',
-      Blockly.JavaScript.ORDER_ASSIGNMENT) || '';
+  var argument0 = javascript.javascriptGenerator.valueToCode(block, 'VALUE',
+      javascript.Order.ASSIGNMENT) || '';
   return 'y = ' + argument0 + ';';
 };
 
@@ -453,7 +453,7 @@ Graph.options_ = {
  * https://developers.google.com/chart/interactive/docs/gallery/linechart
  */
 Graph.drawVisualization = function() {
-  var formula = Blockly.JavaScript.workspaceToCode(Graph.workspace);
+  var formula = javascript.javascriptGenerator.workspaceToCode(Graph.workspace);
   if (formula === Graph.oldFormula_) {
     // No change in the formula, don't recompute.
     return;


### PR DESCRIPTION
Since the graph demo loads Blockly from a script tag, we need to update the way it uses the generator.

`Blockly.JavaScript` becomes `javascript.javascriptGenerator`
`Blockly.JavaScript['block_name']` becomes `javascript.javascriptGenerator.forBlock['block_name']`
`Blockly.JavaScript.ORDER_FOO` becomes `javascript.Order.FOO`


