### PR TITLE
fix: only update plugin package locks after dependabot

### DIFF
--- a/.github/workflows/dependabot_update.yml
+++ b/.github/workflows/dependabot_update.yml
@@ -41,9 +41,7 @@ jobs:
       # Running npm ci also runs lerna bootstrap,
       # which does the magic update we need to remove local dependencies.
       - name: Fix package locks
-        run: |
-          npm ci
-          cd examples && npm ci
+        run: npm ci
 
       # If any package-locks were updated by lerna bootstrap, commit them
       # Using `[dependabot skip]` in the commit message allows dependabot


### PR DESCRIPTION
This PR changes the Github action to only update package-locks in `plugins/` on a dependabot PR. This is acceptable because when dependabot changes something in `examples/` we actually shouldn't need to clean up after it. Examples are not dependent on each other, so there are no extraneous dependencies to remove from their package-locks.

The reason I am bothering to remove doing it from examples is that doing an `npm ci` inside of examples is broken more often than doing it for just plugins :/ This is unfortunate, but it shouldn't block cleaning up after dependabot.  It's much more important that the cleanup happens for plugins and not be blocked by unrelated problems with examples.

I am separately fixing the current issues with examples however in https://github.com/google/blockly-samples/pull/1777.