### PR TITLE
chore: update private packages to latest dev-scripts

### DIFF
--- a/plugins/renderer-inline-row-separators/package.json
+++ b/plugins/renderer-inline-row-separators/package.json
@@ -39,7 +39,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^2.0.1",
+    "@blockly/dev-scripts": "^3.0.0",
     "@blockly/dev-tools": "^7.1.0",
     "blockly": "^10.0.0",
     "chai": "^4.2.0",

--- a/plugins/serialize-disabled-interactions/package.json
+++ b/plugins/serialize-disabled-interactions/package.json
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^2.0.1",
+    "@blockly/dev-scripts": "^3.0.0",
     "@blockly/dev-tools": "^7.0.3",
     "blockly": "^10.0.0",
     "chai": "^4.3.4"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes ci not completind

### Proposed Changes

- Update two private packages to `@blockly/dev-scripts@3.0.0`

### Reason for Changes

1. In the last publish action, `@blockly/dev-scripts` had a breaking change and was updated to v3
2. When we publish, we don't want private packages to have their version number bumped
3. Therefore, we set `no-private` in the lerna flags to have it not bump their version numbers
4. This causes lerna to also not bump their dependencies when they depend on local plugins
5. Now these two plugins use v2 of dev-scripts but the local version is v3
6. Because of this, lerna thinks they can't use the local version and doesn't perform local symlinking. The plugins use the version on npm rather than local version
7. The dev-scripts package is expected to be in the package-lock since it is coming from npm instead of local.
8. Therefore, `package.json` and `package-lock.json` are out of sync, causing `npm ci` to fail.
9. We fix this by updating these plugins to latest `dev-scripts` so they can once again use the local version of that plugin

### Test Coverage

Tested npm ci locally and it does not fail

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

I've asked lerna for a longer term solution for this and haven't heard back. To stop this problem from recurring we can either:
- set lerna to use force mode which will always use local versions of plugins even if their versions aren't compatible
- remove the no-private flag when we publish. this is relatively new.  we added this because private plugins kept getting their version updated which then made it kind of weird the first time we want to publish a new plugin and it doesn't start at 1.0.0. but apparently this flag also prevents the plugins from being updated to use new versions of other plugins.
- deal with this manually forever by replicating this PR every time we do a breaking change to `dev-scripts` or `dev-tools` and have private packages
