### PR TITLE
fix: resolved 15 ESLint warnings

### DIFF
--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -131,7 +131,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    */
   loadExtraState: function (
     this: DynamicListCreateBlock,
-    state: { itemCount?: number; [x: string]: unknown} | string,
+    state: {itemCount?: number; [x: string]: unknown} | string,
   ) {
     if (typeof state === 'string') {
       this.domToMutation(Blockly.utils.xml.textToDom(state));

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -131,14 +131,14 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    */
   loadExtraState: function (
     this: DynamicListCreateBlock,
-    state: {[x: string]: number} | string,
+    state: { itemCount?: number; [x: string]: unknown} | string,
   ) {
     if (typeof state === 'string') {
       this.domToMutation(Blockly.utils.xml.textToDom(state));
       return;
     }
 
-    this.itemCount = state['itemCount'];
+    this.itemCount = state['itemCount'] ?? 0;
     // minInputs are added automatically.
     for (let i = this.minInputs; i < this.itemCount; i++) {
       this.appendValueInput('ADD' + i);

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -131,7 +131,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    */
   loadExtraState: function (
     this: DynamicListCreateBlock,
-    state: {[x: string]: any} | string,
+    state: {[x: string]: number} | string,
   ) {
     if (typeof state === 'string') {
       this.domToMutation(Blockly.utils.xml.textToDom(state));

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -127,7 +127,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    */
   loadExtraState: function (
     this: DynamicTextJoinBlock,
-    state: {[x: string]: any} | string,
+    state: {[x: string]: number} | string,
   ) {
     if (typeof state === 'string') {
       this.domToMutation(Blockly.utils.xml.textToDom(state));

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -127,14 +127,14 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    */
   loadExtraState: function (
     this: DynamicTextJoinBlock,
-    state: {[x: string]: number} | string,
+    state: { itemCount?: number; [x: string]: unknown} | string,
   ) {
     if (typeof state === 'string') {
       this.domToMutation(Blockly.utils.xml.textToDom(state));
       return;
     }
 
-    this.itemCount = state['itemCount'];
+    this.itemCount = state['itemCount'] ?? 0;
     // minInputs are added automatically.
     for (let i = this.minInputs; i < this.itemCount; i++) {
       this.appendValueInput('ADD' + i);

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -127,7 +127,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    */
   loadExtraState: function (
     this: DynamicTextJoinBlock,
-    state: { itemCount?: number; [x: string]: unknown} | string,
+    state: {itemCount?: number; [x: string]: unknown} | string,
   ) {
     if (typeof state === 'string') {
       this.domToMutation(Blockly.utils.xml.textToDom(state));

--- a/plugins/block-dynamic-connection/test/dynamic_if.mocha.js
+++ b/plugins/block-dynamic-connection/test/dynamic_if.mocha.js
@@ -16,7 +16,7 @@ suite('If block', function () {
    * Asserts that the if block has the expected inputs.
    * @param {!Blockly.Block} block The block to check.
    * @param {!Array<RegExp>} expectedInputs The expected inputs.
-   * @param type {string=} The block type expected. Defaults to 'dynamic_if'.
+   * @param {string=} type The block type expected. Defaults to 'dynamic_if'.
    */
   function assertBlockStructure(block, expectedInputs, type = 'dynamic_if') {
     assert.equal(block.type, type);

--- a/plugins/field-bitmap/src/field-bitmap.js
+++ b/plugins/field-bitmap/src/field-bitmap.js
@@ -218,6 +218,11 @@ export class FieldBitmap extends Blockly.Field {
     return editable;
   }
 
+  /**
+   * Gets the rectangle built out of dimentions matching SVG's <g> element.
+   * @returns {Blockly.utils.Rect} The newly created rectangle of same size
+   *     as the SVG element.
+   */
   getScaledBBox() {
     const boundingBox = this.fieldGroup_.getBoundingClientRect();
     return new Blockly.utils.Rect(

--- a/plugins/field-dependent-dropdown/src/dependent_dropdown_options_change.ts
+++ b/plugins/field-dependent-dropdown/src/dependent_dropdown_options_change.ts
@@ -151,6 +151,7 @@ export class DependentDropdownOptionsChange extends Blockly.Events.BlockBase {
   static fromJson(
     json: DependentDropdownOptionsChangeJson,
     workspace: Blockly.Workspace,
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     event?: any,
   ): DependentDropdownOptionsChange {
     const newEvent = super.fromJson(

--- a/plugins/keyboard-navigation/src/navigation_controller.js
+++ b/plugins/keyboard-navigation/src/navigation_controller.js
@@ -235,7 +235,7 @@ export class NavigationController {
   fieldShortcutHandler(workspace, shortcut) {
     const cursor = workspace.getCursor();
     if (!cursor || !cursor.getCurNode()) {
-      return;
+      return false;
     }
     const curNode = cursor.getCurNode();
     if (curNode.getType() === Blockly.ASTNode.types.FIELD) {

--- a/plugins/migration/bin/fix-imports.js
+++ b/plugins/migration/bin/fix-imports.js
@@ -59,7 +59,7 @@ export const fixImports = createSubCommand(
 let MigrationData;
 
 // TODO (#1211): Make this database format more robust.
-/** @type {MigrationData[]} */
+/** @type {Array.<MigrationData>} */
 const database = [
   {
     import: 'blockly/dart',
@@ -135,7 +135,7 @@ function fixImport(contents, migrationData) {
  * Returns the identifier a given import is assigned to.
  * @param {string} contents The string contents of the file to migrate.
  * @param {MigrationData} migrationData Data defining what to migrate and how.
- * @returns The identifier associated with the import associated with the
+ * @returns {string} The identifier associated with the import associated with the
  *     migration data.
  */
 function getIdentifier(contents, migrationData) {
@@ -155,7 +155,7 @@ function getIdentifier(contents, migrationData) {
  * with references to the actual import (if any references are found).
  * @param {string} contents The string contents of the file to migrate.
  * @param {MigrationData} migrationData Data defining what to migrate and how.
- * @param identifier
+ * @param {string} identifier The string to be replaced in the file contents.
  * @returns {string} The migrated contents of the file.
  */
 function replaceReferences(contents, migrationData, identifier) {

--- a/plugins/migration/bin/fix-imports.js
+++ b/plugins/migration/bin/fix-imports.js
@@ -59,7 +59,7 @@ export const fixImports = createSubCommand(
 let MigrationData;
 
 // TODO (#1211): Make this database format more robust.
-/** @type {Array.<MigrationData>} */
+/** @type {Array<MigrationData>} */
 const database = [
   {
     import: 'blockly/dart',

--- a/plugins/shadow-block-converter/src/shadow_block_converter.ts
+++ b/plugins/shadow-block-converter/src/shadow_block_converter.ts
@@ -77,6 +77,7 @@ export class BlockShadowChange extends Blockly.Events.BlockBase {
   static fromJson(
     json: BlockChangeJson,
     workspace: Blockly.Workspace,
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     event?: any,
   ): BlockShadowChange {
     const newEvent = super.fromJson(

--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -146,6 +146,7 @@ export class Minimap {
     }
     if (
       event.type === Blockly.Events.BLOCK_CREATE &&
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
       (event as any).xml.tagName === 'shadow'
     ) {
       return; // Filter out shadow blocks.

--- a/plugins/workspace-minimap/test/index.ts
+++ b/plugins/workspace-minimap/test/index.ts
@@ -40,10 +40,7 @@ function createWorkspace(
 document.addEventListener('DOMContentLoaded', function () {
   createPlayground(
     document.getElementById('root'),
-    createWorkspace as (
-      blocklyDiv: HTMLElement,
-      options: Blockly.BlocklyOptions,
-    ) => Blockly.WorkspaceSvg,
+    createWorkspace,
     {
       toolbox: toolboxCategories,
     },

--- a/plugins/workspace-minimap/test/index.ts
+++ b/plugins/workspace-minimap/test/index.ts
@@ -10,7 +10,7 @@
 
 import * as Blockly from 'blockly';
 import {toolboxCategories, createPlayground} from '@blockly/dev-tools';
-import {Minimap, PositionedMinimap} from '../src/index';
+import {PositionedMinimap} from '../src/index';
 
 let minimap = null;
 let workspace = null;
@@ -38,7 +38,14 @@ function createWorkspace(
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  createPlayground(document.getElementById('root'), createWorkspace as any, {
-    toolbox: toolboxCategories,
-  });
+  createPlayground(
+    document.getElementById('root'),
+    createWorkspace as (
+      blocklyDiv: HTMLElement,
+      options: Blockly.BlocklyOptions,
+    ) => Blockly.WorkspaceSvg,
+    {
+      toolbox: toolboxCategories,
+    },
+  );
 });

--- a/plugins/workspace-minimap/test/index.ts
+++ b/plugins/workspace-minimap/test/index.ts
@@ -38,11 +38,7 @@ function createWorkspace(
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  createPlayground(
-    document.getElementById('root'),
-    createWorkspace,
-    {
-      toolbox: toolboxCategories,
-    },
-  );
+  createPlayground(document.getElementById('root'), createWorkspace, {
+    toolbox: toolboxCategories,
+  });
 });

--- a/scripts/gh-predeploy.js
+++ b/scripts/gh-predeploy.js
@@ -456,8 +456,7 @@ function prepareExample(exampleDir, isLocal, done) {
   // Cancel early if the package.json says this is not a demo.
   const {blocklyDemoConfig: demoConfig} = packageJson;
   if (!demoConfig) {
-    done();
-    return;
+    return done();
   }
   console.log(`Preparing ${exampleDir} example for deployment.`);
 

--- a/scripts/gh-predeploy.js
+++ b/scripts/gh-predeploy.js
@@ -445,7 +445,7 @@ function createExamplePage(pageRoot, pagePath, demoConfig, isLocal) {
  * @param {boolean} isLocal True if building for a local test. False if
  *     building for gh-pages.
  * @param {Function} done Completed callback.
- * @returns {Function} Gulp task.
+ * @returns {Function | undefined} Gulp task.
  */
 function prepareExample(exampleDir, isLocal, done) {
   const baseDir = 'examples';
@@ -456,7 +456,8 @@ function prepareExample(exampleDir, isLocal, done) {
   // Cancel early if the package.json says this is not a demo.
   const {blocklyDemoConfig: demoConfig} = packageJson;
   if (!demoConfig) {
-    return done();
+    done();
+    return;
   }
   console.log(`Preparing ${exampleDir} example for deployment.`);
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes #1978  

### Proposed Changes

Fixes these warnings (_some of them were repeated warnings_):
* Unexpected any. Specify a different type - @typescript-eslint/no-explicit-any
* Missing JSDoc @param "type" type - jsdoc/require-param-type
* Missing JSDoc comment - jsdoc/require-jsdoc
* JSDoc @returns declaration present but return expression not available in function - jsdoc/require-returns-check
* Syntax error in type: MigrationData[]                                                                                                      
* Missing JSDoc @returns type  
* Missing JSDoc @param "identifier" description - jsdoc/require-param-description
* Missing JSDoc @param "identifier" type
* 'Minimap' is defined but never used - @typescript-eslint/no-unused-vars
* JSDoc @returns declaration present but return expression not available in function - jsdoc/require-returns-check

### Reason for Changes

These changes are done because aligning the code with the linting rules allows for the static analysis tool to catch any uncaught bugs at compile time.

### Test Coverage

`npm run test` results:
><img width="532" alt="image" src="https://github.com/google/blockly-samples/assets/71615163/9a6e3d6d-737a-4d31-a411-5ad1ae7c40c7">

`npm run build` results:
><img width="478" alt="image" src="https://github.com/google/blockly-samples/assets/71615163/d49a69d5-490d-4898-b37b-72f8e94513a5">


### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

The only warning left to be fixed is,

>![image](https://github.com/google/blockly-samples/assets/71615163/c3fd5c4c-9bc7-4945-a503-ccf030a93aa3)
