### PR TITLE
fix: Fix the link to contextmenu_items.ts in the context menu codelab.

### DIFF
--- a/codelabs/context_menu_option/context_menu_option.md
+++ b/codelabs/context_menu_option/context_menu_option.md
@@ -344,7 +344,7 @@ Blockly.ContextMenuRegistry.registry.unregister('workspaceDelete');
 
 ### Default options
 
-For a list of the default options that Blockly provides, look at [contextmenu_items.js](https://github.com/google/blockly/blob/master/core/contextmenu_items.js). Each entry contains both the `id` and the `weight`.
+For a list of the default options that Blockly provides, look at [contextmenu_items.ts](https://github.com/google/blockly/blob/master/core/contextmenu_items.ts). Each entry contains both the `id` and the `weight`.
 
 ## Summary
 


### PR DESCRIPTION
This PR fixes #1832 by updating a link in the context menu codelab to point to the new Typescript context menu item file in Blockly core, rather than the old Javascript version.