### PR TITLE
Only run the migration script against JS/TS files.

### DIFF
--- a/plugins/migration/bin/command.js
+++ b/plugins/migration/bin/command.js
@@ -117,10 +117,13 @@ export function addSubCommand(command) {
  *   fileNames: !Array<string>}} The required info.
  */
 export function extractRequiredInfo(command) {
+  const jsTsFileMatcher = new RegExp('^(t|j)s', 'i');
   return {
     fromVersion: command.opts().from,
     toVersion: command.opts().to || 'latest',
-    fileNames: command.processedArgs[0],
+    fileNames: command.processedArgs[0].filter((filename) => {
+      return jsTsFileMatcher.test(filename.split('.').pop());
+    }),
   };
 }
 


### PR DESCRIPTION
## The basics
- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes #1319

### Proposed Changes
This PR updates the migration script to only process files ending in .js*/.ts*, to prevent replacing random bytes in images and other files.
