### PR TITLE
fix: add compose and decompose to mutator test block

### DIFF
--- a/plugins/block-test/src/basic.js
+++ b/plugins/block-test/src/basic.js
@@ -148,6 +148,13 @@ Blockly.Blocks['test_basic_empty_with_mutator'] = {
   init: function() {
     this.setMutator(new Blockly.icons.MutatorIcon(['math_number'], this));
   },
+
+  decompose: function(workspace) {
+    const topBlock = workspace.newBlock('math_number');
+    topBlock.initSvg();
+    return topBlock;
+  },
+  compose: function() {},
 };
 
 


### PR DESCRIPTION
Partial fix to https://github.com/google/blockly/issues/7288

Add `decompose` and `compose` to the relevant failing block.