### PR TITLE
fix: update lerna publish command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -168,7 +168,7 @@ function publishFromPackage(done) {
 
   // Run lerna publish. Will not update versions.
   console.log(`Publishing plugins from package.json versions.`);
-  execSync(`lerna publish --no-private --from-package`, {
+  execSync(`lerna publish from-package --no-private`, {
     cwd: releaseDir,
     stdio: 'inherit',
   });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes problem with running `npm run publish:unpublishedOnly`

### Proposed Changes

Updates command for publishing packages from package.json version, used when recovering from a half-published state

### Reason for Changes

Old one didn't work... I looked through the release notes for breaking changes in lerna and didn't see this mentioned. So I think this most likely never worked and we just haven't had to use it since I introduced these manual publish commands. oops

### Test Coverage

I tested the new command because I used it to manually publish plugins this morning.

### Documentation

no

### Additional Information

<!-- Anything else we should know? -->
