### PR TITLE
chore: fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Use latest npm
-      run: npm install -g npm@latest
-
     - name: Npm Install
       run: npm install
 


### PR DESCRIPTION
https://github.com/google/blockly-samples/actions/runs/6061559703/job/16518085439?pr=1890


Latest NPM requires node 18 or higher, so all of our CI in samples is going to start failing. Not sure why we were explicitly installing a version of npm (vs just letting github handle it), since I can't find that in any example workflows. So I just deleted it.
