### PR TITLE
chore: update the email address used for the robot

### DIFF
--- a/.github/workflows/dependabot_update.yml
+++ b/.github/workflows/dependabot_update.yml
@@ -34,8 +34,8 @@ jobs:
       # https://github.com/actions/checkout/issues/13#issuecomment-724415212
       - name: Git identity
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email '<41898282+github-actions[bot]@users.noreply.github.com'
+          git config --global user.name 'blockly[bot]'
+          git config --global user.email 'blockly-github-robot@google.com'
 
       - name: Setup node
         uses: actions/setup-node@v3


### PR DESCRIPTION
This workflow now runs successfully! Please also review the rest of this file because I've made changes that I committed directly to master in the process of debugging this action.

However, even commits authored by robots must sign the Google CLA. So I've created an email address for our robot following the guidance provided internally, and applied for the robot to be exempt from CLA requirements. Edit: The robot was approved for CLA exemption.

What I'm unsure on is whether I can really just provide any ol' email address here... do I somehow need to verify that I have permission to use this email to author the commit? I dunno.

The earlier changes I made include:
- giving write access to the contents of the repo (unfortunately there does not seem to be a way to give write access only to specific branches but that would be cool)
- running `npm run clean:node && npm run boot -- --no-ci` in order to update the package-lock files. Normally `lerna bootstrap` runs `npm install` locally and `npm ci` when in CI. We don't want ci in this particular case because we really do want it to make changes to the `package-lock` file. That's the whole point of this action. The `clean:node` is required because lerna won't touch the package-locks if there was nothing new to actually install.