### PR TITLE
feat: add option skip backpack serializer registration

### DIFF
--- a/plugins/workspace-backpack/README.md
+++ b/plugins/workspace-backpack/README.md
@@ -47,6 +47,7 @@ This plugin takes an optional configuration object.
 {
   allowEmptyBackpackOpen: (boolean|undefined),
   useFilledBackpackImage: (boolean|undefined),
+  skipSerializerRegistration: (boolean|undefined),
   contextMenu: {
     emptyBackpack: (boolean|undefined),
     removeFromBackpack: (boolean|undefined),
@@ -80,6 +81,7 @@ passed in options that is undefined:
 const defaultOptions = {
   allowEmptyBackpackOpen: true,
   useFilledBackpackImage: false,
+  skipSerializerRegistration: false,
   contextMenu: {
     emptyBackpack: true,
     removeFromBackpack: true,
@@ -96,6 +98,8 @@ being opened if the backpack is empty.
 
 The `useFilledBackpackImage` property, if set to `true`, will change the
 backpack image when the backpack has something in it.
+
+The `skipSerializerRegistration` property, if set to `true`, will not register the backpack serializer with the workspace serializer. Set this to `true` if you don't want the backpack to be serialized alongside the workspace.
 
 The `disablePreconditionChecks` property will prevent the "Copy to Backpack"
 context menu option from disabling the context menu option if the block is

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -153,6 +153,29 @@ export class Backpack extends Blockly.DragTarget {
      * @private
      */
     this.SPRITE_SIZE_ = 80;
+
+    this.registerSerializer();
+  }
+
+  /**
+   * Registers serializer if options.skipSerializerRegistration is false
+   * and it hasn't been registered already.
+   * @private
+   */
+  registerSerializer() {
+    if (this.options_.skipSerializerRegistration) {
+      return;
+    }
+
+    if (Blockly.registry.hasItem(
+        Blockly.registry.Type.SERIALIZER,
+        'backpack')) {
+      return;
+    }
+
+    Blockly.serialization.registry.register(
+        'backpack',
+        new BackpackSerializer());
   }
 
   /**
@@ -890,6 +913,4 @@ class BackpackSerializer {
   }
 }
 
-Blockly.serialization.registry.register(
-    'backpack',
-    new BackpackSerializer());
+

--- a/plugins/workspace-backpack/src/options.d.ts
+++ b/plugins/workspace-backpack/src/options.d.ts
@@ -19,6 +19,7 @@ export interface BackpackContextMenuOptions {
 export interface BackpackOptions {
   allowEmptyBackpackOpen?: boolean;
   useFilledBackpackImage?: boolean;
+  skipSerializerRegistration?: boolean;
   contextMenu?: BackpackContextMenuOptions;
 }
 /**

--- a/plugins/workspace-backpack/src/options.js
+++ b/plugins/workspace-backpack/src/options.js
@@ -26,6 +26,7 @@ export let BackpackContextMenuOptions;
  * @typedef {{
  *    allowEmptyBackpackOpen: (boolean|undefined),
  *    useFilledBackpackImage: (boolean|undefined),
+ *    skipSerializerRegistration: (boolean|undefined),
  *    contextMenu:(!BackpackContextMenuOptions|undefined)
  * }}
  */
@@ -41,6 +42,7 @@ export function parseOptions(options) {
   const defaults = {
     allowEmptyBackpackOpen: true,
     useFilledBackpackImage: false,
+    skipSerializerRegistration: false,
     contextMenu: {
       emptyBackpack: true,
       removeFromBackpack: true,
@@ -60,6 +62,9 @@ export function parseOptions(options) {
         options.allowEmptyBackpackOpen ?? defaults.allowEmptyBackpackOpen,
     useFilledBackpackImage:
         options.useFilledBackpackImage ?? defaults.useFilledBackpackImage,
+    skipSerializerRegistration:
+        options.skipSerializerRegistration ??
+            defaults.skipSerializerRegistration,
     contextMenu: {
       ...defaults.contextMenu,
       ...options.contextMenu,


### PR DESCRIPTION
Add option to skip backpack serializer registration.

## Usage

```
new Backpack(workspace, {
  skipSerializerRegistration: true,
})
```

## Tests

Tested with the following:

```
new Backpack(workspace) // Registers serializer
```

```
new Backpack(workspace, { skipSerializerRegistration: false}) // Registers serializer
```

```
new Backpack(workspace, { skipSerializerRegistration: true }) // Does not register serializer
```

```
new Backpack(workspace) // Registers serializer
new Backpack(workspace) // Does not register serializer, as it's already registered
new Backpack(workspace, { skipSerializerRegistration: true }) // Does not register serializer, but it also doesn't unregister serializer
```

Closes https://github.com/google/blockly-samples/issues/1826