### PR TITLE
fix: loading parameters for shareable procedure blocks

### DIFF
--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -461,12 +461,19 @@ const procedureDefMutator = {
       this.model_ = map.get(procedureId);
     }
 
-    if (state['params'] && !this.getProcedureModel().getParameters().length) {
-      for (let i = 0; i < state['params'].length; i++) {
-        const {name, id, paramId} = state['params'][i];
-        this.getProcedureModel().insertParameter(
-            new ObservableParameterModel(this.workspace, name, paramId, id), i);
+    const model = this.getProcedureModel();
+    const newParams = state['params'] ?? [];
+    const newIds = new Set(newParams.map((p) => p.id));
+    const currParams = model.getParameters();
+    for (let i = currParams.length - 1; i >= 0; i--) {
+      if (!newIds.has(currParams[i].getId)) {
+        model.deleteParameter(i);
       }
+    }
+    for (let i = 0; i < newParams.length; i++) {
+      const {name, id, paramId} = state['params'][i];
+      this.getProcedureModel().insertParameter(
+          new ObservableParameterModel(this.workspace, name, paramId, id), i);
     }
 
     this.doProcedureUpdate();

--- a/plugins/block-shareable-procedures/src/events_procedure_base.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_base.ts
@@ -27,6 +27,7 @@ export abstract class ProcedureBase extends Blockly.Events.Abstract {
       readonly procedure: Blockly.procedures.IProcedureModel) {
     super();
     this.workspaceId = workspace.id;
+    this.recordUndo = false;
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/google/blockly-samples/issues/1873

Removed the `!getParameters().length` check that was causing the mirroring errors.

Makes Undo and Redo work correctly by:
  1) Disables `recordUndo` on all procedure data model events so that undo and redo is only handled by `BlockChange` events.
  2) Changing `loadState` to delete parameters that no longer exist in addition to creating new ones.

## Testing

Tested that mirroring works properly with undo and redo. Tested that sharing procedure models continues to work.