### PR TITLE
fix: fixup keyboard nav to remove blockly version check

### DIFF
--- a/plugins/keyboard-navigation/package-lock.json
+++ b/plugins/keyboard-navigation/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.6",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^10.2.0-beta.0",
+        "blockly": "^10.2.0-beta.3",
         "chai": "^4.2.0",
         "jsdom": "^16.4.0",
         "jsdom-global": "^3.0.2",
@@ -20,7 +20,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^10.2.0-beta.0"
+        "blockly": "^10.2.0-beta.3"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "10.2.0-beta.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.2.0-beta.0.tgz",
-      "integrity": "sha512-KL1P6J4QbxgE1vENHOemj+FzSCktfJmOpfjML6yj4fO/0zPlRPhl+YQNefXoCxl5Cm+qTPd/7UsVbKitgpNphw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.2.0.tgz",
+      "integrity": "sha512-9jPGdiU3/pzyc2abyqoWcG+ddQwLBixb8HHr5QH2oSn+HialbaR94hS0hqgKXptMr7eD5/ZwEqVK+ptq8Gxe0A==",
       "dev": true,
       "dependencies": {
         "jsdom": "22.1.0"
@@ -2778,9 +2778,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "10.2.0-beta.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.2.0-beta.0.tgz",
-      "integrity": "sha512-KL1P6J4QbxgE1vENHOemj+FzSCktfJmOpfjML6yj4fO/0zPlRPhl+YQNefXoCxl5Cm+qTPd/7UsVbKitgpNphw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.2.0.tgz",
+      "integrity": "sha512-9jPGdiU3/pzyc2abyqoWcG+ddQwLBixb8HHr5QH2oSn+HialbaR94hS0hqgKXptMr7eD5/ZwEqVK+ptq8Gxe0A==",
       "dev": true,
       "requires": {
         "jsdom": "22.1.0"

--- a/plugins/keyboard-navigation/package.json
+++ b/plugins/keyboard-navigation/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^2.0.1",
     "@blockly/dev-tools": "^7.1.0",
-    "blockly": "^10.2.0-beta.0",
+    "blockly": "^10.2.0-beta.3",
     "chai": "^4.2.0",
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",
@@ -49,7 +49,7 @@
     "sinon": "^9.0.1"
   },
   "peerDependencies": {
-    "blockly": "^10.2.0-beta.0"
+    "blockly": "^10.2.0-beta.3"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/keyboard-navigation/src/navigation.js
+++ b/plugins/keyboard-navigation/src/navigation.js
@@ -872,21 +872,14 @@ export class Navigation {
       if (!destConnection.isSuperior()) {
         const rootBlock = movingBlock.getRootBlock();
 
-        // DO NOT DO CHECKS BASED ON BLOCKLY VERSION.
-        // We have to do this because are calling an internal method, which we
-        // should not be doing.
-        if (/** @type {string} */ (Blockly.VERSION) === '10.2.0') {
-          const originalOffsetToTarget = {
-            x: destConnection.x - movingConnection.x,
-            y: destConnection.y - movingConnection.y,
-          };
-          const originalOffsetInBlock =
-              movingConnection.getOffsetInBlock().clone();
-          rootBlock.positionNearConnection(
-              movingConnection, originalOffsetToTarget, originalOffsetInBlock);
-        } else {
-          rootBlock.positionNearConnection(movingConnection, destConnection);
-        }
+        const originalOffsetToTarget = {
+          x: destConnection.x - movingConnection.x,
+          y: destConnection.y - movingConnection.y,
+        };
+        const originalOffsetInBlock =
+            movingConnection.getOffsetInBlock().clone();
+        rootBlock.positionNearConnection(
+            movingConnection, originalOffsetToTarget, originalOffsetInBlock);
       }
       destConnection.connect(movingConnection);
       return true;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes check and makes keyboard nav only compatible with v10.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Don't have version checks in your code.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Ran tests with the latest beta and they pass.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A