### PR TITLE
fix: dynamic if teardown

### DIFF
--- a/plugins/block-dynamic-connection/src/dynamic_if.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_if.ts
@@ -31,7 +31,10 @@ interface CaseInputPair {
 
 /* eslint-disable @typescript-eslint/naming-convention */
 const DYNAMIC_IF_MIXIN = {
-  /** Minimum number of inputs for this block. */
+  /**
+   * Minimum number of inputs for this block.
+   * @deprecated This is unused.
+   */
   minInputs: 1,
 
   /** Count of else-if cases. */
@@ -47,13 +50,7 @@ const DYNAMIC_IF_MIXIN = {
   init(this: DynamicIfBlock): void {
     this.setHelpUrl(Blockly.Msg['CONTROLS_IF_HELPURL']);
     this.setStyle('logic_blocks');
-
-    this.appendValueInput('IF0')
-        .setCheck('Boolean')
-        .appendField(Blockly.Msg['CONTROLS_IF_MSG_IF'], 'if');
-    this.appendStatementInput('DO0')
-        .appendField(Blockly.Msg['CONTROLS_IF_MSG_THEN']);
-
+    this.addFirstCase();
     this.setNextStatement(true);
     this.setPreviousStatement(true);
     this.setTooltip(Blockly.Msg['LISTS_CREATE_WITH_TOOLTIP']);
@@ -231,8 +228,9 @@ const DYNAMIC_IF_MIXIN = {
     const targetCaseConns = this.collectTargetCaseConns();
     const targetElseConn = this.getInput('ELSE')?.connection?.targetConnection;
 
-    this.deleteDynamicInputs();
+    this.tearDownBlock();
 
+    this.addFirstCase();
     this.addCaseInputs(targetCaseConns);
     if (targetElseConn) this.addElseInput(targetElseConn);
 
@@ -260,12 +258,9 @@ const DYNAMIC_IF_MIXIN = {
     return targetConns;
   },
 
-  /**
-   * Deletes all of the inputs on this block except for the default "if"
-   * and "do" inputs.
-   */
-  deleteDynamicInputs(this: DynamicIfBlock): void {
-    for (let i = this.inputList.length - 1; i >= 2; i--) {
+  /** Deletes all inputs on the block so it can be rebuilt. */
+  tearDownBlock(this: DynamicIfBlock): void {
+    for (let i = this.inputList.length - 1; i >= 0; i--) {
       this.removeInput(this.inputList[i].name);
     }
   },
@@ -300,6 +295,18 @@ const DYNAMIC_IF_MIXIN = {
     this.appendStatementInput('ELSE')
         .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSE'])
         .connection?.connect(targetElseConn);
+  },
+
+  /**
+   * Adds the first 'IF' and 'DO' inputs and their associated labels to this
+   * block.
+   */
+  addFirstCase(this: DynamicIfBlock): void {
+    this.appendValueInput('IF0')
+        .setCheck('Boolean')
+        .appendField(Blockly.Msg['CONTROLS_IF_MSG_IF'], 'if');
+    this.appendStatementInput('DO0')
+        .appendField(Blockly.Msg['CONTROLS_IF_MSG_THEN']);
   },
 };
 

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -165,9 +165,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
     this.itemCount = targetConns.length;
   },
 
-  /**
-   * Deletes all inputs on the block so it can be rebuilt.
-   */
+  /** Deletes all inputs on the block so it can be rebuilt. */
   tearDownBlock(this: DynamicListCreateBlock): void {
     for (let i = this.inputList.length - 1; i >= 0; i--) {
       this.removeInput(this.inputList[i].name);


### PR DESCRIPTION
Dependent on https://github.com/google/blockly-samples/pull/1885

Work on #1843 

Tears down the entire block instead of leaving the top input. This was causing a bug as outlined below.

Also deprecated `minInputs` since it's not being used, and implementing it like I did for the list blocks seems like more hastle than it's worth.

## The Bug

Sometimes your if an else-ifs would be out of order, or you would get two else-ifs instead of one if and one else-if. This only happened when loading from the old serialization format.

### To Reproduce

1) Open up the dynamic connections plugin on the block-dynamic-serialization branch.
2) Load the following XML into the demo:
```xml
<xml xmlns="https://developers.google.com/blockly/xml">
  <block type="controls_if" id="sakn]=Bg/(7J)B4fgb%_" x="249" y="279">
    <mutation inputs="1,2" else="false" next="3"></mutation>
    <value name="IF1">
      <block type="logic_boolean" id="B5(rV1:^?a_:eoCGcNCN">
        <field name="BOOL">TRUE</field>
      </block>
    </value>
    <value name="IF2">
      <block type="logic_boolean" id="a`lufX}(^;Q)EbJYSdc@">
        <field name="BOOL">FALSE</field>
      </block>
    </value>
  </block>
</xml>
```
3) Drag the block.
4) Observe.
![image](https://github.com/google/blockly-samples/assets/25440652/f006820c-204d-41c7-a9e2-9e2516bc71ca)

### Testing

Retested the reproduction steps and this no longer reproduces.