### PR TITLE
chore: Update root package eslint-config version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blockly/eslint-config": "^2.1.7",
+        "@blockly/eslint-config": "^3.0.0",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "eslint": "^7.15.0",
         "gh-pages": "^3.1.0",
@@ -195,16 +195,16 @@
       }
     },
     "node_modules/@blockly/eslint-config": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-2.1.21.tgz",
-      "integrity": "sha512-v5z9W1gC9NXuKsgZm+6wheXBulZxy2LybfH5ioHb66FL93zKJSuj2gQCz7NayaV5BzNLAIFvdShuTp7e1eNBLw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-3.0.0.tgz",
+      "integrity": "sha512-8xqQ09plxuonCNqy4YsAphK0onowRWzLiRhRp0Ubcmkm0veMDgMdqxmn5D1ppKyUH9WUI7G4HQ2EgbnA9577nA==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "babel-eslint": "^10.1.0",
         "eslint-config-google": "^0.14.0",
-        "eslint-plugin-jsdoc": "^37.2.3"
+        "eslint-plugin-jsdoc": "^46.2.6"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -214,17 +214,17 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.18.0.tgz",
-      "integrity": "sha512-TjT8KJULV4I6ZiwIoKr6eMs+XpRejqwJ/VA+QPDeFGe9j6bZFKmMJ81EeFsGm6JNZhnzm37aoxVROmTh2PZoyA==",
+      "version": "0.39.4",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.39.4.tgz",
+      "integrity": "sha512-Jvw915fjqQct445+yron7Dufix9A+m9j1fCJYlCo1FWlRvTxa3pjJelxdSTdaLWcTwRU6vbL+NYjO4YuNIS5Qg==",
       "dev": true,
       "dependencies": {
-        "comment-parser": "1.3.0",
-        "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "~2.2.2"
+        "comment-parser": "1.3.1",
+        "esquery": "^1.5.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16 || ^17"
+        "node": ">=16"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -650,21 +650,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@npmcli/arborist/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@npmcli/arborist/node_modules/validate-npm-package-name": {
@@ -1981,6 +1966,15 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
@@ -2608,6 +2602,18 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/builtins": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
@@ -3199,9 +3205,9 @@
       "dev": true
     },
     "node_modules/comment-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-      "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
       "dev": true,
       "engines": {
         "node": ">= 12.0.0"
@@ -3650,9 +3656,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -4223,22 +4229,23 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "37.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.7.1.tgz",
-      "integrity": "sha512-ySxDTedl6qKXT/VeTwcZlhsRtvNQZGPklyVnaL5+ge20vowzFA9CKvrY0NXRqvdIz6JBVMFpxX9DSmS3OyAUOQ==",
+      "version": "46.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.4.3.tgz",
+      "integrity": "sha512-Prc7ol+vCIghPeECpwZq5+P+VZfoi87suywvbYCiCnkI1kTmVSdcOC2M8mioglWxBbd28wbb1OVjg/8OzGzatA==",
       "dev": true,
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.18.0",
-        "comment-parser": "1.3.0",
-        "debug": "^4.3.3",
+        "@es-joy/jsdoccomment": "~0.39.4",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.4.0",
-        "regextras": "^0.8.0",
-        "semver": "^7.3.5",
+        "esquery": "^1.5.0",
+        "is-builtin-module": "^3.2.1",
+        "semver": "^7.5.1",
         "spdx-expression-parse": "^3.0.1"
       },
       "engines": {
-        "node": "^12 || ^14 || ^16 || ^17"
+        "node": ">=16"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
@@ -4475,9 +4482,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -6724,6 +6731,21 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -7176,9 +7198,9 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.2.tgz",
-      "integrity": "sha512-zRokSWcPLSWkoNzsWn9pq7YYSwDhKyEe+cJYT2qaPqLOOJb5sFSi46BPj81vP+e8chvCNdQL9RG86Bi9EI6MDw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
@@ -7914,21 +7936,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/libnpmpublish/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/libnpmpublish/node_modules/validate-npm-package-name": {
@@ -11568,15 +11575,6 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
-    "node_modules/regextras": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
-      "integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.14"
-      }
-    },
     "node_modules/registry-auth-token": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
@@ -11924,9 +11922,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -14157,27 +14155,27 @@
       }
     },
     "@blockly/eslint-config": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-2.1.21.tgz",
-      "integrity": "sha512-v5z9W1gC9NXuKsgZm+6wheXBulZxy2LybfH5ioHb66FL93zKJSuj2gQCz7NayaV5BzNLAIFvdShuTp7e1eNBLw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@blockly/eslint-config/-/eslint-config-3.0.0.tgz",
+      "integrity": "sha512-8xqQ09plxuonCNqy4YsAphK0onowRWzLiRhRp0Ubcmkm0veMDgMdqxmn5D1ppKyUH9WUI7G4HQ2EgbnA9577nA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "babel-eslint": "^10.1.0",
         "eslint-config-google": "^0.14.0",
-        "eslint-plugin-jsdoc": "^37.2.3"
+        "eslint-plugin-jsdoc": "^46.2.6"
       }
     },
     "@es-joy/jsdoccomment": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.18.0.tgz",
-      "integrity": "sha512-TjT8KJULV4I6ZiwIoKr6eMs+XpRejqwJ/VA+QPDeFGe9j6bZFKmMJ81EeFsGm6JNZhnzm37aoxVROmTh2PZoyA==",
+      "version": "0.39.4",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.39.4.tgz",
+      "integrity": "sha512-Jvw915fjqQct445+yron7Dufix9A+m9j1fCJYlCo1FWlRvTxa3pjJelxdSTdaLWcTwRU6vbL+NYjO4YuNIS5Qg==",
       "dev": true,
       "requires": {
-        "comment-parser": "1.3.0",
-        "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "~2.2.2"
+        "comment-parser": "1.3.1",
+        "esquery": "^1.5.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
       }
     },
     "@eslint/eslintrc": {
@@ -14523,15 +14521,6 @@
             "proc-log": "^2.0.1",
             "semver": "^7.3.5",
             "validate-npm-package-name": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
           }
         },
         "validate-npm-package-name": {
@@ -15478,6 +15467,12 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
+    "are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true
+    },
     "are-we-there-yet": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
@@ -15958,6 +15953,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true
+    },
     "builtins": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
@@ -16435,9 +16436,9 @@
       "dev": true
     },
     "comment-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-      "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
       "dev": true
     },
     "common-ancestor-path": {
@@ -16817,9 +16818,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -17367,18 +17368,19 @@
       "requires": {}
     },
     "eslint-plugin-jsdoc": {
-      "version": "37.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.7.1.tgz",
-      "integrity": "sha512-ySxDTedl6qKXT/VeTwcZlhsRtvNQZGPklyVnaL5+ge20vowzFA9CKvrY0NXRqvdIz6JBVMFpxX9DSmS3OyAUOQ==",
+      "version": "46.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.4.3.tgz",
+      "integrity": "sha512-Prc7ol+vCIghPeECpwZq5+P+VZfoi87suywvbYCiCnkI1kTmVSdcOC2M8mioglWxBbd28wbb1OVjg/8OzGzatA==",
       "dev": true,
       "requires": {
-        "@es-joy/jsdoccomment": "~0.18.0",
-        "comment-parser": "1.3.0",
-        "debug": "^4.3.3",
+        "@es-joy/jsdoccomment": "~0.39.4",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.4.0",
-        "regextras": "^0.8.0",
-        "semver": "^7.3.5",
+        "esquery": "^1.5.0",
+        "is-builtin-module": "^3.2.1",
+        "semver": "^7.5.1",
         "spdx-expression-parse": "^3.0.1"
       },
       "dependencies": {
@@ -17449,9 +17451,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -19216,6 +19218,15 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.3.0"
+      }
+    },
     "is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -19548,9 +19559,9 @@
       }
     },
     "jsdoc-type-pratt-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.2.tgz",
-      "integrity": "sha512-zRokSWcPLSWkoNzsWn9pq7YYSwDhKyEe+cJYT2qaPqLOOJb5sFSi46BPj81vP+e8chvCNdQL9RG86Bi9EI6MDw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
       "dev": true
     },
     "jsesc": {
@@ -20143,15 +20154,6 @@
             "proc-log": "^2.0.1",
             "semver": "^7.3.5",
             "validate-npm-package-name": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
           }
         },
         "validate-npm-package-name": {
@@ -22960,12 +22962,6 @@
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
-    "regextras": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
-      "integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
-      "dev": true
-    },
     "registry-auth-token": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
@@ -23229,9 +23225,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:ghpages": "gulp testGhPages"
   },
   "devDependencies": {
-    "@blockly/eslint-config": "^2.1.7",
+    "@blockly/eslint-config": "^3.0.0",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "eslint": "^7.15.0",
     "gh-pages": "^3.1.0",

--- a/plugins/dev-tools/src/index.d.ts
+++ b/plugins/dev-tools/src/index.d.ts
@@ -50,6 +50,7 @@ declare namespace DevTools {
 
   /**
    * Create the Blockly playground.
+   * @returns A promise to the playground API.
    */
   function createPlayground(container: HTMLElement, createWorkspace?:
   (blocklyDiv: HTMLElement, options: Blockly.BlocklyOptions) =>
@@ -58,6 +59,7 @@ declare namespace DevTools {
 
   /**
    * Use dat.GUI to add controls to adjust configuration of a Blockly workspace.
+   * @returns The dat.GUI instance.
    */
   function addGUIControls(createWorkspace:
   (options: Blockly.BlocklyOptions) => Blockly.Workspace,
@@ -66,6 +68,7 @@ declare namespace DevTools {
   /**
    * Generates a number of field testing blocks for a specific field and returns
    * the toolbox xml string.
+   * @returns The toolbox xml string.
    */
   export function generateFieldTestBlocks(fieldName: string, options?:
   FieldGeneratorOptions|FieldGeneratorOptions[]): string;

--- a/plugins/workspace-backpack/src/options.d.ts
+++ b/plugins/workspace-backpack/src/options.d.ts
@@ -25,7 +25,7 @@ export interface BackpackOptions {
  * Returns a new options object with all properties set, using default values
  * if not specified in the optional options that were passed in.
  * @param {BackpackOptions=} options The options to use.
- * @return {!BackpackOptions} The created options object.
+ * @returns {!BackpackOptions} The created options object.
  */
 export declare function parseOptions(
   options?: BackpackOptions,


### PR DESCRIPTION
In https://github.com/google/blockly-samples/pull/1740 I updated the version of jsdoc that our eslint-config plugin uses. In this PR I'm updating the version of the eslint-config plugin that the rest of blockly-samples uses, so that other plugins can use it. Both of these are an attempt to address lint warnings found in https://github.com/google/blockly-samples/pull/1719