### PR TITLE
feat: have field-slider fire intermediate change events

### DIFF
--- a/plugins/field-slider/src/field_slider.ts
+++ b/plugins/field-slider/src/field_slider.ts
@@ -160,7 +160,23 @@ export class FieldSlider extends Blockly.FieldNumber {
    * Sets the text to match the slider's position.
    */
   private onSliderChange_() {
-    this.setEditorValue_(this.sliderInput?.value);
+    // Intermediate value changes from user input are not confirmed until the
+    // user closes the editor, and may be numerous. Inhibit reporting these as
+    // normal block change events, and instead report them as special
+    // intermediate changes that do not get recorded in undo history.
+    const oldValue = this.value_;
+    this.setEditorValue_(this.sliderInput?.value, false);
+    if (this.getSourceBlock()) {
+      Blockly.Events.fire(
+          new (Blockly.Events.get(
+              Blockly.Events.BLOCK_FIELD_INTERMEDIATE_CHANGE))(
+              this.sourceBlock_,
+              this.name || null,
+              oldValue,
+              this.value_
+          )
+      );
+    }
     this.resizeEditor_();
   }
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/1914.

### Proposed Changes

Changes the type of "change events" from `BlockChange` to `BlockFieldIntermediateChange`.

### Reason for Changes

Currently, the slider field fires a BlockChange every time the slider is moved, however, people might want to ignore intermediate changes, so it should fire a different event type.

### Test Coverage

I tested manually using Inspect Elements in Chrome.

### Documentation
Not applicable.

### Additional Information

Thanks for letting me contribute in GHC Open Source Day!