### PR TITLE
feat: dynamic json serialization

### DIFF
--- a/plugins/block-dynamic-connection/src/dynamic_if.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_if.ts
@@ -122,8 +122,7 @@ const DYNAMIC_IF_MIXIN = {
     }
     const hasElse = xmlElement.getAttribute('else');
     if (hasElse == 'true') {
-      this.appendStatementInput('ELSE')
-          .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSE'], 'else');
+      this.addElseInput();
     }
   },
 
@@ -136,14 +135,10 @@ const DYNAMIC_IF_MIXIN = {
         xmlElement.getAttribute('elseif') ?? '0', 10) || 0;
     this.elseCount = parseInt(xmlElement.getAttribute('else') ?? '0', 10) || 0;
     for (let i = 1; i <= this.elseifCount; i++) {
-      this.appendValueInput('IF' + i).setCheck('Boolean').appendField(
-          Blockly.Msg['CONTROLS_IF_MSG_ELSEIF']);
-      this.appendStatementInput('DO' + i).appendField(
-          Blockly.Msg['CONTROLS_IF_MSG_THEN']);
+      this.insertElseIf(this.inputList.length, i);
     }
     if (this.elseCount) {
-      this.appendStatementInput('ELSE').appendField(
-          Blockly.Msg['CONTROLS_IF_MSG_ELSE']);
+      this.addElseInput();
     }
   },
 
@@ -193,8 +188,7 @@ const DYNAMIC_IF_MIXIN = {
   onPendingConnection(
       this: DynamicIfBlock, connection: Blockly.Connection): void {
     if (connection.type === Blockly.NEXT_STATEMENT && !this.getInput('ELSE')) {
-      this.appendStatementInput('ELSE')
-          .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSE'], 'else');
+      this.addElseInput();
     }
     const inputIndex = this.findInputIndexForConnection(connection);
     if (inputIndex === null) {
@@ -232,7 +226,9 @@ const DYNAMIC_IF_MIXIN = {
 
     this.addFirstCase();
     this.addCaseInputs(targetCaseConns);
-    if (targetElseConn) this.addElseInput(targetElseConn);
+    if (targetElseConn) {
+      this.addElseInput().connection?.connect(targetElseConn);
+    }
 
     this.elseifCount = Math.max(targetCaseConns.length - 1, 0);
     this.elseCount = targetElseConn ? 1 : 0;
@@ -288,13 +284,12 @@ const DYNAMIC_IF_MIXIN = {
   },
 
   /**
-   * Adds an else input to this block, and attaches the given connection to it.
-   * @param targetElseConn The connection to connect to the new else input.
+   * Adds an else input to this block.
+   * @returns The appended input.
    */
-  addElseInput(this: DynamicIfBlock, targetElseConn: Blockly.Connection): void {
-    this.appendStatementInput('ELSE')
-        .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSE'])
-        .connection?.connect(targetElseConn);
+  addElseInput(this: DynamicIfBlock): Blockly.Input {
+    return this.appendStatementInput('ELSE')
+        .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSE']);
   },
 
   /**

--- a/plugins/block-dynamic-connection/src/dynamic_if.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_if.ts
@@ -171,7 +171,12 @@ const DYNAMIC_IF_MIXIN = {
    * @param state The state to apply to this block, ie the else if count
    *     and else state.
    */
-  loadExtraState: function(this: DynamicIfBlock, state: IfExtraState) {
+  loadExtraState: function(this: DynamicIfBlock, state: IfExtraState | string) {
+    if (typeof state === 'string') {
+      this.domToMutation(Blockly.utils.xml.textToDom(state));
+      return;
+    }
+
     this.elseifCount = state['elseIfCount'] || 0;
     this.elseCount = state['hasElse'] ? 1 : 0;
     for (let i = 1; i <= this.elseifCount; i++) {

--- a/plugins/block-dynamic-connection/src/dynamic_if.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_if.ts
@@ -29,6 +29,12 @@ interface CaseInputPair {
   doInput: Blockly.Input;
 }
 
+/** Extra state for serializing controls_if blocks. */
+interface IfExtraState {
+  elseIfCount?: number;
+  hasElse?: boolean;
+}
+
 /* eslint-disable @typescript-eslint/naming-convention */
 const DYNAMIC_IF_MIXIN = {
   /**
@@ -134,6 +140,40 @@ const DYNAMIC_IF_MIXIN = {
     this.elseifCount = parseInt(
         xmlElement.getAttribute('elseif') ?? '0', 10) || 0;
     this.elseCount = parseInt(xmlElement.getAttribute('else') ?? '0', 10) || 0;
+    for (let i = 1; i <= this.elseifCount; i++) {
+      this.insertElseIf(this.inputList.length, i);
+    }
+    if (this.elseCount) {
+      this.addElseInput();
+    }
+  },
+
+  /**
+   * Returns the state of this block as a JSON serializable object.
+   * @returns The state of this block, ie the else if count and else state.
+   */
+  saveExtraState: function(this: DynamicIfBlock): IfExtraState | null {
+    if (!this.elseifCount && !this.elseCount) {
+      return null;
+    }
+    const state = Object.create(null);
+    if (this.elseifCount) {
+      state['elseIfCount'] = this.elseifCount;
+    }
+    if (this.elseCount) {
+      state['hasElse'] = true;
+    }
+    return state;
+  },
+
+  /**
+   * Applies the given state to this block.
+   * @param state The state to apply to this block, ie the else if count
+   *     and else state.
+   */
+  loadExtraState: function(this: DynamicIfBlock, state: IfExtraState) {
+    this.elseifCount = state['elseIfCount'] || 0;
+    this.elseCount = state['hasElse'] ? 1 : 0;
     for (let i = 1; i <= this.elseifCount; i++) {
       this.insertElseIf(this.inputList.length, i);
     }

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -113,7 +113,12 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    * @param state The state to apply to this block, ie the item count.
    */
   loadExtraState: function(
-      this: DynamicListCreateBlock, state: {[x: string]: any}) {
+      this: DynamicListCreateBlock, state: ({[x: string]: any} | string)) {
+    if (typeof state === 'string') {
+      this.domToMutation(Blockly.utils.xml.textToDom(state));
+      return;
+    }
+
     this.itemCount = state['itemCount'];
     // minInputs are added automatically.
     for (let i = this.minInputs; i < this.itemCount; i++) {

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -99,6 +99,29 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
   },
 
   /**
+   * Returns the state of this block as a JSON serializable object.
+   * @returns The state of this block, ie the item count.
+   */
+  saveExtraState: function(this: DynamicListCreateBlock): {itemCount: number} {
+    return {
+      'itemCount': this.itemCount,
+    };
+  },
+
+  /**
+   * Applies the given state to this block.
+   * @param state The state to apply to this block, ie the item count.
+   */
+  loadExtraState: function(
+      this: DynamicListCreateBlock, state: {[x: string]: any}) {
+    this.itemCount = state['itemCount'];
+    // minInputs are added automatically.
+    for (let i = this.minInputs; i < this.itemCount; i++) {
+      this.appendValueInput('ADD' + i);
+    }
+  },
+
+  /**
    * Check whether a new input should be added and determine where it should go.
    * @param connection The connection that has a pending connection.
    * @returns The index before which to insert a new input, or null if no input

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -97,6 +97,29 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
   },
 
   /**
+   * Returns the state of this block as a JSON serializable object.
+   * @returns The state of this block, ie the item count.
+   */
+  saveExtraState: function(this: DynamicTextJoinBlock): {itemCount: number} {
+    return {
+      'itemCount': this.itemCount,
+    };
+  },
+
+  /**
+   * Applies the given state to this block.
+   * @param state The state to apply to this block, ie the item count.
+   */
+  loadExtraState: function(
+      this: DynamicTextJoinBlock, state: {[x: string]: any}) {
+    this.itemCount = state['itemCount'];
+    // minInputs are added automatically.
+    for (let i = this.minInputs; i < this.itemCount; i++) {
+      this.appendValueInput('ADD' + i);
+    }
+  },
+
+  /**
    * Check whether a new input should be added and determine where it should go.
    * @param connection The connection that has a pending connection.
    * @returns The index before which to insert a new input, or null if no input

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -111,7 +111,12 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * @param state The state to apply to this block, ie the item count.
    */
   loadExtraState: function(
-      this: DynamicTextJoinBlock, state: {[x: string]: any}) {
+      this: DynamicTextJoinBlock, state: ({[x: string]: any} | string)) {
+    if (typeof state === 'string') {
+      this.domToMutation(Blockly.utils.xml.textToDom(state));
+      return;
+    }
+
     this.itemCount = state['itemCount'];
     // minInputs are added automatically.
     for (let i = this.minInputs; i < this.itemCount; i++) {

--- a/plugins/block-dynamic-connection/test/dynamic_if.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_if.mocha.js
@@ -526,6 +526,79 @@ suite('If block', function() {
             block, [/IF0/, /DO0/, /IF1/, /DO1/, /ELSE/], 'dynamic_if');
       },
     },
+    {
+      title: 'one if one else with children - json with stringified old XML',
+      json: {
+        'type': 'dynamic_if',
+        'id': '1',
+        'extraState':
+            '<mutation inputs="1,2" else="true" next="3"></mutation>',
+        'inputs': {
+          'IF1': {
+            'block': {
+              'type': 'logic_boolean',
+              'id': '2',
+              'fields': {
+                'BOOL': 'TRUE',
+              },
+            },
+          },
+          'IF2': {
+            'block': {
+              'type': 'logic_boolean',
+              'id': '3',
+              'fields': {
+                'BOOL': 'TRUE',
+              },
+            },
+          },
+          'ELSE': {
+            'block': {
+              'type': 'text_print',
+              'id': '4',
+            },
+          },
+        },
+      },
+      expectedJson: {
+        'type': 'dynamic_if',
+        'id': '1',
+        'extraState': {
+          'elseIfCount': 1,
+          'hasElse': true,
+        },
+        'inputs': {
+          'IF0': {
+            'block': {
+              'type': 'logic_boolean',
+              'id': '2',
+              'fields': {
+                'BOOL': 'TRUE',
+              },
+            },
+          },
+          'IF1': {
+            'block': {
+              'type': 'logic_boolean',
+              'id': '3',
+              'fields': {
+                'BOOL': 'TRUE',
+              },
+            },
+          },
+          'ELSE': {
+            'block': {
+              'type': 'text_print',
+              'id': '4',
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(
+            block, [/IF0/, /DO0/, /IF1/, /DO1/, /ELSE/], 'dynamic_if');
+      },
+    },
   ];
   testHelpers.runSerializationTestSuite(testCases);
 });

--- a/plugins/block-dynamic-connection/test/dynamic_if.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_if.mocha.js
@@ -485,6 +485,47 @@ suite('If block', function() {
             block, [/IF0/, /DO0/, /IF1/, /DO1/, /ELSE/], 'dynamic_if');
       },
     },
+    {
+      title: 'one if one else with children - json',
+      json: {
+        'type': 'dynamic_if',
+        'id': '1',
+        'extraState': {
+          'elseIfCount': 1,
+          'hasElse': true,
+        },
+        'inputs': {
+          'IF0': {
+            'block': {
+              'type': 'logic_boolean',
+              'id': '2',
+              'fields': {
+                'BOOL': 'TRUE',
+              },
+            },
+          },
+          'IF1': {
+            'block': {
+              'type': 'logic_boolean',
+              'id': '3',
+              'fields': {
+                'BOOL': 'TRUE',
+              },
+            },
+          },
+          'ELSE': {
+            'block': {
+              'type': 'text_print',
+              'id': '4',
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(
+            block, [/IF0/, /DO0/, /IF1/, /DO1/, /ELSE/], 'dynamic_if');
+      },
+    },
   ];
   testHelpers.runSerializationTestSuite(testCases);
 });

--- a/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
@@ -363,6 +363,81 @@ suite('List create block', function() {
         assertBlockStructure(block, [/ADD0/, /ADD1/], 'lists_create_with');
       },
     },
+    {
+      title: 'two inputs one child - json',
+      json: {
+        'type': 'dynamic_list_create',
+        'id': '1',
+        'extraState': {
+          'itemCount': 2,
+        },
+        'inputs': {
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': 2,
+              'fields': {
+                'TEXT': 'abc',
+              },
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
+      },
+    },
+    {
+      title: 'multiple inputs with children - json',
+      json: {
+        'type': 'dynamic_list_create',
+        'id': '1',
+        'extraState': {
+          'itemCount': 4,
+        },
+        'inputs': {
+          'ADD0': {
+            'block': {
+              'type': 'text',
+              'id': '2',
+              'fields': {
+                'TEXT': 'a',
+              },
+            },
+          },
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': '3',
+              'fields': {
+                'TEXT': 'b',
+              },
+            },
+          },
+          'ADD2': {
+            'block': {
+              'type': 'text',
+              'id': '4',
+              'fields': {
+                'TEXT': 'c',
+              },
+            },
+          },
+          'ADD3': {
+            'block': {
+              'type': 'text',
+              'id': '5',
+              'fields': {
+                'TEXT': 'd',
+              },
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
+      },
+    },
   ];
   testHelpers.runSerializationTestSuite(testCases);
 });

--- a/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
@@ -438,6 +438,101 @@ suite('List create block', function() {
         assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
       },
     },
+    {
+      title: 'multiple inputs with children - json with stringified old XML',
+      json: {
+        'type': 'dynamic_list_create',
+        'id': '1',
+        'extraState':
+            '<mutation inputs="ADD0,ADD1,ADD2,ADD3" next="4"></mutation>',
+        'inputs': {
+          'ADD0': {
+            'block': {
+              'type': 'text',
+              'id': '2',
+              'fields': {
+                'TEXT': 'a',
+              },
+            },
+          },
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': '3',
+              'fields': {
+                'TEXT': 'b',
+              },
+            },
+          },
+          'ADD2': {
+            'block': {
+              'type': 'text',
+              'id': '4',
+              'fields': {
+                'TEXT': 'c',
+              },
+            },
+          },
+          'ADD3': {
+            'block': {
+              'type': 'text',
+              'id': '5',
+              'fields': {
+                'TEXT': 'd',
+              },
+            },
+          },
+        },
+      },
+      expectedJson: {
+        'type': 'dynamic_list_create',
+        'id': '1',
+        'extraState': {
+          'itemCount': 4,
+        },
+        'inputs': {
+          'ADD0': {
+            'block': {
+              'type': 'text',
+              'id': '2',
+              'fields': {
+                'TEXT': 'a',
+              },
+            },
+          },
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': '3',
+              'fields': {
+                'TEXT': 'b',
+              },
+            },
+          },
+          'ADD2': {
+            'block': {
+              'type': 'text',
+              'id': '4',
+              'fields': {
+                'TEXT': 'c',
+              },
+            },
+          },
+          'ADD3': {
+            'block': {
+              'type': 'text',
+              'id': '5',
+              'fields': {
+                'TEXT': 'd',
+              },
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
+      },
+    },
   ];
   testHelpers.runSerializationTestSuite(testCases);
 });

--- a/plugins/block-dynamic-connection/test/dynamic_text_join.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_text_join.mocha.js
@@ -438,6 +438,101 @@ suite('Text join block', function() {
         assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
       },
     },
+    {
+      title: 'multiple inputs with children - json with stringified old XML',
+      json: {
+        'type': 'dynamic_text_join',
+        'id': '1',
+        'extraState':
+            '<mutation inputs="ADD0,ADD1,ADD2,ADD3" next="4"></mutation>',
+        'inputs': {
+          'ADD0': {
+            'block': {
+              'type': 'text',
+              'id': '2',
+              'fields': {
+                'TEXT': 'a',
+              },
+            },
+          },
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': '3',
+              'fields': {
+                'TEXT': 'b',
+              },
+            },
+          },
+          'ADD2': {
+            'block': {
+              'type': 'text',
+              'id': '4',
+              'fields': {
+                'TEXT': 'c',
+              },
+            },
+          },
+          'ADD3': {
+            'block': {
+              'type': 'text',
+              'id': '5',
+              'fields': {
+                'TEXT': 'd',
+              },
+            },
+          },
+        },
+      },
+      expectedJson: {
+        'type': 'dynamic_text_join',
+        'id': '1',
+        'extraState': {
+          'itemCount': 4,
+        },
+        'inputs': {
+          'ADD0': {
+            'block': {
+              'type': 'text',
+              'id': '2',
+              'fields': {
+                'TEXT': 'a',
+              },
+            },
+          },
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': '3',
+              'fields': {
+                'TEXT': 'b',
+              },
+            },
+          },
+          'ADD2': {
+            'block': {
+              'type': 'text',
+              'id': '4',
+              'fields': {
+                'TEXT': 'c',
+              },
+            },
+          },
+          'ADD3': {
+            'block': {
+              'type': 'text',
+              'id': '5',
+              'fields': {
+                'TEXT': 'd',
+              },
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
+      },
+    },
   ];
   testHelpers.runSerializationTestSuite(testCases);
 });

--- a/plugins/block-dynamic-connection/test/dynamic_text_join.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_text_join.mocha.js
@@ -11,7 +11,7 @@ const {overrideOldBlockDefinitions} = require('../src/index');
 
 const assert = chai.assert;
 
-suite.only('Text join block', function() {
+suite('Text join block', function() {
   /**
    * Asserts that the text join block has the expected inputs.
    * @param {!Blockly.Block} block The block to check.
@@ -361,6 +361,81 @@ suite.only('Text join block', function() {
           '  <mutation items="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
         assertBlockStructure(block, [/ADD0/, /ADD1/], 'lists_create_with');
+      },
+    },
+    {
+      title: 'two inputs one child - json',
+      json: {
+        'type': 'dynamic_text_join',
+        'id': '1',
+        'extraState': {
+          'itemCount': 2,
+        },
+        'inputs': {
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': 2,
+              'fields': {
+                'TEXT': 'abc',
+              },
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
+      },
+    },
+    {
+      title: 'multiple inputs with children - json',
+      json: {
+        'type': 'dynamic_text_join',
+        'id': '1',
+        'extraState': {
+          'itemCount': 4,
+        },
+        'inputs': {
+          'ADD0': {
+            'block': {
+              'type': 'text',
+              'id': '2',
+              'fields': {
+                'TEXT': 'a',
+              },
+            },
+          },
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': '3',
+              'fields': {
+                'TEXT': 'b',
+              },
+            },
+          },
+          'ADD2': {
+            'block': {
+              'type': 'text',
+              'id': '4',
+              'fields': {
+                'TEXT': 'c',
+              },
+            },
+          },
+          'ADD3': {
+            'block': {
+              'type': 'text',
+              'id': '5',
+              'fields': {
+                'TEXT': 'd',
+              },
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
       },
     },
   ];


### PR DESCRIPTION
Closes #1843
Closes https://github.com/google/blockly-samples/issues/906
Closes https://github.com/google/blockly-samples/issues/1622 because the block definitions are now compatible with built-in generators

Adds serializing to JSON to all of the dynamic blocks.

We also have to make sure we can load Xml that had been stringified and put in XML. Added tests for this. We only need to worry about the old XML format because the changes that add the new format and this change will go out together. But I just pass the XML to `domToMutation` anyway, which handles both so it doesn't matter.