### PR TITLE
chore: switch to new umd library output in webpack

### DIFF
--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -77,7 +77,9 @@ module.exports = (env) => {
       path: isProduction ? resolveApp('dist') : resolveApp('build'),
       publicPath: isProduction ? '/dist/' : '/build/',
       filename: outputFile,
-      libraryTarget: 'umd',
+      library: {
+        type: 'umd',
+      },
       globalObject: 'this',
       clean: true,
     },


### PR DESCRIPTION

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details

`libraryTarget` is deprecated so we use the new configuration `library.type = 'umd'`.


### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #1849 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

I built the library in the old way and the new way and verify the build output has no differences.

For those who are curious, if we add `name: 'Blockly'` to the library section, we get the following diff:

```
<   "object" == typeof exports && "object" == typeof module
<     ? (module.exports = e(require("blockly/core")))
<     : "function" == typeof define && define.amd
<     ? define(["blockly/core"], e)
<     : "object" == typeof exports
<     ? (exports.Blockly = e(require("blockly/core")))
<     : (t.Blockly = e(t.Blockly));
---
>   if ("object" == typeof exports && "object" == typeof module)
>     module.exports = e(require("blockly/core"));
>   else if ("function" == typeof define && define.amd)
>     define(["blockly/core"], e);
>   else {
>     var o =
>       "object" == typeof exports ? e(require("blockly/core")) : e(t.Blockly);
>     for (var s in o) ("object" == typeof exports ? exports : t)[s] = o[s];
>   }
```

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

cc @rachel-fenichel 
