### PR TITLE
fix: #1898 publish types for content-highlight

### DIFF
--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -13,6 +13,7 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",

--- a/plugins/content-highlight/tsconfig.json
+++ b/plugins/content-highlight/tsconfig.json
@@ -7,6 +7,8 @@
     "sourceMap": true,
     "moduleResolution": "nodenext",
     "lib": ["es2021", "dom"],
+    "declaration": true,
+    "declarationMap": true,
     // Point at the local Blockly. See #1934. Remove if we add hoisting.
     "paths": {
       "blockly/*": ["node_modules/blockly/*"]


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly-samples/issues/1898

### Proposed Changes

adds configurations to generate or publish types for this plugin

### Reason for Changes

Currently types for this plugin are not being generated or exported

### Test Coverage

not applicable - config change

### Documentation

No

### Additional Information

<!-- Anything else we should know? -->
