### PR TITLE
chore: remove raf polyfill

### DIFF
--- a/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
+++ b/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
@@ -29,7 +29,8 @@ const {ProcedureCreate} = require('../src/events_procedure_create');
 suite('Procedures', function() {
   setup(function() {
     this.jsdomCleanup =
-        require('jsdom-global')('<!DOCTYPE html><div id="blocklyDiv"></div>');
+        require('jsdom-global')('<!DOCTYPE html><div id="blocklyDiv"></div>',
+            {pretendToBeVisual: true});
 
     this.sandbox = sinon.createSandbox();
     globalThis.clock = this.sandbox.useFakeTimers();
@@ -72,11 +73,6 @@ suite('Procedures', function() {
         .callsFake(() => {
           return this.workspace;
         });
-    window.requestAnimationFrame = this.sandbox.stub()
-        .callsFake((callback) => {
-          callback();
-        });
-    window.cancelAnimationFrame = this.sandbox.stub();
   });
 
   teardown(function() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Related to https://github.com/google/blockly/issues/6937

### Proposed Changes

JSDom provides a `pretendToBeVisual` option which will automatically polyfill raf in a NodeJS environment.  For more options see:
https://github.com/jsdom/jsdom#pretending-to-be-a-visual-browser

### Reason for Changes

This change will remove custom polyfill that we added in this test.

### Test Coverage

I ran the affected test and made sure it passes

### Documentation
N/A

### Additional Information

<!-- Anything else we should know? -->
cc @maribethb cc @BeksOmega 