### PR TITLE
fix: Provide a useful description for the fixed-edges plugin.

### DIFF
--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockly/fixed-edges",
   "version": "4.0.1",
-  "description": "A Blockly MetricsManager for configuring fixed sides.",
+  "description": "A plugin that provides a MetricsManager that can be used to prevent the workspace from expanding to the top/left/right/bottom when blocks are dragged to that edge.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
     "build": "blockly-scripts build",


### PR DESCRIPTION
Fixes #1070. Improves the description of the fixed edges plugin to describe what it does, vs saying that the fixed edges plugin lets you configure fixed edges.