### PR TITLE
chore: reprivate inline row separators

### DIFF
--- a/plugins/renderer-inline-row-separators/package.json
+++ b/plugins/renderer-inline-row-separators/package.json
@@ -2,6 +2,7 @@
   "name": "@blockly/renderer-inline-row-separators",
   "version": "0.5.0",
   "description": "A plugin to treat dummy inputs like line breaks.",
+  "private": true,
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
     "build": "blockly-scripts build",


### PR DESCRIPTION
Reverts https://github.com/google/blockly-samples/pull/1993
