### PR TITLE
feat: Publish types for block-shareable-procedures

### DIFF
--- a/plugins/block-shareable-procedures/package.json
+++ b/plugins/block-shareable-procedures/package.json
@@ -13,6 +13,7 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",

--- a/plugins/block-shareable-procedures/tsconfig.json
+++ b/plugins/block-shareable-procedures/tsconfig.json
@@ -10,7 +10,9 @@
     // Point at the local Blockly. See #1934. Remove if we add hoisting.
     "paths": {
       "blockly/*": ["node_modules/blockly/*"]
-    }
+    },
+    "declaration": true, 
+    "declarationMap": true
   },
   "include": [
     "src", "test"

--- a/plugins/jsconfig.json
+++ b/plugins/jsconfig.json
@@ -3,9 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "checkJs": true,
-    "resolveJsonModule": true,
-    "declaration": true,
-    "declarationMap": true
+    "resolveJsonModule": true
   },
   "exclude": [
     "**/node_modules",

--- a/plugins/jsconfig.json
+++ b/plugins/jsconfig.json
@@ -4,6 +4,8 @@
     "target": "es6",
     "checkJs": true,
     "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true
   },
   "exclude": [
     "**/node_modules",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves
fixes #1897 

### Proposed Changes
1. Added the following config options to the "compilerOptions" section of the tsconfig.json
```"declaration": true, "declarationMap": true,```

2. Added the following property to the package.json next to the "main" property:
```"types": "./dist/index.d.ts"```

### Reason for Changes
 <ul> - Category: Plugins </ul>
 <ul> - Component: block-shareable-procedure </ul>

The types for the plugin were not generated or exported
