### PR TITLE
Fixes: Publish types for shadow-block-converter

### DIFF
--- a/plugins/shadow-block-converter/package.json
+++ b/plugins/shadow-block-converter/package.json
@@ -12,6 +12,7 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",


### PR DESCRIPTION
## The basics


- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

- Fixes #1907


### Proposed Changes

- add `"types": "./dist/index.d.ts"` 

### Reason for Changes

- Currently types for this plugin are not being exported :/

### Test Coverage

### Documentation


### Additional Information

