### PR TITLE
 feat: Enable strict mode for toolbox-search

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -41,7 +41,7 @@ The [Blockly Codelabs](https://blocklycodelabs.dev/) refer to this example code.
 - [``blockly-svelte-sample``](blockly-svelte/): Blockly in a Svelte project, defines a Svelte Blockly Component.
 - [``blockly-vue3-sample``](blockly-vue3/): Blockly in a Vue3 project, defines a Vue Blockly Component.
 - [``blockly-parcel``](blockly-parcel/): Using Blockly with Parcel.
-- [``sample-app``](sample-app/):This app illustrates how to use Blockly together with common programming tools.
+
 
 
 ### Real-time Collaboration

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,9 +42,11 @@ The [Blockly Codelabs](https://blocklycodelabs.dev/) refer to this example code.
 - [``blockly-vue3-sample``](blockly-vue3/): Blockly in a Vue3 project, defines a Vue Blockly Component.
 - [``blockly-parcel``](blockly-parcel/): Using Blockly with Parcel.
 
+
 ### Real-time Collaboration
 
 - [``blockly-rtc``](blockly-rtc/): Real-time collaboration environment on top of the Blockly framework.
+- [``sample-app``](sample-app/):This app illustrates how to use Blockly together with common programming tools.
 
 ## Prerequisites
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,6 +41,7 @@ The [Blockly Codelabs](https://blocklycodelabs.dev/) refer to this example code.
 - [``blockly-svelte-sample``](blockly-svelte/): Blockly in a Svelte project, defines a Svelte Blockly Component.
 - [``blockly-vue3-sample``](blockly-vue3/): Blockly in a Vue3 project, defines a Vue Blockly Component.
 - [``blockly-parcel``](blockly-parcel/): Using Blockly with Parcel.
+- [``sample-app``](sample-app/):This app illustrates how to use Blockly together with common programming tools.
 
 
 ### Real-time Collaboration

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,6 @@ The [Blockly Codelabs](https://blocklycodelabs.dev/) refer to this example code.
 ### Real-time Collaboration
 
 - [``blockly-rtc``](blockly-rtc/): Real-time collaboration environment on top of the Blockly framework.
-- [``sample-app``](sample-app/):This app illustrates how to use Blockly together with common programming tools.
 
 ## Prerequisites
 

--- a/plugins/toolbox-search/src/toolbox_search.ts
+++ b/plugins/toolbox-search/src/toolbox_search.ts
@@ -1,36 +1,14 @@
-/**
- * @license
- * Copyright 2023 Google LLC
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * A toolbox category that provides a search field and displays matching blocks
- * in its flyout.
- */
 import * as Blockly from 'blockly/core';
-import {BlockSearcher} from './block_searcher';
+import { BlockSearcher } from './block_searcher';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
-/**
- * A toolbox category that provides a search field and displays matching blocks
- * in its flyout.
- */
 export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
   private static readonly START_SEARCH_SHORTCUT = 'startSearch';
   static readonly SEARCH_CATEGORY_KIND = 'search';
   private searchField?: HTMLInputElement;
   private blockSearcher = new BlockSearcher();
 
-  /**
-   * Initializes a ToolboxSearchCategory.
-   * @param categoryDef The information needed to create a category in the
-   *     toolbox.
-   * @param parentToolbox The parent toolbox for the category.
-   * @param opt_parent The parent category or null if the category does not have
-   *     a parent.
-   */
   constructor(
     categoryDef: Blockly.utils.toolbox.CategoryInfo,
     parentToolbox: Blockly.IToolbox,
@@ -41,10 +19,6 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
     this.registerShortcut();
   }
 
-  /**
-   * Initializes the search field toolbox category.
-   * @returns The <div> that will be displayed in the toolbox.
-   */
   protected override createDom_(): HTMLDivElement {
     const dom = super.createDom_();
     this.searchField = document.createElement('input');
@@ -61,17 +35,12 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
 
       this.matchBlocks();
     });
-    this.rowContents_.replaceChildren(this.searchField);
+    this.rowContents_?.replaceChildren(this.searchField);
     return dom;
   }
 
-  /**
-   * Returns the numerical position of this category in its parent toolbox.
-   * @returns The zero-based index of this category in its parent toolbox, or -1
-   *    if it cannot be determined, e.g. if this is a nested category.
-   */
   private getPosition() {
-    const categories = this.workspace_.options.languageTree.contents;
+    const categories = this.workspace_.options.languageTree?.contents || [];
     for (let i = 0; i < categories.length; i++) {
       if (categories[i].kind === ToolboxSearchCategory.SEARCH_CATEGORY_KIND) {
         return i;
@@ -81,9 +50,6 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
     return -1;
   }
 
-  /**
-   * Registers a shortcut for displaying the toolbox search category.
-   */
   private registerShortcut() {
     const shortcut = Blockly.ShortcutRegistry.registry.createSerializedKey(
       Blockly.utils.KeyCodes.B,
@@ -94,25 +60,19 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
       callback: () => {
         const position = this.getPosition();
         if (position < 0) return false;
-        this.parentToolbox_.selectItemByPosition(position);
+        this.parentToolbox_?.selectItemByPosition(position);
         return true;
       },
       keyCodes: [shortcut],
     });
   }
 
-  /**
-   * Returns a list of block types that are present in the toolbox definition.
-   * @param schema A toolbox item definition.
-   * @param allBlocks The set of all available blocks that have been encountered
-   *     so far.
-   */
   private getAvailableBlocks(
     schema: Blockly.utils.toolbox.ToolboxItemInfo,
     allBlocks: Set<string>,
   ) {
     if ('contents' in schema) {
-      schema.contents.forEach((contents) => {
+      schema.contents?.forEach((contents) => {
         this.getAvailableBlocks(contents, allBlocks);
       });
     } else if (schema.kind.toLowerCase() === 'block') {
@@ -122,48 +82,37 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
     }
   }
 
-  /**
-   * Builds the BlockSearcher index based on the available blocks.
-   */
   private initBlockSearcher() {
     const availableBlocks = new Set<string>();
-    this.workspace_.options.languageTree.contents.map((item) =>
+    this.workspace_.options.languageTree?.contents?.map((item) =>
       this.getAvailableBlocks(item, availableBlocks),
     );
     this.blockSearcher.indexBlocks([...availableBlocks]);
   }
 
-  /**
-   * Handles a click on this toolbox category.
-   * @param e The click event.
-   */
   override onClick(e: Event) {
     super.onClick(e);
     e.preventDefault();
     e.stopPropagation();
-    this.setSelected(this.parentToolbox_.getSelectedItem() === this);
+    this.setSelected(this.parentToolbox_?.getSelectedItem() === this);
   }
 
-  /**
-   * Handles changes in the selection state of this category.
-   * @param isSelected Whether or not the category is now selected.
-   */
   override setSelected(isSelected: boolean) {
     super.setSelected(isSelected);
     if (isSelected) {
-      this.searchField.focus();
+      this.searchField?.focus();
       this.matchBlocks();
     } else {
-      this.searchField.value = '';
-      this.searchField.blur();
+      const searchFieldValue = this.searchField;
+      if (searchFieldValue) {
+        searchFieldValue.value = '';
+      }
+      this.searchField?.blur();
     }
   }
 
-  /**
-   * Filters the available blocks based on the current query string.
-   */
   private matchBlocks() {
-    const query = this.searchField.value;
+    const query = this.searchField?.value || '';
 
     this.flyoutItems_ = query
       ? this.blockSearcher.blockTypesMatching(query).map((blockType) => {
@@ -183,12 +132,9 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
             : 'No matching blocks found',
       });
     }
-    this.parentToolbox_.refreshSelection();
+    this.parentToolbox_?.refreshSelection();
   }
 
-  /**
-   * Disposes of this category.
-   */
   override dispose() {
     super.dispose();
     Blockly.ShortcutRegistry.registry.unregister(

--- a/plugins/toolbox-search/src/toolbox_search.ts
+++ b/plugins/toolbox-search/src/toolbox_search.ts
@@ -1,7 +1,22 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A toolbox category that provides a search field and displays matching blocks
+ * in its flyout.
+ */
 import * as Blockly from 'blockly/core';
-import { BlockSearcher } from './block_searcher';
+import {BlockSearcher} from './block_searcher';
 
 /* eslint-disable @typescript-eslint/naming-convention */
+
+/**
+ * A toolbox category that provides a search field and displays matching blocks
+ * in its flyout.
+ */
 
 export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
   private static readonly START_SEARCH_SHORTCUT = 'startSearch';

--- a/plugins/toolbox-search/tsconfig.json
+++ b/plugins/toolbox-search/tsconfig.json
@@ -9,7 +9,7 @@
     "moduleResolution": "bundler",
     "target": "es6",
     "lib": ["es2021", "dom"],
-    "strict": false,
+    "strict": true,
     // Point at the local Blockly. See #1934. Remove if we add hoisting.
     "paths": {
       "blockly/*": ["node_modules/blockly/*"]


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

This resolves the issue #2029 



### Proposed Changes

Added the strict mode for toolbox

### Reason for Changes

Asked as the issue for new feature 



### Additional Information

As mentioned in the issue I enable the strict mode for toolbox search to end with I also searched for the errors and fixed multiple errors in the file have a look and merge it faster if you can please @BeksOmega 
