### PR TITLE
fix: #1906 add publish types for field-slider

### DIFF
--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -12,6 +12,7 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes [#1906](https://github.com/google/blockly-samples/compare/osd...justjess246:blockly-samples:publishTypesForFieldSlider?expand=1)

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds configurations to generate or publish types for this plugin

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Currently types for this plugin are not being generated or exported

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Not applicable because config change

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
No

### Additional Information

<!-- Anything else we should know? -->
