### PR TITLE
fix: fix continuous toolbox not enabling blocks

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousFlyout.js
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.js
@@ -229,6 +229,10 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
       return false;
     }
 
+    if (!block.isEnabled()) {
+      return false;
+    }
+
     for (const input of block.inputList) {
       for (const field of input.fieldRow) {
         // No variables.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2002

### Proposed Changes

do not recycle disabled blocks

### Reason for Changes

Blocks are being disabled if maxBlock constraint is met.  They are also being currently recycled and will be pushed to permanentlyDisabled list.  

Before this change:
If `maxBlocks` is set, when you add `maxBlocks` blocks the blocks will be disabled in the flyout and does not get renabled when the blocks are recycled.

If `maxInstances` is set on a block, after you add `maxInstances` of that block the block will be disabled.  Removing one will not renable it.

After:
As expected, when we recycle blocks for `maxBlocks` then we will enable blocks in the flyout.
For `maxInstances`, when we recycle the constrainted block you'll be able to add more blocks of that type.



### Test Coverage

tested in max-blocks-demo

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

cc @gonfunko @BeksOmega 
