### PR TITLE
fix: Use the normal, non-drag cursor when hovering over a bitmap field.

### DIFF
--- a/plugins/field-bitmap/src/field-bitmap.js
+++ b/plugins/field-bitmap/src/field-bitmap.js
@@ -35,6 +35,7 @@ export class FieldBitmap extends Blockly.Field {
     super(value, validator, config);
 
     this.SERIALIZABLE = true;
+    this.CURSOR = 'default';
 
     // Configure value, height, and width
     if (this.getValue() !== null) {
@@ -209,7 +210,13 @@ export class FieldBitmap extends Blockly.Field {
    * @returns {boolean} True since it is always editable.
    */
   updateEditable() {
-    return true;
+    const editable = super.updateEditable();
+    // Blockly.Field's implementation sets these classes as appropriate, but
+    // since this field has no text they just mess up the rendering of the
+    // grid lines.
+    Blockly.utils.dom.removeClass(this.fieldGroup_, 'blocklyNonEditableText');
+    Blockly.utils.dom.removeClass(this.fieldGroup_, 'blocklyEditableText');
+    return editable;
   }
 
   /**


### PR DESCRIPTION
Fixes #1167 by updating the bitmap field to use a normal cursor instead of the block-drag-hand. updateEditable() is responsible for actually setting the cursor in the base field class, so I updated the bitmap field to call super() there.