### PR TITLE
feat: have backpack hide scrollbars when flyout opens

### DIFF
--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -679,7 +679,12 @@ export class Backpack extends Blockly.DragTarget {
     }
     const jsons = this.contents_.map((text) => JSON.parse(text));
     this.flyout_.show(jsons);
-    this.workspace_.scrollbar?.setVisible(false);
+    // TODO: We can remove the setVisible check when updating from ^10.0.0 to
+    //    ^11.
+    if (this.workspace_.scrollbar &&
+    /** @type {*} */ (this.workspace_.scrollbar).setVisible) {
+      /** @type {*} */ (this.workspace_.scrollbar).setVisible(false);
+    }
     Blockly.Events.fire(new BackpackOpen(true, this.workspace_.id));
   }
 
@@ -703,7 +708,12 @@ export class Backpack extends Blockly.DragTarget {
       return;
     }
     this.flyout_.hide();
-    this.workspace_.scrollbar?.setVisible(true);
+    // TODO: We can remove the setVisible check when updating from ^10.0.0 to
+    //    ^11.
+    if (this.workspace_.scrollbar &&
+    /** @type {*} */ (this.workspace_.scrollbar).setVisible) {
+      /** @type {*} */ (this.workspace_.scrollbar).setVisible(true);
+    }
     Blockly.Events.fire(new BackpackOpen(false, this.workspace_.id));
   }
 

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -679,7 +679,7 @@ export class Backpack extends Blockly.DragTarget {
     }
     const jsons = this.contents_.map((text) => JSON.parse(text));
     this.flyout_.show(jsons);
-    this.workspace_.scrollbar.setVisible(false);
+    this.workspace_.scrollbar?.setVisible(false);
     Blockly.Events.fire(new BackpackOpen(true, this.workspace_.id));
   }
 
@@ -703,7 +703,7 @@ export class Backpack extends Blockly.DragTarget {
       return;
     }
     this.flyout_.hide();
-    this.workspace_.scrollbar.setVisible(true);
+    this.workspace_.scrollbar?.setVisible(true);
     Blockly.Events.fire(new BackpackOpen(false, this.workspace_.id));
   }
 

--- a/plugins/workspace-backpack/src/backpack.js
+++ b/plugins/workspace-backpack/src/backpack.js
@@ -679,6 +679,7 @@ export class Backpack extends Blockly.DragTarget {
     }
     const jsons = this.contents_.map((text) => JSON.parse(text));
     this.flyout_.show(jsons);
+    this.workspace_.scrollbar.setVisible(false);
     Blockly.Events.fire(new BackpackOpen(true, this.workspace_.id));
   }
 
@@ -702,6 +703,7 @@ export class Backpack extends Blockly.DragTarget {
       return;
     }
     this.flyout_.hide();
+    this.workspace_.scrollbar.setVisible(true);
     Blockly.Events.fire(new BackpackOpen(false, this.workspace_.id));
   }
 
@@ -940,5 +942,3 @@ class BackpackSerializer {
     backpack.empty();
   }
 }
-
-


### PR DESCRIPTION
Fixes #1841 

### Testing

Opened and closed the backpack and observed that scrollbars where hidden and shown.

### Additional Info

Dependent on v10.1