### PR TITLE
fix: dynamic text serialization

### DIFF
--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -45,6 +45,12 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * @returns XML storage element.
    */
   mutationToDom(this: DynamicTextJoinBlock): Element {
+    // If we call finalizeConnections here without disabling events, we get into
+    // an event loop.
+    Blockly.Events.disable();
+    this.finalizeConnections();
+    Blockly.Events.enable();
+
     const container = Blockly.utils.xml.createElement('mutation');
     container.setAttribute('items', `${this.itemCount}`);
     return container;

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -28,8 +28,13 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
   /** Minimum number of inputs for this block. */
   minInputs: 2,
 
+  /** Count of the item inputs. */
+  itemCount: 0,
+
   /** Block for concatenating any number of strings. */
   init(this: DynamicTextJoinBlock): void {
+    this.itemCount = this.minInputs;
+
     this.setHelpUrl(Blockly.Msg['TEXT_JOIN_HELPURL']);
     this.setStyle('text_blocks');
     this.addFirstInput();
@@ -44,10 +49,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    */
   mutationToDom(this: DynamicTextJoinBlock): Element {
     const container = Blockly.utils.xml.createElement('mutation');
-    const inputNames =
-        this.inputList.map((input: Blockly.Input) => input.name).join(',');
-    container.setAttribute('inputs', inputNames);
-    container.setAttribute('next', String(this.inputCounter));
+    container.setAttribute('items', `${this.itemCount}`);
     return container;
   },
 
@@ -85,13 +87,13 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * @param xmlElement XML storage element.
    */
   deserializeCounts(this: DynamicTextJoinBlock, xmlElement: Element): void {
-    const itemCount = Math.max(
+    this.itemCount = Math.max(
         parseInt(xmlElement.getAttribute('items') ?? '0', 10), this.minInputs);
-    // Two inputs are added automatically.
-    for (let i = this.minInputs; i < itemCount; i++) {
+    // minInputs are added automatically.
+    for (let i = this.minInputs; i < this.itemCount; i++) {
       this.appendValueInput('ADD' + i);
     }
-    this.inputCounter = itemCount;
+    this.inputCounter = this.itemCount + 1;
   },
 
   /**
@@ -159,6 +161,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
             this.inputList.map((i) => i.connection?.targetConnection));
     this.tearDownBlock();
     this.addItemInputs(targetConns);
+    this.itemCount = targetConns.length;
   },
 
   /** Deletes all inputs on this block so it can be rebuilt. */

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -22,9 +22,6 @@ type DynamicTextJoinMixinType = typeof DYNAMIC_TEXT_JOIN_MIXIN;
 /* eslint-disable @typescript-eslint/naming-convention */
 const DYNAMIC_TEXT_JOIN_MIXIN = {
   /* eslint-enable @typescript-eslint/naming-convention */
-  /** Counter for the next input to add to this block. */
-  inputCounter: 2,
-
   /** Minimum number of inputs for this block. */
   minInputs: 2,
 
@@ -78,8 +75,6 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
       this.inputList[0]
           .appendField(Blockly.Msg['TEXT_JOIN_TITLE_CREATEWITH']);
     }
-    const next = parseInt(xmlElement.getAttribute('next') ?? '0', 10) || 0;
-    this.inputCounter = next;
   },
 
   /**
@@ -93,7 +88,6 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
     for (let i = this.minInputs; i < this.itemCount; i++) {
       this.appendValueInput('ADD' + i);
     }
-    this.inputCounter = this.itemCount + 1;
   },
 
   /**
@@ -147,7 +141,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
     if (insertIndex == null) {
       return;
     }
-    this.appendValueInput('ADD' + (this.inputCounter++));
+    this.appendValueInput(`ADD${Blockly.utils.idGenerator.genUid()}`);
     this.moveNumberedInputBefore(this.inputList.length - 1, insertIndex);
   },
 

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -32,9 +32,8 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
   init(this: DynamicTextJoinBlock): void {
     this.setHelpUrl(Blockly.Msg['TEXT_JOIN_HELPURL']);
     this.setStyle('text_blocks');
-    this.appendValueInput('ADD0')
-        .appendField(Blockly.Msg['TEXT_JOIN_TITLE_CREATEWITH']);
-    this.appendValueInput('ADD1');
+    this.addFirstInput();
+    for (let i = 1; i < this.minInputs; i++) this.appendValueInput(`ADD${i}`);
     this.setOutput(true, 'String');
     this.setTooltip(Blockly.Msg['TEXT_JOIN_TOOLTIP']);
   },
@@ -101,7 +100,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * @returns The index before which to insert a new input, or null if no input
    *     should be added.
    */
-  getIndexForNewInput(
+  findInputIndexForConnection(
       this: DynamicTextJoinBlock,
       connection: Blockly.Connection): number | null {
     if (!connection.targetConnection) {
@@ -142,7 +141,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    */
   onPendingConnection(
       this: DynamicTextJoinBlock, connection: Blockly.Connection): void {
-    const insertIndex = this.getIndexForNewInput(connection);
+    const insertIndex = this.findInputIndexForConnection(connection);
     if (insertIndex == null) {
       return;
     }
@@ -155,26 +154,71 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * drag ends if the dragged block had a pending connection with this block.
    */
   finalizeConnections(this: DynamicTextJoinBlock): void {
-    if (this.inputList.length > this.minInputs) {
-      let toRemove: string[] = [];
-      this.inputList.forEach((input: Blockly.Input) => {
-        if (!input.connection?.targetConnection) {
-          toRemove.push(input.name);
-        }
-      });
+    const targetConns =
+        this.removeUnnecessaryEmptyConns(
+            this.inputList.map((i) => i.connection?.targetConnection));
+    this.tearDownBlock();
+    this.addItemInputs(targetConns);
+  },
 
-      if (this.inputList.length - toRemove.length < this.minInputs) {
-        // Always show at least two inputs
-        toRemove = toRemove.slice(this.minInputs);
-      }
-      toRemove.forEach((inputName) => this.removeInput(inputName));
-      // The first input should have the block text. If we removed the
-      // first input, add the block text to the new first input.
-      if (this.inputList[0].fieldRow.length == 0) {
-        this.inputList[0]
-            .appendField(Blockly.Msg['TEXT_JOIN_TITLE_CREATEWITH']);
+  /** Deletes all inputs on this block so it can be rebuilt. */
+  tearDownBlock(this: DynamicTextJoinBlock): void {
+    for (let i = this.inputList.length - 1; i >= 0; i--) {
+      this.removeInput(this.inputList[i].name);
+    }
+  },
+
+  /**
+   * Filters the given target connections so that empty connections are removed,
+   * unless we need those to reach the minimum input count. Empty connections
+   * are removed starting at the end of the array.
+   * @param targetConns The list of connections associated with inputs.
+   * @returns A filtered list of connections (or null/undefined) which should
+   *     be attached to inputs.
+   */
+  removeUnnecessaryEmptyConns(
+      this: DynamicTextJoinBlock,
+      targetConns: Array<Blockly.Connection | undefined | null>
+  ): Array<Blockly.Connection | undefined | null> {
+    const filteredConns = [...targetConns];
+    for (let i = filteredConns.length - 1; i >= 0; i--) {
+      if (!filteredConns[i] && filteredConns.length > this.minInputs) {
+        filteredConns.splice(i, 1);
       }
     }
+    return filteredConns;
+  },
+
+  /**
+   * Adds inputs based on the given array of target conns. An input is added for
+   * every entry in the array (if it does not already exist). If the entry is
+   * a connection and not null/undefined the connection will be connected to
+   * the input.
+   * @param targetConns The connections defining the inputs to add.
+   */
+  addItemInputs(
+      this: DynamicTextJoinBlock,
+      targetConns: Array<Blockly.Connection | undefined | null>,
+  ): void {
+    const input = this.addFirstInput();
+    const firstConn = targetConns[0];
+    if (firstConn) input.connection?.connect(firstConn);
+
+    for (let i = 1; i < targetConns.length; i++) {
+      const input = this.appendValueInput(`ADD${i}`);
+
+      const targetConn = targetConns[i];
+      if (targetConn) input.connection?.connect(targetConn);
+    }
+  },
+
+  /**
+   * Adds the top input with the label to this block.
+   * @returns The added input.
+   */
+  addFirstInput(this: DynamicTextJoinBlock): Blockly.Input {
+    return this.appendValueInput('ADD0')
+        .appendField(Blockly.Msg['TEXT_JOIN_TITLE_CREATEWITH']);
   },
 };
 

--- a/plugins/block-dynamic-connection/test/dynamic_text_join.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_text_join.mocha.js
@@ -11,11 +11,11 @@ const {overrideOldBlockDefinitions} = require('../src/index');
 
 const assert = chai.assert;
 
-suite('Text join block', function() {
+suite.only('Text join block', function() {
   /**
    * Asserts that the text join block has the expected inputs.
    * @param {!Blockly.Block} block The block to check.
-   * @param {!Array<string>} expectedInputs The expected inputs.
+   * @param {!Array<RegExp>} expectedInputs The expected inputs.
    * @type {string=} The block type expected. Defaults to 'dynamic_text_join'.
    */
   function assertBlockStructure(
@@ -25,7 +25,7 @@ suite('Text join block', function() {
     assert.equal(block.inputList.length, expectedInputs.length);
     assert.isTrue(expectedInputs.length >= 2);
     for (let i = 0; i < expectedInputs.length; i++) {
-      assert.equal(block.inputList[i].name, expectedInputs[i]);
+      assert.match(block.inputList[i].name, expectedInputs[i]);
     }
   }
 
@@ -52,7 +52,7 @@ suite('Text join block', function() {
 
   test('Creation', function() {
     const block = this.workspace.newBlock('dynamic_text_join');
-    assertBlockStructure(block, ['ADD0', 'ADD1']);
+    assertBlockStructure(block, [/ADD0/, /ADD1/]);
   });
 
   suite('onPendingConnection', function() {
@@ -60,7 +60,7 @@ suite('Text join block', function() {
       const block = this.workspace.newBlock('dynamic_text_join');
       const connection = block.inputList[0].connection;
       block.onPendingConnection(connection);
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
     });
 
     test('pending connection with empty next connection', function() {
@@ -68,7 +68,7 @@ suite('Text join block', function() {
       const connection = block.inputList[0].connection;
       connectBlockToConnection(this.workspace, block.inputList[0].connection);
       block.onPendingConnection(connection);
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
     });
 
     test('pending connection adds connection', function() {
@@ -76,18 +76,18 @@ suite('Text join block', function() {
       connectBlockToConnection(this.workspace, block.inputList[0].connection);
       connectBlockToConnection(this.workspace, block.inputList[1].connection);
       block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['ADD0', 'ADD2', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD2/, /ADD1/]);
       block.onPendingConnection(block.inputList[2].connection);
-      assertBlockStructure(block, ['ADD0', 'ADD2', 'ADD1', 'ADD3']);
+      assertBlockStructure(block, [/ADD0/, /ADD2/, /ADD1/, /ADD3/]);
     });
   });
 
   suite('finalizeConnections', function() {
     test('does not go below 2 connections', function() {
       const block = this.workspace.newBlock('dynamic_text_join');
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
       block.finalizeConnections();
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
     });
 
     test('removes empty connections', function() {
@@ -95,9 +95,9 @@ suite('Text join block', function() {
       connectBlockToConnection(this.workspace, block.inputList[0].connection);
       connectBlockToConnection(this.workspace, block.inputList[1].connection);
       block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['ADD0', 'ADD2', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD2/, /ADD1/]);
       block.finalizeConnections();
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
     });
 
     test('updates the field if the first connection is removed', function() {
@@ -106,7 +106,7 @@ suite('Text join block', function() {
       block.onPendingConnection(block.inputList[1].connection);
       connectBlockToConnection(this.workspace, block.inputList[2].connection);
       block.finalizeConnections();
-      assertBlockStructure(block, ['ADD1', 'ADD2']);
+      assertBlockStructure(block, [/ADD1/, /ADD2/]);
       assert.equal(block.inputList[0].fieldRow[0].value_,
           Blockly.Msg.TEXT_JOIN_TITLE_CREATEWITH);
     });
@@ -121,7 +121,7 @@ suite('Text join block', function() {
           'type="dynamic_text_join" id="1">\n' +
           '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD0', 'ADD1']);
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
       },
     },
     {
@@ -135,7 +135,7 @@ suite('Text join block', function() {
           '      <field name="TEXT">abc</field>\n' +
           '    </block>\n  </value>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD0', 'ADD1']);
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
       },
     },
     {
@@ -161,7 +161,7 @@ suite('Text join block', function() {
           '      <field name="TEXT">a</field>\n' +
           '    </block>\n  </value>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD1', 'ADD5', 'ADD2', 'ADD4']);
+        assertBlockStructure(block, [/ADD1/, /ADD5/, /ADD2/, /ADD4/]);
       },
     },
     {
@@ -176,7 +176,7 @@ suite('Text join block', function() {
           '  <mutation inputs="ADD0,ADD1,ADD2" next="3"></mutation>\n</block>',
       assertBlockStructure: (block) => {
         assertBlockStructure(
-            block, ['ADD0', 'ADD1', 'ADD2'], 'text_join');
+            block, [/ADD0/, /ADD1/, /ADD2/], 'text_join');
       },
     },
     {
@@ -190,7 +190,7 @@ suite('Text join block', function() {
           'type="text_join" id="1">\n' +
           '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD0', 'ADD1'], 'text_join');
+        assertBlockStructure(block, [/ADD0/, /ADD1/], 'text_join');
       },
     },
   ];

--- a/plugins/block-dynamic-connection/test/dynamic_text_join.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_text_join.mocha.js
@@ -23,7 +23,6 @@ suite.only('Text join block', function() {
   ) {
     assert.equal(block.type, type);
     assert.equal(block.inputList.length, expectedInputs.length);
-    assert.isTrue(expectedInputs.length >= 2);
     for (let i = 0; i < expectedInputs.length; i++) {
       assert.match(block.inputList[i].name, expectedInputs[i]);
     }
@@ -44,71 +43,111 @@ suite.only('Text join block', function() {
   setup(function() {
     this.workspace = new Blockly.Workspace();
     overrideOldBlockDefinitions();
+
+    const def1 = {...Blockly.Blocks['dynamic_text_join']};
+    def1.minInputs = 1;
+    Blockly.Blocks['dynamic_text_1_input'] = def1;
+
+    const def5 = {...Blockly.Blocks['dynamic_text_join']};
+    def5.minInputs = 5;
+    Blockly.Blocks['dynamic_text_5_inputs'] = def5;
   });
 
   teardown(function() {
     this.workspace.dispose();
+    delete Blockly.Blocks['dynamic_text_5_inputs'];
   });
 
-  test('Creation', function() {
-    const block = this.workspace.newBlock('dynamic_text_join');
-    assertBlockStructure(block, [/ADD0/, /ADD1/]);
-  });
-
-  suite('onPendingConnection', function() {
-    test('pending connection with empty connection', function() {
+  suite('Creation', function() {
+    test('the default definition has two inputs', function() {
       const block = this.workspace.newBlock('dynamic_text_join');
-      const connection = block.inputList[0].connection;
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
+    });
+
+    test('minInputs controls the number of inputs', function() {
+      const block = this.workspace.newBlock('dynamic_text_5_inputs');
+      assertBlockStructure(
+          block,
+          [/ADD0/, /ADD1/, /ADD2/, /ADD3/, /ADD4/],
+          'dynamic_text_5_inputs');
+    });
+  });
+
+  suite('adding inputs', function() {
+    test('attaching min items does not add an input', function() {
+      const block = this.workspace.newBlock('dynamic_text_1_input');
+      const connection = block.getInput('ADD0').connection;
+
       block.onPendingConnection(connection);
-      assertBlockStructure(block, [/ADD0/, /ADD1/]);
+
+      assertBlockStructure(block, [/ADD0/], 'dynamic_text_1_input');
     });
 
-    test('pending connection with empty next connection', function() {
-      const block = this.workspace.newBlock('dynamic_text_join');
-      const connection = block.inputList[0].connection;
-      connectBlockToConnection(this.workspace, block.inputList[0].connection);
+    test('attaching three items creates an input', function() {
+      const block = this.workspace.newBlock('dynamic_text_1_input');
+      const connection = block.getInput('ADD0').connection;
+      connectBlockToConnection(this.workspace, connection);
+
       block.onPendingConnection(connection);
-      assertBlockStructure(block, [/ADD0/, /ADD1/]);
-    });
 
-    test('pending connection adds connection', function() {
-      const block = this.workspace.newBlock('dynamic_text_join');
-      connectBlockToConnection(this.workspace, block.inputList[0].connection);
-      connectBlockToConnection(this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, [/ADD0/, /ADD2/, /ADD1/]);
-      block.onPendingConnection(block.inputList[2].connection);
-      assertBlockStructure(block, [/ADD0/, /ADD2/, /ADD1/, /ADD3/]);
+      assertBlockStructure(block, [/ADD0/, /ADD.*/], 'dynamic_text_1_input');
     });
   });
 
-  suite('finalizeConnections', function() {
-    test('does not go below 2 connections', function() {
-      const block = this.workspace.newBlock('dynamic_text_join');
-      assertBlockStructure(block, [/ADD0/, /ADD1/]);
+  suite('finalizing inputs', function() {
+    test('the block does not go below min inputs', function() {
+      const block = this.workspace.newBlock('dynamic_text_5_inputs');
+
       block.finalizeConnections();
-      assertBlockStructure(block, [/ADD0/, /ADD1/]);
+
+      assertBlockStructure(
+          block,
+          [/ADD0/, /ADD1/, /ADD2/, /ADD3/, /ADD4/],
+          'dynamic_text_5_inputs');
     });
 
-    test('removes empty connections', function() {
-      const block = this.workspace.newBlock('dynamic_text_join');
-      connectBlockToConnection(this.workspace, block.inputList[0].connection);
-      connectBlockToConnection(this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, [/ADD0/, /ADD2/, /ADD1/]);
+    test('an extra input with no blocks is removed', function() {
+      const block = this.workspace.newBlock('dynamic_text_1_input');
+      const connection = block.getInput('ADD0').connection;
+      connectBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
+
       block.finalizeConnections();
-      assertBlockStructure(block, [/ADD0/, /ADD1/]);
+
+      assertBlockStructure(block, [/ADD0/], 'dynamic_text_1_input');
     });
 
-    test('updates the field if the first connection is removed', function() {
-      const block = this.workspace.newBlock('dynamic_text_join');
+    test('an extra input with blocks is kept', function() {
+      const block = this.workspace.newBlock('dynamic_text_1_input');
+      const connection = block.getInput('ADD0').connection;
+      connectBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
       connectBlockToConnection(this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[1].connection);
-      connectBlockToConnection(this.workspace, block.inputList[2].connection);
+
       block.finalizeConnections();
-      assertBlockStructure(block, [/ADD1/, /ADD2/]);
-      assert.equal(block.inputList[0].fieldRow[0].value_,
-          Blockly.Msg.TEXT_JOIN_TITLE_CREATEWITH);
+
+      assertBlockStructure(block, [/ADD0/, /ADD1/], 'dynamic_text_1_input');
+    });
+
+    test('extra inputs are removed starting at the end', function() {
+      const block = this.workspace.newBlock('dynamic_text_5_inputs');
+      const connection0 = block.getInput('ADD0').connection;
+      const connection1 = block.getInput('ADD1').connection;
+      connectBlockToConnection(this.workspace, connection0);
+      connectBlockToConnection(this.workspace, connection1);
+      block.onPendingConnection(connection0);
+
+      block.finalizeConnections();
+
+      assertBlockStructure(
+          block,
+          [/ADD0/, /ADD1/, /ADD2/, /ADD3/, /ADD4/],
+          'dynamic_text_5_inputs');
+      assert.isOk(block.getInputTargetBlock('ADD0'));
+      assert.isNotOk(
+          block.getInputTargetBlock('ADD1'),
+          'Expected the empty input created by pending to still exist.');
+      assert.isOk(block.getInputTargetBlock('ADD2'));
     });
   });
 
@@ -119,13 +158,29 @@ suite.only('Text join block', function() {
       expectedXml:
           '<block xmlns="https://developers.google.com/blockly/xml" ' +
           'type="dynamic_text_join" id="1">\n' +
-          '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n</block>',
+          '  <mutation items="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
         assertBlockStructure(block, [/ADD0/, /ADD1/]);
       },
     },
     {
-      title: 'two inputs with one child',
+      title: 'default state - old serialization',
+      xml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation items="2"></mutation>\n' +
+          '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
+      },
+    },
+    {
+      title: 'two inputs with one child - old serialization',
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_text_join" id="1">\n' +
@@ -133,13 +188,75 @@ suite.only('Text join block', function() {
           '  <value name="ADD1">\n' +
           '    <block type="text" id="2">\n' +
           '      <field name="TEXT">abc</field>\n' +
-          '    </block>\n  </value>\n</block>',
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation items="2"></mutation>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">abc</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
         assertBlockStructure(block, [/ADD0/, /ADD1/]);
       },
     },
     {
-      title: 'multiple inputs with children',
+      title: 'multiple inputs with children - old serialization',
+      xml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation inputs="ADD0,ADD1,ADD2,ADD3" next="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation items="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
+      },
+    },
+    {
+      title: 'multiple non-sequential inputs with children - old serialization',
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_text_join" id="1">\n' +
@@ -159,38 +276,91 @@ suite.only('Text join block', function() {
           '  <value name="ADD4">\n' +
           '    <block type="text" id="5">\n' +
           '      <field name="TEXT">a</field>\n' +
-          '    </block>\n  </value>\n</block>',
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation items="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, [/ADD1/, /ADD5/, /ADD2/, /ADD4/]);
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
       },
     },
     {
-      title: 'standard/core XML is deserialized correctly',
+      title: 'two inputs one child - standard serialization',
       xml:
-        '<block type="text_join" id="1" x="63" y="113">' +
-        '  <mutation items="3"></mutation>' +
-        '</block>',
-      expectedXml:
-          '<block xmlns="https://developers.google.com/blockly/xml" ' +
-          'type="text_join" id="1">\n' +
-          '  <mutation inputs="ADD0,ADD1,ADD2" next="3"></mutation>\n</block>',
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation items="2"></mutation>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">abc</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(
-            block, [/ADD0/, /ADD1/, /ADD2/], 'text_join');
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
+      },
+    },
+    {
+      title: 'multiple inputs with children - standard serialization',
+      xml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation items="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
       },
     },
     {
       title: 'standard/core XML still maintains minimum inputs',
       xml:
-        '<block type="text_join" id="1" x="63" y="113">' +
+        '<block type="lists_create_with" id="1" x="63" y="113">' +
         '  <mutation items="0"></mutation>' +
         '</block>',
       expectedXml:
           '<block xmlns="https://developers.google.com/blockly/xml" ' +
-          'type="text_join" id="1">\n' +
-          '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n</block>',
+          'type="lists_create_with" id="1">\n' +
+          '  <mutation items="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, [/ADD0/, /ADD1/], 'text_join');
+        assertBlockStructure(block, [/ADD0/, /ADD1/], 'lists_create_with');
       },
     },
   ];


### PR DESCRIPTION
Dependent on #1886

Work on https://github.com/google/blockly-samples/issues/1843

Changes the serialization of the dynamic text blocks to match the serialization in core. Also makes it so the minInputs actually controls the minimum number of inputs.

This means that we have to tear down the inputs every time and re-add them so that they have the correct indexing (strictly increasing from 0).