### PR TITLE
chore: update node versions in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
       matrix:
         node-version: [16.x, 18.x, 20.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -40,10 +40,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+    - name: Setup node
+      uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 20
 
     - name: Npm Install
       run: npm install

--- a/.github/workflows/dependabot_update.yml
+++ b/.github/workflows/dependabot_update.yml
@@ -6,7 +6,10 @@
 name: Clean up after dependabot
 
 # Triggered when a PR is (re)opened or synchronized
-on: pull_request
+on: 
+  pull_request:
+    paths:
+      - "plugins/**"
 
 permissions:
   pull-requests: write # This action adds commits to PRs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 20
 
     - name: Configure npm
       run: npm config set //wombat-dressing-room.appspot.com/:_authToken=$NODE_AUTH_TOKEN

--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 20
 
     - name: NPM install
       # Use CI so that we don't update dependencies in this step.


### PR DESCRIPTION
- updates node versions to 20 where we're only using one version
- updates checkout and setup-node actions to v3
- updates the dependabot workflow to only run on plugin PRs