### PR TITLE
chore: fix tsconfig paths

### DIFF
--- a/plugins/block-dynamic-connection/tsconfig.json
+++ b/plugins/block-dynamic-connection/tsconfig.json
@@ -8,6 +8,10 @@
       "moduleResolution": "node",
       "target": "ES2015",
       "strict": true,
+      // Point at the local Blockly. See #1934. Remove if we add hoisting.
+      "paths": {
+        "blockly/*": ["node_modules/blockly/*"]
+      }
   },
   // NOTE: `test/**/*` is automatically included in `blockly-scripts start`.
   // Only src matters for production builds.

--- a/plugins/block-shareable-procedures/tsconfig.json
+++ b/plugins/block-shareable-procedures/tsconfig.json
@@ -5,7 +5,11 @@
     "allowJs": true,
     "sourceMap": true,
     "lib": ["es6", "dom"],
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    // Point at the local Blockly. See #1934. Remove if we add hoisting.
+    "paths": {
+      "blockly/*": ["node_modules/blockly/*"]
+    }
   },
   "include": [
     "src", "test"

--- a/plugins/block-shareable-procedures/tsconfig.json
+++ b/plugins/block-shareable-procedures/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "build",
     "target": "es6",
     "allowJs": true,

--- a/plugins/content-highlight/tsconfig.json
+++ b/plugins/content-highlight/tsconfig.json
@@ -5,7 +5,11 @@
     "allowJs": true,
     "sourceMap": true,
     "moduleResolution": "nodenext",
-    "lib": ["es2021", "dom"]
+    "lib": ["es2021", "dom"],
+    // Point at the local Blockly. See #1934. Remove if we add hoisting.
+    "paths": {
+      "blockly/*": ["node_modules/blockly/*"]
+    }
   },
   "include": [
     "src", "test"

--- a/plugins/content-highlight/tsconfig.json
+++ b/plugins/content-highlight/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "build",
     "target": "es6",
     "allowJs": true,

--- a/plugins/dev-create/templates/typescript-block/template/tsconfig.json
+++ b/plugins/dev-create/templates/typescript-block/template/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "build",
     "target": "es5",
     "allowJs": true,

--- a/plugins/dev-create/templates/typescript-block/template/tsconfig.json
+++ b/plugins/dev-create/templates/typescript-block/template/tsconfig.json
@@ -4,7 +4,11 @@
     "target": "es5",
     "allowJs": true,
     "sourceMap": true,
-    "lib": ["es6", "dom"]
+    "lib": ["es6", "dom"],
+    // Point at the local Blockly. See #1934. Remove if we add hoisting.
+    "paths": {
+      "blockly/*": ["node_modules/blockly/*"]
+    }
   },
   "include": [
     "src", "test"

--- a/plugins/dev-create/templates/typescript-field/template/tsconfig.json
+++ b/plugins/dev-create/templates/typescript-field/template/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "build",
     "target": "es5",
     "allowJs": true,

--- a/plugins/dev-create/templates/typescript-field/template/tsconfig.json
+++ b/plugins/dev-create/templates/typescript-field/template/tsconfig.json
@@ -4,7 +4,11 @@
     "target": "es5",
     "allowJs": true,
     "sourceMap": true,
-    "lib": ["es6", "dom"]
+    "lib": ["es6", "dom"],
+    // Point at the local Blockly. See #1934. Remove if we add hoisting.
+    "paths": {
+      "blockly/*": ["node_modules/blockly/*"]
+    }
   },
   "include": [
     "src", "test"

--- a/plugins/dev-create/templates/typescript-plugin/template/tsconfig.json
+++ b/plugins/dev-create/templates/typescript-plugin/template/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "build",
     "target": "es5",
     "allowJs": true,

--- a/plugins/dev-create/templates/typescript-plugin/template/tsconfig.json
+++ b/plugins/dev-create/templates/typescript-plugin/template/tsconfig.json
@@ -4,7 +4,11 @@
     "target": "es5",
     "allowJs": true,
     "sourceMap": true,
-    "lib": ["es6", "dom"]
+    "lib": ["es6", "dom"],
+    // Point at the local Blockly. See #1934. Remove if we add hoisting.
+    "paths": {
+      "blockly/*": ["node_modules/blockly/*"]
+    }
   },
   "include": [
     "src", "test"

--- a/plugins/dev-create/templates/typescript-theme/template/tsconfig.json
+++ b/plugins/dev-create/templates/typescript-theme/template/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "build",
     "target": "es5",
     "allowJs": true,

--- a/plugins/dev-create/templates/typescript-theme/template/tsconfig.json
+++ b/plugins/dev-create/templates/typescript-theme/template/tsconfig.json
@@ -4,7 +4,11 @@
     "target": "es5",
     "allowJs": true,
     "sourceMap": true,
-    "lib": ["es6", "dom"]
+    "lib": ["es6", "dom"],
+    // Point at the local Blockly. See #1934. Remove if we add hoisting.
+    "paths": {
+      "blockly/*": ["node_modules/blockly/*"]
+    }
   },
   "include": [
     "src", "test"

--- a/plugins/field-angle/tsconfig.json
+++ b/plugins/field-angle/tsconfig.json
@@ -8,6 +8,10 @@
         "moduleResolution": "node",
         "target": "ES2015",
         "strict": true,
+        // Point at the local Blockly. See #1934. Remove if we add hoisting.
+        "paths": {
+          "blockly/*": ["node_modules/blockly/*"]
+        }
     },
     // NOTE: `test/**/*` is automatically included in `blockly-scripts start`.
     // Only src matters for production builds.

--- a/plugins/field-colour-hsv-sliders/tsconfig.json
+++ b/plugins/field-colour-hsv-sliders/tsconfig.json
@@ -8,6 +8,10 @@
       "moduleResolution": "node",
       "target": "ES2015",
       "strict": true,
+      // Point at the local Blockly. See #1934. Remove if we add hoisting.
+      "paths": {
+        "blockly/*": ["node_modules/blockly/*"]
+      }
   },
   // NOTE: `test/**/*` is automatically included in `blockly-scripts start`.
   // Only src matters for production builds.

--- a/plugins/field-colour/tsconfig.json
+++ b/plugins/field-colour/tsconfig.json
@@ -8,6 +8,10 @@
         "moduleResolution": "node",
         "target": "ES2015",
         "strict": true,
+        // Point at the local Blockly. See #1934. Remove if we add hoisting.
+        "paths": {
+          "blockly/*": ["node_modules/blockly/*"]
+        }
     },
     // NOTE: `test/**/*` is automatically included in `blockly-scripts start`.
     // Only src matters for production builds.

--- a/plugins/field-date/tsconfig.json
+++ b/plugins/field-date/tsconfig.json
@@ -8,6 +8,10 @@
       "moduleResolution": "node",
       "target": "ES2015",
       "strict": true,
+      // Point at the local Blockly. See #1934. Remove if we add hoisting.
+      "paths": {
+        "blockly/*": ["node_modules/blockly/*"]
+      }
   },
   // NOTE: `test/**/*` is automatically included in `blockly-scripts start`.
   // Only src matters for production builds.

--- a/plugins/field-dependent-dropdown/tsconfig.json
+++ b/plugins/field-dependent-dropdown/tsconfig.json
@@ -8,6 +8,10 @@
       "moduleResolution": "node",
       "target": "ES2015",
       "strict": true,
+      // Point at the local Blockly. See #1934. Remove if we add hoisting.
+      "paths": {
+        "blockly/*": ["node_modules/blockly/*"]
+      }
   },
   // NOTE: `test/**/*` is automatically included in `blockly-scripts start`.
   // Only src matters for production builds.

--- a/plugins/field-grid-dropdown/tsconfig.json
+++ b/plugins/field-grid-dropdown/tsconfig.json
@@ -8,6 +8,10 @@
         "moduleResolution": "node",
         "target": "ES2015",
         "strict": true,
+        // Point at the local Blockly. See #1934. Remove if we add hoisting.
+        "paths": {
+          "blockly/*": ["node_modules/blockly/*"]
+        }
     },
     // NOTE: `test/**/*` is automatically included in `blockly-scripts start`.
     // Only src matters for production builds.

--- a/plugins/field-multilineinput/tsconfig.json
+++ b/plugins/field-multilineinput/tsconfig.json
@@ -8,6 +8,10 @@
         "moduleResolution": "node",
         "target": "ES2015",
         "strict": true,
+        // Point at the local Blockly. See #1934. Remove if we add hoisting.
+        "paths": {
+          "blockly/*": ["node_modules/blockly/*"]
+        }
     },
     // NOTE: `test/**/*` is automatically included in `blockly-scripts start`.
     // Only src matters for production builds.

--- a/plugins/field-slider/tsconfig.json
+++ b/plugins/field-slider/tsconfig.json
@@ -8,6 +8,10 @@
         "moduleResolution": "node",
         "target": "ES2015",
         "strict": true,
+        // Point at the local Blockly. See #1934. Remove if we add hoisting.
+        "paths": {
+          "blockly/*": ["node_modules/blockly/*"]
+        }
     },
     // NOTE: `test/**/*` is automatically included in `blockly-scripts start`.
     // Only src matters for production builds.

--- a/plugins/renderer-inline-row-separators/tsconfig.json
+++ b/plugins/renderer-inline-row-separators/tsconfig.json
@@ -8,6 +8,10 @@
       "moduleResolution": "node",
       "target": "ES2015",
       "strict": true,
+      // Point at the local Blockly. See #1934. Remove if we add hoisting.
+      "paths": {
+        "blockly/*": ["node_modules/blockly/*"]
+      }
   },
   // NOTE: `test/**/*` is automatically included in `blockly-scripts start`.
   // Only src matters for production builds.

--- a/plugins/shadow-block-converter/tsconfig.json
+++ b/plugins/shadow-block-converter/tsconfig.json
@@ -8,6 +8,10 @@
       "moduleResolution": "node",
       "target": "ES2015",
       "strict": true,
+      // Point at the local Blockly. See #1934. Remove if we add hoisting.
+      "paths": {
+        "blockly/*": ["node_modules/blockly/*"]
+      }
   },
   // NOTE: `test/**/*` is automatically included in `blockly-scripts start`.
   // Only src matters for production builds.

--- a/plugins/toolbox-search/tsconfig.json
+++ b/plugins/toolbox-search/tsconfig.json
@@ -5,7 +5,11 @@
     "allowJs": true,
     "sourceMap": true,
     "moduleResolution": "nodenext",
-    "lib": ["es2021", "dom"]
+    "lib": ["es2021", "dom"],
+    // Point at the local Blockly. See #1934. Remove if we add hoisting.
+    "paths": {
+      "blockly/*": ["node_modules/blockly/*"]
+    }
   },
   "include": [
     "src", "test"

--- a/plugins/toolbox-search/tsconfig.json
+++ b/plugins/toolbox-search/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "build",
     "target": "es6",
     "allowJs": true,

--- a/plugins/workspace-minimap/tsconfig.json
+++ b/plugins/workspace-minimap/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+      "baseUrl": "./",
       "outDir": "build",
       "target": "es5",
       "allowJs": true,

--- a/plugins/workspace-minimap/tsconfig.json
+++ b/plugins/workspace-minimap/tsconfig.json
@@ -4,7 +4,11 @@
       "target": "es5",
       "allowJs": true,
       "sourceMap": true,
-      "lib": ["es6", "dom"]
+      "lib": ["es6", "dom"],
+      // Point at the local Blockly. See #1934. Remove if we add hoisting.
+      "paths": {
+        "blockly/*": ["node_modules/blockly/*"]
+      }
     },
     "include": [
       "src", "test"

--- a/plugins/workspace-search/tsconfig.json
+++ b/plugins/workspace-search/tsconfig.json
@@ -5,7 +5,11 @@
     "allowJs": true,
     "sourceMap": true,
     "moduleResolution": "nodenext",
-    "lib": ["es2021", "dom"]
+    "lib": ["es2021", "dom"],
+    // Point at the local Blockly. See #1934. Remove if we add hoisting.
+    "paths": {
+      "blockly/*": ["node_modules/blockly/*"]
+    }
   },
   "include": [
     "src", "test"

--- a/plugins/workspace-search/tsconfig.json
+++ b/plugins/workspace-search/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "build",
     "target": "es6",
     "allowJs": true,

--- a/plugins/zoom-to-fit/tsconfig.json
+++ b/plugins/zoom-to-fit/tsconfig.json
@@ -5,7 +5,11 @@
     "allowJs": true,
     "sourceMap": true,
     "moduleResolution": "nodenext",
-    "lib": ["es2021", "dom"]
+    "lib": ["es2021", "dom"],
+    // Point at the local Blockly. See #1934. Remove if we add hoisting.
+    "paths": {
+      "blockly/*": ["node_modules/blockly/*"]
+    }
   },
   "include": [
     "src", "test"

--- a/plugins/zoom-to-fit/tsconfig.json
+++ b/plugins/zoom-to-fit/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "build",
     "target": "es6",
     "allowJs": true,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/1934

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds explicit paths to all of the tsconfigs in plugins.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Make it so that we can bump the version of Blockly in a plugin without having to bump it in dev-tools.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Tested the field-colour plugin bumping it to `10.2.0-beta.2` and ensured that it continued to work.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Marked as `chore` because this is a fix to tooling.
