### PR TITLE
fix: Publish types for zoom-to-fit #1911

### DIFF
--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -11,6 +11,7 @@
     "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",

--- a/plugins/zoom-to-fit/tsconfig.json
+++ b/plugins/zoom-to-fit/tsconfig.json
@@ -10,7 +10,9 @@
     // Point at the local Blockly. See #1934. Remove if we add hoisting.
     "paths": {
       "blockly/*": ["node_modules/blockly/*"]
-    }
+    },
+    "declaration": true,
+    "declarationMap": true,
   },
   "include": [
     "src", "test"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/1911

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. --> 
types for this plugin were not being generated or exported, we fixed it.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Zoom-to-fit doesn't work

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
Solution was already suggested in the issue description and it made sense
