### PR TITLE
fix(sample-app-ts): Fix #1785 and related problems

### DIFF
--- a/examples/sample-app-ts/src/generators/javascript.ts
+++ b/examples/sample-app-ts/src/generators/javascript.ts
@@ -12,24 +12,27 @@ import * as Blockly from 'blockly/core';
 // This file has no side effects!
 export const forBlock = Object.create(null);
 
-forBlock['add_text'] = function(
-    block: Blockly.Block, generator: Blockly.CodeGenerator) {
-  const text = generator.valueToCode(block, 'TEXT', Order.NONE) || '\'\'';
-  const color = generator.valueToCode(block, 'COLOR', Order.ATOMIC) ||
-       '\'#ffffff\'';
+forBlock['add_text'] = function (
+  block: Blockly.Block,
+  generator: Blockly.CodeGenerator
+) {
+  const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
+  const color =
+    generator.valueToCode(block, 'COLOR', Order.ATOMIC) || "'#ffffff'";
 
   const addText = generator.provideFunction_(
-      'addText',
-      ['function ' + generator.FUNCTION_NAME_PLACEHOLDER_ +
-          '(text, color) {',
-      '  // Add text to the output area.',
-      '  const outputDiv = document.getElementById(\'output\');',
-      '  const textEl = document.createElement(\'p\');',
-      '  textEl.innerText = text;',
-      '  textEl.style.color = color;',
-      '  outputDiv.appendChild(textEl);',
-      '}']);
-    // Generate the function call for this block.
+    'addText',
+    `function ${generator.FUNCTION_NAME_PLACEHOLDER_}(text, color) {
+
+  // Add text to the output area.
+  const outputDiv = document.getElementById('output');
+  const textEl = document.createElement('p');
+  textEl.innerText = text;
+  textEl.style.color = color;
+  outputDiv.appendChild(textEl);
+}`
+  );
+  // Generate the function call for this block.
   const code = `${addText}(${text}, ${color});\n`;
   return code;
 };

--- a/examples/sample-app-ts/src/generators/javascript.ts
+++ b/examples/sample-app-ts/src/generators/javascript.ts
@@ -10,9 +10,9 @@ import * as Blockly from 'blockly/core';
 // Export all the code generators for our custom blocks,
 // but don't register them with Blockly yet.
 // This file has no side effects!
-export const generator = Object.create(null);
+export const forBlock = Object.create(null);
 
-generator.forEach['add_text'] = function(
+forBlock['add_text'] = function(
     block: Blockly.Block, generator: Blockly.CodeGenerator) {
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || '\'\'';
   const color = generator.valueToCode(block, 'COLOR', Order.ATOMIC) ||

--- a/examples/sample-app-ts/src/index.ts
+++ b/examples/sample-app-ts/src/index.ts
@@ -40,7 +40,7 @@ if (ws) {
   runCode();
 
   // Every time the workspace changes state, save the changes to storage.
-  ws.addChangeListener((e: Blockly.Events.UiBase) => {
+  ws.addChangeListener((e: Blockly.Events.Abstract) => {
     // UI events are things like scrolling, zooming, etc.
     // No need to save after one of these.
     if (e.isUiEvent) return;
@@ -49,7 +49,7 @@ if (ws) {
 
 
   // Whenever the workspace changes meaningfully, run the code again.
-  ws.addChangeListener((e: Blockly.Events.UiBase) => {
+  ws.addChangeListener((e: Blockly.Events.Abstract) => {
     // Don't run the code when the workspace finishes loading; we're
     // already running it once when the application starts.
     // Don't run the code during drags; we might have invalid state.

--- a/examples/sample-app-ts/src/index.ts
+++ b/examples/sample-app-ts/src/index.ts
@@ -6,7 +6,7 @@
 
 import * as Blockly from 'blockly';
 import {blocks} from './blocks/text';
-import {generator} from './generators/javascript';
+import {forBlock} from './generators/javascript';
 import {javascriptGenerator} from 'blockly/javascript';
 import {save, load} from './serialization';
 import {toolbox} from './toolbox';
@@ -14,7 +14,7 @@ import './index.css';
 
 // Register the blocks and generator with Blockly
 Blockly.common.defineBlocks(blocks);
-Object.assign(javascriptGenerator, generator);
+Object.assign(javascriptGenerator.forBlock, forBlock);
 
 // Set up UI elements and inject Blockly
 const codeDiv = document.getElementById('generatedCode')?.firstChild;

--- a/examples/sample-app/src/generators/javascript.js
+++ b/examples/sample-app/src/generators/javascript.js
@@ -11,23 +11,24 @@ import {Order} from 'blockly/javascript';
 // This file has no side effects!
 export const forBlock = Object.create(null);
 
-forBlock['add_text'] = function(block, generator) {
-  const text = generator.valueToCode(block, 'TEXT', Order.NONE) || '\'\'';
-  const color = generator.valueToCode(block, 'COLOR', Order.ATOMIC) ||
-      '\'#ffffff\'';
+forBlock['add_text'] = function (block, generator) {
+  const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
+  const color =
+    generator.valueToCode(block, 'COLOR', Order.ATOMIC) || "'#ffffff'";
 
   const addText = generator.provideFunction_(
-      'addText',
-      ['function ' + generator.FUNCTION_NAME_PLACEHOLDER_ +
-          '(text, color) {',
-      '  // Add text to the output area.',
-      '  const outputDiv = document.getElementById(\'output\');',
-      '  const textEl = document.createElement(\'p\');',
-      '  textEl.innerText = text;',
-      '  textEl.style.color = color;',
-      '  outputDiv.appendChild(textEl);',
-      '}']);
-    // Generate the function call for this block.
+    'addText',
+    `function ${generator.FUNCTION_NAME_PLACEHOLDER_}(text, color) {
+
+  // Add text to the output area.
+  const outputDiv = document.getElementById('output');
+  const textEl = document.createElement('p');
+  textEl.innerText = text;
+  textEl.style.color = color;
+  outputDiv.appendChild(textEl);
+}`
+  );
+  // Generate the function call for this block.
   const code = `${addText}(${text}, ${color});\n`;
   return code;
 };

--- a/examples/sample-app/src/generators/javascript.js
+++ b/examples/sample-app/src/generators/javascript.js
@@ -9,9 +9,9 @@ import {Order} from 'blockly/javascript';
 // Export all the code generators for our custom blocks,
 // but don't register them with Blockly yet.
 // This file has no side effects!
-export const generator = Object.create(null);
+export const forBlock = Object.create(null);
 
-generator.forBlock['add_text'] = function(block, generator) {
+forBlock['add_text'] = function(block, generator) {
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || '\'\'';
   const color = generator.valueToCode(block, 'COLOR', Order.ATOMIC) ||
       '\'#ffffff\'';

--- a/examples/sample-app/src/index.js
+++ b/examples/sample-app/src/index.js
@@ -6,7 +6,7 @@
 
 import * as Blockly from 'blockly';
 import {blocks} from './blocks/text';
-import {generator} from './generators/javascript';
+import {forBlock} from './generators/javascript';
 import {javascriptGenerator} from 'blockly/javascript';
 import {save, load} from './serialization';
 import {toolbox} from './toolbox';
@@ -14,7 +14,7 @@ import './index.css';
 
 // Register the blocks and generator with Blockly
 Blockly.common.defineBlocks(blocks);
-Object.assign(javascriptGenerator, generator);
+Object.assign(javascriptGenerator.forBlock, forBlock);
 
 // Set up UI elements and inject Blockly
 const codeDiv = document.getElementById('generatedCode').firstChild;
@@ -58,5 +58,3 @@ ws.addChangeListener((e) => {
   }
   runCode();
 });
-
-


### PR DESCRIPTION
* Fix type declarations for the event listener callbacks passed to `addChangeListener`, to have them take `Abstract` instead of `UiBase` events, since that is how `addChangeListener` is declared (and there is no facility to receive only `UiBase` events).  Part of #1785.

* Fix export/import of generator functions for both `sample-app` and `sample-app-ts`.

  The changes made in #1758 to update generator declarations were not quite correct; in particular, they did not properly account for the need to apply `Object.assign` only to `javascriptGenerator.forBlock`, not to all of `javascriptGenerator`.

  Not technically part of #1785, since it the error was not causing _build_ failures, but very much necessary to get the sample apps working again.

* Update formatting of generator to use template literals and apply our usual Prettier style from core.
