### PR TITLE
fix: toolbox search with XML toolboxes of kind BLOCK

### DIFF
--- a/plugins/toolbox-search/src/toolbox_search.ts
+++ b/plugins/toolbox-search/src/toolbox_search.ts
@@ -109,7 +109,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
       schema.contents.forEach((contents) => {
         this.getAvailableBlocks(contents, allBlocks);
       });
-    } else if (schema.kind === 'block') {
+    } else if (schema.kind.toLowerCase() === 'block') {
       if ('type' in schema && schema.type) {
         allBlocks.add(schema.type);
       }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly-samples/issues/1925

### Proposed Changes

This PR adds an explicit lowerCase casting to schema.kind field which is being compared against 'block' literal.

### Reason for Changes

In the _toolbox_ object attached to the issue, the schema.kind field has value = 'BLOCK' in uppercase whereas in code we are comparing the field value with `schema.kind === 'block'`.  So I converted the check field to lowercase against the literal. Which will ensure case insensitivity of the expression. The expression now becomes `schema.kind.toLowercase() === 'block'`.
### Test Coverage
1. Run it using the steps mentioned in the issue. 
2. Search for blocks present in the test toolbox object present in the issue.
3. Here's the sample of working output - 
<img width="1280" alt="image" src="https://github.com/google/blockly-samples/assets/47386692/9236f46c-3894-46e6-905f-add95a378dab">

