### PR TITLE
add: flyout auto close in continuous toolbox

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousToolbox.js
+++ b/plugins/continuous-toolbox/src/ContinuousToolbox.js
@@ -32,7 +32,9 @@ export class ContinuousToolbox extends Blockly.Toolbox {
     this.workspace_.addChangeListener((e) => {
       if (e.type === Blockly.Events.BLOCK_CREATE ||
           e.type === Blockly.Events.BLOCK_DELETE) {
-        this.refreshSelection();
+        if (flyout.isVisible()) {
+          this.refreshSelection();
+        }
       }
     });
   }
@@ -86,6 +88,7 @@ export class ContinuousToolbox extends Blockly.Toolbox {
       const target = this.getFlyout()
           .getCategoryScrollPosition(newItem.name_).y;
       this.getFlyout().scrollTo(target);
+      this.refreshSelection();
     }
   }
 
@@ -143,6 +146,14 @@ export class ContinuousToolbox extends Blockly.Toolbox {
       return flyout.getClientRect();
     }
     return super.getClientRect();
+  }
+
+  /**
+   * Controls the auto-closing behavior of the flyout
+   * @param {boolean} isEnabled true to enable auto-close
+   */
+  setAutoClose(isEnabled) {
+    this.getFlyout().autoClose = isEnabled;
   }
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #1922

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This PR adds an option to auto-close continuous toolbox flyout.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
As discussed in the issue, In normal toolbox, when dragging a block from flyout, it autocloses the flyout. But continous toolbox flyout stays always opened.
