### PR TITLE
chore: Update field readmes for fields moved out of core.

### DIFF
--- a/plugins/field-angle/README.md
+++ b/plugins/field-angle/README.md
@@ -15,7 +15,42 @@ npm install @blockly/field-angle --save
 ```
 
 ## Usage
-See the [Blockly Angle Field documentation](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/angle) on what parameters and configurations this field supports.
+This field accepts up to 9 parameters, in addition to the 4 accepted by the
+[number field][number-field]:
+  * "value" to specify the default value of the angle field. Defaults to 0.
+  * "mode" to specify the basic setup of the angle field. Either Mode.COMPASS
+    or Mode.PROTRACTOR. COMPASS specifies "clockwise" should be "true", and the
+    "offset" should be "90". PROTRACTOR specifies that "clockwise" should be
+    "false" and the "offset" should be 0. These settings can be overridden by
+    the following options. Defaults to PROTRACTOR.
+  * "clockwise" to specify whether the value of the angle field should increase
+    in the clockwise direction (if true) or in the counter-clockwise direction
+    (if false). Defaults to false.
+  * "offset" to specify where the minimum/maximum displayed value of the angle
+    field should be. The offset is in degree units that consider the circle to
+    be 360 degrees. A 0 offset (or multiple of 360) specifies the right side of
+    the circle as the minimum/maximum value. More positive values rotate
+    clockwise and more negative values rotate counter clockwise (regardless of
+    the "clockwise" setting). Defaults to 0.
+  * "displayMin" to specify the minimum displayed value of the angle field. The
+    minimum displayed value may not actually be a selectable value. For example,
+    you may have a full 0-360 degree circle ("displayMin" of 0), but only be
+    able to select angle values from 90-270. Defaults to 0.
+  * "displayMax" to specify the maximum displayed value of the angle field. The
+    maximum displayed value may not actually be a selectable value. For example,
+    you may have a full 0-360 degree circle ("displayMax" of 360), but only be
+    able to select angle values from 90-270. Defaults to 360.
+  * "minorTick" to specify the distance between small tick marks on the angle
+    picker. The minorTick is in units from your displayMin-displayMax. The ticks
+    start at your "min" rounded up to a multiple of your "minorTick". The
+    ticks end at you "max" rounded down to a multiple of your "minorTick".
+    Defaults to 15.
+  * "majorTick" to specify the distance between big tick marks on the angle
+    picker. The majorTick is in units from your displayMin-displayMax. The ticks
+    start at your "min" rounded up to a multiple of your "majorTick". The
+    ticks end at you "max" rounded down to a multiple of your "majorTick".
+    Defaults to 45.
+  * "symbol" to specify the unit symbol to append to your number. Defaults to °.
 
 ### JavaScript
 ```js
@@ -51,3 +86,5 @@ Blockly.defineBlocksWithJsonArray([
 ## License
 
 Apache 2.0
+
+[number-field]: https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/number#creation

--- a/plugins/field-colour/README.md
+++ b/plugins/field-colour/README.md
@@ -15,8 +15,17 @@ npm install @blockly/field-colour --save
 ```
 
 ## Usage
-See the [Blockly Colour Input Field documentation](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/colour) on what parameters and configurations this field supports.
 
+This field accepts up to 4 parameters:
+  * "colour" to specify the default colour. Defaults to the first value in the
+    "colourOptions" array. Should be a "#rrggbb" string.
+  * "colourOptions" to specify the colour options in the dropdown. Defaults to
+    a set of 70 colors, including grays, reds, oranges, yellows, olives, greens,
+    turquoises, blues, purples, and violets. Should be "#rrggbb" strings.
+  * "colourTitles" to specify the tooltips for the colour options. Defaults to
+    the "#rrggbb" values of the provided colour options.
+  * "columns" to specify the number of columns the colour dropdown should have.
+    Defaults to 7.
 
 ### JavaScript
 ```js
@@ -26,7 +35,7 @@ Blockly.Blocks["test_field_colour"] = {
   init: function () {
     this.appendDummyInput()
       .appendField("colour: ")
-      .appendField(new FieldColour(90), "FIELDNAME");
+      .appendField(new FieldColour("#ffcccc"), "FIELDNAME");
   }
 };
 ```
@@ -43,11 +52,17 @@ Blockly.defineBlocksWithJsonArray([
             {
                 "type": "field_colour",
                 "name": "FIELDNAME",
-                "value": 50
+                "colour": "#ffcccc"
             }
         ]
     }]);
 ```
+
+### API Reference
+
+* `setColours`: Sets the colour options, and optionally the titles for the
+  options. The colourss should be an array of #rrggbb strings.
+* `setColumns`: Sets the number of columns the dropdown should have.
 
 ## License
 

--- a/plugins/field-multilineinput/README.md
+++ b/plugins/field-multilineinput/README.md
@@ -15,17 +15,28 @@ npm install @blockly/field-multilineinput --save
 ```
 
 ## Usage
-See the [Blockly Multiline Text Input Field documentation](https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/multiline-text-input) on what parameters and configurations this field supports.
+
+This field accepts up to 3 parameters:
+  * "text" to specify the default text. Defaults to `""`.
+  * "maxLines" to specify the maximum number of lines displayed before scrolling
+    functionality is enabled. Defaults to `Infinity`.
+  * "spellcheck" to specify whether spell checking is enabled. Defaults to
+  `true`.
+
+The multiline input field is a subclass of Blockly.FieldInput
 
 ### JavaScript
 ```js
 import * as Blockly from 'blockly';
 import {FieldMultilineInput} from '@blockly/field-multilineinput';
+
 Blockly.Blocks["test_field_multilineinput"] = {
   init: function () {
     this.appendDummyInput()
       .appendField("multilineinput: ")
-      .appendField(new FieldMultilineInput(90), "FIELDNAME");
+      .appendField(
+          new FieldMultilineInput("some text \n with newlines"),
+          "FIELDNAME");
   }
 };
 ```
@@ -34,6 +45,7 @@ Blockly.Blocks["test_field_multilineinput"] = {
 ```js
 import * as Blockly from 'blockly';
 import '@blockly/field-multilineinput';
+
 Blockly.defineBlocksWithJsonArray([
     {
         "type": "test_field_multilineinput",
@@ -42,11 +54,19 @@ Blockly.defineBlocksWithJsonArray([
             {
                 "type": "field_multilineinput",
                 "name": "FIELDNAME",
-                "value": 50
+                "text": "some text \n with newlines"
             }
-        ]
     }]);
 ```
+
+### API reference
+
+* `setMaxLines`: Sets the maximum number of displayed lines before
+  scrolling functionality is enabled.
+* `getMaxLines`: Returns the maximum number of displayed lines before
+  scrolling functionality is enabled.
+* `setSpellcheck`: Sets whether spell checking is enabled.
+* `getSpellcheck`: Returns whether spell checking is enabled.
 
 ## License
 


### PR DESCRIPTION
Closes https://github.com/google/blockly-samples/issues/1840

Update the field docs for fields moved out of core to specify their config options and APIs (if applicable).