### PR TITLE
fix: debug renderer for v10

### DIFF
--- a/plugins/dev-tools/src/debugDrawer.js
+++ b/plugins/dev-tools/src/debugDrawer.js
@@ -207,11 +207,14 @@ export class DebugDrawer {
       colour = 'goldenrod';
       fill = colour;
     }
+    // TODO: This method is still internal, so we're going to have continual
+    //   problems. We should consider making it public.
+    const offset = conn.getOffsetInBlock();
     this.debugElements_.push(Blockly.utils.dom.createSvgElement('circle',
         {
           'class': 'blockRenderDebug',
-          'cx': conn.offsetInBlock_.x,
-          'cy': conn.offsetInBlock_.y,
+          'cx': offset.x,
+          'cy': offset.y,
           'r': size,
           'fill': fill,
           'stroke': colour,

--- a/plugins/dev-tools/src/debugDrawer.js
+++ b/plugins/dev-tools/src/debugDrawer.js
@@ -207,8 +207,8 @@ export class DebugDrawer {
       colour = 'goldenrod';
       fill = colour;
     }
-    // TODO: This method is still internal, so we're going to have continual
-    //   problems. We should consider making it public.
+    // TODO(blockly/7227): This method is still internal, so we're going to
+    //   have continual problems. We should consider making it public.
     const offset = conn.getOffsetInBlock();
     this.debugElements_.push(Blockly.utils.dom.createSvgElement('circle',
         {


### PR DESCRIPTION
The debug render was accessing a private property that was renamed, so it is broken with v10 of core. This changes it to use the new method, which is still internal (so not much better).

I'm going to file an issue in core for making this method public.