### PR TITLE
fix: serialization of dynamic list blocks

### DIFF
--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -22,12 +22,10 @@ type DynamicListCreateMixinType = typeof DYNAMIC_LIST_CREATE_MIXIN;
 /* eslint-disable @typescript-eslint/naming-convention */
 const DYNAMIC_LIST_CREATE_MIXIN = {
   /* eslint-enable @typescript-eslint/naming-convention */
-  /** Counter for the next input to add to this block. */
-  inputCounter: 3,
-
   /** Minimum number of inputs for this block. */
   minInputs: 2,
 
+  /** Count of item inputs. */
   itemCount: 0,
 
   /** Block for concatenating any number of strings. */
@@ -78,8 +76,6 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
       this.inputList[0]
           .appendField(Blockly.Msg['LISTS_CREATE_WITH_INPUT_WITH']);
     }
-    const next = parseInt(xmlElement.getAttribute('next') ?? '0', 10) || 0;
-    this.inputCounter = next;
   },
 
   /**
@@ -93,7 +89,6 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
     for (let i = this.minInputs; i < this.itemCount; i++) {
       this.appendValueInput('ADD' + i);
     }
-    this.inputCounter = this.itemCount + 1;
   },
 
   /**
@@ -146,7 +141,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
     if (insertIndex == null) {
       return;
     }
-    this.appendValueInput('ADD' + (this.inputCounter++));
+    this.appendValueInput(`ADD${Blockly.utils.idGenerator.genUid()}`);
     this.moveNumberedInputBefore(this.inputList.length - 1, insertIndex);
   },
 

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -46,6 +46,12 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    * @returns XML storage element.
    */
   mutationToDom(this: DynamicListCreateBlock): Element {
+    // If we call finalizeConnections here without disabling events, we get into
+    // an event loop.
+    Blockly.Events.disable();
+    this.finalizeConnections();
+    Blockly.Events.enable();
+
     const container = Blockly.utils.xml.createElement('mutation');
     container.setAttribute('items', `${this.itemCount}`);
     return container;

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -35,7 +35,9 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
     this.setHelpUrl(Blockly.Msg['LISTS_CREATE_WITH_HELPURL']);
     this.setStyle('list_blocks');
     this.addFirstInput();
-    for (let i = 1; i < this.minInputs; i++) this.appendValueInput(`ADD${i}`);
+    for (let i = 1; i < this.minInputs; i++) {
+      this.appendValueInput(`ADD${i}`);
+    }
     this.setOutput(true, 'Array');
     this.setTooltip(Blockly.Msg['LISTS_CREATE_WITH_TOOLTIP']);
   },

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -34,8 +34,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
 
     this.setHelpUrl(Blockly.Msg['LISTS_CREATE_WITH_HELPURL']);
     this.setStyle('list_blocks');
-    this.appendValueInput('ADD0')
-        .appendField(Blockly.Msg['LISTS_CREATE_WITH_INPUT_WITH']);
+    this.addFirstInput();
     for (let i = 1; i < this.minInputs; i++) this.appendValueInput(`ADD${i}`);
     this.setOutput(true, 'Array');
     this.setTooltip(Blockly.Msg['LISTS_CREATE_WITH_TOOLTIP']);
@@ -159,16 +158,16 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
     const targetConns =
         this.removeUnnecessaryEmptyConns(
             this.inputList.map((i) => i.connection?.targetConnection));
-    this.deleteDynamicInputs();
+    this.tearDownBlock();
     this.addItemInputs(targetConns);
     this.itemCount = targetConns.length;
   },
 
   /**
-   * Deletes all inputs except for the first one, which is static.
+   * Deletes all inputs on the block so it can be rebuilt.
    */
-  deleteDynamicInputs(this: DynamicListCreateBlock): void {
-    for (let i = this.inputList.length - 1; i >= 1; i--) {
+  tearDownBlock(this: DynamicListCreateBlock): void {
+    for (let i = this.inputList.length - 1; i >= 0; i--) {
       this.removeInput(this.inputList[i].name);
     }
   },
@@ -204,13 +203,25 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
       this: DynamicListCreateBlock,
       targetConns: Array<Blockly.Connection | undefined | null>,
   ): void {
-    for (let i = 0; i < targetConns.length; i++) {
-      let input = this.getInput(`ADD${i}`);
-      if (!input) input = this.appendValueInput(`ADD${i}`);
+    const input = this.addFirstInput();
+    const firstConn = targetConns[0];
+    if (firstConn) input.connection?.connect(firstConn);
+
+    for (let i = 1; i < targetConns.length; i++) {
+      const input = this.appendValueInput(`ADD${i}`);
 
       const targetConn = targetConns[i];
       if (targetConn) input.connection?.connect(targetConn);
     }
+  },
+
+  /**
+   * Adds the top input with the label to this block.
+   * @returns The added input.
+   */
+  addFirstInput(this: DynamicListCreateBlock): Blockly.Input {
+    return this.appendValueInput('ADD0')
+        .appendField(Blockly.Msg['LISTS_CREATE_WITH_INPUT_WITH']);
   },
 };
 

--- a/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
@@ -23,7 +23,6 @@ suite.only('List create block', function() {
   ) {
     assert.equal(block.type, type);
     assert.equal(block.inputList.length, expectedInputs.length);
-    assert.isTrue(expectedInputs.length >= 2);
     for (let i = 0; i < expectedInputs.length; i++) {
       assert.match(block.inputList[i].name, expectedInputs[i]);
     }
@@ -44,71 +43,111 @@ suite.only('List create block', function() {
   setup(function() {
     this.workspace = new Blockly.Workspace();
     overrideOldBlockDefinitions();
+
+    const def1 = {...Blockly.Blocks['dynamic_list_create']};
+    def1.minInputs = 1;
+    Blockly.Blocks['dynamic_list_1_input'] = def1;
+
+    const def5 = {...Blockly.Blocks['dynamic_list_create']};
+    def5.minInputs = 5;
+    Blockly.Blocks['dynamic_list_5_inputs'] = def5;
   });
 
   teardown(function() {
     this.workspace.dispose();
+    delete Blockly.Blocks['dynamic_list_5_inputs'];
   });
 
-  test('Creation', function() {
-    const block = this.workspace.newBlock('dynamic_list_create');
-    assertBlockStructure(block, [/ADD0/, /ADD1/]);
-  });
-
-  suite('onPendingConnection', function() {
-    test('pending connection with empty connection', function() {
+  suite('Creation', function() {
+    test('the default definition has two inputs', function() {
       const block = this.workspace.newBlock('dynamic_list_create');
-      const connection = block.inputList[0].connection;
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
+    });
+
+    test('minInputs controls the number of inputs', function() {
+      const block = this.workspace.newBlock('dynamic_list_5_inputs');
+      assertBlockStructure(
+          block,
+          [/ADD0/, /ADD1/, /ADD2/, /ADD3/, /ADD4/],
+          'dynamic_list_5_inputs');
+    });
+  });
+
+  suite('adding inputs', function() {
+    test('attaching min items does not add an input', function() {
+      const block = this.workspace.newBlock('dynamic_list_1_input');
+      const connection = block.getInput('ADD0').connection;
+
       block.onPendingConnection(connection);
-      assertBlockStructure(block, [/ADD0/, /ADD1/]);
+
+      assertBlockStructure(block, [/ADD0/], 'dynamic_list_1_input');
     });
 
-    test('pending connection with empty next connection', function() {
-      const block = this.workspace.newBlock('dynamic_list_create');
-      const connection = block.inputList[0].connection;
-      connectBlockToConnection(this.workspace, block.inputList[0].connection);
+    test('attaching three items creates an input', function() {
+      const block = this.workspace.newBlock('dynamic_list_1_input');
+      const connection = block.getInput('ADD0').connection;
+      connectBlockToConnection(this.workspace, connection);
+
       block.onPendingConnection(connection);
-      assertBlockStructure(block, [/ADD0/, /ADD1/]);
-    });
 
-    test('pending connection adds connection', function() {
-      const block = this.workspace.newBlock('dynamic_list_create');
-      connectBlockToConnection(this.workspace, block.inputList[0].connection);
-      connectBlockToConnection(this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, [/ADD0/, /ADD2/, /ADD1/]);
-      block.onPendingConnection(block.inputList[2].connection);
-      assertBlockStructure(block, [/ADD0/, /ADD2/, /ADD1/, /ADD3/]);
+      assertBlockStructure(block, [/ADD0/, /ADD.*/], 'dynamic_list_1_input');
     });
   });
 
-  suite('finalizeConnections', function() {
-    test('does not go below 2 connections', function() {
-      const block = this.workspace.newBlock('dynamic_list_create');
-      assertBlockStructure(block, [/ADD0/, /ADD1/]);
+  suite('finalizing inputs', function() {
+    test('the block does not go below min inputs', function() {
+      const block = this.workspace.newBlock('dynamic_list_5_inputs');
+
       block.finalizeConnections();
-      assertBlockStructure(block, [/ADD0/, /ADD1/]);
+
+      assertBlockStructure(
+          block,
+          [/ADD0/, /ADD1/, /ADD2/, /ADD3/, /ADD4/],
+          'dynamic_list_5_inputs');
     });
 
-    test('removes empty connections', function() {
-      const block = this.workspace.newBlock('dynamic_list_create');
-      connectBlockToConnection(this.workspace, block.inputList[0].connection);
-      connectBlockToConnection(this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, [/ADD0/, /ADD2/, /ADD1/]);
+    test('an extra input with no blocks is removed', function() {
+      const block = this.workspace.newBlock('dynamic_list_1_input');
+      const connection = block.getInput('ADD0').connection;
+      connectBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
+
       block.finalizeConnections();
-      assertBlockStructure(block, [/ADD0/, /ADD1/]);
+
+      assertBlockStructure(block, [/ADD0/], 'dynamic_list_1_input');
     });
 
-    test('updates the field if the first connection is removed', function() {
-      const block = this.workspace.newBlock('dynamic_list_create');
+    test('an extra input with blocks is kept', function() {
+      const block = this.workspace.newBlock('dynamic_list_1_input');
+      const connection = block.getInput('ADD0').connection;
+      connectBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
       connectBlockToConnection(this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[1].connection);
-      connectBlockToConnection(this.workspace, block.inputList[2].connection);
+
       block.finalizeConnections();
-      assertBlockStructure(block, [/ADD1/, /ADD2/]);
-      assert.equal(block.inputList[0].fieldRow[0].value_,
-          Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH);
+
+      assertBlockStructure(block, [/ADD0/, /ADD1/], 'dynamic_list_1_input');
+    });
+
+    test('extra inputs are removed starting at the end', function() {
+      const block = this.workspace.newBlock('dynamic_list_5_inputs');
+      const connection0 = block.getInput('ADD0').connection;
+      const connection1 = block.getInput('ADD1').connection;
+      connectBlockToConnection(this.workspace, connection0);
+      connectBlockToConnection(this.workspace, connection1);
+      block.onPendingConnection(connection0);
+
+      block.finalizeConnections();
+
+      assertBlockStructure(
+          block,
+          [/ADD0/, /ADD1/, /ADD2/, /ADD3/, /ADD4/],
+          'dynamic_list_5_inputs');
+      assert.isOk(block.getInputTargetBlock('ADD0'));
+      assert.isNotOk(
+          block.getInputTargetBlock('ADD1'),
+          'Expected the empty input created by pending to still exist.');
+      assert.isOk(block.getInputTargetBlock('ADD2'));
     });
   });
 
@@ -119,13 +158,29 @@ suite.only('List create block', function() {
       expectedXml:
           '<block xmlns="https://developers.google.com/blockly/xml" ' +
           'type="dynamic_list_create" id="1">\n' +
-          '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n</block>',
+          '  <mutation items="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
         assertBlockStructure(block, [/ADD0/, /ADD1/]);
       },
     },
     {
-      title: 'two inputs with one child',
+      title: 'default state - old serialization',
+      xml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation items="2"></mutation>\n' +
+          '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
+      },
+    },
+    {
+      title: 'two inputs with one child - old serialization',
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_list_create" id="1">\n' +
@@ -133,13 +188,76 @@ suite.only('List create block', function() {
           '  <value name="ADD1">\n' +
           '    <block type="text" id="2">\n' +
           '      <field name="TEXT">abc</field>\n' +
-          '    </block>\n  </value>\n</block>',
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation items="2"></mutation>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">abc</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
         assertBlockStructure(block, [/ADD0/, /ADD1/]);
       },
     },
     {
-      title: 'multiple inputs with children',
+      title: 'multiple inputs with children - old serialization',
+      xml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation inputs="ADD0,ADD1,ADD2,ADD3" next="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation items="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
+      },
+    },
+    {
+      title: 'multiple non-sequential inputs with children - old serialization',
+      skip: true,
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_list_create" id="1">\n' +
@@ -159,24 +277,77 @@ suite.only('List create block', function() {
           '  <value name="ADD4">\n' +
           '    <block type="text" id="5">\n' +
           '      <field name="TEXT">a</field>\n' +
-          '    </block>\n  </value>\n</block>',
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation items="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, [/ADD1/, /ADD5/, /ADD2/, /ADD4/]);
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
       },
     },
     {
-      title: 'standard/core XML is deserialized correctly',
+      title: 'two inputs one child - standard serialization',
       xml:
-        '<block type="lists_create_with" id="1" x="63" y="113">' +
-        '  <mutation items="3"></mutation>' +
-        '</block>',
-      expectedXml:
-          '<block xmlns="https://developers.google.com/blockly/xml" ' +
-          'type="lists_create_with" id="1">\n' +
-          '  <mutation inputs="ADD0,ADD1,ADD2" next="3"></mutation>\n</block>',
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation items="2"></mutation>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">abc</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(
-            block, ['ADD0', 'ADD1', 'ADD2'], 'lists_create_with');
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
+      },
+    },
+    {
+      title: 'multiple inputs with children - standard serialization',
+      xml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation items="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
       },
     },
     {
@@ -188,7 +359,7 @@ suite.only('List create block', function() {
       expectedXml:
           '<block xmlns="https://developers.google.com/blockly/xml" ' +
           'type="lists_create_with" id="1">\n' +
-          '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n</block>',
+          '  <mutation items="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
         assertBlockStructure(block, [/ADD0/, /ADD1/], 'lists_create_with');
       },

--- a/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
@@ -11,11 +11,11 @@ const {overrideOldBlockDefinitions} = require('../src/index');
 
 const assert = chai.assert;
 
-suite('List create block', function() {
+suite.only('List create block', function() {
   /**
    * Asserts that the list create block has the expected inputs.
    * @param {!Blockly.Block} block The block to check.
-   * @param {!Array<string>} expectedInputs The expected inputs.
+   * @param {!Array<RegExp>} expectedInputs The expected inputs.
    * @type {string=} The block type expected. Defaults to 'dynamic_list_create'.
    */
   function assertBlockStructure(
@@ -25,7 +25,7 @@ suite('List create block', function() {
     assert.equal(block.inputList.length, expectedInputs.length);
     assert.isTrue(expectedInputs.length >= 2);
     for (let i = 0; i < expectedInputs.length; i++) {
-      assert.equal(block.inputList[i].name, expectedInputs[i]);
+      assert.match(block.inputList[i].name, expectedInputs[i]);
     }
   }
 
@@ -52,7 +52,7 @@ suite('List create block', function() {
 
   test('Creation', function() {
     const block = this.workspace.newBlock('dynamic_list_create');
-    assertBlockStructure(block, ['ADD0', 'ADD1']);
+    assertBlockStructure(block, [/ADD0/, /ADD1/]);
   });
 
   suite('onPendingConnection', function() {
@@ -60,7 +60,7 @@ suite('List create block', function() {
       const block = this.workspace.newBlock('dynamic_list_create');
       const connection = block.inputList[0].connection;
       block.onPendingConnection(connection);
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
     });
 
     test('pending connection with empty next connection', function() {
@@ -68,7 +68,7 @@ suite('List create block', function() {
       const connection = block.inputList[0].connection;
       connectBlockToConnection(this.workspace, block.inputList[0].connection);
       block.onPendingConnection(connection);
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
     });
 
     test('pending connection adds connection', function() {
@@ -76,18 +76,18 @@ suite('List create block', function() {
       connectBlockToConnection(this.workspace, block.inputList[0].connection);
       connectBlockToConnection(this.workspace, block.inputList[1].connection);
       block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['ADD0', 'ADD2', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD2/, /ADD1/]);
       block.onPendingConnection(block.inputList[2].connection);
-      assertBlockStructure(block, ['ADD0', 'ADD2', 'ADD1', 'ADD3']);
+      assertBlockStructure(block, [/ADD0/, /ADD2/, /ADD1/, /ADD3/]);
     });
   });
 
   suite('finalizeConnections', function() {
     test('does not go below 2 connections', function() {
       const block = this.workspace.newBlock('dynamic_list_create');
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
       block.finalizeConnections();
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
     });
 
     test('removes empty connections', function() {
@@ -95,9 +95,9 @@ suite('List create block', function() {
       connectBlockToConnection(this.workspace, block.inputList[0].connection);
       connectBlockToConnection(this.workspace, block.inputList[1].connection);
       block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['ADD0', 'ADD2', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD2/, /ADD1/]);
       block.finalizeConnections();
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
     });
 
     test('updates the field if the first connection is removed', function() {
@@ -106,7 +106,7 @@ suite('List create block', function() {
       block.onPendingConnection(block.inputList[1].connection);
       connectBlockToConnection(this.workspace, block.inputList[2].connection);
       block.finalizeConnections();
-      assertBlockStructure(block, ['ADD1', 'ADD2']);
+      assertBlockStructure(block, [/ADD1/, /ADD2/]);
       assert.equal(block.inputList[0].fieldRow[0].value_,
           Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH);
     });
@@ -121,7 +121,7 @@ suite('List create block', function() {
           'type="dynamic_list_create" id="1">\n' +
           '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD0', 'ADD1']);
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
       },
     },
     {
@@ -135,7 +135,7 @@ suite('List create block', function() {
           '      <field name="TEXT">abc</field>\n' +
           '    </block>\n  </value>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD0', 'ADD1']);
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
       },
     },
     {
@@ -161,7 +161,7 @@ suite('List create block', function() {
           '      <field name="TEXT">a</field>\n' +
           '    </block>\n  </value>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD1', 'ADD5', 'ADD2', 'ADD4']);
+        assertBlockStructure(block, [/ADD1/, /ADD5/, /ADD2/, /ADD4/]);
       },
     },
     {
@@ -190,7 +190,7 @@ suite('List create block', function() {
           'type="lists_create_with" id="1">\n' +
           '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD0', 'ADD1'], 'lists_create_with');
+        assertBlockStructure(block, [/ADD0/, /ADD1/], 'lists_create_with');
       },
     },
   ];

--- a/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
@@ -11,7 +11,7 @@ const {overrideOldBlockDefinitions} = require('../src/index');
 
 const assert = chai.assert;
 
-suite.only('List create block', function() {
+suite('List create block', function() {
   /**
    * Asserts that the list create block has the expected inputs.
    * @param {!Blockly.Block} block The block to check.
@@ -257,7 +257,6 @@ suite.only('List create block', function() {
     },
     {
       title: 'multiple non-sequential inputs with children - old serialization',
-      skip: true,
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_list_create" id="1">\n' +

--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -513,14 +513,11 @@ function registerEditorCommands(editor, playground) {
   const loadXml = () => {
     const xml = editor.getModel().getValue();
     const workspace = playground.getWorkspace();
-    Blockly.Events.disable();
     try {
       Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(xml), workspace);
     } catch (e) {
       // If this fails that's fine.
       return false;
-    } finally {
-      Blockly.Events.enable();
     }
     return true;
   };

--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -513,11 +513,14 @@ function registerEditorCommands(editor, playground) {
   const loadXml = () => {
     const xml = editor.getModel().getValue();
     const workspace = playground.getWorkspace();
+    Blockly.Events.disable();
     try {
       Blockly.Xml.domToWorkspace(Blockly.utils.xml.textToDom(xml), workspace);
     } catch (e) {
       // If this fails that's fine.
       return false;
+    } finally {
+      Blockly.Events.enable();
     }
     return true;
   };


### PR DESCRIPTION
Work on https://github.com/google/blockly-samples/issues/1843

Changes the serialization of the dynamic list blocks to match the serialization in core. Also makes it so the `minInputs` actually controls the minimum number of inputs.

This means that we have to tear down the inputs every time and re-add them so that they have the correct indexing (strictly increasing from 0).

This just fixes the list blocks, I'll upgrade the text blocks in another PR, which is why this is against a feature branch and not against the main branch directly.

Changes I implemented here that need to be backported to if-blocks (which I will do in my next PR):
- Making `minInputs` control the minimum number of inputs (or cases for if-blocks).
- Tearing down the entire block instead of leaving the top one.