### PR TITLE
fix: include ts files in sample app create

### DIFF
--- a/plugins/dev-create/package.json
+++ b/plugins/dev-create/package.json
@@ -14,7 +14,8 @@
   ],
   "files": [
     "*",
-    "templates/sample-app/*"
+    "templates/sample-app/*",
+    "templates/sample-app-ts/*"
   ],
   "scripts": {
     "prepack": "cp -r ../../examples/sample-app ./templates && cp -r ../../examples/sample-app-ts ./templates"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes issue where running `npx @blockly/create-package app foo --typescript` gives `ENOENT: no such file or directory, stat ' [...] node_modules/@blockly/create-package/templates/sample-app-ts'`

### Proposed Changes

Includes the `templates/sample-app-ts` in the files attribute so they get packed. They're in the gitignore file so they aren't committed after being copied during publish, and for some reason npm looks at the gitignore to decide what files to include so you have to specifically include them -_-

### Reason for Changes

bugs

### Test Coverage

manually tested with `npm pack --dry-run`

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

