### PR TITLE
feat: add publish types for toolbox-search

### DIFF
--- a/plugins/toolbox-search/package.json
+++ b/plugins/toolbox-search/package.json
@@ -12,6 +12,7 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "",

--- a/plugins/toolbox-search/tsconfig.json
+++ b/plugins/toolbox-search/tsconfig.json
@@ -10,7 +10,9 @@
     // Point at the local Blockly. See #1934. Remove if we add hoisting.
     "paths": {
       "blockly/*": ["node_modules/blockly/*"]
-    }
+    },
+    "declaration": true,
+    "declarationMap": true,
   },
   "include": [
     "src", "test"

--- a/plugins/toolbox-search/tsconfig.json
+++ b/plugins/toolbox-search/tsconfig.json
@@ -12,7 +12,7 @@
       "blockly/*": ["node_modules/blockly/*"]
     },
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": true
   },
   "include": [
     "src", "test"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #1908 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Add `declaration` and `declarationMap` config options to tsconfig.json of toolbox-search
* Add `types` property to package.json of toolbox-search

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Currently, types for the toolbox-search plugin are not being generated or exported.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Not applicable (config change)

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
Completed as part of GHC Open Source Day!
