### PR TITLE
chore: fix field date test case

### DIFF
--- a/plugins/field-date/src/field_date.ts
+++ b/plugins/field-date/src/field_date.ts
@@ -8,6 +8,7 @@
  * @fileoverview Plugin overview.
  */
 import * as Blockly from 'blockly/core';
+import {getLocaleDateString} from './utils';
 
 /**
  * Class for a date input field.
@@ -165,26 +166,6 @@ export class FieldDate extends Blockly.FieldTextInput {
     return htmlInput;
   }
   /* eslint-enable @typescript-eslint/naming-convention */
-}
-
-/**
- * Get the string formatted locally to the user.
- * @param dateString A string in the format 'yyyy-mm-dd'
- * @returns the locale date string for the date.
- */
-function getLocaleDateString(dateString: string): string {
-  // NOTE: `date.toLocaleDateString()` will be the day before for western dates
-  // due to an unspecified time & timezone assuming midnight at GMT+0.
-  const date = new Date(dateString);
-
-  // NOTE: This format varies per region.
-  // Ex: "5/12/2023", "12/05/2023", "12.5.2023", "2023/5/12", "१२/५/२०२३"
-  const language = navigator.language ?? 'en-US';
-  // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#using_options
-  return new Intl.DateTimeFormat(language, {
-    // Print the date for GMT+0 since the date object assumes midnight at GMT+0.
-    timeZone: 'UTC',
-  }).format(date);
 }
 
 /**

--- a/plugins/field-date/src/utils.ts
+++ b/plugins/field-date/src/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Get the string formatted locally to the user.
+ * @param dateString A string in the format 'yyyy-mm-dd'
+ * @returns the locale date string for the date.
+ */
+export function getLocaleDateString(dateString: string): string {
+  // NOTE: `date.toLocaleDateString()` will be the day before for western dates
+  // due to an unspecified time & timezone assuming midnight at GMT+0.
+  const date = new Date(dateString);
+
+  // NOTE: This format varies per region.
+  // Ex: "5/12/2023", "12/05/2023", "12.5.2023", "2023/5/12", "१२/५/२०२३"
+  const language = navigator.language ?? 'en-US';
+  // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#using_options
+  return new Intl.DateTimeFormat(language, {
+    // Print the date for GMT+0 since the date object assumes midnight at GMT+0.
+    timeZone: 'UTC',
+  }).format(date);
+}

--- a/plugins/field-date/test/field_date_test.mocha.js
+++ b/plugins/field-date/test/field_date_test.mocha.js
@@ -7,6 +7,7 @@
 import {assert} from 'chai';
 import {testHelpers} from '@blockly/dev-tools';
 import {FieldDate} from '../src/index';
+import {getLocaleDateString} from '../src/utils';
 
 const {
   assertFieldValue,
@@ -24,7 +25,7 @@ if (!global.navigator) {
   };
 }
 
-suite.skip('FieldDate', function () {
+suite('FieldDate', function () {
   /**
    * Configuration for field tests with invalid values.
    * @type {Array<FieldCreationTestCase>}
@@ -106,7 +107,7 @@ suite.skip('FieldDate', function () {
     });
     suite('Value -> New Value', function () {
       const initialValue = '2020-02-20';
-      const initialText = new Date(initialValue).toLocaleDateString();
+      const initialText = getLocaleDateString(initialValue);
       setup(function () {
         this.field = new FieldDate(initialValue);
       });


### PR DESCRIPTION
## The basics

Share getLocaleDateString function between field_date and mocha tests

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2045

### Proposed Changes

Instead of using a different way to formate locale date, using the same function as the field-date implementation

### Reason for Changes

Fixes flaky test

### Test Coverage

npm run test

### Documentation

N/A

### Additional Information

cc @cpcallen @maribethb 