### PR TITLE
fix: serialization of dynamic blocks

### DIFF
--- a/plugins/block-dynamic-connection/README.md
+++ b/plugins/block-dynamic-connection/README.md
@@ -18,17 +18,14 @@ import * as BlockDynamicConnection from '@blockly/block-dynamic-connection';
 ## API
 - `overrideOldBlockDefinitions`: Replaces the Blockly default blocks with the
   dynamic connection blocks. This enables projects to use the dynamic block
-  plugin without changing existing XML.
-  Note that if you enable this, you will **never** be able to switch back to
-  non-dynamic connections, because this changes the way mutations are
-  serialized.
+  plugin without changing existing XML/JSON.
 
-## XML
-```xml
-<block type="dynamic_text_join"></block>
-<block type="dynamic_list_create"></block>
-<block type="dynamic_if"></block>
-```
+
+## Blocks
+
+* `dynamic_text_join` replaces `text_join`
+* `dynamic_list_create` replaces `lists_create_with`
+* `dynamic_if` replaces `controls_if`
 
 ## License
 Apache 2.0

--- a/plugins/block-dynamic-connection/src/dynamic_if.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_if.ts
@@ -19,14 +19,26 @@ interface DynamicIfMixin extends DynamicIfMixinType {}
 /* eslint-enable @typescript-eslint/no-empty-interface */
 type DynamicIfMixinType = typeof DYNAMIC_IF_MIXIN;
 
+interface CaseConnectionPair {
+  ifTarget?: Blockly.Connection | null;
+  doTarget?: Blockly.Connection | null;
+}
+
+interface CaseInputPair {
+  ifInput: Blockly.Input;
+  doInput: Blockly.Input;
+}
+
 /* eslint-disable @typescript-eslint/naming-convention */
 const DYNAMIC_IF_MIXIN = {
-  /* eslint-enable @typescript-eslint/naming-convention */
-  /** Counter for the next input to add to this block. */
-  inputCounter: 1,
-
   /** Minimum number of inputs for this block. */
   minInputs: 1,
+
+  /** Count of else-if cases. */
+  elseifCount: 0,
+
+  /** Count of else cases (either 0 or 1). */
+  elseCount: 0,
 
   /**
    * Block for if/elseif/else statements. Must have one if input.
@@ -51,15 +63,22 @@ const DYNAMIC_IF_MIXIN = {
    * Create XML to represent if/elseif/else inputs.
    * @returns XML storage element.
    */
-  mutationToDom(this: DynamicIfBlock): Element {
+  mutationToDom(this: DynamicIfBlock): Element|null {
+    // If we call finalizeConnections here without disabling events, we get into
+    // an event loop.
+    Blockly.Events.disable();
+    this.finalizeConnections();
+    Blockly.Events.enable();
+
+    if (!this.elseifCount && !this.elseCount) return null;
+
     const container = Blockly.utils.xml.createElement('mutation');
-    const inputNames = this.inputList
-        .filter((input: Blockly.Input) => input.name.includes('IF'))
-        .map((input: Blockly.Input) => input.name.replace('IF', '')).join(',');
-    container.setAttribute('inputs', inputNames);
-    const hasElse = !!this.getInput('ELSE');
-    container.setAttribute('else', String(hasElse));
-    container.setAttribute('next', String(this.inputCounter));
+    if (this.elseifCount) {
+      container.setAttribute('elseif', `${this.elseifCount}`);
+    }
+    if (this.elseCount) {
+      container.setAttribute('else', '1');
+    }
     return container;
   },
 
@@ -109,8 +128,6 @@ const DYNAMIC_IF_MIXIN = {
       this.appendStatementInput('ELSE')
           .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSE'], 'else');
     }
-    const next = parseInt(xmlElement.getAttribute('next') ?? '0', 10) || 0;
-    this.inputCounter = next;
   },
 
   /**
@@ -118,20 +135,19 @@ const DYNAMIC_IF_MIXIN = {
    * @param xmlElement XML storage element.
    */
   deserializeCounts(this: DynamicIfBlock, xmlElement: Element): void {
-    const elseifCount = parseInt(
+    this.elseifCount = parseInt(
         xmlElement.getAttribute('elseif') ?? '0', 10) || 0;
-    const elseCount = parseInt(xmlElement.getAttribute('else') ?? '0', 10) || 0;
-    for (let i = 1; i <= elseifCount; i++) {
+    this.elseCount = parseInt(xmlElement.getAttribute('else') ?? '0', 10) || 0;
+    for (let i = 1; i <= this.elseifCount; i++) {
       this.appendValueInput('IF' + i).setCheck('Boolean').appendField(
           Blockly.Msg['CONTROLS_IF_MSG_ELSEIF']);
       this.appendStatementInput('DO' + i).appendField(
           Blockly.Msg['CONTROLS_IF_MSG_THEN']);
     }
-    if (elseCount) {
+    if (this.elseCount) {
       this.appendStatementInput('ELSE').appendField(
           Blockly.Msg['CONTROLS_IF_MSG_ELSE']);
     }
-    this.inputCounter = elseifCount + 1;
   },
 
   /**
@@ -154,18 +170,21 @@ const DYNAMIC_IF_MIXIN = {
   /**
    * Inserts a boolean value input and statement input at the specified index.
    * @param index Index of the input before which to add new inputs.
+   * @param id An ID to append to the case statement input names to make them
+   *     unique.
+   * @returns The added inputs.
    */
-  insertElseIf(this: DynamicIfBlock, index: number): void {
-    const caseNumber = this.inputCounter;
-    this
-        .appendValueInput('IF' + caseNumber)
+  insertElseIf(
+      this: DynamicIfBlock, index: number, id: string | number
+  ): CaseInputPair {
+    const ifInput = this.appendValueInput('IF' + id)
         .setCheck('Boolean')
         .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSEIF'], 'elseif');
-    this.appendStatementInput('DO' + caseNumber)
+    const doInput = this.appendStatementInput('DO' + id)
         .appendField(Blockly.Msg['CONTROLS_IF_MSG_THEN']);
-    this.moveInputBefore('IF' + caseNumber, this.inputList[index].name);
-    this.moveInputBefore('DO' + caseNumber, this.inputList[index + 1].name);
-    this.inputCounter++;
+    this.moveInputBefore('IF' + id, this.inputList[index].name);
+    this.moveInputBefore('DO' + id, this.inputList[index + 1].name);
+    return {ifInput, doInput};
   },
 
   /**
@@ -188,7 +207,7 @@ const DYNAMIC_IF_MIXIN = {
     if (connection.targetConnection && input.name.includes('IF')) {
       const nextIfInput = this.inputList[inputIndex + 2];
       if (!nextIfInput || nextIfInput.name == 'ELSE') {
-        this.insertElseIf(inputIndex + 2);
+        this.insertElseIf(inputIndex + 2, Blockly.utils.idGenerator.genUid());
       } else {
         const nextIfConnection =
             nextIfInput &&
@@ -198,7 +217,7 @@ const DYNAMIC_IF_MIXIN = {
           nextIfConnection &&
           !nextIfConnection.getSourceBlock().isInsertionMarker()
         ) {
-          this.insertElseIf(inputIndex + 2);
+          this.insertElseIf(inputIndex + 2, Blockly.utils.idGenerator.genUid());
         }
       }
     }
@@ -209,39 +228,78 @@ const DYNAMIC_IF_MIXIN = {
    * drag ends if the dragged block had a pending connection with this block.
    */
   finalizeConnections(this: DynamicIfBlock): void {
-    const toRemove = [];
-    // Remove Else If inputs if neither the if nor the do has a connected block.
-    for (let i = 2; i < this.inputList.length - 1; i += 2) {
-      const ifConnection = this.inputList[i];
-      const doConnection = this.inputList[i + 1];
-      if (!ifConnection.connection?.targetConnection &&
-          !doConnection.connection?.targetConnection) {
-        toRemove.push(ifConnection.name);
-        toRemove.push(doConnection.name);
-      }
-    }
-    toRemove.forEach((input) => this.removeInput(input));
+    const targetCaseConns = this.collectTargetCaseConns();
+    const targetElseConn = this.getInput('ELSE')?.connection?.targetConnection;
 
-    // Remove Else input if it doesn't have a connected block.
-    const elseInput = this.getInput('ELSE');
-    if (elseInput && !elseInput.connection?.targetConnection) {
-      this.removeInput(elseInput.name);
-    }
+    this.deleteDynamicInputs();
 
-    // Remove the If input if it is empty and there is at least one Else If
-    if (this.inputList.length > 2) {
-      const ifInput = this.inputList[0];
-      const doInput = this.inputList[1];
-      const nextInput = this.inputList[2];
-      if (nextInput.name.includes('IF') &&
-          !ifInput.connection?.targetConnection &&
-          !doInput.connection?.targetConnection) {
-        this.removeInput(ifInput.name);
-        this.removeInput(doInput.name);
-        nextInput.removeField('elseif');
-        nextInput.appendField(Blockly.Msg['CONTROLS_IF_MSG_IF'], 'if');
-      }
+    this.addCaseInputs(targetCaseConns);
+    if (targetElseConn) this.addElseInput(targetElseConn);
+
+    this.elseifCount = Math.max(targetCaseConns.length - 1, 0);
+    this.elseCount = targetElseConn ? 1 : 0;
+  },
+
+  /**
+   * Collects all of the target blocks attached to case inputs. If neither the
+   * if nor the due input in a case has an attached block, that input is
+   * skipped. If only one of them has an attached block, the other value in
+   * the pair is undefined.
+   * @returns  A list of target connections attached to case inputs.
+   */
+  collectTargetCaseConns(this: DynamicIfBlock): CaseConnectionPair[] {
+    const targetConns = [];
+    for (let i = 0; i < this.inputList.length - 1; i += 2) {
+      const ifTarget =
+          this.inputList[i].connection?.targetConnection;
+      const doTarget =
+          this.inputList[i + 1].connection?.targetConnection;
+      if (!ifTarget && !doTarget) continue;
+      targetConns.push({ifTarget, doTarget});
     }
+    return targetConns;
+  },
+
+  /**
+   * Deletes all of the inputs on this block except for the default "if"
+   * and "do" inputs.
+   */
+  deleteDynamicInputs(this: DynamicIfBlock): void {
+    for (let i = this.inputList.length - 1; i >= 2; i--) {
+      this.removeInput(this.inputList[i].name);
+    }
+  },
+
+  /**
+   * Adds inputs for all of the given target connection pairs (if the input
+   * doesn't already exist), and connects the target connections to them.
+   *
+   * This is essentially rebuilding all of the cases with strictly ascending
+   * case numbers.
+   * @param targetConns The list of target connections to attach to this block.
+   */
+  addCaseInputs(this: DynamicIfBlock, targetConns: CaseConnectionPair[]): void {
+    for (let i = 0; i < targetConns.length; i++) {
+      let ifInput = this.getInput(`IF${i}`);
+      let doInput = this.getInput(`DO${i}`);
+      if (!ifInput || !doInput) {
+        ({ifInput, doInput} = this.insertElseIf(i * 2, i));
+      }
+
+      const {ifTarget, doTarget} = targetConns[i];
+      if (ifTarget) ifInput.connection?.connect(ifTarget);
+      if (doTarget) doInput.connection?.connect(doTarget);
+    }
+  },
+
+  /**
+   * Adds an else input to this block, and attaches the given connection to it.
+   * @param targetElseConn The connection to connect to the new else input.
+   */
+  addElseInput(this: DynamicIfBlock, targetElseConn: Blockly.Connection): void {
+    this.appendStatementInput('ELSE')
+        .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSE'])
+        .connection?.connect(targetElseConn);
   },
 };
 

--- a/plugins/block-dynamic-connection/src/dynamic_if.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_if.ts
@@ -31,7 +31,10 @@ interface CaseInputPair {
 
 /* eslint-disable @typescript-eslint/naming-convention */
 const DYNAMIC_IF_MIXIN = {
-  /** Minimum number of inputs for this block. */
+  /**
+   * Minimum number of inputs for this block.
+   * @deprecated This is unused.
+   */
   minInputs: 1,
 
   /** Count of else-if cases. */
@@ -47,13 +50,7 @@ const DYNAMIC_IF_MIXIN = {
   init(this: DynamicIfBlock): void {
     this.setHelpUrl(Blockly.Msg['CONTROLS_IF_HELPURL']);
     this.setStyle('logic_blocks');
-
-    this.appendValueInput('IF0')
-        .setCheck('Boolean')
-        .appendField(Blockly.Msg['CONTROLS_IF_MSG_IF'], 'if');
-    this.appendStatementInput('DO0')
-        .appendField(Blockly.Msg['CONTROLS_IF_MSG_THEN']);
-
+    this.addFirstCase();
     this.setNextStatement(true);
     this.setPreviousStatement(true);
     this.setTooltip(Blockly.Msg['LISTS_CREATE_WITH_TOOLTIP']);
@@ -231,8 +228,9 @@ const DYNAMIC_IF_MIXIN = {
     const targetCaseConns = this.collectTargetCaseConns();
     const targetElseConn = this.getInput('ELSE')?.connection?.targetConnection;
 
-    this.deleteDynamicInputs();
+    this.tearDownBlock();
 
+    this.addFirstCase();
     this.addCaseInputs(targetCaseConns);
     if (targetElseConn) this.addElseInput(targetElseConn);
 
@@ -260,12 +258,9 @@ const DYNAMIC_IF_MIXIN = {
     return targetConns;
   },
 
-  /**
-   * Deletes all of the inputs on this block except for the default "if"
-   * and "do" inputs.
-   */
-  deleteDynamicInputs(this: DynamicIfBlock): void {
-    for (let i = this.inputList.length - 1; i >= 2; i--) {
+  /** Deletes all inputs on the block so it can be rebuilt. */
+  tearDownBlock(this: DynamicIfBlock): void {
+    for (let i = this.inputList.length - 1; i >= 0; i--) {
       this.removeInput(this.inputList[i].name);
     }
   },
@@ -300,6 +295,18 @@ const DYNAMIC_IF_MIXIN = {
     this.appendStatementInput('ELSE')
         .appendField(Blockly.Msg['CONTROLS_IF_MSG_ELSE'])
         .connection?.connect(targetElseConn);
+  },
+
+  /**
+   * Adds the first 'IF' and 'DO' inputs and their associated labels to this
+   * block.
+   */
+  addFirstCase(this: DynamicIfBlock): void {
+    this.appendValueInput('IF0')
+        .setCheck('Boolean')
+        .appendField(Blockly.Msg['CONTROLS_IF_MSG_IF'], 'if');
+    this.appendStatementInput('DO0')
+        .appendField(Blockly.Msg['CONTROLS_IF_MSG_THEN']);
   },
 };
 

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -22,19 +22,22 @@ type DynamicListCreateMixinType = typeof DYNAMIC_LIST_CREATE_MIXIN;
 /* eslint-disable @typescript-eslint/naming-convention */
 const DYNAMIC_LIST_CREATE_MIXIN = {
   /* eslint-enable @typescript-eslint/naming-convention */
-  /** Counter for the next input to add to this block. */
-  inputCounter: 2,
-
   /** Minimum number of inputs for this block. */
   minInputs: 2,
 
+  /** Count of item inputs. */
+  itemCount: 0,
+
   /** Block for concatenating any number of strings. */
   init(this: DynamicListCreateBlock): void {
+    this.itemCount = this.minInputs;
+
     this.setHelpUrl(Blockly.Msg['LISTS_CREATE_WITH_HELPURL']);
     this.setStyle('list_blocks');
-    this.appendValueInput('ADD0')
-        .appendField(Blockly.Msg['LISTS_CREATE_WITH_INPUT_WITH']);
-    this.appendValueInput('ADD1');
+    this.addFirstInput();
+    for (let i = 1; i < this.minInputs; i++) {
+      this.appendValueInput(`ADD${i}`);
+    }
     this.setOutput(true, 'Array');
     this.setTooltip(Blockly.Msg['LISTS_CREATE_WITH_TOOLTIP']);
   },
@@ -44,11 +47,14 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    * @returns XML storage element.
    */
   mutationToDom(this: DynamicListCreateBlock): Element {
+    // If we call finalizeConnections here without disabling events, we get into
+    // an event loop.
+    Blockly.Events.disable();
+    this.finalizeConnections();
+    Blockly.Events.enable();
+
     const container = Blockly.utils.xml.createElement('mutation');
-    const inputNames =
-        this.inputList.map((input: Blockly.Input) => input.name).join(',');
-    container.setAttribute('inputs', inputNames);
-    container.setAttribute('next', String(this.inputCounter));
+    container.setAttribute('items', `${this.itemCount}`);
     return container;
   },
 
@@ -77,8 +83,6 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
       this.inputList[0]
           .appendField(Blockly.Msg['LISTS_CREATE_WITH_INPUT_WITH']);
     }
-    const next = parseInt(xmlElement.getAttribute('next') ?? '0', 10) || 0;
-    this.inputCounter = next;
   },
 
   /**
@@ -86,13 +90,12 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    * @param xmlElement XML storage element.
    */
   deserializeCounts(this: DynamicListCreateBlock, xmlElement: Element): void {
-    const itemCount = Math.max(
+    this.itemCount = Math.max(
         parseInt(xmlElement.getAttribute('items') ?? '0', 10), this.minInputs);
-    // Two inputs are added automatically.
-    for (let i = this.minInputs; i < itemCount; i++) {
+    // minInputs are added automatically.
+    for (let i = this.minInputs; i < this.itemCount; i++) {
       this.appendValueInput('ADD' + i);
     }
-    this.inputCounter = itemCount;
   },
 
   /**
@@ -101,7 +104,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    * @returns The index before which to insert a new input, or null if no input
    *     should be added.
    */
-  getIndexForNewInput(
+  findInputIndexForConnection(
       this: DynamicListCreateBlock,
       connection: Blockly.Connection): number | null {
     if (!connection.targetConnection) {
@@ -141,11 +144,11 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    */
   onPendingConnection(
       this: DynamicListCreateBlock, connection: Blockly.Connection): void {
-    const insertIndex = this.getIndexForNewInput(connection);
+    const insertIndex = this.findInputIndexForConnection(connection);
     if (insertIndex == null) {
       return;
     }
-    this.appendValueInput('ADD' + (this.inputCounter++));
+    this.appendValueInput(`ADD${Blockly.utils.idGenerator.genUid()}`);
     this.moveNumberedInputBefore(this.inputList.length - 1, insertIndex);
   },
 
@@ -154,26 +157,73 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    * drag ends if the dragged block had a pending connection with this block.
    */
   finalizeConnections(this: DynamicListCreateBlock): void {
-    if (this.inputList.length > this.minInputs) {
-      let toRemove: string[] = [];
-      this.inputList.forEach((input: Blockly.Input) => {
-        if (!input.connection?.targetConnection) {
-          toRemove.push(input.name);
-        }
-      });
+    const targetConns =
+        this.removeUnnecessaryEmptyConns(
+            this.inputList.map((i) => i.connection?.targetConnection));
+    this.tearDownBlock();
+    this.addItemInputs(targetConns);
+    this.itemCount = targetConns.length;
+  },
 
-      if (this.inputList.length - toRemove.length < this.minInputs) {
-        // Always show at least two inputs
-        toRemove = toRemove.slice(this.minInputs);
-      }
-      toRemove.forEach((inputName) => this.removeInput(inputName));
-      // The first input should have the block text. If we removed the
-      // first input, add the block text to the new first input.
-      if (this.inputList[0].fieldRow.length == 0) {
-        this.inputList[0]
-            .appendField(Blockly.Msg['LISTS_CREATE_WITH_INPUT_WITH']);
+  /**
+   * Deletes all inputs on the block so it can be rebuilt.
+   */
+  tearDownBlock(this: DynamicListCreateBlock): void {
+    for (let i = this.inputList.length - 1; i >= 0; i--) {
+      this.removeInput(this.inputList[i].name);
+    }
+  },
+
+  /**
+   * Filters the given target connections so that empty connections are removed,
+   * unless we need those to reach the minimum input count. Empty connections
+   * are removed starting at the end of the array.
+   * @param targetConns The list of connections associated with inputs.
+   * @returns A filtered list of connections (or null/undefined) which should
+   *     be attached to inputs.
+   */
+  removeUnnecessaryEmptyConns(
+      targetConns: Array<Blockly.Connection | undefined | null>
+  ): Array<Blockly.Connection | undefined | null> {
+    const filteredConns = [...targetConns];
+    for (let i = filteredConns.length - 1; i >= 0; i--) {
+      if (!filteredConns[i] && filteredConns.length > this.minInputs) {
+        filteredConns.splice(i, 1);
       }
     }
+    return filteredConns;
+  },
+
+  /**
+   * Adds inputs based on the given array of target cons. An input is added for
+   * every entry in the array (if it does not already exist). If the entry is
+   * a connection and not null/undefined the connection will be connected to
+   * the input.
+   * @param targetConns The connections defining the inputs to add.
+   */
+  addItemInputs(
+      this: DynamicListCreateBlock,
+      targetConns: Array<Blockly.Connection | undefined | null>,
+  ): void {
+    const input = this.addFirstInput();
+    const firstConn = targetConns[0];
+    if (firstConn) input.connection?.connect(firstConn);
+
+    for (let i = 1; i < targetConns.length; i++) {
+      const input = this.appendValueInput(`ADD${i}`);
+
+      const targetConn = targetConns[i];
+      if (targetConn) input.connection?.connect(targetConn);
+    }
+  },
+
+  /**
+   * Adds the top input with the label to this block.
+   * @returns The added input.
+   */
+  addFirstInput(this: DynamicListCreateBlock): Blockly.Input {
+    return this.appendValueInput('ADD0')
+        .appendField(Blockly.Msg['LISTS_CREATE_WITH_INPUT_WITH']);
   },
 };
 

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -165,9 +165,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
     this.itemCount = targetConns.length;
   },
 
-  /**
-   * Deletes all inputs on the block so it can be rebuilt.
-   */
+  /** Deletes all inputs on the block so it can be rebuilt. */
   tearDownBlock(this: DynamicListCreateBlock): void {
     for (let i = this.inputList.length - 1; i >= 0; i--) {
       this.removeInput(this.inputList[i].name);

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -99,6 +99,34 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
   },
 
   /**
+   * Returns the state of this block as a JSON serializable object.
+   * @returns The state of this block, ie the item count.
+   */
+  saveExtraState: function(this: DynamicListCreateBlock): {itemCount: number} {
+    return {
+      'itemCount': this.itemCount,
+    };
+  },
+
+  /**
+   * Applies the given state to this block.
+   * @param state The state to apply to this block, ie the item count.
+   */
+  loadExtraState: function(
+      this: DynamicListCreateBlock, state: ({[x: string]: any} | string)) {
+    if (typeof state === 'string') {
+      this.domToMutation(Blockly.utils.xml.textToDom(state));
+      return;
+    }
+
+    this.itemCount = state['itemCount'];
+    // minInputs are added automatically.
+    for (let i = this.minInputs; i < this.itemCount; i++) {
+      this.appendValueInput('ADD' + i);
+    }
+  },
+
+  /**
    * Check whether a new input should be added and determine where it should go.
    * @param connection The connection that has a pending connection.
    * @returns The index before which to insert a new input, or null if no input

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -97,6 +97,34 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
   },
 
   /**
+   * Returns the state of this block as a JSON serializable object.
+   * @returns The state of this block, ie the item count.
+   */
+  saveExtraState: function(this: DynamicTextJoinBlock): {itemCount: number} {
+    return {
+      'itemCount': this.itemCount,
+    };
+  },
+
+  /**
+   * Applies the given state to this block.
+   * @param state The state to apply to this block, ie the item count.
+   */
+  loadExtraState: function(
+      this: DynamicTextJoinBlock, state: ({[x: string]: any} | string)) {
+    if (typeof state === 'string') {
+      this.domToMutation(Blockly.utils.xml.textToDom(state));
+      return;
+    }
+
+    this.itemCount = state['itemCount'];
+    // minInputs are added automatically.
+    for (let i = this.minInputs; i < this.itemCount; i++) {
+      this.appendValueInput('ADD' + i);
+    }
+  },
+
+  /**
    * Check whether a new input should be added and determine where it should go.
    * @param connection The connection that has a pending connection.
    * @returns The index before which to insert a new input, or null if no input

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -22,19 +22,20 @@ type DynamicTextJoinMixinType = typeof DYNAMIC_TEXT_JOIN_MIXIN;
 /* eslint-disable @typescript-eslint/naming-convention */
 const DYNAMIC_TEXT_JOIN_MIXIN = {
   /* eslint-enable @typescript-eslint/naming-convention */
-  /** Counter for the next input to add to this block. */
-  inputCounter: 2,
-
   /** Minimum number of inputs for this block. */
   minInputs: 2,
 
+  /** Count of the item inputs. */
+  itemCount: 0,
+
   /** Block for concatenating any number of strings. */
   init(this: DynamicTextJoinBlock): void {
+    this.itemCount = this.minInputs;
+
     this.setHelpUrl(Blockly.Msg['TEXT_JOIN_HELPURL']);
     this.setStyle('text_blocks');
-    this.appendValueInput('ADD0')
-        .appendField(Blockly.Msg['TEXT_JOIN_TITLE_CREATEWITH']);
-    this.appendValueInput('ADD1');
+    this.addFirstInput();
+    for (let i = 1; i < this.minInputs; i++) this.appendValueInput(`ADD${i}`);
     this.setOutput(true, 'String');
     this.setTooltip(Blockly.Msg['TEXT_JOIN_TOOLTIP']);
   },
@@ -44,11 +45,14 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * @returns XML storage element.
    */
   mutationToDom(this: DynamicTextJoinBlock): Element {
+    // If we call finalizeConnections here without disabling events, we get into
+    // an event loop.
+    Blockly.Events.disable();
+    this.finalizeConnections();
+    Blockly.Events.enable();
+
     const container = Blockly.utils.xml.createElement('mutation');
-    const inputNames =
-        this.inputList.map((input: Blockly.Input) => input.name).join(',');
-    container.setAttribute('inputs', inputNames);
-    container.setAttribute('next', String(this.inputCounter));
+    container.setAttribute('items', `${this.itemCount}`);
     return container;
   },
 
@@ -77,8 +81,6 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
       this.inputList[0]
           .appendField(Blockly.Msg['TEXT_JOIN_TITLE_CREATEWITH']);
     }
-    const next = parseInt(xmlElement.getAttribute('next') ?? '0', 10) || 0;
-    this.inputCounter = next;
   },
 
   /**
@@ -86,13 +88,12 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * @param xmlElement XML storage element.
    */
   deserializeCounts(this: DynamicTextJoinBlock, xmlElement: Element): void {
-    const itemCount = Math.max(
+    this.itemCount = Math.max(
         parseInt(xmlElement.getAttribute('items') ?? '0', 10), this.minInputs);
-    // Two inputs are added automatically.
-    for (let i = this.minInputs; i < itemCount; i++) {
+    // minInputs are added automatically.
+    for (let i = this.minInputs; i < this.itemCount; i++) {
       this.appendValueInput('ADD' + i);
     }
-    this.inputCounter = itemCount;
   },
 
   /**
@@ -101,7 +102,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * @returns The index before which to insert a new input, or null if no input
    *     should be added.
    */
-  getIndexForNewInput(
+  findInputIndexForConnection(
       this: DynamicTextJoinBlock,
       connection: Blockly.Connection): number | null {
     if (!connection.targetConnection) {
@@ -142,11 +143,11 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    */
   onPendingConnection(
       this: DynamicTextJoinBlock, connection: Blockly.Connection): void {
-    const insertIndex = this.getIndexForNewInput(connection);
+    const insertIndex = this.findInputIndexForConnection(connection);
     if (insertIndex == null) {
       return;
     }
-    this.appendValueInput('ADD' + (this.inputCounter++));
+    this.appendValueInput(`ADD${Blockly.utils.idGenerator.genUid()}`);
     this.moveNumberedInputBefore(this.inputList.length - 1, insertIndex);
   },
 
@@ -155,26 +156,72 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * drag ends if the dragged block had a pending connection with this block.
    */
   finalizeConnections(this: DynamicTextJoinBlock): void {
-    if (this.inputList.length > this.minInputs) {
-      let toRemove: string[] = [];
-      this.inputList.forEach((input: Blockly.Input) => {
-        if (!input.connection?.targetConnection) {
-          toRemove.push(input.name);
-        }
-      });
+    const targetConns =
+        this.removeUnnecessaryEmptyConns(
+            this.inputList.map((i) => i.connection?.targetConnection));
+    this.tearDownBlock();
+    this.addItemInputs(targetConns);
+    this.itemCount = targetConns.length;
+  },
 
-      if (this.inputList.length - toRemove.length < this.minInputs) {
-        // Always show at least two inputs
-        toRemove = toRemove.slice(this.minInputs);
-      }
-      toRemove.forEach((inputName) => this.removeInput(inputName));
-      // The first input should have the block text. If we removed the
-      // first input, add the block text to the new first input.
-      if (this.inputList[0].fieldRow.length == 0) {
-        this.inputList[0]
-            .appendField(Blockly.Msg['TEXT_JOIN_TITLE_CREATEWITH']);
+  /** Deletes all inputs on this block so it can be rebuilt. */
+  tearDownBlock(this: DynamicTextJoinBlock): void {
+    for (let i = this.inputList.length - 1; i >= 0; i--) {
+      this.removeInput(this.inputList[i].name);
+    }
+  },
+
+  /**
+   * Filters the given target connections so that empty connections are removed,
+   * unless we need those to reach the minimum input count. Empty connections
+   * are removed starting at the end of the array.
+   * @param targetConns The list of connections associated with inputs.
+   * @returns A filtered list of connections (or null/undefined) which should
+   *     be attached to inputs.
+   */
+  removeUnnecessaryEmptyConns(
+      this: DynamicTextJoinBlock,
+      targetConns: Array<Blockly.Connection | undefined | null>
+  ): Array<Blockly.Connection | undefined | null> {
+    const filteredConns = [...targetConns];
+    for (let i = filteredConns.length - 1; i >= 0; i--) {
+      if (!filteredConns[i] && filteredConns.length > this.minInputs) {
+        filteredConns.splice(i, 1);
       }
     }
+    return filteredConns;
+  },
+
+  /**
+   * Adds inputs based on the given array of target conns. An input is added for
+   * every entry in the array (if it does not already exist). If the entry is
+   * a connection and not null/undefined the connection will be connected to
+   * the input.
+   * @param targetConns The connections defining the inputs to add.
+   */
+  addItemInputs(
+      this: DynamicTextJoinBlock,
+      targetConns: Array<Blockly.Connection | undefined | null>,
+  ): void {
+    const input = this.addFirstInput();
+    const firstConn = targetConns[0];
+    if (firstConn) input.connection?.connect(firstConn);
+
+    for (let i = 1; i < targetConns.length; i++) {
+      const input = this.appendValueInput(`ADD${i}`);
+
+      const targetConn = targetConns[i];
+      if (targetConn) input.connection?.connect(targetConn);
+    }
+  },
+
+  /**
+   * Adds the top input with the label to this block.
+   * @returns The added input.
+   */
+  addFirstInput(this: DynamicTextJoinBlock): Blockly.Input {
+    return this.appendValueInput('ADD0')
+        .appendField(Blockly.Msg['TEXT_JOIN_TITLE_CREATEWITH']);
   },
 };
 

--- a/plugins/block-dynamic-connection/test/dynamic_if.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_if.mocha.js
@@ -485,6 +485,120 @@ suite('If block', function() {
             block, [/IF0/, /DO0/, /IF1/, /DO1/, /ELSE/], 'dynamic_if');
       },
     },
+    {
+      title: 'one if one else with children - json',
+      json: {
+        'type': 'dynamic_if',
+        'id': '1',
+        'extraState': {
+          'elseIfCount': 1,
+          'hasElse': true,
+        },
+        'inputs': {
+          'IF0': {
+            'block': {
+              'type': 'logic_boolean',
+              'id': '2',
+              'fields': {
+                'BOOL': 'TRUE',
+              },
+            },
+          },
+          'IF1': {
+            'block': {
+              'type': 'logic_boolean',
+              'id': '3',
+              'fields': {
+                'BOOL': 'TRUE',
+              },
+            },
+          },
+          'ELSE': {
+            'block': {
+              'type': 'text_print',
+              'id': '4',
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(
+            block, [/IF0/, /DO0/, /IF1/, /DO1/, /ELSE/], 'dynamic_if');
+      },
+    },
+    {
+      title: 'one if one else with children - json with stringified old XML',
+      json: {
+        'type': 'dynamic_if',
+        'id': '1',
+        'extraState':
+            '<mutation inputs="1,2" else="true" next="3"></mutation>',
+        'inputs': {
+          'IF1': {
+            'block': {
+              'type': 'logic_boolean',
+              'id': '2',
+              'fields': {
+                'BOOL': 'TRUE',
+              },
+            },
+          },
+          'IF2': {
+            'block': {
+              'type': 'logic_boolean',
+              'id': '3',
+              'fields': {
+                'BOOL': 'TRUE',
+              },
+            },
+          },
+          'ELSE': {
+            'block': {
+              'type': 'text_print',
+              'id': '4',
+            },
+          },
+        },
+      },
+      expectedJson: {
+        'type': 'dynamic_if',
+        'id': '1',
+        'extraState': {
+          'elseIfCount': 1,
+          'hasElse': true,
+        },
+        'inputs': {
+          'IF0': {
+            'block': {
+              'type': 'logic_boolean',
+              'id': '2',
+              'fields': {
+                'BOOL': 'TRUE',
+              },
+            },
+          },
+          'IF1': {
+            'block': {
+              'type': 'logic_boolean',
+              'id': '3',
+              'fields': {
+                'BOOL': 'TRUE',
+              },
+            },
+          },
+          'ELSE': {
+            'block': {
+              'type': 'text_print',
+              'id': '4',
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(
+            block, [/IF0/, /DO0/, /IF1/, /DO1/, /ELSE/], 'dynamic_if');
+      },
+    },
   ];
   testHelpers.runSerializationTestSuite(testCases);
 });

--- a/plugins/block-dynamic-connection/test/dynamic_if.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_if.mocha.js
@@ -15,15 +15,15 @@ suite('If block', function() {
   /**
    * Asserts that the if block has the expected inputs.
    * @param {!Blockly.Block} block The block to check.
-   * @param {!Array<string>} expectedInputs The expected inputs.
-   * @type {string=} The block type expected. Defaults to 'dynamic_if'.
+   * @param {!Array<RegExp>} expectedInputs The expected inputs.
+   * @param type {string=} The block type expected. Defaults to 'dynamic_if'.
    */
   function assertBlockStructure(block, expectedInputs, type = 'dynamic_if') {
     assert.equal(block.type, type);
     assert.equal(block.inputList.length, expectedInputs.length);
     assert.isTrue(expectedInputs.length >= 2);
     for (let i = 0; i < expectedInputs.length; i++) {
-      assert.equal(block.inputList[i].name, expectedInputs[i]);
+      assert.match(block.inputList[i].name, expectedInputs[i]);
     }
   }
 
@@ -62,79 +62,139 @@ suite('If block', function() {
 
   test('Creation', function() {
     const block = this.workspace.newBlock('dynamic_if');
-    assertBlockStructure(block, ['IF0', 'DO0']);
+    assertBlockStructure(block, [/IF0/, /DO0/]);
   });
 
-  suite('onPendingConnection', function() {
-    test('pending connection with empty connection', function() {
+  suite('adding inputs', function() {
+    test('attaching the first predicate does not create a case', function() {
       const block = this.workspace.newBlock('dynamic_if');
-      const connection = block.inputList[0].connection;
+      const connection = block.getInput('IF0').connection;
+
       block.onPendingConnection(connection);
-      assertBlockStructure(block, ['IF0', 'DO0']);
+
+      assertBlockStructure(block, [/IF0/, /DO0/]);
     });
 
-    test('pending connection with empty next connection', function() {
+    test('attaching the second predicate creates a case', function() {
       const block = this.workspace.newBlock('dynamic_if');
-      const connection = block.inputList[0].connection;
-      connectBooleanBlockToConnection(
-          this.workspace, block.inputList[0].connection);
-      block.onPendingConnection(connection);
-      assertBlockStructure(block, ['IF0', 'DO0', 'IF1', 'DO1']);
-      connectStatementBlockToConnection(
-          this.workspace, block.inputList[3].connection);
-      block.finalizeConnections();
+      const connection = block.getInput('IF0').connection;
+      connectBooleanBlockToConnection(this.workspace, connection);
 
       block.onPendingConnection(connection);
-      assertBlockStructure(block, ['IF0', 'DO0', 'IF1', 'DO1']);
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /IF.*/, /DO.*/]);
     });
 
-    test('pending connection adds connection', function() {
+    test('attaching the first statement creates an else', function() {
       const block = this.workspace.newBlock('dynamic_if');
-      connectBooleanBlockToConnection(
-          this.workspace, block.inputList[0].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['IF0', 'DO0', 'IF1', 'DO1']);
+      const connection = block.getInput('DO0').connection;
+
+      block.onPendingConnection(connection);
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /ELSE/]);
+    });
+
+    test('attaching the second statement creates an else', function() {
+      const block = this.workspace.newBlock('dynamic_if');
+      const connection = block.getInput('DO0').connection;
+      connectStatementBlockToConnection(this.workspace, connection);
+
+      block.onPendingConnection(connection);
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /ELSE/]);
+    });
+
+    test('attaching to the next connection creates an else', function() {
+      const block = this.workspace.newBlock('dynamic_if');
+      const connection = block.nextConnection;
+
+      block.onPendingConnection(connection);
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /ELSE/]);
     });
   });
 
-  suite('finalizeConnections', function() {
-    test('does not go below 2 connections', function() {
+  suite('finalizing inputs', function() {
+    test('the block does not go below one case', function() {
       const block = this.workspace.newBlock('dynamic_if');
-      assertBlockStructure(block, ['IF0', 'DO0']);
+
       block.finalizeConnections();
-      assertBlockStructure(block, ['IF0', 'DO0']);
+
+      assertBlockStructure(block, [/IF0/, /DO0/]);
     });
 
-    test('removes empty connections', function() {
+    test('a case with no blocks is removed', function() {
       const block = this.workspace.newBlock('dynamic_if');
-      connectBooleanBlockToConnection(
-          this.workspace, block.inputList[0].connection);
-      connectStatementBlockToConnection(
-          this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['IF0', 'DO0', 'IF1', 'DO1']);
+      const connection = block.getInput('IF0').connection;
+      connectBooleanBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
+
       block.finalizeConnections();
-      assertBlockStructure(block, ['IF0', 'DO0']);
+
+      assertBlockStructure(block, [/IF0/, /DO0/]);
     });
 
-    test('updates the field if the first connection is removed', function() {
+    test('a case with a predicate and statements is kept', function() {
       const block = this.workspace.newBlock('dynamic_if');
-      connectBooleanBlockToConnection(
-          this.workspace, block.inputList[0].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['IF0', 'DO0', 'IF1', 'DO1']);
-      // Add Else If
+      const connection = block.getInput('IF0').connection;
+      connectBooleanBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
       connectBooleanBlockToConnection(
           this.workspace, block.inputList[2].connection);
-      block.finalizeConnections();
-      assertBlockStructure(block, ['IF0', 'DO0', 'IF1', 'DO1']);
+      connectStatementBlockToConnection(
+          this.workspace, block.inputList[3].connection);
 
-      // Remove If
-      block.inputList[0].connection.disconnect();
       block.finalizeConnections();
-      assertBlockStructure(block, ['IF1', 'DO1']);
-      assert.equal(block.inputList[0].fieldRow[0].value_,
-          Blockly.Msg.CONTROLS_IF_MSG_IF);
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /IF1/, /DO1/]);
+    });
+
+    test('a case with only a predicate is kept', function() {
+      const block = this.workspace.newBlock('dynamic_if');
+      const connection = block.getInput('IF0').connection;
+      connectBooleanBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
+      connectBooleanBlockToConnection(
+          this.workspace, block.inputList[2].connection);
+
+      block.finalizeConnections();
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /IF1/, /DO1/]);
+    });
+
+    test('a case with only statements is kept', function() {
+      const block = this.workspace.newBlock('dynamic_if');
+      const connection = block.getInput('IF0').connection;
+      connectBooleanBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
+      connectStatementBlockToConnection(
+          this.workspace, block.inputList[3].connection);
+
+      block.finalizeConnections();
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /IF1/, /DO1/]);
+    });
+
+    test('an else with no statements is removed', function() {
+      const block = this.workspace.newBlock('dynamic_if');
+      const connection = block.getInput('DO0').connection;
+      block.onPendingConnection(connection);
+
+      block.finalizeConnections();
+
+      assertBlockStructure(block, [/IF0/, /DO0/]);
+    });
+
+    test('an else with statements is kept', function() {
+      const block = this.workspace.newBlock('dynamic_if');
+      const connection = block.getInput('DO0').connection;
+      block.onPendingConnection(connection);
+      connectStatementBlockToConnection(
+          this.workspace, block.getInput('ELSE').connection);
+
+      block.finalizeConnections();
+
+      assertBlockStructure(block, [/IF0/, /DO0/, /ELSE/]);
     });
   });
 
@@ -143,15 +203,15 @@ suite('If block', function() {
       title: 'empty XML',
       xml: '<block type="dynamic_if"/>',
       expectedXml:
-          '<block xmlns="https://developers.google.com/blockly/xml" ' +
-          'type="dynamic_if" id="1">\n' +
-          '  <mutation inputs="0" else="false" next="1"></mutation>\n</block>',
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_if" id="1">' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['IF0', 'DO0']);
+        assertBlockStructure(block, [/IF0/, /DO0/]);
       },
     },
     {
-      title: 'one if one else',
+      title: 'one if one else - old serialization',
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_if" id="1">\n' +
@@ -171,12 +231,31 @@ suite('If block', function() {
           '    </block>\n' +
           '  </statement>\n' +
           '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_if" id="1">\n' +
+          '  <mutation else="1"></mutation>\n' +
+          '  <value name="IF0">\n' +
+          '    <block type="logic_boolean" id="2">\n' +
+          '      <field name="BOOL">TRUE</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '  <statement name="ELSE">\n' +
+          '    <block type="text_print" id="3">\n' +
+          '      <value name="TEXT">\n' +
+          '        <shadow type="text" id="4">\n' +
+          '          <field name="TEXT">abc</field>\n' +
+          '        </shadow>\n' +
+          '      </value>\n' +
+          '    </block>\n' +
+          '  </statement>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['IF0', 'DO0', 'ELSE']);
+        assertBlockStructure(block, [/IF0/, /DO0/, /ELSE/]);
       },
     },
     {
-      title: 'multiple inputs with children',
+      title: 'multiple inputs with children - old serialization',
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_if" id="1">\n' +
@@ -203,7 +282,49 @@ suite('If block', function() {
           '  <statement name="DO2">\n' +
           '    <block type="text_print" id="6">\n' +
           '      <value name="TEXT">\n' +
-          '        <shadow type="text" id="^7">\n' +
+          '        <shadow type="text" id="7">\n' +
+          '          <field name="TEXT">abc</field>\n' +
+          '        </shadow>\n' +
+          '      </value>\n' +
+          '    </block>\n' +
+          '  </statement>\n' +
+          '  <statement name="ELSE">\n' +
+          '    <block type="text_print" id="8">\n' +
+          '      <value name="TEXT">\n' +
+          '        <shadow type="text" id="9">\n' +
+          '          <field name="TEXT">abc</field>\n' +
+          '        </shadow>\n' +
+          '      </value>\n' +
+          '    </block>\n' +
+          '  </statement>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_if" id="1">\n' +
+          '  <mutation elseif="2" else="1"></mutation>\n' +
+          '  <value name="IF0">\n' +
+          '    <block type="logic_boolean" id="2">\n' +
+          '      <field name="BOOL">TRUE</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '  <statement name="DO0">\n' +
+          '    <block type="text_print" id="3">\n' +
+          '      <value name="TEXT">\n' +
+          '        <shadow type="text" id="4">\n' +
+          '          <field name="TEXT">abc</field>\n' +
+          '        </shadow>\n' +
+          '      </value>\n' +
+          '    </block>\n' +
+          '  </statement>\n' +
+          '  <value name="IF1">\n' +
+          '    <block type="logic_boolean" id="5">\n' +
+          '      <field name="BOOL">TRUE</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '  <statement name="DO2">\n' +
+          '    <block type="text_print" id="6">\n' +
+          '      <value name="TEXT">\n' +
+          '        <shadow type="text" id="7">\n' +
           '          <field name="TEXT">abc</field>\n' +
           '        </shadow>\n' +
           '      </value>\n' +
@@ -221,22 +342,147 @@ suite('If block', function() {
           '</block>',
       assertBlockStructure: (block) => {
         assertBlockStructure(
-            block, ['IF0', 'DO0', 'IF1', 'DO1', 'IF2', 'DO2', 'ELSE']);
+            block, [/IF0/, /DO0/, /IF1/, /DO1/, /IF2/, /DO2/, /ELSE/]);
       },
     },
     {
-      title: 'standard/core XML is deserialized correctly',
+      title: 'multiple nonsequential inputs - old serialization',
       xml:
-        '<block type="controls_if" id="1" x="38" y="63">' +
-        '  <mutation elseif="1" else= "1" ></mutation>' +
-        '</block>',
+        '<block type="dynamic_if" id="1">\n' +
+        '  <mutation inputs="1,3,2" else="false" next="4"></mutation>\n' +
+        '  <value name="IF1">\n' +
+        '    <block type="logic_boolean" id="1">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="DO1">\n' +
+        '    <block type="text_print" id="3">\n' +
+        '      <value name="TEXT">\n' +
+        '        <shadow type="text" id="4">\n' +
+        '          <field name="TEXT">abc</field>\n' +
+        '        </shadow>\n' +
+        '      </value>\n' +
+        '    </block>\n' +
+        '  </statement>\n' +
+        '  <value name="IF3">\n' +
+        '    <block type="logic_boolean" id="5">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="DO3">\n' +
+        '    <block type="text_print" id="6">\n' +
+        '      <value name="TEXT">\n' +
+        '        <shadow type="text" id="7">\n' +
+        '          <field name="TEXT">abc</field>\n' +
+        '        </shadow>\n' +
+        '      </value>\n' +
+        '    </block>\n' +
+        '  </statement>\n' +
+        '  <value name="IF2">\n' +
+        '    <block type="logic_boolean" id="8">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="DO2">\n' +
+        '    <block type="text_print" id="9">\n' +
+        '      <value name="TEXT">\n' +
+        '        <shadow type="text" id="10">\n' +
+        '          <field name="TEXT">abc</field>\n' +
+        '        </shadow>\n' +
+        '      </value>\n' +
+        '    </block>\n' +
+        '  </statement>\n' +
+        '</block>\n',
       expectedXml:
-          '<block xmlns="https://developers.google.com/blockly/xml" ' +
-          'type="controls_if" id="1">\n' +
-          '  <mutation inputs="0,1" else="true" next="2"></mutation>\n</block>',
+        '<block xmlns="https://developers.google.com/blockly/xml" ' +
+        'type="dynamic_if" id="1">\n' +
+        '  <mutation elseif="2"></mutation>\n' +
+        '  <value name="IF0">\n' +
+        '    <block type="logic_boolean" id="1">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="DO0">\n' +
+        '    <block type="text_print" id="3">\n' +
+        '      <value name="TEXT">\n' +
+        '        <shadow type="text" id="4">\n' +
+        '          <field name="TEXT">abc</field>\n' +
+        '        </shadow>\n' +
+        '      </value>\n' +
+        '    </block>\n' +
+        '  </statement>\n' +
+        '  <value name="IF1">\n' +
+        '    <block type="logic_boolean" id="5">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="DO1">\n' +
+        '    <block type="text_print" id="6">\n' +
+        '      <value name="TEXT">\n' +
+        '        <shadow type="text" id="7">\n' +
+        '          <field name="TEXT">abc</field>\n' +
+        '        </shadow>\n' +
+        '      </value>\n' +
+        '    </block>\n' +
+        '  </statement>\n' +
+        '  <value name="IF2">\n' +
+        '    <block type="logic_boolean" id="8">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="DO2">\n' +
+        '    <block type="text_print" id="9">\n' +
+        '      <value name="TEXT">\n' +
+        '        <shadow type="text" id="10">\n' +
+        '          <field name="TEXT">abc</field>\n' +
+        '        </shadow>\n' +
+        '      </value>\n' +
+        '    </block>\n' +
+        '  </statement>\n' +
+        '</block>',
       assertBlockStructure: (block) => {
         assertBlockStructure(
-            block, ['IF0', 'DO0', 'IF1', 'DO1', 'ELSE'], 'controls_if');
+            block, [/IF0/, /DO0/, /IF1/, /DO1/, /IF2/, /DO2/]);
+      },
+    },
+    {
+      title: 'one if one else - standard serialization',
+      xml:
+        '<block xmlns="https://developers.google.com/blockly/xml"' +
+        ' type="dynamic_if" id="1">\n' +
+        '  <mutation elseif="1" else="1"></mutation>\n' +
+        '</block>',
+      expectedXml:
+        '<block xmlns="https://developers.google.com/blockly/xml"' +
+        ' type="dynamic_if" id="1"></block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(
+            block, [/IF0/, /DO0/], 'dynamic_if');
+      },
+    },
+    {
+      title: 'one if one else with children - standard serialization',
+      xml:
+        '<block xmlns="https://developers.google.com/blockly/xml"' +
+        ' type="dynamic_if" id="1">\n' +
+        '  <mutation elseif="1" else="1"></mutation>\n' +
+        '  <value name="IF0">\n' +
+        '    <block type="logic_boolean" id="2">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <value name="IF1">\n' +
+        '    <block type="logic_boolean" id="3">\n' +
+        '      <field name="BOOL">TRUE</field>\n' +
+        '    </block>\n' +
+        '  </value>\n' +
+        '  <statement name="ELSE">\n' +
+        '    <block type="text_print" id="4"></block>\n' +
+        '  </statement>\n' +
+        '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(
+            block, [/IF0/, /DO0/, /IF1/, /DO1/, /ELSE/], 'dynamic_if');
       },
     },
   ];

--- a/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
@@ -15,7 +15,7 @@ suite('List create block', function() {
   /**
    * Asserts that the list create block has the expected inputs.
    * @param {!Blockly.Block} block The block to check.
-   * @param {!Array<string>} expectedInputs The expected inputs.
+   * @param {!Array<RegExp>} expectedInputs The expected inputs.
    * @type {string=} The block type expected. Defaults to 'dynamic_list_create'.
    */
   function assertBlockStructure(
@@ -23,9 +23,8 @@ suite('List create block', function() {
   ) {
     assert.equal(block.type, type);
     assert.equal(block.inputList.length, expectedInputs.length);
-    assert.isTrue(expectedInputs.length >= 2);
     for (let i = 0; i < expectedInputs.length; i++) {
-      assert.equal(block.inputList[i].name, expectedInputs[i]);
+      assert.match(block.inputList[i].name, expectedInputs[i]);
     }
   }
 
@@ -44,71 +43,111 @@ suite('List create block', function() {
   setup(function() {
     this.workspace = new Blockly.Workspace();
     overrideOldBlockDefinitions();
+
+    const def1 = {...Blockly.Blocks['dynamic_list_create']};
+    def1.minInputs = 1;
+    Blockly.Blocks['dynamic_list_1_input'] = def1;
+
+    const def5 = {...Blockly.Blocks['dynamic_list_create']};
+    def5.minInputs = 5;
+    Blockly.Blocks['dynamic_list_5_inputs'] = def5;
   });
 
   teardown(function() {
     this.workspace.dispose();
+    delete Blockly.Blocks['dynamic_list_5_inputs'];
   });
 
-  test('Creation', function() {
-    const block = this.workspace.newBlock('dynamic_list_create');
-    assertBlockStructure(block, ['ADD0', 'ADD1']);
-  });
-
-  suite('onPendingConnection', function() {
-    test('pending connection with empty connection', function() {
+  suite('Creation', function() {
+    test('the default definition has two inputs', function() {
       const block = this.workspace.newBlock('dynamic_list_create');
-      const connection = block.inputList[0].connection;
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
+    });
+
+    test('minInputs controls the number of inputs', function() {
+      const block = this.workspace.newBlock('dynamic_list_5_inputs');
+      assertBlockStructure(
+          block,
+          [/ADD0/, /ADD1/, /ADD2/, /ADD3/, /ADD4/],
+          'dynamic_list_5_inputs');
+    });
+  });
+
+  suite('adding inputs', function() {
+    test('attaching min items does not add an input', function() {
+      const block = this.workspace.newBlock('dynamic_list_1_input');
+      const connection = block.getInput('ADD0').connection;
+
       block.onPendingConnection(connection);
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+
+      assertBlockStructure(block, [/ADD0/], 'dynamic_list_1_input');
     });
 
-    test('pending connection with empty next connection', function() {
-      const block = this.workspace.newBlock('dynamic_list_create');
-      const connection = block.inputList[0].connection;
-      connectBlockToConnection(this.workspace, block.inputList[0].connection);
+    test('attaching three items creates an input', function() {
+      const block = this.workspace.newBlock('dynamic_list_1_input');
+      const connection = block.getInput('ADD0').connection;
+      connectBlockToConnection(this.workspace, connection);
+
       block.onPendingConnection(connection);
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
-    });
 
-    test('pending connection adds connection', function() {
-      const block = this.workspace.newBlock('dynamic_list_create');
-      connectBlockToConnection(this.workspace, block.inputList[0].connection);
-      connectBlockToConnection(this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['ADD0', 'ADD2', 'ADD1']);
-      block.onPendingConnection(block.inputList[2].connection);
-      assertBlockStructure(block, ['ADD0', 'ADD2', 'ADD1', 'ADD3']);
+      assertBlockStructure(block, [/ADD0/, /ADD.*/], 'dynamic_list_1_input');
     });
   });
 
-  suite('finalizeConnections', function() {
-    test('does not go below 2 connections', function() {
-      const block = this.workspace.newBlock('dynamic_list_create');
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+  suite('finalizing inputs', function() {
+    test('the block does not go below min inputs', function() {
+      const block = this.workspace.newBlock('dynamic_list_5_inputs');
+
       block.finalizeConnections();
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+
+      assertBlockStructure(
+          block,
+          [/ADD0/, /ADD1/, /ADD2/, /ADD3/, /ADD4/],
+          'dynamic_list_5_inputs');
     });
 
-    test('removes empty connections', function() {
-      const block = this.workspace.newBlock('dynamic_list_create');
-      connectBlockToConnection(this.workspace, block.inputList[0].connection);
-      connectBlockToConnection(this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['ADD0', 'ADD2', 'ADD1']);
+    test('an extra input with no blocks is removed', function() {
+      const block = this.workspace.newBlock('dynamic_list_1_input');
+      const connection = block.getInput('ADD0').connection;
+      connectBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
+
       block.finalizeConnections();
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+
+      assertBlockStructure(block, [/ADD0/], 'dynamic_list_1_input');
     });
 
-    test('updates the field if the first connection is removed', function() {
-      const block = this.workspace.newBlock('dynamic_list_create');
+    test('an extra input with blocks is kept', function() {
+      const block = this.workspace.newBlock('dynamic_list_1_input');
+      const connection = block.getInput('ADD0').connection;
+      connectBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
       connectBlockToConnection(this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[1].connection);
-      connectBlockToConnection(this.workspace, block.inputList[2].connection);
+
       block.finalizeConnections();
-      assertBlockStructure(block, ['ADD1', 'ADD2']);
-      assert.equal(block.inputList[0].fieldRow[0].value_,
-          Blockly.Msg.LISTS_CREATE_WITH_INPUT_WITH);
+
+      assertBlockStructure(block, [/ADD0/, /ADD1/], 'dynamic_list_1_input');
+    });
+
+    test('extra inputs are removed starting at the end', function() {
+      const block = this.workspace.newBlock('dynamic_list_5_inputs');
+      const connection0 = block.getInput('ADD0').connection;
+      const connection1 = block.getInput('ADD1').connection;
+      connectBlockToConnection(this.workspace, connection0);
+      connectBlockToConnection(this.workspace, connection1);
+      block.onPendingConnection(connection0);
+
+      block.finalizeConnections();
+
+      assertBlockStructure(
+          block,
+          [/ADD0/, /ADD1/, /ADD2/, /ADD3/, /ADD4/],
+          'dynamic_list_5_inputs');
+      assert.isOk(block.getInputTargetBlock('ADD0'));
+      assert.isNotOk(
+          block.getInputTargetBlock('ADD1'),
+          'Expected the empty input created by pending to still exist.');
+      assert.isOk(block.getInputTargetBlock('ADD2'));
     });
   });
 
@@ -119,13 +158,29 @@ suite('List create block', function() {
       expectedXml:
           '<block xmlns="https://developers.google.com/blockly/xml" ' +
           'type="dynamic_list_create" id="1">\n' +
-          '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n</block>',
+          '  <mutation items="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD0', 'ADD1']);
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
       },
     },
     {
-      title: 'two inputs with one child',
+      title: 'default state - old serialization',
+      xml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation items="2"></mutation>\n' +
+          '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
+      },
+    },
+    {
+      title: 'two inputs with one child - old serialization',
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_list_create" id="1">\n' +
@@ -133,13 +188,75 @@ suite('List create block', function() {
           '  <value name="ADD1">\n' +
           '    <block type="text" id="2">\n' +
           '      <field name="TEXT">abc</field>\n' +
-          '    </block>\n  </value>\n</block>',
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation items="2"></mutation>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">abc</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD0', 'ADD1']);
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
       },
     },
     {
-      title: 'multiple inputs with children',
+      title: 'multiple inputs with children - old serialization',
+      xml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation inputs="ADD0,ADD1,ADD2,ADD3" next="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation items="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
+      },
+    },
+    {
+      title: 'multiple non-sequential inputs with children - old serialization',
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_list_create" id="1">\n' +
@@ -159,24 +276,77 @@ suite('List create block', function() {
           '  <value name="ADD4">\n' +
           '    <block type="text" id="5">\n' +
           '      <field name="TEXT">a</field>\n' +
-          '    </block>\n  </value>\n</block>',
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation items="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD1', 'ADD5', 'ADD2', 'ADD4']);
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
       },
     },
     {
-      title: 'standard/core XML is deserialized correctly',
+      title: 'two inputs one child - standard serialization',
       xml:
-        '<block type="lists_create_with" id="1" x="63" y="113">' +
-        '  <mutation items="3"></mutation>' +
-        '</block>',
-      expectedXml:
-          '<block xmlns="https://developers.google.com/blockly/xml" ' +
-          'type="lists_create_with" id="1">\n' +
-          '  <mutation inputs="ADD0,ADD1,ADD2" next="3"></mutation>\n</block>',
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation items="2"></mutation>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">abc</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(
-            block, ['ADD0', 'ADD1', 'ADD2'], 'lists_create_with');
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
+      },
+    },
+    {
+      title: 'multiple inputs with children - standard serialization',
+      xml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_list_create" id="1">\n' +
+          '  <mutation items="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
       },
     },
     {
@@ -188,9 +358,9 @@ suite('List create block', function() {
       expectedXml:
           '<block xmlns="https://developers.google.com/blockly/xml" ' +
           'type="lists_create_with" id="1">\n' +
-          '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n</block>',
+          '  <mutation items="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD0', 'ADD1'], 'lists_create_with');
+        assertBlockStructure(block, [/ADD0/, /ADD1/], 'lists_create_with');
       },
     },
   ];

--- a/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_list_create.mocha.js
@@ -363,6 +363,176 @@ suite('List create block', function() {
         assertBlockStructure(block, [/ADD0/, /ADD1/], 'lists_create_with');
       },
     },
+    {
+      title: 'two inputs one child - json',
+      json: {
+        'type': 'dynamic_list_create',
+        'id': '1',
+        'extraState': {
+          'itemCount': 2,
+        },
+        'inputs': {
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': 2,
+              'fields': {
+                'TEXT': 'abc',
+              },
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
+      },
+    },
+    {
+      title: 'multiple inputs with children - json',
+      json: {
+        'type': 'dynamic_list_create',
+        'id': '1',
+        'extraState': {
+          'itemCount': 4,
+        },
+        'inputs': {
+          'ADD0': {
+            'block': {
+              'type': 'text',
+              'id': '2',
+              'fields': {
+                'TEXT': 'a',
+              },
+            },
+          },
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': '3',
+              'fields': {
+                'TEXT': 'b',
+              },
+            },
+          },
+          'ADD2': {
+            'block': {
+              'type': 'text',
+              'id': '4',
+              'fields': {
+                'TEXT': 'c',
+              },
+            },
+          },
+          'ADD3': {
+            'block': {
+              'type': 'text',
+              'id': '5',
+              'fields': {
+                'TEXT': 'd',
+              },
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
+      },
+    },
+    {
+      title: 'multiple inputs with children - json with stringified old XML',
+      json: {
+        'type': 'dynamic_list_create',
+        'id': '1',
+        'extraState':
+            '<mutation inputs="ADD0,ADD1,ADD2,ADD3" next="4"></mutation>',
+        'inputs': {
+          'ADD0': {
+            'block': {
+              'type': 'text',
+              'id': '2',
+              'fields': {
+                'TEXT': 'a',
+              },
+            },
+          },
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': '3',
+              'fields': {
+                'TEXT': 'b',
+              },
+            },
+          },
+          'ADD2': {
+            'block': {
+              'type': 'text',
+              'id': '4',
+              'fields': {
+                'TEXT': 'c',
+              },
+            },
+          },
+          'ADD3': {
+            'block': {
+              'type': 'text',
+              'id': '5',
+              'fields': {
+                'TEXT': 'd',
+              },
+            },
+          },
+        },
+      },
+      expectedJson: {
+        'type': 'dynamic_list_create',
+        'id': '1',
+        'extraState': {
+          'itemCount': 4,
+        },
+        'inputs': {
+          'ADD0': {
+            'block': {
+              'type': 'text',
+              'id': '2',
+              'fields': {
+                'TEXT': 'a',
+              },
+            },
+          },
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': '3',
+              'fields': {
+                'TEXT': 'b',
+              },
+            },
+          },
+          'ADD2': {
+            'block': {
+              'type': 'text',
+              'id': '4',
+              'fields': {
+                'TEXT': 'c',
+              },
+            },
+          },
+          'ADD3': {
+            'block': {
+              'type': 'text',
+              'id': '5',
+              'fields': {
+                'TEXT': 'd',
+              },
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
+      },
+    },
   ];
   testHelpers.runSerializationTestSuite(testCases);
 });

--- a/plugins/block-dynamic-connection/test/dynamic_text_join.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_text_join.mocha.js
@@ -11,7 +11,7 @@ const {overrideOldBlockDefinitions} = require('../src/index');
 
 const assert = chai.assert;
 
-suite.only('Text join block', function() {
+suite('Text join block', function() {
   /**
    * Asserts that the text join block has the expected inputs.
    * @param {!Blockly.Block} block The block to check.
@@ -361,6 +361,176 @@ suite.only('Text join block', function() {
           '  <mutation items="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
         assertBlockStructure(block, [/ADD0/, /ADD1/], 'lists_create_with');
+      },
+    },
+    {
+      title: 'two inputs one child - json',
+      json: {
+        'type': 'dynamic_text_join',
+        'id': '1',
+        'extraState': {
+          'itemCount': 2,
+        },
+        'inputs': {
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': 2,
+              'fields': {
+                'TEXT': 'abc',
+              },
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
+      },
+    },
+    {
+      title: 'multiple inputs with children - json',
+      json: {
+        'type': 'dynamic_text_join',
+        'id': '1',
+        'extraState': {
+          'itemCount': 4,
+        },
+        'inputs': {
+          'ADD0': {
+            'block': {
+              'type': 'text',
+              'id': '2',
+              'fields': {
+                'TEXT': 'a',
+              },
+            },
+          },
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': '3',
+              'fields': {
+                'TEXT': 'b',
+              },
+            },
+          },
+          'ADD2': {
+            'block': {
+              'type': 'text',
+              'id': '4',
+              'fields': {
+                'TEXT': 'c',
+              },
+            },
+          },
+          'ADD3': {
+            'block': {
+              'type': 'text',
+              'id': '5',
+              'fields': {
+                'TEXT': 'd',
+              },
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
+      },
+    },
+    {
+      title: 'multiple inputs with children - json with stringified old XML',
+      json: {
+        'type': 'dynamic_text_join',
+        'id': '1',
+        'extraState':
+            '<mutation inputs="ADD0,ADD1,ADD2,ADD3" next="4"></mutation>',
+        'inputs': {
+          'ADD0': {
+            'block': {
+              'type': 'text',
+              'id': '2',
+              'fields': {
+                'TEXT': 'a',
+              },
+            },
+          },
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': '3',
+              'fields': {
+                'TEXT': 'b',
+              },
+            },
+          },
+          'ADD2': {
+            'block': {
+              'type': 'text',
+              'id': '4',
+              'fields': {
+                'TEXT': 'c',
+              },
+            },
+          },
+          'ADD3': {
+            'block': {
+              'type': 'text',
+              'id': '5',
+              'fields': {
+                'TEXT': 'd',
+              },
+            },
+          },
+        },
+      },
+      expectedJson: {
+        'type': 'dynamic_text_join',
+        'id': '1',
+        'extraState': {
+          'itemCount': 4,
+        },
+        'inputs': {
+          'ADD0': {
+            'block': {
+              'type': 'text',
+              'id': '2',
+              'fields': {
+                'TEXT': 'a',
+              },
+            },
+          },
+          'ADD1': {
+            'block': {
+              'type': 'text',
+              'id': '3',
+              'fields': {
+                'TEXT': 'b',
+              },
+            },
+          },
+          'ADD2': {
+            'block': {
+              'type': 'text',
+              'id': '4',
+              'fields': {
+                'TEXT': 'c',
+              },
+            },
+          },
+          'ADD3': {
+            'block': {
+              'type': 'text',
+              'id': '5',
+              'fields': {
+                'TEXT': 'd',
+              },
+            },
+          },
+        },
+      },
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
       },
     },
   ];

--- a/plugins/block-dynamic-connection/test/dynamic_text_join.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_text_join.mocha.js
@@ -11,11 +11,11 @@ const {overrideOldBlockDefinitions} = require('../src/index');
 
 const assert = chai.assert;
 
-suite('Text join block', function() {
+suite.only('Text join block', function() {
   /**
    * Asserts that the text join block has the expected inputs.
    * @param {!Blockly.Block} block The block to check.
-   * @param {!Array<string>} expectedInputs The expected inputs.
+   * @param {!Array<RegExp>} expectedInputs The expected inputs.
    * @type {string=} The block type expected. Defaults to 'dynamic_text_join'.
    */
   function assertBlockStructure(
@@ -23,9 +23,8 @@ suite('Text join block', function() {
   ) {
     assert.equal(block.type, type);
     assert.equal(block.inputList.length, expectedInputs.length);
-    assert.isTrue(expectedInputs.length >= 2);
     for (let i = 0; i < expectedInputs.length; i++) {
-      assert.equal(block.inputList[i].name, expectedInputs[i]);
+      assert.match(block.inputList[i].name, expectedInputs[i]);
     }
   }
 
@@ -44,71 +43,111 @@ suite('Text join block', function() {
   setup(function() {
     this.workspace = new Blockly.Workspace();
     overrideOldBlockDefinitions();
+
+    const def1 = {...Blockly.Blocks['dynamic_text_join']};
+    def1.minInputs = 1;
+    Blockly.Blocks['dynamic_text_1_input'] = def1;
+
+    const def5 = {...Blockly.Blocks['dynamic_text_join']};
+    def5.minInputs = 5;
+    Blockly.Blocks['dynamic_text_5_inputs'] = def5;
   });
 
   teardown(function() {
     this.workspace.dispose();
+    delete Blockly.Blocks['dynamic_text_5_inputs'];
   });
 
-  test('Creation', function() {
-    const block = this.workspace.newBlock('dynamic_text_join');
-    assertBlockStructure(block, ['ADD0', 'ADD1']);
-  });
-
-  suite('onPendingConnection', function() {
-    test('pending connection with empty connection', function() {
+  suite('Creation', function() {
+    test('the default definition has two inputs', function() {
       const block = this.workspace.newBlock('dynamic_text_join');
-      const connection = block.inputList[0].connection;
+      assertBlockStructure(block, [/ADD0/, /ADD1/]);
+    });
+
+    test('minInputs controls the number of inputs', function() {
+      const block = this.workspace.newBlock('dynamic_text_5_inputs');
+      assertBlockStructure(
+          block,
+          [/ADD0/, /ADD1/, /ADD2/, /ADD3/, /ADD4/],
+          'dynamic_text_5_inputs');
+    });
+  });
+
+  suite('adding inputs', function() {
+    test('attaching min items does not add an input', function() {
+      const block = this.workspace.newBlock('dynamic_text_1_input');
+      const connection = block.getInput('ADD0').connection;
+
       block.onPendingConnection(connection);
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+
+      assertBlockStructure(block, [/ADD0/], 'dynamic_text_1_input');
     });
 
-    test('pending connection with empty next connection', function() {
-      const block = this.workspace.newBlock('dynamic_text_join');
-      const connection = block.inputList[0].connection;
-      connectBlockToConnection(this.workspace, block.inputList[0].connection);
+    test('attaching three items creates an input', function() {
+      const block = this.workspace.newBlock('dynamic_text_1_input');
+      const connection = block.getInput('ADD0').connection;
+      connectBlockToConnection(this.workspace, connection);
+
       block.onPendingConnection(connection);
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
-    });
 
-    test('pending connection adds connection', function() {
-      const block = this.workspace.newBlock('dynamic_text_join');
-      connectBlockToConnection(this.workspace, block.inputList[0].connection);
-      connectBlockToConnection(this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['ADD0', 'ADD2', 'ADD1']);
-      block.onPendingConnection(block.inputList[2].connection);
-      assertBlockStructure(block, ['ADD0', 'ADD2', 'ADD1', 'ADD3']);
+      assertBlockStructure(block, [/ADD0/, /ADD.*/], 'dynamic_text_1_input');
     });
   });
 
-  suite('finalizeConnections', function() {
-    test('does not go below 2 connections', function() {
-      const block = this.workspace.newBlock('dynamic_text_join');
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+  suite('finalizing inputs', function() {
+    test('the block does not go below min inputs', function() {
+      const block = this.workspace.newBlock('dynamic_text_5_inputs');
+
       block.finalizeConnections();
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+
+      assertBlockStructure(
+          block,
+          [/ADD0/, /ADD1/, /ADD2/, /ADD3/, /ADD4/],
+          'dynamic_text_5_inputs');
     });
 
-    test('removes empty connections', function() {
-      const block = this.workspace.newBlock('dynamic_text_join');
-      connectBlockToConnection(this.workspace, block.inputList[0].connection);
-      connectBlockToConnection(this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[0].connection);
-      assertBlockStructure(block, ['ADD0', 'ADD2', 'ADD1']);
+    test('an extra input with no blocks is removed', function() {
+      const block = this.workspace.newBlock('dynamic_text_1_input');
+      const connection = block.getInput('ADD0').connection;
+      connectBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
+
       block.finalizeConnections();
-      assertBlockStructure(block, ['ADD0', 'ADD1']);
+
+      assertBlockStructure(block, [/ADD0/], 'dynamic_text_1_input');
     });
 
-    test('updates the field if the first connection is removed', function() {
-      const block = this.workspace.newBlock('dynamic_text_join');
+    test('an extra input with blocks is kept', function() {
+      const block = this.workspace.newBlock('dynamic_text_1_input');
+      const connection = block.getInput('ADD0').connection;
+      connectBlockToConnection(this.workspace, connection);
+      block.onPendingConnection(connection);
       connectBlockToConnection(this.workspace, block.inputList[1].connection);
-      block.onPendingConnection(block.inputList[1].connection);
-      connectBlockToConnection(this.workspace, block.inputList[2].connection);
+
       block.finalizeConnections();
-      assertBlockStructure(block, ['ADD1', 'ADD2']);
-      assert.equal(block.inputList[0].fieldRow[0].value_,
-          Blockly.Msg.TEXT_JOIN_TITLE_CREATEWITH);
+
+      assertBlockStructure(block, [/ADD0/, /ADD1/], 'dynamic_text_1_input');
+    });
+
+    test('extra inputs are removed starting at the end', function() {
+      const block = this.workspace.newBlock('dynamic_text_5_inputs');
+      const connection0 = block.getInput('ADD0').connection;
+      const connection1 = block.getInput('ADD1').connection;
+      connectBlockToConnection(this.workspace, connection0);
+      connectBlockToConnection(this.workspace, connection1);
+      block.onPendingConnection(connection0);
+
+      block.finalizeConnections();
+
+      assertBlockStructure(
+          block,
+          [/ADD0/, /ADD1/, /ADD2/, /ADD3/, /ADD4/],
+          'dynamic_text_5_inputs');
+      assert.isOk(block.getInputTargetBlock('ADD0'));
+      assert.isNotOk(
+          block.getInputTargetBlock('ADD1'),
+          'Expected the empty input created by pending to still exist.');
+      assert.isOk(block.getInputTargetBlock('ADD2'));
     });
   });
 
@@ -119,13 +158,29 @@ suite('Text join block', function() {
       expectedXml:
           '<block xmlns="https://developers.google.com/blockly/xml" ' +
           'type="dynamic_text_join" id="1">\n' +
-          '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n</block>',
+          '  <mutation items="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD0', 'ADD1']);
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
       },
     },
     {
-      title: 'two inputs with one child',
+      title: 'default state - old serialization',
+      xml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation items="2"></mutation>\n' +
+          '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
+      },
+    },
+    {
+      title: 'two inputs with one child - old serialization',
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_text_join" id="1">\n' +
@@ -133,13 +188,75 @@ suite('Text join block', function() {
           '  <value name="ADD1">\n' +
           '    <block type="text" id="2">\n' +
           '      <field name="TEXT">abc</field>\n' +
-          '    </block>\n  </value>\n</block>',
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation items="2"></mutation>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">abc</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD0', 'ADD1']);
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
       },
     },
     {
-      title: 'multiple inputs with children',
+      title: 'multiple inputs with children - old serialization',
+      xml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation inputs="ADD0,ADD1,ADD2,ADD3" next="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation items="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
+      },
+    },
+    {
+      title: 'multiple non-sequential inputs with children - old serialization',
       xml:
           '<block xmlns="https://developers.google.com/blockly/xml"' +
           ' type="dynamic_text_join" id="1">\n' +
@@ -159,38 +276,91 @@ suite('Text join block', function() {
           '  <value name="ADD4">\n' +
           '    <block type="text" id="5">\n' +
           '      <field name="TEXT">a</field>\n' +
-          '    </block>\n  </value>\n</block>',
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      expectedXml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation items="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD1', 'ADD5', 'ADD2', 'ADD4']);
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
       },
     },
     {
-      title: 'standard/core XML is deserialized correctly',
+      title: 'two inputs one child - standard serialization',
       xml:
-        '<block type="text_join" id="1" x="63" y="113">' +
-        '  <mutation items="3"></mutation>' +
-        '</block>',
-      expectedXml:
-          '<block xmlns="https://developers.google.com/blockly/xml" ' +
-          'type="text_join" id="1">\n' +
-          '  <mutation inputs="ADD0,ADD1,ADD2" next="3"></mutation>\n</block>',
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation items="2"></mutation>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">abc</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(
-            block, ['ADD0', 'ADD1', 'ADD2'], 'text_join');
+        assertBlockStructure(block, [/ADD0/, /ADD1/]);
+      },
+    },
+    {
+      title: 'multiple inputs with children - standard serialization',
+      xml:
+          '<block xmlns="https://developers.google.com/blockly/xml"' +
+          ' type="dynamic_text_join" id="1">\n' +
+          '  <mutation items="4"></mutation>\n' +
+          '  <value name="ADD0">\n' +
+          '    <block type="text" id="2">\n' +
+          '      <field name="TEXT">b</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD1">\n' +
+          '    <block type="text" id="3">\n' +
+          '      <field name="TEXT">d</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD2">\n' +
+          '    <block type="text" id="4">\n' +
+          '      <field name="TEXT">c</field>\n' +
+          '    </block>\n  </value>\n' +
+          '  <value name="ADD3">\n' +
+          '    <block type="text" id="5">\n' +
+          '      <field name="TEXT">a</field>\n' +
+          '    </block>\n' +
+          '  </value>\n' +
+          '</block>',
+      assertBlockStructure: (block) => {
+        assertBlockStructure(block, [/ADD0/, /ADD1/, /ADD2/, /ADD3/]);
       },
     },
     {
       title: 'standard/core XML still maintains minimum inputs',
       xml:
-        '<block type="text_join" id="1" x="63" y="113">' +
+        '<block type="lists_create_with" id="1" x="63" y="113">' +
         '  <mutation items="0"></mutation>' +
         '</block>',
       expectedXml:
           '<block xmlns="https://developers.google.com/blockly/xml" ' +
-          'type="text_join" id="1">\n' +
-          '  <mutation inputs="ADD0,ADD1" next="2"></mutation>\n</block>',
+          'type="lists_create_with" id="1">\n' +
+          '  <mutation items="2"></mutation>\n</block>',
       assertBlockStructure: (block) => {
-        assertBlockStructure(block, ['ADD0', 'ADD1'], 'text_join');
+        assertBlockStructure(block, [/ADD0/, /ADD1/], 'lists_create_with');
       },
     },
   ];


### PR DESCRIPTION
Fixes were verified in individual PRs. This merges into the 2023-q3-eq branch so that the fixes can go out with the EOQ release.

Originally I thought they could just go out at once when they were done, but then I ran into connection highlights not being disposed (https://github.com/google/blockly/pull/7454) so I think it's best to release this fix with that one.
