### PR TITLE
fix: Fire intermediate events instead of change events while dragging angle field

### DIFF
--- a/plugins/field-angle/src/field_angle.ts
+++ b/plugins/field-angle/src/field_angle.ts
@@ -448,12 +448,13 @@ export class FieldAngle extends Blockly.FieldNumber {
         this.value_ !== oldValue
       ) {
         Blockly.Events.fire(
-          new (Blockly.Events.get(Blockly.Events.BLOCK_FIELD_INTERMEDIATE_CHANGE))(
-            this.sourceBlock_,
-            this.name || null,
-            oldValue,
-            this.value_
-          )
+            new (Blockly.Events.get(
+                Blockly.Events.BLOCK_FIELD_INTERMEDIATE_CHANGE))(
+                this.sourceBlock_,
+                this.name || null,
+                oldValue,
+                this.value_
+            )
         );
       }
     }

--- a/plugins/field-angle/src/field_angle.ts
+++ b/plugins/field-angle/src/field_angle.ts
@@ -435,7 +435,27 @@ export class FieldAngle extends Blockly.FieldNumber {
   private displayMouseOrKeyboardValue(angle: number) {
     const validAngle = this.doClassValidation_(angle);
     if (validAngle !== null && validAngle !== this.value_) {
-      this.setEditorValue_(validAngle);
+      // this.setEditorValue_(validAngle);
+      // Intermediate value changes from user input are not confirmed until the
+      // user closes the editor, and may be numerous. Inhibit reporting these as
+      // normal block change events, and instead report them as special
+      // intermediate changes that do not get recorded in undo history.
+      const oldValue = this.value_;
+      this.setEditorValue_(angle, false);
+      if (
+        this.sourceBlock_ &&
+        Blockly.Events.isEnabled() &&
+        this.value_ !== oldValue
+      ) {
+        Blockly.Events.fire(
+          new (Blockly.Events.get(Blockly.Events.BLOCK_FIELD_INTERMEDIATE_CHANGE))(
+            this.sourceBlock_,
+            this.name || null,
+            oldValue,
+            this.value_
+          )
+        );
+      }
     }
   }
 

--- a/plugins/field-angle/src/field_angle.ts
+++ b/plugins/field-angle/src/field_angle.ts
@@ -435,7 +435,6 @@ export class FieldAngle extends Blockly.FieldNumber {
   private displayMouseOrKeyboardValue(angle: number) {
     const validAngle = this.doClassValidation_(angle);
     if (validAngle !== null && validAngle !== this.value_) {
-      // this.setEditorValue_(validAngle);
       // Intermediate value changes from user input are not confirmed until the
       // user closes the editor, and may be numerous. Inhibit reporting these as
       // normal block change events, and instead report them as special


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly-samples/issues/1717

### Proposed Changes

When dragging the angle widget, fire intermediate events instead of change events, until letting go of the mouse button.

### Reason for Changes

The number of change events fired while dragging the angle widget can be excessive (in cases where the application is performing expensive processing in response to change events, such as serializing the workspace), so we want to fire a different "intermediate" event while dragging the field value, and then fire a single normal change event when committing the new value.

### Test Coverage

I manually tested the events by running `npm run start` in the plugin directory to access the demo, then opening the browser developer console and running this script:
```
Blockly.getMainWorkspace().addChangeListener(function(event) {
    console.log({type: event.type, oldValue: event.oldValue, newValue: event.newValue, group: event.group})
});
```
Then I manipulated the field widget and confirmed that dragging it fired intermediate events and dismissing the widget fired a regular change event (if the final value is different from the initial value).

### Documentation

N/A

### Additional Information

This copies a feature that was previously added to the core repo in: https://github.com/google/blockly/pull/7151 

That change only added the feature to built-in Blockly fields. Fields that are added in plugins, such as this angle field, need to be updated separately to take advantage of the new feature.

`FieldAngle` extends `Blockly.FieldNumber`, which extends `Blockly.FieldInput`, which handles firing the regular change event when the editor widget is dismissed, so this PR does not need to implement that aspect of the feature. This PR only needed to inhibit firing change events while dragging the angle value, and instead fire the intermediate events.
