### PR TITLE
chore: fix backpack docs

### DIFF
--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -12,12 +12,11 @@
 import * as Blockly from 'blockly/core';
 import {registerContextMenus} from './backpack_helpers';
 import {BackpackChange, BackpackOpen} from './ui_events';
-import {BackpackContextMenuOptions, BackpackOptions, parseOptions} from './options';
+import {parseOptions} from './options';
 
 /**
  * Class for backpack that can be used save blocks from the workspace for
  * future use.
- * @param {!Blockly.WorkspaceSvg} workspace The workspace to sit in.
  * @implements {Blockly.IAutoHideable}
  * @implements {Blockly.IPositionable}
  * @extends {Blockly.DragTarget}
@@ -27,7 +26,8 @@ export class Backpack extends Blockly.DragTarget {
    * Constructor for a backpack.
    * @param {!Blockly.WorkspaceSvg} targetWorkspace The target workspace that
    *     the backpack will be added to.
-   * @param {!BackpackOptions=} backpackOptions The backpack options to use.
+   * @param {!import("./options").BackpackOptions=} backpackOptions The backpack
+   *     options to use.
    */
   constructor(targetWorkspace, backpackOptions) {
     super();
@@ -47,7 +47,7 @@ export class Backpack extends Blockly.DragTarget {
 
     /**
      * The backpack options.
-     * @type {!BackpackOptions}
+     * @type {!import("./options").BackpackOptions}
      */
     this.options_ = parseOptions(backpackOptions);
 

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -13,6 +13,7 @@ import * as Blockly from 'blockly/core';
 import {registerContextMenus} from './backpack_helpers';
 import {BackpackChange, BackpackOpen} from './ui_events';
 import {parseOptions} from './options';
+// import {BackpackOptions} from './options';
 
 /**
  * Class for backpack that can be used save blocks from the workspace for
@@ -26,8 +27,7 @@ export class Backpack extends Blockly.DragTarget {
    * Constructor for a backpack.
    * @param {!Blockly.WorkspaceSvg} targetWorkspace The target workspace that
    *     the backpack will be added to.
-   * @param {!import("./options").BackpackOptions=} backpackOptions The backpack
-   *     options to use.
+   * @param backpackOptions The backpack options to use.
    */
   constructor(targetWorkspace, backpackOptions) {
     super();
@@ -47,7 +47,6 @@ export class Backpack extends Blockly.DragTarget {
 
     /**
      * The backpack options.
-     * @type {!import("./options").BackpackOptions}
      */
     this.options_ = parseOptions(backpackOptions);
 


### PR DESCRIPTION
Fixup the backpack docs:
  * No need to apply `@param` to a class.
  * It says using `import("./options")` is the correct way to handle importing a type into JS. But we'll see what CI says about that :P