### PR TITLE
fix: Adding sample-app to examples Readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -41,12 +41,13 @@ The [Blockly Codelabs](https://blocklycodelabs.dev/) refer to this example code.
 - [``blockly-svelte-sample``](blockly-svelte/): Blockly in a Svelte project, defines a Svelte Blockly Component.
 - [``blockly-vue3-sample``](blockly-vue3/): Blockly in a Vue3 project, defines a Vue Blockly Component.
 - [``blockly-parcel``](blockly-parcel/): Using Blockly with Parcel.
+- [``sample-app``](sample-app/):This app illustrates how to use Blockly together with common programming tools.
 
 
 ### Real-time Collaboration
 
 - [``blockly-rtc``](blockly-rtc/): Real-time collaboration environment on top of the Blockly framework.
-- [``sample-app``](sample-app/):This app illustrates how to use Blockly together with common programming tools.
+
 
 ## Prerequisites
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,9 +42,11 @@ The [Blockly Codelabs](https://blocklycodelabs.dev/) refer to this example code.
 - [``blockly-vue3-sample``](blockly-vue3/): Blockly in a Vue3 project, defines a Vue Blockly Component.
 - [``blockly-parcel``](blockly-parcel/): Using Blockly with Parcel.
 
+
 ### Real-time Collaboration
 
 - [``blockly-rtc``](blockly-rtc/): Real-time collaboration environment on top of the Blockly framework.
+- [``sample-app``](sample-app/):This app illustrates how to use Blockly together with common programming tools.
 
 ## Prerequisites
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

made changes in the example readme 

### Reason for Changes

sample-app was missing to be added 







### Additional Information

I added the sample-app in the readme file of the Examples , I added it with the link 
It was added in the repo in past few weeks So i guess was not mentioned in the readme So i made sure and added it @BeksOmega Have a look 