### PR TITLE
fix: deleting procedures with callers not being undoable

### DIFF
--- a/plugins/block-shareable-procedures/src/events_procedure_base.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_base.ts
@@ -27,7 +27,6 @@ export abstract class ProcedureBase extends Blockly.Events.Abstract {
       readonly procedure: Blockly.procedures.IProcedureModel) {
     super();
     this.workspaceId = workspace.id;
-    this.recordUndo = false;
   }
 
   /**

--- a/plugins/block-shareable-procedures/src/events_procedure_parameter_base.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_parameter_base.ts
@@ -29,6 +29,7 @@ export abstract class ProcedureParameterBase extends ProcedureBase {
       procedure: Blockly.procedures.IProcedureModel,
       readonly parameter: Blockly.procedures.IParameterModel) {
     super(workspace, procedure);
+    this.recordUndo = false;
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/1891

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Moves the recordUndo disabling to the parameter event level instead of the base procedure event level.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
We want to disable recording undo for parameter changes but not for all changes (because in some cases we actually do need to handle life cycle for the models separately, e.g. in the case of deletion).

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested by disabling the secondary workspace in the test page, and re-enabling undo and redo.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
