### PR TITLE
chore: unprivate backpack plugin

### DIFF
--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -11,7 +11,6 @@
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },
-  "private": true,
   "main": "./dist/index.js",
   "types": "./src/index.d.ts",
   "module": "./src/index.js",


### PR DESCRIPTION
Remove the private property from the backpack package so that it gets published with the v10 bump.