### PR TITLE
fix: Shadow blocks replicated in minimap

### DIFF
--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -132,10 +132,12 @@ export class Minimap {
      * @param event The primary workspace event.
      */
     private mirror(event: Blockly.Events.Abstract): void {
-      // TODO: shadow blocks get mirrored too (not supposed to happen)
-
       if (!blockEvents.has(event.type)) {
         return; // Filter out events.
+      }
+      if (event.type === Blockly.Events.BLOCK_CREATE &&
+        (event as any).xml.tagName === 'shadow') {
+        return; // Filter out shadow blocks.
       }
       // Run the event in the minimap.
       const json = event.toJson();


### PR DESCRIPTION
**Description**
Shadow blocks were being mirrored in the minimap through the BLOCK_CREATE event. Now we check to see if their xml is of type shadow to filter them out.

**Tests**
To verify that it was working I manually checked in the playground. I added/removed a block from a shadow block's place and the shadow block was not mirrored over.