### PR TITLE
chore: Setting style property to make CSP less grumpy.

### DIFF
--- a/plugins/field-angle/src/field_angle.ts
+++ b/plugins/field-angle/src/field_angle.ts
@@ -238,8 +238,8 @@ export class FieldAngle extends Blockly.FieldNumber {
       'version': '1.1',
       'height': FieldAngle.HALF * 2 + 'px',
       'width': FieldAngle.HALF * 2 + 'px',
-      'style': 'touch-action: none',
     });
+    svg.style.touchAction = 'none';
     const circle = Blockly.utils.dom.createSvgElement(
         Blockly.utils.Svg.CIRCLE, {
           'cx': FieldAngle.HALF,

--- a/plugins/workspace-minimap/src/positioned_minimap.ts
+++ b/plugins/workspace-minimap/src/positioned_minimap.ts
@@ -161,13 +161,13 @@ export class PositionedMinimap extends Minimap implements Blockly.IPositionable 
      */
     private setAttributes(): void {
       const injectDiv = this.minimapWorkspace.getInjectionDiv();
-      injectDiv.parentElement.setAttribute('style',
-          `z-index: 2;
-          position: absolute;
-          width: ${this.width}px;
-          height: ${this.height}px;
-          top: ${this.top}px;
-          left: ${this.left}px;`);
+      const style = injectDiv.parentElement.style;
+      style.zIndex = 2;
+      style.position = 'absolute';
+      style.width = `${this.width}px`;
+      style.height = `${this.height}px`;
+      style.top = `${this.top}px`;
+      style.left = `${this.left}px;`;
       Blockly.svgResize(this.minimapWorkspace);
     }
 }

--- a/plugins/workspace-minimap/src/positioned_minimap.ts
+++ b/plugins/workspace-minimap/src/positioned_minimap.ts
@@ -162,7 +162,7 @@ export class PositionedMinimap extends Minimap implements Blockly.IPositionable 
     private setAttributes(): void {
       const injectDiv = this.minimapWorkspace.getInjectionDiv();
       const style = injectDiv.parentElement.style;
-      style.zIndex = 2;
+      style.zIndex = '2';
       style.position = 'absolute';
       style.width = `${this.width}px`;
       style.height = `${this.height}px`;


### PR DESCRIPTION
"Content-Security-Policy: The page’s settings blocked the loading of a resource at inline (“style-src”)."

The 'style' property should be set as an object, not as a string, according to CSP rules.

Back-ported from Blockly Games.
