### PR TITLE
feat: add github workflow to check that examples works from a clean install

### DIFF
--- a/.github/workflows/clean_install_examples.yml
+++ b/.github/workflows/clean_install_examples.yml
@@ -23,6 +23,11 @@ jobs:
 
       - name: Check install status
         run: |
-          echo "If this step fails, reproduce locally by running `npm run clean:node && cd examples && npx lerna clean --yes` first"
           npm ci
           cd examples && npm ci
+
+      - name: Pro-tip in case of failure
+        if: ${{ failure() }}
+        run: |
+          echo "To reproduce locally, you need to replicate the fresh install process and get rid of all node_modules directories. Try running"
+          echo "npm run clean:node && cd examples && npx lerna clean --yes && npm ci"

--- a/.github/workflows/clean_install_examples.yml
+++ b/.github/workflows/clean_install_examples.yml
@@ -1,0 +1,28 @@
+# This workflow checks that examples can be installed cleanly.
+# It only runs on PRs that affect the `examples/` directory.
+
+name: Check examples install status
+
+on: 
+  pull_request:
+    paths:
+      - 'examples/**'
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - name: Check install status
+        run: |
+          echo "If this step fails, reproduce locally by running `npm run clean:node && cd examples && npx lerna clean --yes` first"
+          npm ci
+          cd examples && npm ci

--- a/examples/backpack-demo/package.json
+++ b/examples/backpack-demo/package.json
@@ -17,7 +17,7 @@
     ]
   },
   "dependencies": {
-    "@blockly/workspace-backpack": "^5.0.0",
+    "@blockly/workspace-backpack": "^3.0.0",
     "blockly": "^10.0.0"
   }
 }

--- a/examples/backpack-demo/package.json
+++ b/examples/backpack-demo/package.json
@@ -17,7 +17,7 @@
     ]
   },
   "dependencies": {
-    "@blockly/workspace-backpack": "^3.0.0",
+    "@blockly/workspace-backpack": "^5.0.0",
     "blockly": "^10.0.0"
   }
 }


### PR DESCRIPTION
Adds a GitHub Action workflow that only runs on PRs where `examples/` is affected.

Fixes #1511 

## Alternatives considered

I chose to make this a GH Action instead of a locally run test because:
- we don't have a way to run tests locally only if certain paths were changed, and this is an annoying thing to have to check if you are only updating plugins
- this test specifically checks the behavior of the true fresh clean install experience i.e. you have no `node_modules` directories present (npm behaves differently in the normal case where you do already have some things installed). it would be really annoying to clear out all of your node_modules directories locally when running tests.
- examples having outdated peer dependencies shouldn't block plugins from publishing (as they would if this were part of `npm run test`)