### PR TITLE
chore: fix reserializing callers with no model directly after serializing

### DIFF
--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -967,7 +967,18 @@ const procedureCallerMutator = {
   saveExtraState: function () {
     const state = Object.create(null);
     const model = this.getProcedureModel();
-    if (!model) return state;
+    if (!model) {
+      // We reached here because we've deserialized a caller into a workspace
+      // where its model did not already exist (no procedures array in the json,
+      // and deserialized before any definition block), and are reserializing
+      // it before the event delay has elapsed and change listeners have run.
+      // (If they had run, we would have found or created a model).
+      // Just reserialize any deserialized state. Nothing should have happened
+      // in-between to change it.
+      state['name'] = this.getFieldValue('NAME');
+      state['params'] = this.paramsFromSerializedState_;
+      return state;
+    }
     state['name'] = model.getName();
     if (model.getParameters().length) {
       state['params'] = model.getParameters().map((p) => p.getName());


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that if you serialize a procedure caller with no reference to a model directly after serializing, we get state that is valid/loadable.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
State was not previously valid/loadable in this case

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Loaded the following JSON into the playground (with one workspace):
```json
{
  "blocks": {
    "languageVersion": 0,
    "blocks": [
      {
        "type": "procedures_callnoreturn",
        "extraState": {
          "name": "do something",
          "params": [
            "x"
          ]
        }
      }
    ]
  },
  "variables": [
    {
      "name": "x",
      "id": "g/9$8tDNyiY|/-n)+U7a"
    }
  ]
}
```
And got the exact same JSON back out. If you let the event delay run, this JSON properly creates a definition block and links up the models.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
