### PR TITLE
feat: make playground open state persistent (#1921)

### DIFF
--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -123,6 +123,7 @@ export function createPlayground(
         // Load / Save playground state.
         const playgroundState = new LocalStorageState(`playgroundState_${id}`, {
           activeTab: 'XML',
+          playgroundOpen: true,
           autoGenerate: config && config.auto != undefined ? config.auto : true,
           workspaceXml: '',
         });
@@ -377,18 +378,26 @@ export function createPlayground(
         guiElement.style.minWidth = '100%';
         guiContainer.appendChild(guiElement);
 
-        // Create minimize button
-        minimizeButton.addEventListener('click', (e) => {
-          if (playgroundDiv.style.display === 'none') {
+        // Click handler to toggle the playground.
+        const togglePlayground = (e) => {
+          const shouldOpen = playgroundDiv.style.display === 'none';
+          if (shouldOpen) {
             playgroundDiv.style.display = 'flex';
             minimizeButton.textContent = 'Collapse';
           } else {
             playgroundDiv.style.display = 'none';
             minimizeButton.textContent = 'Expand';
           }
-
+          playgroundState.set('playgroundOpen', shouldOpen);
+          playgroundState.save();
           Blockly.svgResize(workspace);
-        });
+        };
+        minimizeButton.addEventListener('click', togglePlayground);
+
+        // Start minimized if the playground was previously closed.
+        if (playgroundState.get('playgroundOpen') === false) {
+          togglePlayground();
+        }
 
         // Playground API.
 


### PR DESCRIPTION


## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details

### Proposed Changes

This makes the playground collapse/expand state persistent between reloads.

### Reason for Changes

When working on code generation, it's nice to have it open all the time. This is the current behavior. When designing blocks, it's nice if it doesn't re-open on every save/relaunch.

When working on a single (split) screen, this means you can keep working/saving in your development code editor without the playground obscuring much of the workspace every time the page auto-reloads.

### Test Coverage

This has been tested manually, and inspected in the browser dev tools to validate the playground state.

### Documentation

N/A

### Additional Information

It is implemented by clicking collapse on the user's behalf to keep the code change minimal. It does mean that you'll briefly see the playground on reload.
