### PR TITLE
fix: issues with building and testing plugins with beta

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -224,7 +224,7 @@ function deployToGhPages(repo) {
 function preparePluginsForLocal(isBeta) {
   return (done) => {
     if (isBeta) {
-      execSync(`lerna add blockly@beta --dev`, {stdio: 'inherit'});
+      execSync(`npx lerna exec -- npm install blockly@beta --force `, {stdio: 'inherit'});
     }
     execSync(`npm run boot`, {stdio: 'inherit'});
     // Bundles all the plugins.
@@ -244,7 +244,7 @@ function prepareExamplesForLocal(isBeta) {
     const examplesDirectory = 'examples';
     if (isBeta) {
       execSync(
-          `lerna add blockly@beta`, {cwd: examplesDirectory, stdio: 'inherit'});
+          `npx lerna exec -- npm install blockly@beta --force`, {cwd: examplesDirectory, stdio: 'inherit'});
     }
     execSync(`npm run boot`, {cwd: examplesDirectory, stdio: 'inherit'});
     // Bundles any examples that define a predeploy script (ex. blockly-react).

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean:node": "lerna clean --yes",
     "deploy:prepare": "npm run deploy:prepare:plugins && npm run deploy:prepare:examples && gulp predeploy",
     "deploy:prepare:examples": "cd examples && npm run predeploy",
-    "deploy:prepare:plugins": "npm run clean && lerna run predeploy",
+    "deploy:prepare:plugins": "npm run clean && lerna run build && lerna run predeploy",
     "deploy": "npm run deploy:prepare && gulp deploy",
     "deploy:upstream": "npm run deploy:prepare && gulp deployUpstream",
     "license": "gulp checkLicenses",


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

### Proposed Changes


Makes `npm run test:ghpages:beta` actually do what it claims.
Also pulls in https://github.com/google/blockly-samples/pull/1974 so that the published version of the demo will work.

### Reason for Changes

Scripts should do what they say they do, and the HSV plugin demo page should work. #1974 was correct but against the osd branch, which we will not merge before the end of quarter release.

### Test Coverage
Ran `npm run test:ghpages:beta` and checked `Blockly.VERSION` in the console in several playgrounds.
