### PR TITLE
fix: update all usages of generators in script tags for blockly v10

### DIFF
--- a/codelabs/getting_started/getting_started.md
+++ b/codelabs/getting_started/getting_started.md
@@ -376,7 +376,7 @@ When Blockly generates JavaScript code for blocks in a workspace, it translates 
 Add the following code to the bottom of `scripts/sound_blocks.js`:
 
 ```js
-Blockly.JavaScript['play_sound'] = function(block) {
+javascript.javascriptGenerator.forBlock['play_sound'] = function(block) {
   let value = '\'' + block.getFieldValue('VALUE') + '\'';
   return 'MusicMaker.queueSound(' + value + ');\n';
 };
@@ -404,12 +404,12 @@ The function `handlePlay` is already defined in `scripts/main.js`, but it's empt
 loadWorkspace(event.target);
 ```
 
-Next, you need to generate the code out of that workspace, which you can do with a call to `Blockly.JavaScript.workspaceToCode`.
+Next, you need to generate the code out of that workspace, which you can do with a call to `javascript.javascriptGenerator.workspaceToCode`.
 
 The user's code will consist of many `MusicMaker.queueSound` calls. At the end of our generated script, add a call to `MusicMaker.play` to play all the sounds added to the queue:
 
 ```js
-let code = Blockly.JavaScript.workspaceToCode(Blockly.getMainWorkspace());
+let code = javascript.javascriptGenerator.workspaceToCode(Blockly.getMainWorkspace());
 code += 'MusicMaker.play();';
 ```
 
@@ -430,7 +430,7 @@ The end result should look like this:
 ```js
 function handlePlay(event) {
   loadWorkspace(event.target);
-  let code = Blockly.JavaScript.workspaceToCode(Blockly.getMainWorkspace());
+  let code = javascript.javascriptGenerator.workspaceToCode(Blockly.getMainWorkspace());
   code += 'MusicMaker.play();';
   try {
     eval(code);

--- a/codelabs/validation_and_warnings/validation_and_warnings.md
+++ b/codelabs/validation_and_warnings/validation_and_warnings.md
@@ -105,7 +105,7 @@ You can drag this block out from the toolbox into the workspace, but if you try 
 
 ```js
 // Define how to generate JavaScript from the custom block.
-Blockly.JavaScript['list_range'] = function(block) {
+javascript.javascriptGenerator['list_range'] = function(block) {
   const first = this.getFieldValue('FIRST');
   const last = this.getFieldValue('LAST');
   const numbers = [];
@@ -113,7 +113,7 @@ Blockly.JavaScript['list_range'] = function(block) {
     numbers.push(i);
   }
   const code = '[' + numbers.join(', ') + ']';
-  return [code, Blockly.JavaScript.ORDER_NONE];
+  return [code, javascript.Order.NONE];
 };
 ```
 

--- a/examples/generator-demo/index.html
+++ b/examples/generator-demo/index.html
@@ -233,18 +233,18 @@
 
     function showCode() {
       // Generate JavaScript code and display it.
-      Blockly.JavaScript.INFINITE_LOOP_TRAP = null;
-      var code = Blockly.JavaScript.workspaceToCode(demoWorkspace);
+      javascript.javascriptGenerator.INFINITE_LOOP_TRAP = null;
+      var code = javascript.javascriptGenerator.workspaceToCode(demoWorkspace);
       alert(code);
     }
 
     function runCode() {
       // Generate JavaScript code and run it.
       window.LoopTrap = 1000;
-      Blockly.JavaScript.INFINITE_LOOP_TRAP =
+      javascript.javascriptGenerator.INFINITE_LOOP_TRAP =
           'if (--window.LoopTrap < 0) throw "Infinite loop.";\n';
-      var code = Blockly.JavaScript.workspaceToCode(demoWorkspace);
-      Blockly.JavaScript.INFINITE_LOOP_TRAP = null;
+      var code = javascript.javascriptGenerator.workspaceToCode(demoWorkspace);
+      javascript.javascriptGenerator.INFINITE_LOOP_TRAP = null;
       try {
         eval(code);
       } catch (e) {

--- a/examples/getting-started-codelab/complete-code/scripts/main.js
+++ b/examples/getting-started-codelab/complete-code/scripts/main.js
@@ -9,7 +9,7 @@
 
   function handlePlay(event) {
     loadWorkspace(event.target);
-    let code = Blockly.JavaScript.workspaceToCode(Blockly.getMainWorkspace());
+    let code = javascript.javascriptGenerator.workspaceToCode(Blockly.getMainWorkspace());
     code += 'MusicMaker.play();';
     // Eval can be dangerous. For more controlled execution, check
     // https://github.com/NeilFraser/JS-Interpreter.

--- a/examples/getting-started-codelab/complete-code/scripts/sound_blocks.js
+++ b/examples/getting-started-codelab/complete-code/scripts/sound_blocks.js
@@ -28,7 +28,7 @@ Blockly.defineBlocksWithJsonArray([
   }
 ]);
 
-Blockly.JavaScript['play_sound'] = function(block) {
+javascript.javascriptGenerator.forBlock['play_sound'] = function(block) {
   let value = '\'' + block.getFieldValue('VALUE') + '\'';
   return 'MusicMaker.queueSound(' + value + ');\n';
 };

--- a/examples/headless-demo/index.html
+++ b/examples/headless-demo/index.html
@@ -154,7 +154,7 @@
       }
       var demoWorkspace = new Blockly.Workspace();
       Blockly.serialization.workspaces.load(json, demoWorkspace);
-      var code = Blockly.Python.workspaceToCode(demoWorkspace);
+      var code = python.pythonGenerator.workspaceToCode(demoWorkspace);
       // Create a headless workspace.
       document.getElementById('code_output').value = code;
     }

--- a/examples/interpreter-demo/async-execution.html
+++ b/examples/interpreter-demo/async-execution.html
@@ -307,8 +307,8 @@
     const demoWorkspace = Blockly.inject('blocklyDiv',
         {media: './node_modules/blockly/media/',
          toolbox: toolboxJson});
-    Blockly.JavaScript.STATEMENT_PREFIX = 'highlightBlock(%1);\n';
-    Blockly.JavaScript.addReservedWords('highlightBlock');
+    javascript.javascriptGenerator.STATEMENT_PREFIX = 'highlightBlock(%1);\n';
+    javascript.javascriptGenerator.addReservedWords('highlightBlock');
     Blockly.serialization.workspaces.load(startBlocks, demoWorkspace)
 
     const outputArea = document.getElementById('output');
@@ -364,7 +364,7 @@
         // First statement of this code.
         // Clear the program output.
         resetStepUi(true);
-        const latestCode = Blockly.JavaScript.workspaceToCode(demoWorkspace);
+        const latestCode = javascript.javascriptGenerator.workspaceToCode(demoWorkspace);
         runButton.disabled = 'disabled';
 
         // And then show generated code in an alert.

--- a/examples/interpreter-demo/backwards.html
+++ b/examples/interpreter-demo/backwards.html
@@ -155,8 +155,8 @@
     const demoWorkspace = Blockly.inject('blocklyDiv',
         {media: './node_modules/blockly/media/',
          toolbox: toolboxJson});
-    Blockly.JavaScript.STATEMENT_PREFIX = 'highlightBlock(%1);\n';
-    Blockly.JavaScript.addReservedWords('highlightBlock');
+    javascript.javascriptGenerator.STATEMENT_PREFIX = 'highlightBlock(%1);\n';
+    javascript.javascriptGenerator.addReservedWords('highlightBlock');
     Blockly.serialization.workspaces.load(startBlocks, demoWorkspace)
 
 
@@ -266,7 +266,7 @@
         // First statement of this code.
         // Clear the program output.
         resetStepUi(true);
-        const latestCode = Blockly.JavaScript.workspaceToCode(demoWorkspace);
+        const latestCode = javascript.javascriptGenerator.workspaceToCode(demoWorkspace);
         serializationStack.length = 0;
         document.getElementById('stepBackwardsButton').disabled = 'disabled';
         myInterpreter = new Interpreter(latestCode, initApi);

--- a/examples/interpreter-demo/step-execution.html
+++ b/examples/interpreter-demo/step-execution.html
@@ -28,7 +28,7 @@
 
   <p>This is a demo of executing code step-by-step with a sandboxed JavaScript interpreter.</p>
 
-  <p>The generator's <code>Blockly.JavaScript.STATEMENT_PREFIX</code> is assigned
+  <p>The generator's <code>javascript.javascriptGenerator.STATEMENT_PREFIX</code> is assigned
   <code>'highlightBlock(%1);\n'</code>, where <code>%1</code> is the block ID.
   The call to <code>highlightBlock()</code> will highlight the identified block
   and set the variable <code>highlightPause</code> to <code>true</code>.</p>
@@ -148,8 +148,8 @@
     const demoWorkspace = Blockly.inject('blocklyDiv',
         {media: './node_modules/blockly/media/',
          toolbox: toolboxJson});
-    Blockly.JavaScript.STATEMENT_PREFIX = 'highlightBlock(%1);\n';
-    Blockly.JavaScript.addReservedWords('highlightBlock');
+    javascript.javascriptGenerator.STATEMENT_PREFIX = 'highlightBlock(%1);\n';
+    javascript.javascriptGenerator.addReservedWords('highlightBlock');
     Blockly.serialization.workspaces.load(startBlocks, demoWorkspace)
 
     const outputArea = document.getElementById('output');
@@ -204,7 +204,7 @@
         // First statement of this code.
         // Clear the program output.
         resetStepUi(true);
-        const latestCode = Blockly.JavaScript.workspaceToCode(demoWorkspace);
+        const latestCode = javascript.javascriptGenerator.workspaceToCode(demoWorkspace);
         myInterpreter = new Interpreter(latestCode, initApi);
 
         // And then show generated code in an alert.

--- a/examples/interpreter-demo/wait_block.js
+++ b/examples/interpreter-demo/wait_block.js
@@ -13,25 +13,25 @@
  */
 
 Blockly.defineBlocksWithJsonArray([{
-  "type": "wait_seconds",
-  "message0": " wait %1 seconds",
-  "args0": [{
-    "type": "field_number",
-    "name": "SECONDS",
-    "min": 0,
-    "max": 600,
-    "value": 1,
+  'type': 'wait_seconds',
+  'message0': ' wait %1 seconds',
+  'args0': [{
+    'type': 'field_number',
+    'name': 'SECONDS',
+    'min': 0,
+    'max': 600,
+    'value': 1,
   }],
-  "previousStatement": null,
-  "nextStatement": null,
-  "colour": "%{BKY_LOOPS_HUE}",
+  'previousStatement': null,
+  'nextStatement': null,
+  'colour': '%{BKY_LOOPS_HUE}',
 }]);
 
 /**
  * Generator for wait block creates call to new method
  * <code>waitForSeconds()</code>.
  */
-Blockly.JavaScript['wait_seconds'] = function(block) {
+javascript.javascriptGenerator.forBlock['wait_seconds'] = function(block) {
   const seconds = Number(block.getFieldValue('SECONDS'));
   const code = 'waitForSeconds(' + seconds + ');\n';
   return code;
@@ -43,12 +43,12 @@ Blockly.JavaScript['wait_seconds'] = function(block) {
  */
 function initInterpreterWaitForSeconds(interpreter, globalObject) {
   // Ensure function name does not conflict with variable names.
-  Blockly.JavaScript.addReservedWords('waitForSeconds');
+  javascript.javascriptGenerator.addReservedWords('waitForSeconds');
 
   const wrapper = interpreter.createAsyncFunction(
-    function(timeInSeconds, callback) {
+      function(timeInSeconds, callback) {
       // Delay the call to the callback.
-      setTimeout(callback, timeInSeconds * 1000);
-    });
+        setTimeout(callback, timeInSeconds * 1000);
+      });
   interpreter.setProperty(globalObject, 'waitForSeconds', wrapper);
 }

--- a/examples/validation-and-warnings-codelab/complete-code/index.js
+++ b/examples/validation-and-warnings-codelab/complete-code/index.js
@@ -57,7 +57,7 @@ Blockly.Extensions.register('list_range_validation', function() {
 });
 
 // Define how to generate JavaScript from the custom block.
-Blockly.JavaScript['list_range'] = function(block) {
+javascript.javascriptGenerator.forBlock['list_range'] = function(block) {
   const first = this.getFieldValue('FIRST');
   const last = this.getFieldValue('LAST');
   const numbers = [];
@@ -65,7 +65,7 @@ Blockly.JavaScript['list_range'] = function(block) {
     numbers.push(i);
   }
   const code = '[' + numbers.join(', ') + ']';
-  return [code, Blockly.JavaScript.ORDER_NONE];
+  return [code, javascript.Order.NONE];
 };
 
 // Define which blocks are available in the toolbox.
@@ -122,7 +122,7 @@ let workspace = null;
   });
 
   workspace.addChangeListener(event => {
-    const code = Blockly.JavaScript.workspaceToCode(workspace);
+    const code = javascript.javascriptGenerator.workspaceToCode(workspace);
     document.getElementById('generatedCodeContainer').value = code;
   });
 }
@@ -133,6 +133,6 @@ let workspace = null;
  * Called from index.html when the execute button is clicked.
  */
 function executeCode() {
-  const code = Blockly.JavaScript.workspaceToCode(workspace);
+  const code = javascript.javascriptGenerator.workspaceToCode(workspace);
   eval(code);
 }

--- a/examples/validation-and-warnings-codelab/starter-code/index.js
+++ b/examples/validation-and-warnings-codelab/starter-code/index.js
@@ -48,7 +48,7 @@ function start() {
   });
 
   workspace.addChangeListener(event => {
-    const code = Blockly.JavaScript.workspaceToCode(workspace);
+    const code = javascript.javascriptGenerator.workspaceToCode(workspace);
     document.getElementById('generatedCodeContainer').value = code;
   });
 }
@@ -59,6 +59,6 @@ function start() {
  * Called from index.html when the execute button is clicked.
  */
 function executeCode() {
-  const code = Blockly.JavaScript.workspaceToCode(workspace);
+  const code = javascript.javascriptGenerator.workspaceToCode(workspace);
   eval(code);
 }

--- a/plugins/field-colour-hsv-sliders/README.md
+++ b/plugins/field-colour-hsv-sliders/README.md
@@ -28,6 +28,8 @@ To use it, you'll need to add this field to a block type definition, and add tha
 ```js
 import * as Blockly from 'blockly';
 import '@blockly/field-colour-hsv-sliders';
+import {javascriptGenerator, Order} from 'blockly/javascript';
+
 Blockly.defineBlocksWithJsonArray([
   {
     'type': 'colour_hsv_sliders',
@@ -43,9 +45,9 @@ Blockly.defineBlocksWithJsonArray([
     'style': 'colour_blocks'
   }
 ]);
-Blockly.JavaScript['colour_hsv_sliders'] = function(block) {
-  const code = Blockly.JavaScript.quote_(block.getFieldValue('COLOUR'));
-  return [code, Blockly.JavaScript.ORDER_ATOMIC];
+javascriptGenerator.forBlock['colour_hsv_sliders'] = function(block) {
+  const code = javascriptGenerator.quote_(block.getFieldValue('COLOUR'));
+  return [code, Order.ATOMIC];
 };
 ```
 
@@ -54,6 +56,8 @@ Blockly.JavaScript['colour_hsv_sliders'] = function(block) {
 ```js
 import * as Blockly from 'blockly';
 import {FieldColourHsvSliders} from '@blockly/field-colour-hsv-sliders';
+import {javascriptGenerator, Order} from 'blockly/javascript';
+
 Blockly.Blocks['colour_hsv_sliders'] = {
   init: function () {
     this.appendDummyInput()
@@ -63,9 +67,9 @@ Blockly.Blocks['colour_hsv_sliders'] = {
     this.setStyle('colour_blocks');
   }
 };
-Blockly.JavaScript['colour_hsv_sliders'] = function(block) {
-  const code = Blockly.JavaScript.quote_(block.getFieldValue('COLOUR'));
-  return [code, Blockly.JavaScript.ORDER_ATOMIC];
+javascriptGenerator['colour_hsv_sliders'] = function(block) {
+  const code = javascriptGenerator.quote_(block.getFieldValue('COLOUR'));
+  return [code, Order.ATOMIC];
 };
 ```
 


### PR DESCRIPTION
Updated the usage of generators in all examples and codelabs that load Blockly from script tags, except graph demo (done in #1732) and the devsite demo page (which does something slightly different involving dropdowns so I want to test separately).

Generally,
`Blockly.JavaScript` -> `javascript.javascriptGenerator`
`Blockly.JavaScript['block_name']` -> `javascript.javascriptGenerator.forBlock['block_name']`
`Blockly.JavaScript.ORDER_FOO` -> `javascript.Order.FOO`

I tested each of the example pages, and loaded the codelabs complete code page (after locally updating to point to blockly@beta)

Also updated the README of the hsv-colour-sliders plugin which still used old style generator names with import statements, which definitely doesn't work anymore.


N.B. I don't think this change should have been strictly required, because Blockly.JavaScript is supposed to remain backwards-compatible but deprecated for Blockly v10. I think the wrong name is used in https://github.com/google/blockly/pull/7169 and I'm following up with that.