### PR TITLE
fix(packaging): Don't advertise non-existent ESM entrypoints

### DIFF
--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -13,7 +13,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "",
   "keywords": [

--- a/plugins/block-shareable-procedures/package.json
+++ b/plugins/block-shareable-procedures/package.json
@@ -13,7 +13,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -13,7 +13,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/field-angle/package.json
+++ b/plugins/field-angle/package.json
@@ -13,7 +13,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/field-colour-hsv-sliders/package.json
+++ b/plugins/field-colour-hsv-sliders/package.json
@@ -12,7 +12,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/field-colour/package.json
+++ b/plugins/field-colour/package.json
@@ -13,7 +13,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -12,7 +12,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/field-dependent-dropdown/package.json
+++ b/plugins/field-dependent-dropdown/package.json
@@ -12,7 +12,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -11,7 +11,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/field-multilineinput/package.json
+++ b/plugins/field-multilineinput/package.json
@@ -13,7 +13,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -12,7 +12,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/renderer-inline-row-separators/package.json
+++ b/plugins/renderer-inline-row-separators/package.json
@@ -13,7 +13,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/shadow-block-converter/package.json
+++ b/plugins/shadow-block-converter/package.json
@@ -12,7 +12,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/toolbox-search/package.json
+++ b/plugins/toolbox-search/package.json
@@ -12,7 +12,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "",
   "keywords": [

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -13,7 +13,6 @@
   },
   "main": "./dist/index.js",
   "types": "./src/index.d.ts",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/workspace-minimap/package.json
+++ b/plugins/workspace-minimap/package.json
@@ -12,7 +12,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -12,7 +12,6 @@
     "test": "blockly-scripts test"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -11,7 +11,6 @@
     "start": "blockly-scripts start"
   },
   "main": "./dist/index.js",
-  "module": "./src/index.js",
   "unpkg": "./dist/index.js",
   "author": "Blockly Team",
   "keywords": [


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes #1877.

### Proposed Changes

Don't advertise `module` entrypoints on packages that are implemented in TypeScript as at the moment our webpack configuration does not generate any file called `src/index.js`.

### Reason for Changes

For JS packages, we point bundlers looking for an ESM entrypoint at `src/index.js`, thereby letting them ingest the package source code, but TypeScript packages have an `src/index.ts` instead.

Some bundlers (webpack, notably, when suitably configured) might actually be quite happy to ingest that instead, but AFAIK it's not valid to have the `package.json` `module` entrypoint point to anything except an actual ES module.

We have discussed publishing either the TSC output (unbundled JS "sources" one-for-one translated from TS) or a bundled ESM, but we haven't quite figured out the best way to do that yet, so in the meantime let's at least remove the false advertising that is causing errors for certain developer's builds.

### Test Coverage

I ran `npm test` but I don't think that actually tested this change in any meaningful way.  :-(

