### PR TITLE
deprecate: edit row separator readme to deprecate it

### DIFF
--- a/plugins/renderer-inline-row-separators/README.md
+++ b/plugins/renderer-inline-row-separators/README.md
@@ -2,6 +2,16 @@
 
 A [Blockly](https://www.npmjs.com/package/blockly) plugin to create a renderer that treats dummy inputs like row separators, allowing block designers to arrange multiple inline value input connectors on separate rows by inserting dummy inputs between them. Example blocks demonstrating the feature are provided, as well as a function to add the feature to your own renderer.
 
+## When to use
+
+### For Blockly versions >= v10.2.0
+
+This plugin is deprecated because its functionality will be made obsolete by a new feature being introduced in [Blockly v10.2.0](https://github.com/google/blockly/releases/tag/blockly-v10.2.0): row separators can now be easily added either by adding newline characters ("\n") in the message field of JSON block definitions, or by adding EndRowInputs to blocks via the JavaScript API. For more information, see the [Block Inputs documentation](https://developers.google.com/blockly/guides/create-custom-blocks/define-blocks#block_inputs).
+
+### For Blockly versions < v10.2.0
+
+It is strongly recommended that instead of using this plugin, you upgrade to a version of Blockly >= v10.2.0. However if that is not possible, you can use the current version of this plugin. Note that this plugin will be removed in the future, so by newly installing it now, you will be introducing a dependency you will be forced to remove in the future if you want to remain up-to-date with core Blockly.
+
 ## Installation
 
 ### Yarn

--- a/plugins/renderer-inline-row-separators/package.json
+++ b/plugins/renderer-inline-row-separators/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blockly/renderer-inline-row-separators",
   "version": "0.4.3",
+  "private": true,
   "description": "A plugin to treat dummy inputs like line breaks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",

--- a/plugins/serialize-disabled-interactions/README.md
+++ b/plugins/serialize-disabled-interactions/README.md
@@ -32,4 +32,4 @@ v2.0 of this plugin (as v3.0 does not actually serialize these attributes).
 
 Note that this plugin is being removed in the future, so by newly installing it
 now, you will be introducing a dependency you will be forced to remove in the
-future if they you to remain up-to-date with core Blockly.
+future if you want to remain up-to-date with core Blockly.


### PR DESCRIPTION
### Resolves

Addresses part of: https://github.com/google/blockly-samples/issues/1854

### Proposed Changes

Updates the renderer-inline-row-separators plugin's readme to indicate that the plugin is deprecated, explains how to use the new alternative feature.

### Reason for Changes

The plugin is made obsolete by a feature in an upcoming version of Blockly: https://github.com/google/blockly/pull/6944

### Additional Information

The new core Blockly feature is not actually available yet. These readme changes link to a release that has not been published yet, and to documentation that is not up to date yet. See associated documentation changes: cl/559132536 and https://github.com/google/blockly/issues/7360