### PR TITLE
fix: Added Github Actions to check for broken embedded links.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+---
+title: Embedded link(s) inaccessible
+labels: bug
+---
+### Description
+Some links in this repository led to a HTTP Status code 404, which means the content is not accessible. 
+Please check the logs of the workflow below:
+
+
+{{ env.BODY }}
+ 

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,0 +1,26 @@
+# This workflow checks if the embedded links are broken in .md files.
+# It runs every Thursday at 8AM PST (3PM UTC) and goes through .md files of 
+# all  directories and subdirectories. For any broken link found, it creates
+# an issue.
+
+name: Check For Broken Embedded Links
+
+on: 
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 15 * * 4"
+
+jobs:
+  check-for-broken-links:
+    name: Check for broken links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - id: checking_links
+        name: checking_links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'no'
+          use-verbose-mode: 'yes'

--- a/.github/workflows/broken-link-issue.yml
+++ b/.github/workflows/broken-link-issue.yml
@@ -1,0 +1,56 @@
+# This workflow runs only when broken-link-check fails. This creates
+# an issue using an issue template.
+
+name: Markdown Link Check log parser
+on:
+  workflow_run:
+    workflows: [
+      "Check For Broken Embedded Links"
+    ]
+    types:
+      - completed
+defaults:
+  run:
+    shell: pwsh
+jobs:
+  main:
+    name: Markdown Link Check log parser
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run markdown link check log parser
+        id: mlc-log-parser
+        uses: edumserrano/markdown-link-check-log-parser@v1
+        with:
+          run-id: '${{ github.event.workflow_run.id }}'
+          job-name: Check for broken links
+          step-name: checking_links
+          only-errors: 'true'
+          output: 'step-json'
+          json-filepath: './mlc-json-result.json'
+      - name: Dump output from previous step
+        id: data_dump
+        run: >
+          $result = '${{ steps.mlc-log-parser.outputs.mlc-result }}' |
+          ConvertFrom-Json
+
+          Write-Output "Total files checked: $($result.TotalFilesChecked)"
+
+          Write-Output "Total links checked: $($result.TotalLinksChecked)"
+
+          Write-Output "Has errors: $($result.HasErrors)"
+
+          $resultAsJsonIndented = ConvertTo-Json -Depth 4 $result
+
+          Write-Output $resultAsJsonIndented
+          
+      - name: Checkout master
+        uses: actions/checkout@master
+      - run: >
+          Write-Output '${{ steps.mlc-log-parser.outputs.mlc-result }}'
+      - name: Create issue if there are broken links
+        uses: JasonEtco/create-an-issue@v2.9.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          BODY: ${{ steps.mlc-log-parser.outputs.mlc-result }}


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
Fixes #697 

The `broken-link-check.yml` checks for bad links embedded in markdown files throughout the repository. If it fails (ie, one or more links are not working) then the `broken-link-issue.yml` is triggered. This creates an issue with the error info generated by the first workflow. 

Since the output of `broken-link-check` cannot be retrieved before the entire workflow is complete, the 2 tasks had to be divided into 2 separate workflows (instead of jobs or steps).

The issue is created using the `ISSUE_TEMPLATE` file and lists, in JSON-style format, all the details provided by the first workflow. This template can be modified to include assignees, etc. 

These workflows will be triggered every time someone pushes to main and every Thursday at 8 AM PST.

### Proposed Changes

Introduced 2 separate workflows to solve the issue.

### Reason for Changes

The workflows are triggered on 2 occasions and create an issue in case of broken links. I believe this would be a more convenient solution than Node scripts.

### Test Coverage
N/A.

### Documentation

N/A.

### Additional Information

It is important to note that by design, the plugins used in both of these workflow files are only known to work on the **main** branch of the repository. 