### PR TITLE
chore: remove serialize disabled interactions demo

### DIFF
--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -30,7 +30,6 @@
 * [Zoom to Fit](plugins/zoom-to-fit/test/index.html)
 * [Keyboard Navigation](plugins/keyboard-navigation/test/index.html)
 * [Scroll Options](plugins/scroll-options/test/index.html)
-* [Serialize Disabled Interactions](plugins/serialize-disabled-interactions/test/index.html)
 * [Shadow Block Converter](plugins/shadow-block-converter/test/index.html)
 * [Suggested Blocks](plugins/suggested-blocks/test/index.html)
 * [Cross Tab Copy Paste](plugins/cross-tab-copy-paste/test/index.html)


### PR DESCRIPTION
Removes the serialize disabled interactions demo since this plugin is deprecated.