### PR TITLE
fix: Enables strict mode for zoom-to-fit

### DIFF
--- a/plugins/zoom-to-fit/src/index.ts
+++ b/plugins/zoom-to-fit/src/index.ts
@@ -198,8 +198,8 @@ export class ZoomToFitControl implements Blockly.IPositionable {
         i = -1;
       }
     }
-      this.svgGroup?.setAttribute('transform',
-          `translate(${this.left}, ${this.top})`);
+    this.svgGroup?.setAttribute('transform',
+        `translate(${this.left}, ${this.top})`);
   }
 }
 

--- a/plugins/zoom-to-fit/src/index.ts
+++ b/plugins/zoom-to-fit/src/index.ts
@@ -198,10 +198,8 @@ export class ZoomToFitControl implements Blockly.IPositionable {
         i = -1;
       }
     }
-    if (this.svgGroup) {
-      this.svgGroup.setAttribute('transform',
+      this.svgGroup?.setAttribute('transform',
           `translate(${this.left}, ${this.top})`);
-    }
   }
 }
 

--- a/plugins/zoom-to-fit/src/index.ts
+++ b/plugins/zoom-to-fit/src/index.ts
@@ -198,9 +198,10 @@ export class ZoomToFitControl implements Blockly.IPositionable {
         i = -1;
       }
     }
-
-    this.svgGroup.setAttribute('transform',
-        `translate(${this.left}, ${this.top})`);
+    if (this.svgGroup) {
+      this.svgGroup.setAttribute('transform',
+          `translate(${this.left}, ${this.top})`);
+    }
   }
 }
 

--- a/plugins/zoom-to-fit/test/index.ts
+++ b/plugins/zoom-to-fit/test/index.ts
@@ -37,6 +37,10 @@ document.addEventListener('DOMContentLoaded', function() {
       controls: true,
     },
   };
-  createPlayground(document.getElementById('root'), createWorkspace,
-      defaultOptions);
+
+  const element = document.getElementById('root');
+
+  if (element) {
+    createPlayground(element, createWorkspace, defaultOptions);
+  }
 });

--- a/plugins/zoom-to-fit/tsconfig.json
+++ b/plugins/zoom-to-fit/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es6",
     "allowJs": true,
     "sourceMap": true,
+    "strict": true,
     "moduleResolution": "nodenext",
     "lib": ["es2021", "dom"],
     // Point at the local Blockly. See #1934. Remove if we add hoisting.


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Closes #2033 

### Proposed Changes

Enables strict mode for the zoom-to-fit plugin by configuring "strict": true in tsconfig.json.

Typescript errors that arose as a result:
![Error_TS](https://github.com/google/blockly-samples/assets/69362333/9112a329-0660-40b9-baec-e015c8a540d7)

Solved by making changes to index.ts in the src and test directory:
![Solved_TS](https://github.com/google/blockly-samples/assets/69362333/5e8ced4c-f5d6-4da5-8616-eeb6148d243d)


### Reason for Changes

Apart from enabling strict mode, the code now keeps a check for a null object in src/index.ts and a null element in test/index.ts.

### Additional Information

Ran npm run lint and resolved any formatting issues as well. Please do let me know if this is okay or any changes need to be made!
