### PR TITLE
fix: minimap rendering issue

### DIFF
--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -80,6 +80,7 @@ export class Minimap {
             },
             readOnly: true,
             theme: this.primaryWorkspace.getTheme(),
+            renderer: this.primaryWorkspace.options.renderer
           });
 
       this.minimapWorkspace.scrollbar.setContainerVisible(false);

--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -80,7 +80,7 @@ export class Minimap {
             },
             readOnly: true,
             theme: this.primaryWorkspace.getTheme(),
-            renderer: this.primaryWorkspace.options.renderer
+            renderer: this.primaryWorkspace.options.renderer,
           });
 
       this.minimapWorkspace.scrollbar.setContainerVisible(false);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #1926

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This PR modify the [minimap inject call](https://github.com/google/blockly-samples/blob/e45ad05b9f5f6cb717b8337c60df09fa0128e06b/plugins/workspace-minimap/src/minimap.ts#L64) to copy the renderer from the `primaryWorkspace`

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
As discussed in the issue, if we change the renderer option from `geras` to `zelos` in the main workspace then the minimap still uses the `geras` renderer. So if we use the renderer of the main workspace in minimap then this issue will be resolved.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

1. Run it using the steps mentioned in the issue.