### PR TITLE
fix: support xml serialized blocks in setContents() of workspace-back…

### DIFF
--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -498,6 +498,26 @@ export class Backpack extends Blockly.DragTarget {
   }
 
   /**
+   * Converts serialized XML to its equivalent serialized JSON string
+   * @param {!string} blockXml The XML serialized block.
+   * @returns {string} The JSON object as a string.
+   * @private
+   */
+  blockXmlToJsonString(blockXml) {
+    if (!blockXml.startsWith('<block')) {
+      throw new Error('Unrecognized XML format');
+    }
+
+    const workspace = new Blockly.Workspace();
+    const block = Blockly.Xml.domToBlock(
+        Blockly.utils.xml.textToDom(blockXml),
+        workspace,
+    );
+
+    return this.blockToJsonString(block);
+  }
+
+  /**
    * Returns whether the backpack contains a duplicate of the provided Block.
    * @param {!Blockly.Block} block The block to check.
    * @returns {boolean} Whether the backpack contains a duplicate of the
@@ -574,7 +594,12 @@ export class Backpack extends Blockly.DragTarget {
    */
   setContents(contents) {
     this.contents_ = [];
-    this.contents_ = this.filterDuplicates_(contents);
+    this.contents_ = this.filterDuplicates_(
+        // Support XML serialized content for backwards compatiblity: https://github.com/google/blockly-samples/issues/1827
+        contents.map((content) => content.startsWith('<block') ?
+          this.blockXmlToJsonString(content) :
+          content)
+    );
     this.onContentChange_();
   }
 

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -509,12 +509,15 @@ export class Backpack extends Blockly.DragTarget {
     }
 
     const workspace = new Blockly.Workspace();
-    const block = Blockly.Xml.domToBlock(
-        Blockly.utils.xml.textToDom(blockXml),
-        workspace,
-    );
-
-    return this.blockToJsonString(block);
+    try {
+      const block = Blockly.Xml.domToBlock(
+          Blockly.utils.xml.textToDom(blockXml),
+          workspace,
+      );
+      return this.blockToJsonString(block);
+    } finally {
+      workspace.dispose();
+    }
   }
 
   /**

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -499,7 +499,7 @@ export class Backpack extends Blockly.DragTarget {
 
   /**
    * Converts serialized XML to its equivalent serialized JSON string
-   * @param {!string} blockXml The XML serialized block.
+   * @param {string} blockXml The XML serialized block.
    * @returns {string} The JSON object as a string.
    * @private
    */


### PR DESCRIPTION
## Description

Add support for loading serialized XML contents into Backpack for backwards compatibility.

Note: XML support is only during Backpack hydration through backpack.setContents(). Getting contents of the Backpack through backpack.getContents() will still return JSON.

Question to the Blockly team: I assumed in this PR that all Backpack serialized XML starts with `<block`. Please let me know if this was an incorrect assumption and I'll make the necessary changes.

## Tests

Tested by loading backpack (using `Backpack.setContents()`) with the following 2 serialized XMLs:

```
<block xmlns="https://developers.google.com/blockly/xml" type="math_number_property"><mutation divisor_input="true"></mutation><field name="PROPERTY">DIVISIBLE_BY</field><value name="NUMBER_TO_CHECK"><shadow type="math_number"><field name="NUM">0</field></shadow></value></block>
```

```
<block xmlns="https://developers.google.com/blockly/xml" type="procedures_defreturn"><field name="NAME">pick random product</field><statement name="STACK"><block type="variables_set"><field name="VAR">products</field><value name="VALUE"><block type="lists_create_with"><mutation items="3"></mutation><value name="ADD0"><block type="text"><field name="TEXT">Car</field></block></value><value name="ADD1"><block type="text"><field name="TEXT">Plane</field></block></value><value name="ADD2"><block type="text"><field name="TEXT">Train</field></block></value></block></value><next><block type="variables_set"><field name="VAR">product</field><value name="VALUE"><block type="lists_getIndex"><mutation statement="false" at="false"></mutation><field name="MODE">GET</field><field name="WHERE">RANDOM</field><value name="VALUE"><block type="variables_get"><field name="VAR">products</field></block></value></block></value></block></next></block></statement><value name="RETURN"><block type="variables_get"><field name="VAR">product</field></block></value></block>
```

Serializing the backpack (using `Backpack.getContents()`) resulted in these JSON serialized values, respectively:

```
{"type":"math_number_property","extraState":"<mutation divisor_input=\"true\"></mutation>","fields":{"PROPERTY":"DIVISIBLE_BY"},"inputs":{"NUMBER_TO_CHECK":{"shadow":{"type":"math_number","fields":{"NUM":0}}}},"kind":"BLOCK"}
```
and 
```
{"type":"procedures_defreturn","fields":{"NAME":"pick random product"},"inputs":{"STACK":{"block":{"type":"variables_set","fields":{"VAR":{"name":"products","type":""}},"inputs":{"VALUE":{"block":{"type":"lists_create_with","extraState":{"itemCount":3},"inputs":{"ADD0":{"block":{"type":"text","fields":{"TEXT":"Car"}}},"ADD1":{"block":{"type":"text","fields":{"TEXT":"Plane"}}},"ADD2":{"block":{"type":"text","fields":{"TEXT":"Train"}}}}}}},"next":{"block":{"type":"variables_set","fields":{"VAR":{"name":"product","type":""}},"inputs":{"VALUE":{"block":{"type":"lists_getIndex","fields":{"MODE":"GET","WHERE":"RANDOM"},"inputs":{"VALUE":{"block":{"type":"variables_get","fields":{"VAR":{"name":"products","type":""}}}}}}}}}}}},"RETURN":{"block":{"type":"variables_get","fields":{"VAR":{"name":"product","type":""}}}}},"kind":"BLOCK"}
```

Then I loaded the JSON serialized values into the Backpack and everything behaved as expected.

The Backpack looked like before, during, and after the test:

![image](https://github.com/google/blockly-samples/assets/504505/afad4dc8-d846-4dce-99ad-a48a6efb30bf)

## Issue

Relates to https://github.com/google/blockly-samples/issues/1827