### PR TITLE
fix: proc call remain disabled as def changes name

### DIFF
--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -1203,6 +1203,14 @@ const procedureCallerOnChangeMixin = {
     if (this.disposed || this.workspace.isFlyout) return;
     if (event.type === Blockly.Events.BLOCK_MOVE) this.updateArgsMap_(true);
     if (
+      event.type === Blockly.Events.BLOCK_CHANGE &&
+      event.blockId === this.id &&
+      event.element === 'disabled' &&
+      event.group
+    ) {
+      this.previousEnabledState_ = !event.newValue;
+    }
+    if (
       event.type !== Blockly.Events.FINISHED_LOADING &&
       !this.eventIsCreatingThisBlockDuringPaste_(event)
     )

--- a/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
+++ b/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
@@ -1249,6 +1249,26 @@ suite('Procedures', function () {
         );
       },
     );
+
+    test(
+      'if a procedure caller block was already disabled ' +
+        'its definition changes name, it is not reenabled',
+      function () {
+        const defBlock = createProcDefBlock(this.workspace);
+        const callBlock = createProcCallBlock(this.workspace);
+        globalThis.clock.runAll();
+        Blockly.Events.setGroup(true);
+        callBlock.setEnabled(false);
+        globalThis.clock.runAll();
+        defBlock.getProcedureModel().setName("other proc name");
+        globalThis.clock.runAll();
+
+        assert.isFalse(
+          callBlock.isEnabled(),
+          'Expected the caller block to continue to be disabled',
+        );
+      },
+    );
   });
 
   suite('creating procedure blocks', function () {


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2035 

### Proposed Changes

When a proc call changes enabled state independently, previousEnabledState_ should be kept in sync

### Reason for Changes

#2035

### Test Coverage

The unit test requires a setGroup call in order to simulate what happens in UI (ie when a proc call gets disabled)

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

@BeksOmega I am not familiar with groups.  I checked that when a proc call gets disabled in the UI it has a group name but when it is disabled as part of proc def block update it does not have a group name.  So I might be totally wrong here =)
