### PR TITLE
fix: serialization of dynamic if blocks

### DIFF
--- a/plugins/block-dynamic-connection/src/dynamic_if.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_if.ts
@@ -64,7 +64,12 @@ const DYNAMIC_IF_MIXIN = {
    * @returns XML storage element.
    */
   mutationToDom(this: DynamicIfBlock): Element|null {
+    // If we call finalizeConnections here without disabling events, we get into
+    // an event loop.
+    Blockly.Events.disable();
     this.finalizeConnections();
+    Blockly.Events.enable();
+
     if (!this.elseifCount && !this.elseCount) return null;
 
     const container = Blockly.utils.xml.createElement('mutation');

--- a/plugins/block-dynamic-connection/src/dynamic_if.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_if.ts
@@ -64,6 +64,7 @@ const DYNAMIC_IF_MIXIN = {
    * @returns XML storage element.
    */
   mutationToDom(this: DynamicIfBlock): Element|null {
+    this.finalizeConnections();
     if (!this.elseifCount && !this.elseCount) return null;
 
     const container = Blockly.utils.xml.createElement('mutation');
@@ -122,7 +123,6 @@ const DYNAMIC_IF_MIXIN = {
       this.appendStatementInput('ELSE')
           .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSE'], 'else');
     }
-    this.finalizeConnections();
   },
 
   /**
@@ -231,7 +231,7 @@ const DYNAMIC_IF_MIXIN = {
     this.addCaseInputs(targetCaseConns);
     if (targetElseConn) this.addElseInput(targetElseConn);
 
-    this.elseifCount = targetCaseConns.length;
+    this.elseifCount = Math.max(targetCaseConns.length - 1, 0);
     this.elseCount = targetElseConn ? 1 : 0;
   },
 

--- a/plugins/block-dynamic-connection/src/dynamic_if.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_if.ts
@@ -31,15 +31,13 @@ interface CaseInputPair {
 
 /* eslint-disable @typescript-eslint/naming-convention */
 const DYNAMIC_IF_MIXIN = {
-  /* eslint-enable @typescript-eslint/naming-convention */
-  /** Counter for the next input to add to this block. */
-  inputCounter: 1,
-
   /** Minimum number of inputs for this block. */
   minInputs: 1,
 
+  /** Count of else-if cases. */
   elseifCount: 0,
 
+  /** Count of else cases (either 0 or 1). */
   elseCount: 0,
 
   /**
@@ -124,8 +122,6 @@ const DYNAMIC_IF_MIXIN = {
       this.appendStatementInput('ELSE')
           .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSE'], 'else');
     }
-    const next = parseInt(xmlElement.getAttribute('next') ?? '0', 10) || 0;
-    this.inputCounter = next;
     this.finalizeConnections();
   },
 
@@ -147,7 +143,6 @@ const DYNAMIC_IF_MIXIN = {
       this.appendStatementInput('ELSE').appendField(
           Blockly.Msg['CONTROLS_IF_MSG_ELSE']);
     }
-    this.inputCounter = this.elseifCount + 1;
   },
 
   /**
@@ -170,20 +165,20 @@ const DYNAMIC_IF_MIXIN = {
   /**
    * Inserts a boolean value input and statement input at the specified index.
    * @param index Index of the input before which to add new inputs.
-   * @param caseNumber The clause/case name to apply to the new inputs.
+   * @param id An ID to append to the case statement input names to make them
+   *     unique.
    * @returns The added inputs.
    */
   insertElseIf(
-      this: DynamicIfBlock, index: number, caseNumber: number
+      this: DynamicIfBlock, index: number, id: string | number
   ): CaseInputPair {
-    const ifInput = this.appendValueInput('IF' + caseNumber)
+    const ifInput = this.appendValueInput('IF' + id)
         .setCheck('Boolean')
         .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSEIF'], 'elseif');
-    const doInput = this.appendStatementInput('DO' + caseNumber)
+    const doInput = this.appendStatementInput('DO' + id)
         .appendField(Blockly.Msg['CONTROLS_IF_MSG_THEN']);
-    this.moveInputBefore('IF' + caseNumber, this.inputList[index].name);
-    this.moveInputBefore('DO' + caseNumber, this.inputList[index + 1].name);
-    this.inputCounter++;
+    this.moveInputBefore('IF' + id, this.inputList[index].name);
+    this.moveInputBefore('DO' + id, this.inputList[index + 1].name);
     return {ifInput, doInput};
   },
 
@@ -207,7 +202,7 @@ const DYNAMIC_IF_MIXIN = {
     if (connection.targetConnection && input.name.includes('IF')) {
       const nextIfInput = this.inputList[inputIndex + 2];
       if (!nextIfInput || nextIfInput.name == 'ELSE') {
-        this.insertElseIf(inputIndex + 2, this.inputCounter);
+        this.insertElseIf(inputIndex + 2, Blockly.utils.idGenerator.genUid());
       } else {
         const nextIfConnection =
             nextIfInput &&
@@ -217,7 +212,7 @@ const DYNAMIC_IF_MIXIN = {
           nextIfConnection &&
           !nextIfConnection.getSourceBlock().isInsertionMarker()
         ) {
-          this.insertElseIf(inputIndex + 2, this.inputCounter);
+          this.insertElseIf(inputIndex + 2, Blockly.utils.idGenerator.genUid());
         }
       }
     }

--- a/plugins/block-dynamic-connection/test/dynamic_if.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_if.mocha.js
@@ -15,15 +15,15 @@ suite('If block', function() {
   /**
    * Asserts that the if block has the expected inputs.
    * @param {!Blockly.Block} block The block to check.
-   * @param {!Array<string>} expectedInputs The expected inputs.
-   * @type {string=} The block type expected. Defaults to 'dynamic_if'.
+   * @param {!Array<RegExp>} expectedInputs The expected inputs.
+   * @param type {string=} The block type expected. Defaults to 'dynamic_if'.
    */
   function assertBlockStructure(block, expectedInputs, type = 'dynamic_if') {
     assert.equal(block.type, type);
     assert.equal(block.inputList.length, expectedInputs.length);
     assert.isTrue(expectedInputs.length >= 2);
     for (let i = 0; i < expectedInputs.length; i++) {
-      assert.equal(block.inputList[i].name, expectedInputs[i]);
+      assert.match(block.inputList[i].name, expectedInputs[i]);
     }
   }
 
@@ -62,79 +62,139 @@ suite('If block', function() {
 
   test('Creation', function() {
     const block = this.workspace.newBlock('dynamic_if');
-    assertBlockStructure(block, ['IF0', 'DO0']);
+    assertBlockStructure(block, [/IF0/, /DO0/]);
   });
 
-  suite('onPendingConnection', function() {
-    test('pending connection with empty connection', function() {
+  suite('adding inputs', function() {
+    test('attaching the first predicate does not create a case', function() {
       const block = this.workspace.newBlock('dynamic_if');
-      const connection = block.inputList[0].connection;
+      const connection = block.getInput('IF0').connection;
+
       block.onPendingConnection(connection);
-      assertBlockStructure(block, ['IF0', 'DO0']);
+
+      assertBlockStructure(block, [/IF0/, /DO0/]);
     });
 
-    test('pending connection with empty next connection', function() {
+    test('attaching the second predicate creates a case', function() {
       const block = this.workspace.newBlock('dynamic_if');
-      const connection = block.inputList[0].connection;
-      connectBooleanBlockToConnection(
-          this.workspace, block.inputList[0].connection);
-      block.onPendingConnection(connection);
-      assertBlockStructure(block, ['IF0', 'DO0', 'IF1', 'DO1']);
-      connectStatementBlockToConnection(
-          this.workspace, block.inputList[3].connection);
-      block.finalizeConnections();
+      const connection = block.getInput('IF0').connection;
+      connectBooleanBlockToConnection(this.workspace, connection);
 
       block.onPendingConnection(connection);
-      assertBlockStructure(block, ['IF0', 'DO0', 'IF1', 'DO1']);
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /IF.*/, /DO.*/]);
     });
 
-    test('pending connection adds connection', function() {
+    test('attaching the first statement creates an else', function() {
       const block = this.workspace.newBlock('dynamic_if');
-      connectBooleanBlockToConnection(
-          this.workspace, block.inputList[0].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['IF0', 'DO0', 'IF1', 'DO1']);
+      const connection = block.getInput('DO0').connection;
+
+      block.onPendingConnection(connection);
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /ELSE/]);
+    });
+
+    test('attaching the second statement creates an else', function() {
+      const block = this.workspace.newBlock('dynamic_if');
+      const connection = block.getInput('DO0').connection;
+      connectStatementBlockToConnection(this.workspace, connection);
+
+      block.onPendingConnection(connection);
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /ELSE/]);
+    });
+
+    test('attaching to the next connection creates an else', function() {
+      const block = this.workspace.newBlock('dynamic_if');
+      const connection = block.nextConnection;
+
+      block.onPendingConnection(connection);
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /ELSE/]);
     });
   });
 
-  suite('finalizeConnections', function() {
-    test('does not go below 2 connections', function() {
+  suite('finalizing inputs', function() {
+    test('the block does not go below one case', function() {
       const block = this.workspace.newBlock('dynamic_if');
-      assertBlockStructure(block, ['IF0', 'DO0']);
+
       block.finalizeConnections();
-      assertBlockStructure(block, ['IF0', 'DO0']);
+
+      assertBlockStructure(block, [/IF0/, /DO0/]);
     });
 
-    test('removes empty connections', function() {
+    test('a case with no blocks is removed', function() {
       const block = this.workspace.newBlock('dynamic_if');
-      connectBooleanBlockToConnection(
-          this.workspace, block.inputList[0].connection);
-      connectStatementBlockToConnection(
-          this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['IF0', 'DO0', 'IF1', 'DO1']);
+      const connection = block.getInput('IF0').connection;
+      connectBooleanBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
+
       block.finalizeConnections();
-      assertBlockStructure(block, ['IF0', 'DO0']);
+
+      assertBlockStructure(block, [/IF0/, /DO0/]);
     });
 
-    test('updates the field if the first connection is removed', function() {
+    test('a case with a predicate and statements is kept', function() {
       const block = this.workspace.newBlock('dynamic_if');
-      connectBooleanBlockToConnection(
-          this.workspace, block.inputList[0].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['IF0', 'DO0', 'IF1', 'DO1']);
-      // Add Else If
+      const connection = block.getInput('IF0').connection;
+      connectBooleanBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
       connectBooleanBlockToConnection(
           this.workspace, block.inputList[2].connection);
-      block.finalizeConnections();
-      assertBlockStructure(block, ['IF0', 'DO0', 'IF1', 'DO1']);
+      connectStatementBlockToConnection(
+          this.workspace, block.inputList[3].connection);
 
-      // Remove If
-      block.inputList[0].connection.disconnect();
       block.finalizeConnections();
-      assertBlockStructure(block, ['IF1', 'DO1']);
-      assert.equal(block.inputList[0].fieldRow[0].value_,
-          Blockly.Msg.CONTROLS_IF_MSG_IF);
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /IF1/, /DO1/]);
+    });
+
+    test('a case with only a predicate is kept', function() {
+      const block = this.workspace.newBlock('dynamic_if');
+      const connection = block.getInput('IF0').connection;
+      connectBooleanBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
+      connectBooleanBlockToConnection(
+          this.workspace, block.inputList[2].connection);
+
+      block.finalizeConnections();
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /IF1/, /DO1/]);
+    });
+
+    test('a case with only statements is kept', function() {
+      const block = this.workspace.newBlock('dynamic_if');
+      const connection = block.getInput('IF0').connection;
+      connectBooleanBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
+      connectStatementBlockToConnection(
+          this.workspace, block.inputList[3].connection);
+
+      block.finalizeConnections();
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /IF1/, /DO1/]);
+    });
+
+    test('an else with no statements is removed', function() {
+      const block = this.workspace.newBlock('dynamic_if');
+      const connection = block.getInput('DO0').connection;
+      block.onPendingConnection(connection);
+
+      block.finalizeConnections();
+
+      assertBlockStructure(block, [/IF0/, /DO0/]);
+    });
+
+    test('an else with statements is kept', function() {
+      const block = this.workspace.newBlock('dynamic_if');
+      const connection = block.getInput('DO0').connection;
+      block.onPendingConnection(connection);
+      connectStatementBlockToConnection(
+          this.workspace, block.getInput('ELSE').connection);
+
+      block.finalizeConnections();
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /ELSE/]);
     });
   });
 
@@ -143,15 +203,15 @@ suite('If block', function() {
       title: 'empty XML',
       xml: '<block type="dynamic_if"/>',
       expectedXml:
-          '<block xmlns="https://developers.google.com/blockly/xml" ' +
-          'type="dynamic_if" id="1">\n' +
-          '  <mutation inputs="0" else="false" next="1"></mutation>\n</block>',
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_if" id="1">' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['IF0', 'DO0']);
+        assertBlockStructure(block, [/IF0/, /DO0/]);
       },
     },
     {
-      title: 'one if one else',
+      title: 'one if one else - old serialization',
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_if" id="1">\n' +
@@ -171,12 +231,31 @@ suite('If block', function() {
           '    </block>\n' +
           '  </statement>\n' +
           '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_if" id="1">\n' +
+          '  <mutation else="1"></mutation>\n' +
+          '  <value name="IF0">\n' +
+          '    <block type="logic_boolean" id="2">\n' +
+          '      <field name="BOOL">TRUE</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '  <statement name="ELSE">\n' +
+          '    <block type="text_print" id="3">\n' +
+          '      <value name="TEXT">\n' +
+          '        <shadow type="text" id="4">\n' +
+          '          <field name="TEXT">abc</field>\n' +
+          '        </shadow>\n' +
+          '      </value>\n' +
+          '    </block>\n' +
+          '  </statement>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['IF0', 'DO0', 'ELSE']);
+        assertBlockStructure(block, [/IF0/, /DO0/, /ELSE/]);
       },
     },
     {
-      title: 'multiple inputs with children',
+      title: 'multiple inputs with children - old serialization',
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_if" id="1">\n' +
@@ -203,7 +282,49 @@ suite('If block', function() {
           '  <statement name="DO2">\n' +
           '    <block type="text_print" id="6">\n' +
           '      <value name="TEXT">\n' +
-          '        <shadow type="text" id="^7">\n' +
+          '        <shadow type="text" id="7">\n' +
+          '          <field name="TEXT">abc</field>\n' +
+          '        </shadow>\n' +
+          '      </value>\n' +
+          '    </block>\n' +
+          '  </statement>\n' +
+          '  <statement name="ELSE">\n' +
+          '    <block type="text_print" id="8">\n' +
+          '      <value name="TEXT">\n' +
+          '        <shadow type="text" id="9">\n' +
+          '          <field name="TEXT">abc</field>\n' +
+          '        </shadow>\n' +
+          '      </value>\n' +
+          '    </block>\n' +
+          '  </statement>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_if" id="1">\n' +
+          '  <mutation elseif="2" else="1"></mutation>\n' +
+          '  <value name="IF0">\n' +
+          '    <block type="logic_boolean" id="2">\n' +
+          '      <field name="BOOL">TRUE</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '  <statement name="DO0">\n' +
+          '    <block type="text_print" id="3">\n' +
+          '      <value name="TEXT">\n' +
+          '        <shadow type="text" id="4">\n' +
+          '          <field name="TEXT">abc</field>\n' +
+          '        </shadow>\n' +
+          '      </value>\n' +
+          '    </block>\n' +
+          '  </statement>\n' +
+          '  <value name="IF1">\n' +
+          '    <block type="logic_boolean" id="5">\n' +
+          '      <field name="BOOL">TRUE</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '  <statement name="DO2">\n' +
+          '    <block type="text_print" id="6">\n' +
+          '      <value name="TEXT">\n' +
+          '        <shadow type="text" id="7">\n' +
           '          <field name="TEXT">abc</field>\n' +
           '        </shadow>\n' +
           '      </value>\n' +
@@ -221,22 +342,147 @@ suite('If block', function() {
           '</block>',
       assertBlockStructure: (block) => {
         assertBlockStructure(
-            block, ['IF0', 'DO0', 'IF1', 'DO1', 'IF2', 'DO2', 'ELSE']);
+            block, [/IF0/, /DO0/, /IF1/, /DO1/, /IF2/, /DO2/, /ELSE/]);
       },
     },
     {
-      title: 'standard/core XML is deserialized correctly',
+      title: 'multiple nonsequential inputs - old serialization',
       xml:
-        '<block type="controls_if" id="1" x="38" y="63">' +
-        '  <mutation elseif="1" else= "1" ></mutation>' +
-        '</block>',
+        '<block type="dynamic_if" id="1">\n' +
+        '  <mutation inputs="1,3,2" else="false" next="4"></mutation>\n' +
+        '  <value name="IF1">\n' +
+        '    <block type="logic_boolean" id="1">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="DO1">\n' +
+        '    <block type="text_print" id="3">\n' +
+        '      <value name="TEXT">\n' +
+        '        <shadow type="text" id="4">\n' +
+        '          <field name="TEXT">abc</field>\n' +
+        '        </shadow>\n' +
+        '      </value>\n' +
+        '    </block>\n' +
+        '  </statement>\n' +
+        '  <value name="IF3">\n' +
+        '    <block type="logic_boolean" id="5">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="DO3">\n' +
+        '    <block type="text_print" id="6">\n' +
+        '      <value name="TEXT">\n' +
+        '        <shadow type="text" id="7">\n' +
+        '          <field name="TEXT">abc</field>\n' +
+        '        </shadow>\n' +
+        '      </value>\n' +
+        '    </block>\n' +
+        '  </statement>\n' +
+        '  <value name="IF2">\n' +
+        '    <block type="logic_boolean" id="8">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="DO2">\n' +
+        '    <block type="text_print" id="9">\n' +
+        '      <value name="TEXT">\n' +
+        '        <shadow type="text" id="10">\n' +
+        '          <field name="TEXT">abc</field>\n' +
+        '        </shadow>\n' +
+        '      </value>\n' +
+        '    </block>\n' +
+        '  </statement>\n' +
+        '</block>\n',
       expectedXml:
-          '<block xmlns="https://developers.google.com/blockly/xml" ' +
-          'type="controls_if" id="1">\n' +
-          '  <mutation inputs="0,1" else="true" next="2"></mutation>\n</block>',
+        '<block xmlns="https://developers.google.com/blockly/xml" ' +
+        'type="dynamic_if" id="1">\n' +
+        '  <mutation elseif="2"></mutation>\n' +
+        '  <value name="IF0">\n' +
+        '    <block type="logic_boolean" id="1">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="DO0">\n' +
+        '    <block type="text_print" id="3">\n' +
+        '      <value name="TEXT">\n' +
+        '        <shadow type="text" id="4">\n' +
+        '          <field name="TEXT">abc</field>\n' +
+        '        </shadow>\n' +
+        '      </value>\n' +
+        '    </block>\n' +
+        '  </statement>\n' +
+        '  <value name="IF1">\n' +
+        '    <block type="logic_boolean" id="5">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="DO1">\n' +
+        '    <block type="text_print" id="6">\n' +
+        '      <value name="TEXT">\n' +
+        '        <shadow type="text" id="7">\n' +
+        '          <field name="TEXT">abc</field>\n' +
+        '        </shadow>\n' +
+        '      </value>\n' +
+        '    </block>\n' +
+        '  </statement>\n' +
+        '  <value name="IF2">\n' +
+        '    <block type="logic_boolean" id="8">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="DO2">\n' +
+        '    <block type="text_print" id="9">\n' +
+        '      <value name="TEXT">\n' +
+        '        <shadow type="text" id="10">\n' +
+        '          <field name="TEXT">abc</field>\n' +
+        '        </shadow>\n' +
+        '      </value>\n' +
+        '    </block>\n' +
+        '  </statement>\n' +
+        '</block>',
       assertBlockStructure: (block) => {
         assertBlockStructure(
-            block, ['IF0', 'DO0', 'IF1', 'DO1', 'ELSE'], 'controls_if');
+            block, [/IF0/, /DO0/, /IF1/, /DO1/, /IF2/, /DO2/]);
+      },
+    },
+    {
+      title: 'one if one else - standard serialization',
+      xml:
+        '<block xmlns="https://developers.google.com/blockly/xml"' +
+        ' type="dynamic_if" id="1">\n' +
+        '  <mutation elseif="1" else="1"></mutation>\n' +
+        '</block>',
+      expectedXml:
+        '<block xmlns="https://developers.google.com/blockly/xml"' +
+        ' type="dynamic_if" id="1"></block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(
+            block, [/IF0/, /DO0/], 'dynamic_if');
+      },
+    },
+    {
+      title: 'one if one else with children - standard serialization',
+      xml:
+        '<block xmlns="https://developers.google.com/blockly/xml"' +
+        ' type="dynamic_if" id="1">\n' +
+        '  <mutation elseif="1" else="1"></mutation>\n' +
+        '  <value name="IF0">\n' +
+        '    <block type="logic_boolean" id="2">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <value name="IF1">\n' +
+        '    <block type="logic_boolean" id="3">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="ELSE">\n' +
+        '    <block type="text_print" id="4"></block>\n' +
+        '  </statement>\n' +
+        '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(
+            block, [/IF0/, /DO0/, /IF1/, /DO1/, /ELSE/], 'dynamic_if');
       },
     },
   ];


### PR DESCRIPTION
Work on https://github.com/google/blockly-samples/issues/1843

Changes the serialization of the dynamic if blocks to match the serialization in core.

This means that we have to tear down the inputs every time and re-add them so that they have the correct indexing (strictly increasing from 0).

This just fixes the if blocks, I'll upgrade the other blocks in future PRs, which is why this is against a feature branch and not against the main branch directly.