### PR TITLE
fix: run npm ci in lerna action

### DIFF
--- a/.github/workflows/dependabot_update.yml
+++ b/.github/workflows/dependabot_update.yml
@@ -38,10 +38,12 @@ jobs:
         with:
           node-version: 20
 
-      - name: Lerna bootstrap
+      # Running npm ci also runs lerna bootstrap,
+      # which does the magic update we need to remove local dependencies.
+      - name: Npm clean install
         run: |
-          npm run boot
-          cd examples && npm run boot
+          npm ci
+          cd examples && npm ci
 
       # If any package-locks were updated by lerna bootstrap, commit them
       # Using `[dependabot skip]` in the commit message allows dependabot

--- a/.github/workflows/dependabot_update.yml
+++ b/.github/workflows/dependabot_update.yml
@@ -40,7 +40,7 @@ jobs:
 
       # Running npm ci also runs lerna bootstrap,
       # which does the magic update we need to remove local dependencies.
-      - name: Npm clean install
+      - name: Fix package locks
         run: |
           npm ci
           cd examples && npm ci


### PR DESCRIPTION
Updates the dependabot cleanup action to run `npm ci` and not just `npm run boot`. The previous attempt did not run an install at all so lerna was pulled from latest, which doesn't support `lerna bootstrap`... This attempt runs `npm ci` so the correct version of lerna will be installed first. hopefully.