### PR TITLE
chore: fix using JSON in advanced playground

### DIFF
--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -126,7 +126,7 @@ export function createPlayground(
           activeTab: 'JSON',
           playgroundOpen: true,
           autoGenerate: config && config.auto != undefined ? config.auto : true,
-          workspaceJson: {},
+          workspaceJson: '',
         });
         playgroundState.load();
 
@@ -314,7 +314,7 @@ export function createPlayground(
 
 
         // Initialized saved JSON and bind change listener.
-        const initialWorkspaceJson = playgroundState.get('workspaceJson') || {};
+        const initialWorkspaceJson = playgroundState.get('workspaceJson') || '';
         const jsonTab = tabs['JSON'];
         const jsonModel = jsonTab.state.model;
         let isFirstLoad = true;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/1049

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes the `workspaceJson` value consistently a string.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
`jsonModel.setValue` only accepts a string, so this wasn't loading properly before.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Loaded the playground. Steps in https://github.com/google/blockly-samples/issues/1049 did not reproduce.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
