### PR TITLE
chore: temporarily unprivate row separators

### DIFF
--- a/plugins/renderer-inline-row-separators/package.json
+++ b/plugins/renderer-inline-row-separators/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@blockly/renderer-inline-row-separators",
   "version": "0.4.5",
-  "private": true,
   "description": "A plugin to treat dummy inputs like line breaks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",


### PR DESCRIPTION
I need to temporarily make this public so we can release the new readme :P Then I will reprivate and deprecate.