### PR TITLE
fix: Test for minimap playground

### DIFF
--- a/plugins/workspace-minimap/package.json
+++ b/plugins/workspace-minimap/package.json
@@ -11,7 +11,6 @@
     "start": "blockly-scripts start",
     "test": "blockly-scripts test"
   },
-  "private": true,
   "main": "./dist/index.js",
   "module": "./src/index.js",
   "unpkg": "./dist/index.js",

--- a/plugins/workspace-minimap/test/index.ts
+++ b/plugins/workspace-minimap/test/index.ts
@@ -12,6 +12,9 @@ import * as Blockly from 'blockly';
 import {toolboxCategories, createPlayground} from '@blockly/dev-tools';
 import {Minimap, PositionedMinimap} from '../src/index';
 
+let minimap = null;
+let workspace = null;
+
 /**
  * Create a workspace.
  * @param blocklyDiv The blockly container div.
@@ -21,8 +24,11 @@ import {Minimap, PositionedMinimap} from '../src/index';
 function createWorkspace(blocklyDiv: HTMLElement,
     options: Blockly.BlocklyOptions): Blockly.WorkspaceSvg {
   // Creates the primary workspace and adds the minimap.
-  const workspace = Blockly.inject(blocklyDiv, options);
-  const minimap = new PositionedMinimap(workspace);
+  if (minimap) {
+    minimap.dispose();
+  }
+  workspace = Blockly.inject(blocklyDiv, options);
+  minimap = new PositionedMinimap(workspace);
   minimap.init();
 
   return workspace;


### PR DESCRIPTION
**Description**
If you used the playground to change the workspace, it would create duplicate minimaps. To fix this I assigned the minimap to a module-local variable, and dispose of it if it already exists.

In this PR I also removed the private label from the package file.

**Tests**
To test that no minimaps were being duplicated I repeatedly altered the workspace attributes, and changed the window size.