### PR TITLE
fix: Fix the positioning of the dropdown div relative to the bitmap field.

### DIFF
--- a/plugins/field-bitmap/src/field-bitmap.js
+++ b/plugins/field-bitmap/src/field-bitmap.js
@@ -212,6 +212,13 @@ export class FieldBitmap extends Blockly.Field {
     return true;
   }
 
+  getScaledBBox() {
+    const boundingBox = this.fieldGroup_.getBoundingClientRect();
+    return new Blockly.utils.Rect(
+        boundingBox.top, boundingBox.bottom, boundingBox.left,
+        boundingBox.right);
+  }
+
   /**
    * Creates the bitmap editor and add event listeners.
    * @returns {!Element} The newly created dropdown menu.


### PR DESCRIPTION
Fixes #1720. This PR adjusts the way that the bitmap field determines its bounding box, which is in turn used to determine the position of the drop down DIV when it's shown. Manually tested on Chrome, Safari and Firefox at different zoom levels.