### PR TITLE
fix: Focus region bug when primary workspace zoomed

### DIFF
--- a/plugins/workspace-minimap/src/focus_region.ts
+++ b/plugins/workspace-minimap/src/focus_region.ts
@@ -149,10 +149,15 @@ export class FocusRegion {
       const primaryMetrics = this.primaryWorkspace.getMetricsManager();
       const minimapMetrics = this.minimapWorkspace.getMetricsManager();
 
-      const primaryView = primaryMetrics.getViewMetrics();
-      const primaryContent = primaryMetrics.getContentMetrics();
+      const primaryView = primaryMetrics.getViewMetrics(true);
+      const primaryContent = primaryMetrics.getContentMetrics(true);
       const minimapContent = minimapMetrics.getContentMetrics();
       const minimapSvg = minimapMetrics.getSvgMetrics();
+
+      // Return if there is no content.
+      if (primaryContent.width === 0) {
+        return;
+      }
 
       // Get the workscape to pixel scale on the minimap.
       const scale = minimapContent.width /

--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -215,6 +215,7 @@ export class Minimap {
     private onClickUp(): void {
       if (this.onMouseMoveWrapper) {
         Blockly.browserEvents.unbind(this.onMouseMoveWrapper);
+        this.onMouseMoveWrapper = null;
       }
     }
 


### PR DESCRIPTION
**Description**
When the primary workspace zoomed in or out, the focus region would not be sized and positioned correctly. To fix this I used the viewMetrics in workspace units instead of pixel units. 

**Test**
I added the zoom buttons to the playground and ensured that with both zooming in and out, the focus region was sized and positioned correctly.