### PR TITLE
feat: Make the minimap responsive to the window and primaryWorkspace size

### DIFF
--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -67,7 +67,6 @@ export class Minimap {
      */
     private mirror(event: Blockly.Events.Abstract): void {
       // TODO: shadow blocks get mirrored too (not supposed to happen)
-      // TODO: on connect the zoom cuts off the moved block
 
       if (!BlockEvents.has(event.type)) {
         return; // Filter out events.
@@ -78,6 +77,9 @@ export class Minimap {
       duplicate.run(true);
 
       // Resize and center the minimap.
-      this.minimapWorkspace.zoomToFit();
+      // We need to wait for the event to finish rendering to do the zoom.
+      Blockly.renderManagement.finishQueuedRenders().then(() => {
+        this.minimapWorkspace.zoomToFit();
+      });
     }
 }

--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -37,6 +37,14 @@ export class Minimap {
       this.primaryWorkspace = workspace;
       const options = {
         readOnly: true,
+        move: {
+          scrollbars: {
+            vertical: true,
+            horizontal: true,
+          },
+          drag: false,
+          wheel: false,
+        },
       };
       this.minimapWorkspace = Blockly.inject('minimapDiv', options);
     }
@@ -46,6 +54,7 @@ export class Minimap {
      */
     init(): void {
       this.primaryWorkspace.addChangeListener((e) => void this.mirror(e));
+      this.minimapWorkspace.scrollbar.setContainerVisible(false);
     }
 
     /**
@@ -55,10 +64,17 @@ export class Minimap {
      */
     private mirror(event: Blockly.Events.Abstract): void {
       // TODO: shadow blocks get mirrored too (not supposed to happen)
-      if (BlockEvents.has(event.type)) {
-        const json = event.toJson();
-        const duplicate = Blockly.Events.fromJson(json, this.minimapWorkspace);
-        duplicate.run(true);
+      // TODO: on connect the zoom cuts off the moved block
+
+      if (!BlockEvents.has(event.type)) {
+        return; // Filter out events.
       }
+      // Run the event in the minimap.
+      const json = event.toJson();
+      const duplicate = Blockly.Events.fromJson(json, this.minimapWorkspace);
+      duplicate.run(true);
+
+      // Resize and center the minimap.
+      this.minimapWorkspace.zoomToFit();
     }
 }

--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -53,8 +53,11 @@ export class Minimap {
      * Initialize.
      */
     init(): void {
-      this.primaryWorkspace.addChangeListener((e) => void this.mirror(e));
       this.minimapWorkspace.scrollbar.setContainerVisible(false);
+      this.primaryWorkspace.addChangeListener((e) => void this.mirror(e));
+      window.addEventListener('resize', (e) => {
+        this.minimapWorkspace.zoomToFit();
+      });
     }
 
     /**

--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -55,19 +55,9 @@ export class Minimap {
     init(): void {
       this.minimapWorkspace.scrollbar.setContainerVisible(false);
       this.primaryWorkspace.addChangeListener((e) => void this.mirror(e));
-
-      // There could be a performance penalty from doing this live
-      // since this callback gets invoked continuously during a window resize.
-      const debounce = (fn: () => void, ms = 200) => {
-        let timeoutId: ReturnType<typeof setTimeout>;
-        return function(this: object, ...args: object[]) {
-          clearTimeout(timeoutId);
-          timeoutId = setTimeout(() => fn.apply(this, args), ms);
-        };
-      };
-
-      window.addEventListener('resize',
-          debounce(() => this.minimapWorkspace.zoomToFit()));
+      window.addEventListener('resize', () => {
+        this.minimapWorkspace.zoomToFit();
+      });
     }
 
     /**

--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -55,9 +55,19 @@ export class Minimap {
     init(): void {
       this.minimapWorkspace.scrollbar.setContainerVisible(false);
       this.primaryWorkspace.addChangeListener((e) => void this.mirror(e));
-      window.addEventListener('resize', (e) => {
-        this.minimapWorkspace.zoomToFit();
-      });
+
+      // There could be a performance penalty from doing this live
+      // since this callback gets invoked continuously during a window resize.
+      const debounce = (fn: () => void, ms = 200) => {
+        let timeoutId: ReturnType<typeof setTimeout>;
+        return function(this: object, ...args: object[]) {
+          clearTimeout(timeoutId);
+          timeoutId = setTimeout(() => fn.apply(this, args), ms);
+        };
+      };
+
+      window.addEventListener('resize',
+          debounce(() => this.minimapWorkspace.zoomToFit()));
     }
 
     /**

--- a/plugins/workspace-minimap/test/index.ts
+++ b/plugins/workspace-minimap/test/index.ts
@@ -12,22 +12,23 @@ import * as Blockly from 'blockly';
 import {toolboxCategories, createPlayground} from '@blockly/dev-tools';
 import {Minimap, PositionedMinimap} from '../src/index';
 
-/**
- * Create a workspace.
- * @param blocklyDiv The blockly container div.
- * @param options The Blockly options.
- * @returns The created workspace.
- */
-function createWorkspace(blocklyDiv: HTMLElement,
-    options: Blockly.BlocklyOptions): Blockly.WorkspaceSvg {
-  const workspace = Blockly.inject(blocklyDiv, options);
-
-  const minimap = new Minimap(workspace);
-  minimap.init();
-
-  return workspace;
-}
-
+// Creates the primary workspace and adds the minimap.
 const ws = Blockly.inject('primaryDiv', {toolbox: toolboxCategories});
 const mp = new Minimap(ws);
 mp.init();
+
+// Creates 100 random blocks
+for (let i = 0; i < 100; i++) {
+  const prototype = 'controls_if';
+  const block = ws.newBlock(prototype);
+  block.initSvg();
+  block.render();
+}
+
+// Move the blocks to random locations.
+for (const block of ws.getAllBlocks(true)) {
+  const cord = new Blockly.utils.Coordinate(
+      Math.round(Math.random() * 450 + 40),
+      Math.round(Math.random() * 600 + 40));
+  block.moveTo(cord, ['drag']);
+}

--- a/plugins/workspace-minimap/test/index.ts
+++ b/plugins/workspace-minimap/test/index.ts
@@ -13,22 +13,21 @@ import {toolboxCategories, createPlayground} from '@blockly/dev-tools';
 import {Minimap, PositionedMinimap} from '../src/index';
 
 // Creates the primary workspace and adds the minimap.
-const ws = Blockly.inject('primaryDiv', {toolbox: toolboxCategories});
-const mp = new Minimap(ws);
-mp.init();
+const workspace = Blockly.inject('primaryDiv', {toolbox: toolboxCategories});
+const minimap = new Minimap(workspace);
+minimap.init();
 
-// Creates 100 random blocks
+// Creates 100 if blocks
 for (let i = 0; i < 100; i++) {
-  const prototype = 'controls_if';
-  const block = ws.newBlock(prototype);
+  const block = workspace.newBlock('controls_if');
   block.initSvg();
   block.render();
 }
 
 // Move the blocks to random locations.
-for (const block of ws.getAllBlocks(true)) {
+for (const block of workspace.getAllBlocks(true)) {
   const cord = new Blockly.utils.Coordinate(
       Math.round(Math.random() * 450 + 40),
       Math.round(Math.random() * 600 + 40));
-  block.moveTo(cord, ['drag']);
+  block.moveTo(cord);
 }


### PR DESCRIPTION
**Description**
As the primary workspace changes, the minimap will automatically adjust in scale (and it will center itself). It also now is responsive to window size.

**Tests**
I changed the window size in the advanced playground to make sure minimap would respond.
I replicated all the block events in the primary workspace and made sure the changes applied to the minimap. 