### PR TITLE
fix: update more broken / deprecated APIs for v10

### DIFF
--- a/examples/blockly-react/src/generator/generator.js
+++ b/examples/blockly-react/src/generator/generator.js
@@ -26,10 +26,10 @@
 
 import {javascriptGenerator} from 'blockly/javascript';
 
-javascriptGenerator['test_react_field'] = function (block) {
+javascriptGenerator.forBlock['test_react_field'] = function (block) {
     return 'console.log(\'custom block\');\n';
 };
 
-javascriptGenerator['test_react_date_field'] = function (block) {
+javascriptGenerator.forBlock['test_react_date_field'] = function (block) {
     return 'console.log(' + block.getField('DATE').getText() + ');\n';
 };

--- a/examples/blockly-vue/src/blocks/stocks.js
+++ b/examples/blockly-vue/src/blocks/stocks.js
@@ -26,7 +26,7 @@
 
 
 import * as Blockly from 'blockly/core';
-import {javascriptGenerator} from 'blockly/javascript';
+import {javascriptGenerator, Order} from 'blockly/javascript';
 
 Blockly.Blocks["stock_buy_simple"] = {
   init: function() {
@@ -46,14 +46,14 @@ Blockly.Blocks["stock_buy_simple"] = {
   }
 };
 
-javascriptGenerator["stock_buy_simple"] = function(block) {
+javascriptGenerator.forBlock["stock_buy_simple"] = function(block, generator) {
   var number_id = block.getFieldValue("ID");
   var number_amount = block.getFieldValue("Amount");
   var number_price = block.getFieldValue("Price");
-  var value_number = javascriptGenerator.valueToCode(
+  var value_number = generator.valueToCode(
     block,
     "Number",
-    javascriptGenerator.ORDER_ATOMIC
+    Order.ATOMIC
   );
   var code = `buy(${number_id},${number_amount},${number_price},${value_number});\n`;
   return code;
@@ -78,16 +78,16 @@ Blockly.Blocks["stock_buy_prog"] = {
   }
 };
 
-javascriptGenerator["stock_buy_prog"] = function(block) {
-  var value_number = javascriptGenerator.valueToCode(
+javascriptGenerator.forBlock["stock_buy_prog"] = function(block, generator) {
+  var value_number = generator.valueToCode(
     block,
     "Number",
-    javascriptGenerator.ORDER_ATOMIC
+    Order.ATOMIC
   );
-  var value_name = javascriptGenerator.valueToCode(
+  var value_name = generator.valueToCode(
     block,
     "NAME",
-    javascriptGenerator.ORDER_ATOMIC
+    Order.ATOMIC
   );
   var code = `buy(${value_number},${value_name},${value_name});\n`;
   return code;
@@ -110,15 +110,15 @@ Blockly.Blocks["stock_fetch_price"] = {
   }
 };
 
-javascriptGenerator["stock_fetch_price"] = function(block) {
-  var value_fetch = javascriptGenerator.valueToCode(
+javascriptGenerator.forBlock["stock_fetch_price"] = function(block, generator) {
+  var value_fetch = generator.valueToCode(
     block,
     "Fetch",
-    javascriptGenerator.ORDER_ATOMIC
+    Order.ATOMIC
   );
-  var variable_variable = javascriptGenerator.nameDB_.getName(
+  var variable_variable = generator.nameDB_.getName(
     block.getFieldValue("variable"),
-    Blockly.VARIABLE_CATEGORY_NAME
+    Blockly.names.NameType.VARIABLE
   );
   var code = `fetch_price(${value_fetch},${variable_variable});\n`;
   return code;

--- a/examples/blockly-vue3/src/blocks/stocks.js
+++ b/examples/blockly-vue3/src/blocks/stocks.js
@@ -13,7 +13,7 @@
 // https://developers.google.com/blockly/guides/create-custom-blocks/define-blocks
 
 import * as Blockly from "blockly/core";
-import { javascriptGenerator } from "blockly/javascript";
+import {javascriptGenerator, Order} from "blockly/javascript";
 
 Blockly.Blocks["stock_buy_simple"] = {
   init: function () {
@@ -33,15 +33,11 @@ Blockly.Blocks["stock_buy_simple"] = {
   },
 };
 
-javascriptGenerator["stock_buy_simple"] = function (block) {
+javascriptGenerator.forBlock["stock_buy_simple"] = function (block, generator) {
   var number_id = block.getFieldValue("ID");
   var number_amount = block.getFieldValue("Amount");
   var number_price = block.getFieldValue("Price");
-  var value_number = javascriptGenerator.valueToCode(
-    block,
-    "Number",
-    javascriptGenerator.ORDER_ATOMIC
-  );
+  var value_number = generator.valueToCode(block, "Number", Order.ATOMIC);
   var code = `buy(${number_id},${number_amount},${number_price},${value_number});\n`;
   return code;
 };
@@ -61,17 +57,9 @@ Blockly.Blocks["stock_buy_prog"] = {
   },
 };
 
-javascriptGenerator["stock_buy_prog"] = function (block) {
-  var value_number = javascriptGenerator.valueToCode(
-    block,
-    "Number",
-    javascriptGenerator.ORDER_ATOMIC
-  );
-  var value_name = javascriptGenerator.valueToCode(
-    block,
-    "NAME",
-    javascriptGenerator.ORDER_ATOMIC
-  );
+javascriptGenerator.forBlock["stock_buy_prog"] = function (block, generator) {
+  var value_number = generator.valueToCode(block, "Number", Order.ATOMIC);
+  var value_name = generator.valueToCode(block, "NAME", Order.ATOMIC);
   var code = `buy(${value_number},${value_name},${value_name});\n`;
   return code;
 };
@@ -93,15 +81,14 @@ Blockly.Blocks["stock_fetch_price"] = {
   },
 };
 
-javascriptGenerator["stock_fetch_price"] = function (block) {
-  var value_fetch = javascriptGenerator.valueToCode(
-    block,
-    "Fetch",
-    javascriptGenerator.ORDER_ATOMIC
-  );
-  var variable_variable = javascriptGenerator.nameDB_.getName(
+javascriptGenerator.forBlock["stock_fetch_price"] = function (
+  block,
+  generator
+) {
+  var value_fetch = generator.valueToCode(block, "Fetch", Order.ATOMIC);
+  var variable_variable = generator.nameDB_.getName(
     block.getFieldValue("variable"),
-    Blockly.VARIABLE_CATEGORY_NAME
+    Blockly.names.NameType.VARIABLE
   );
   var code = `fetch_price(${value_fetch},${variable_variable});\n`;
   return code;

--- a/examples/custom-renderer-codelab/src/generators/javascript.js
+++ b/examples/custom-renderer-codelab/src/generators/javascript.js
@@ -4,22 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {javascriptGenerator} from 'blockly/javascript';
+import {Order} from 'blockly/javascript';
 
 // Export all the code generators for our custom blocks,
 // but don't register them with Blockly yet.
 // This file has no side effects!
 export const generator = Object.create(null);
 
-generator['add_text'] = function(block) {
-  const text = javascriptGenerator.valueToCode(block, 'TEXT',
-      javascriptGenerator.ORDER_NONE) || '\'\'';
-  const color = javascriptGenerator.valueToCode(block, 'COLOR',
-      javascriptGenerator.ORDER_ATOMIC) || '\'#ffffff\'';
+generator.forBlock['add_text'] = function(block, generator) {
+  const text = generator.valueToCode(block, 'TEXT', Order.NONE) || '\'\'';
+  const color = generator.valueToCode(block, 'COLOR', Order.ATOMIC) ||
+      '\'#ffffff\'';
 
-  const addText = javascriptGenerator.provideFunction_(
+  const addText = generator.provideFunction_(
       'addText',
-      ['function ' + javascriptGenerator.FUNCTION_NAME_PLACEHOLDER_ +
+      ['function ' + generator.FUNCTION_NAME_PLACEHOLDER_ +
           '(text, color) {',
       '  // Add text to the output area.',
       '  const outputDiv = document.getElementById(\'output\');',

--- a/examples/graph-demo/index.html
+++ b/examples/graph-demo/index.html
@@ -408,12 +408,12 @@ Blockly.defineBlocksWithJsonArray([{
   "helpUrl": Blockly.Msg['VARIABLES_SET_HELPURL']
 }]);
 
-javascript.javascriptGenerator.forBlock['graph_set_y'] = function(block) {
+javascript.javascriptGenerator.forBlock['graph_set_y'] = function(block, generator) {
   // block.setDeletable cannot be set from json
   block.setDeletable(false);
 
   // y variable setter.
-  var argument0 = javascript.javascriptGenerator.valueToCode(block, 'VALUE',
+  var argument0 = generator.valueToCode(block, 'VALUE',
       javascript.Order.ASSIGNMENT) || '';
   return 'y = ' + argument0 + ';';
 };

--- a/examples/keyboard-navigation-codelab/src/generators/javascript.js
+++ b/examples/keyboard-navigation-codelab/src/generators/javascript.js
@@ -4,22 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {javascriptGenerator} from 'blockly/javascript';
+import {Order} from 'blockly/javascript';
 
 // Export all the code generators for our custom blocks,
 // but don't register them with Blockly yet.
 // This file has no side effects!
 export const generator = Object.create(null);
 
-generator['add_text'] = function(block) {
-  const text = javascriptGenerator.valueToCode(block, 'TEXT',
-      javascriptGenerator.ORDER_NONE) || '\'\'';
-  const color = javascriptGenerator.valueToCode(block, 'COLOR',
-      javascriptGenerator.ORDER_ATOMIC) || '\'#ffffff\'';
+generator.forBlock['add_text'] = function(block, generator) {
+  const text = generator.valueToCode(block, 'TEXT', Order.NONE) || '\'\'';
+  const color = generator.valueToCode(block, 'COLOR', Order.ATOMIC) ||
+      '\'#ffffff\'';
 
-  const addText = javascriptGenerator.provideFunction_(
+  const addText = generator.provideFunction_(
       'addText',
-      ['function ' + javascriptGenerator.FUNCTION_NAME_PLACEHOLDER_ +
+      ['function ' + generator.FUNCTION_NAME_PLACEHOLDER_ +
           '(text, color) {',
       '  // Add text to the output area.',
       '  const outputDiv = document.getElementById(\'output\');',

--- a/examples/sample-app-ts/src/generators/javascript.ts
+++ b/examples/sample-app-ts/src/generators/javascript.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {javascriptGenerator} from 'blockly/javascript';
+import {Order} from 'blockly/javascript';
 import * as Blockly from 'blockly/core';
 
 // Export all the code generators for our custom blocks,
@@ -12,15 +12,15 @@ import * as Blockly from 'blockly/core';
 // This file has no side effects!
 export const generator = Object.create(null);
 
-generator['add_text'] = function(block: Blockly.Block) {
-  const text = javascriptGenerator.valueToCode(block, 'TEXT',
-      javascriptGenerator.ORDER_NONE) || '\'\'';
-  const color = javascriptGenerator.valueToCode(block, 'COLOR',
-      javascriptGenerator.ORDER_ATOMIC) || '\'#ffffff\'';
+generator.forEach['add_text'] = function(
+    block: Blockly.Block, generator: Blockly.CodeGenerator) {
+  const text = generator.valueToCode(block, 'TEXT', Order.NONE) || '\'\'';
+  const color = generator.valueToCode(block, 'COLOR', Order.ATOMIC) ||
+       '\'#ffffff\'';
 
-  const addText = javascriptGenerator.provideFunction_(
+  const addText = generator.provideFunction_(
       'addText',
-      ['function ' + javascriptGenerator.FUNCTION_NAME_PLACEHOLDER_ +
+      ['function ' + generator.FUNCTION_NAME_PLACEHOLDER_ +
           '(text, color) {',
       '  // Add text to the output area.',
       '  const outputDiv = document.getElementById(\'output\');',

--- a/examples/sample-app/src/generators/javascript.js
+++ b/examples/sample-app/src/generators/javascript.js
@@ -4,22 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {javascriptGenerator} from 'blockly/javascript';
+import {Order} from 'blockly/javascript';
 
 // Export all the code generators for our custom blocks,
 // but don't register them with Blockly yet.
 // This file has no side effects!
 export const generator = Object.create(null);
 
-generator['add_text'] = function(block) {
-  const text = javascriptGenerator.valueToCode(block, 'TEXT',
-      javascriptGenerator.ORDER_NONE) || '\'\'';
-  const color = javascriptGenerator.valueToCode(block, 'COLOR',
-      javascriptGenerator.ORDER_ATOMIC) || '\'#ffffff\'';
+generator.forBlock['add_text'] = function(block, generator) {
+  const text = generator.valueToCode(block, 'TEXT', Order.NONE) || '\'\'';
+  const color = generator.valueToCode(block, 'COLOR', Order.ATOMIC) ||
+      '\'#ffffff\'';
 
-  const addText = javascriptGenerator.provideFunction_(
+  const addText = generator.provideFunction_(
       'addText',
-      ['function ' + javascriptGenerator.FUNCTION_NAME_PLACEHOLDER_ +
+      ['function ' + generator.FUNCTION_NAME_PLACEHOLDER_ +
           '(text, color) {',
       '  // Add text to the output area.',
       '  const outputDiv = document.getElementById(\'output\');',

--- a/plugins/block-test/src/basic.js
+++ b/plugins/block-test/src/basic.js
@@ -146,7 +146,7 @@ Blockly.defineBlocksWithJsonArray([
 
 Blockly.Blocks['test_basic_empty_with_mutator'] = {
   init: function() {
-    this.setMutator(new Blockly.Mutator(['math_number']));
+    this.setMutator(new Blockly.icons.MutatorIcon(['math_number'], this));
   },
 };
 

--- a/plugins/block-test/src/serialization/blocks.js
+++ b/plugins/block-test/src/serialization/blocks.js
@@ -74,7 +74,8 @@ Blockly.Blocks['test_extra_state_xml'].init = function() {
   this.itemCount_ = 3;
   this.updateShape_();
   this.setOutput(true, 'Array');
-  this.setMutator(new Blockly.Mutator(['lists_create_with_item']));
+  this.setMutator(
+      new Blockly.icons.MutatorIcon(['lists_create_with_item'], this));
 };
 
 Blockly.Blocks['test_extra_state_jso'] =
@@ -86,7 +87,8 @@ Blockly.Blocks['test_extra_state_jso'].init = function() {
   this.itemCount_ = 3;
   this.updateShape_();
   this.setOutput(true, 'Array');
-  this.setMutator(new Blockly.Mutator(['lists_create_with_item']));
+  this.setMutator(
+      new Blockly.icons.MutatorIcon(['lists_create_with_item'], this));
 };
 
 Blockly.Blocks['test_extra_state_both'] =
@@ -96,5 +98,6 @@ Blockly.Blocks['test_extra_state_both'].init = function() {
   this.itemCount_ = 3;
   this.updateShape_();
   this.setOutput(true, 'Array');
-  this.setMutator(new Blockly.Mutator(['lists_create_with_item']));
+  this.setMutator(
+      new Blockly.icons.MutatorIcon(['lists_create_with_item'], this));
 };

--- a/plugins/field-colour-hsv-sliders/README.md
+++ b/plugins/field-colour-hsv-sliders/README.md
@@ -45,10 +45,12 @@ Blockly.defineBlocksWithJsonArray([
     'style': 'colour_blocks'
   }
 ]);
-javascriptGenerator.forBlock['colour_hsv_sliders'] = function(block) {
-  const code = javascriptGenerator.quote_(block.getFieldValue('COLOUR'));
-  return [code, Order.ATOMIC];
-};
+
+javascriptGenerator.forBlock['colour_hsv_sliders'] =
+    function(block, generator) {
+      const code = generator.quote_(block.getFieldValue('COLOUR'));
+      return [code, Order.ATOMIC];
+    };
 ```
 
 ### JavaScript
@@ -67,10 +69,11 @@ Blockly.Blocks['colour_hsv_sliders'] = {
     this.setStyle('colour_blocks');
   }
 };
-javascriptGenerator['colour_hsv_sliders'] = function(block) {
-  const code = javascriptGenerator.quote_(block.getFieldValue('COLOUR'));
-  return [code, Order.ATOMIC];
-};
+javascriptGenerator.forBlock['colour_hsv_sliders'] =
+    function(block, generator) {
+      const code = generator.quote_(block.getFieldValue('COLOUR'));
+      return [code, Order.ATOMIC];
+    };
 ```
 
 ## License


### PR DESCRIPTION
Updates generators in all of our examples and plugins (which weren't previously updated).

Also updates references from `Blockly.Mutator` to `Blockly.icons.MutatorIcon` in test blocks.