### PR TITLE
chore: re-enabled jsdoc/tag-lines rule, ran lint:fix script to fix linting issues

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -161,8 +161,7 @@ module.exports = [
       // Ensure there is a blank line between the body and any @tags,
       // as required by the tsdoc spec.
       // TODO: Re-enable soon.
-      // 'jsdoc/tag-lines': ['error', 'any', {'startLines': 1}],
-      'jsdoc/tag-lines': 'off',
+      'jsdoc/tag-lines': ['error', 'any', {'startLines': 1}],
 
       // Already handled by tsc.
       'no-dupe-class-members': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -160,7 +160,6 @@ module.exports = [
       'jsdoc/require-returns': ['off'],
       // Ensure there is a blank line between the body and any @tags,
       // as required by the tsdoc spec.
-      // TODO: Re-enable soon.
       'jsdoc/tag-lines': ['error', 'any', {'startLines': 1}],
 
       // Already handled by tsc.

--- a/plugins/block-dynamic-connection/src/dynamic_if.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_if.ts
@@ -39,6 +39,7 @@ interface IfExtraState {
 const DYNAMIC_IF_MIXIN = {
   /**
    * Minimum number of inputs for this block.
+   *
    * @deprecated This is unused.
    */
   minInputs: 1,
@@ -64,6 +65,7 @@ const DYNAMIC_IF_MIXIN = {
 
   /**
    * Create XML to represent if/elseif/else inputs.
+   *
    * @returns XML storage element.
    */
   mutationToDom(this: DynamicIfBlock): Element | null {
@@ -88,6 +90,7 @@ const DYNAMIC_IF_MIXIN = {
 
   /**
    * Parse XML to restore the inputs.
+   *
    * @param xmlElement XML storage element.
    */
   domToMutation(this: DynamicIfBlock, xmlElement: Element): void {
@@ -100,6 +103,7 @@ const DYNAMIC_IF_MIXIN = {
 
   /**
    * Parses XML based on the 'inputs' attribute (non-standard).
+   *
    * @param xmlElement XML storage element.
    */
   deserializeInputs(this: DynamicIfBlock, xmlElement: Element): void {
@@ -137,6 +141,7 @@ const DYNAMIC_IF_MIXIN = {
 
   /**
    * Parses XML based on the 'elseif' and 'else' attributes (standard).
+   *
    * @param xmlElement XML storage element.
    */
   deserializeCounts(this: DynamicIfBlock, xmlElement: Element): void {
@@ -153,6 +158,7 @@ const DYNAMIC_IF_MIXIN = {
 
   /**
    * Returns the state of this block as a JSON serializable object.
+   *
    * @returns The state of this block, ie the else if count and else state.
    */
   saveExtraState: function (this: DynamicIfBlock): IfExtraState | null {
@@ -178,6 +184,7 @@ const DYNAMIC_IF_MIXIN = {
 
   /**
    * Applies the given state to this block.
+   *
    * @param state The state to apply to this block, ie the else if count
    *     and else state.
    */
@@ -203,6 +210,7 @@ const DYNAMIC_IF_MIXIN = {
   /**
    * Finds the index of a connection. Used to determine where in the block to
    * insert new inputs.
+   *
    * @param connection A connection on this block.
    * @returns The index of the connection in the this.inputList.
    */
@@ -221,6 +229,7 @@ const DYNAMIC_IF_MIXIN = {
 
   /**
    * Inserts a boolean value input and statement input at the specified index.
+   *
    * @param index Index of the input before which to add new inputs.
    * @param id An ID to append to the case statement input names to make them
    *     unique.
@@ -245,6 +254,7 @@ const DYNAMIC_IF_MIXIN = {
   /**
    * Called by a monkey-patched version of InsertionMarkerManager when
    * a block is dragged over one of the connections on this block.
+   *
    * @param connection The connection on this block that has a pending
    *     connection.
    */
@@ -304,6 +314,7 @@ const DYNAMIC_IF_MIXIN = {
    * if nor the due input in a case has an attached block, that input is
    * skipped. If only one of them has an attached block, the other value in
    * the pair is undefined.
+   *
    * @returns  A list of target connections attached to case inputs.
    */
   collectTargetCaseConns(this: DynamicIfBlock): CaseConnectionPair[] {
@@ -330,6 +341,7 @@ const DYNAMIC_IF_MIXIN = {
    *
    * This is essentially rebuilding all of the cases with strictly ascending
    * case numbers.
+   *
    * @param targetConns The list of target connections to attach to this block.
    */
   addCaseInputs(this: DynamicIfBlock, targetConns: CaseConnectionPair[]): void {
@@ -348,6 +360,7 @@ const DYNAMIC_IF_MIXIN = {
 
   /**
    * Adds an else input to this block.
+   *
    * @returns The appended input.
    */
   addElseInput(this: DynamicIfBlock): Blockly.Input {

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -44,6 +44,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
 
   /**
    * Create XML to represent number of text inputs.
+   *
    * @returns XML storage element.
    */
   mutationToDom(this: DynamicListCreateBlock): Element {
@@ -61,6 +62,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
 
   /**
    * Parse XML to restore the text inputs.
+   *
    * @param xmlElement XML storage element.
    */
   domToMutation(this: DynamicListCreateBlock, xmlElement: Element): void {
@@ -73,6 +75,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
 
   /**
    * Parses XML based on the 'inputs' attribute (non-standard).
+   *
    * @param xmlElement XML storage element.
    */
   deserializeInputs(this: DynamicListCreateBlock, xmlElement: Element): void {
@@ -89,6 +92,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
 
   /**
    * Parses XML based on the 'items' attribute (standard).
+   *
    * @param xmlElement XML storage element.
    */
   deserializeCounts(this: DynamicListCreateBlock, xmlElement: Element): void {
@@ -104,6 +108,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
 
   /**
    * Returns the state of this block as a JSON serializable object.
+   *
    * @returns The state of this block, ie the item count.
    */
   saveExtraState: function (this: DynamicListCreateBlock): {itemCount: number} {
@@ -121,6 +126,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
 
   /**
    * Applies the given state to this block.
+   *
    * @param state The state to apply to this block, ie the item count.
    */
   loadExtraState: function (
@@ -141,6 +147,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
 
   /**
    * Check whether a new input should be added and determine where it should go.
+   *
    * @param connection The connection that has a pending connection.
    * @returns The index before which to insert a new input, or null if no input
    *     should be added.
@@ -183,6 +190,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
   /**
    * Called by a monkey-patched version of InsertionMarkerManager when
    * a block is dragged over one of the connections on this block.
+   *
    * @param connection The connection on this block that has a pending
    *     connection.
    */
@@ -222,6 +230,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    * Filters the given target connections so that empty connections are removed,
    * unless we need those to reach the minimum input count. Empty connections
    * are removed starting at the end of the array.
+   *
    * @param targetConns The list of connections associated with inputs.
    * @returns A filtered list of connections (or null/undefined) which should
    *     be attached to inputs.
@@ -243,6 +252,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    * every entry in the array (if it does not already exist). If the entry is
    * a connection and not null/undefined the connection will be connected to
    * the input.
+   *
    * @param targetConns The connections defining the inputs to add.
    */
   addItemInputs(
@@ -263,6 +273,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
 
   /**
    * Adds the top input with the label to this block.
+   *
    * @returns The added input.
    */
   addFirstInput(this: DynamicListCreateBlock): Blockly.Input {

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -42,6 +42,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
 
   /**
    * Create XML to represent number of text inputs.
+   *
    * @returns XML storage element.
    */
   mutationToDom(this: DynamicTextJoinBlock): Element {
@@ -59,6 +60,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
 
   /**
    * Parse XML to restore the text inputs.
+   *
    * @param xmlElement XML storage element.
    */
   domToMutation(this: DynamicTextJoinBlock, xmlElement: Element): void {
@@ -71,6 +73,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
 
   /**
    * Parses XML based on the 'inputs' attribute (non-standard).
+   *
    * @param xmlElement XML storage element.
    */
   deserializeInputs(this: DynamicTextJoinBlock, xmlElement: Element): void {
@@ -85,6 +88,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
 
   /**
    * Parses XML based on the 'items' attribute (standard).
+   *
    * @param xmlElement XML storage element.
    */
   deserializeCounts(this: DynamicTextJoinBlock, xmlElement: Element): void {
@@ -100,6 +104,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
 
   /**
    * Returns the state of this block as a JSON serializable object.
+   *
    * @returns The state of this block, ie the item count.
    */
   saveExtraState: function (this: DynamicTextJoinBlock): {itemCount: number} {
@@ -117,6 +122,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
 
   /**
    * Applies the given state to this block.
+   *
    * @param state The state to apply to this block, ie the item count.
    */
   loadExtraState: function (
@@ -137,6 +143,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
 
   /**
    * Check whether a new input should be added and determine where it should go.
+   *
    * @param connection The connection that has a pending connection.
    * @returns The index before which to insert a new input, or null if no input
    *     should be added.
@@ -179,6 +186,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
   /**
    * Called by a monkey-patched version of InsertionMarkerManager when
    * a block is dragged over one of the connections on this block.
+   *
    * @param connection The connection on this block that has a pending
    *     connection.
    */
@@ -218,6 +226,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * Filters the given target connections so that empty connections are removed,
    * unless we need those to reach the minimum input count. Empty connections
    * are removed starting at the end of the array.
+   *
    * @param targetConns The list of connections associated with inputs.
    * @returns A filtered list of connections (or null/undefined) which should
    *     be attached to inputs.
@@ -240,6 +249,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * every entry in the array (if it does not already exist). If the entry is
    * a connection and not null/undefined the connection will be connected to
    * the input.
+   *
    * @param targetConns The connections defining the inputs to add.
    */
   addItemInputs(
@@ -260,6 +270,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
 
   /**
    * Adds the top input with the label to this block.
+   *
    * @returns The added input.
    */
   addFirstInput(this: DynamicTextJoinBlock): Blockly.Input {

--- a/plugins/block-dynamic-connection/test/index.ts
+++ b/plugins/block-dynamic-connection/test/index.ts
@@ -14,6 +14,7 @@ import * as BlockDynamicConnection from '../src/index';
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -15,6 +15,7 @@ import {ProcedureCreate} from './events_procedure_create';
 
 /**
  * A dictionary of the block definitions provided by this module.
+ *
  * @type {!Object<string, Object>}
  */
 export const blocks = Blockly.common.createBlockDefinitionsFromJsonArray([
@@ -167,6 +168,7 @@ const procedureDefGetDefMixin = function () {
 
     /**
      * Returns the data model for this procedure block.
+     *
      * @returns The data model for this procedure
      *     block.
      */
@@ -177,6 +179,7 @@ const procedureDefGetDefMixin = function () {
     /**
      * True if this is a procedure definition block, false otherwise (i.e.
      * it is a caller).
+     *
      * @returns True because this is a procedure definition block.
      */
     isProcedureDef() {
@@ -185,6 +188,7 @@ const procedureDefGetDefMixin = function () {
 
     /**
      * Return all variables referenced by this block.
+     *
      * @returns List of variable names.
      * @this {Blockly.Block}
      */
@@ -196,6 +200,7 @@ const procedureDefGetDefMixin = function () {
 
     /**
      * Return all variables referenced by this block.
+     *
      * @returns List of variable models.
      * @this {Blockly.Block}
      */
@@ -239,6 +244,7 @@ const procedureDefVarMixin = function () {
     /**
      * Notification that a variable is renaming.
      * If the ID matches one of this block's variables, rename it.
+     *
      * @param oldId ID of variable to rename.
      * @param newId ID of new variable.  May be the same as oldId, but
      *     with an updated name.  Guaranteed to be the same type as the old
@@ -261,6 +267,7 @@ const procedureDefVarMixin = function () {
     /**
      * Notification that a variable is renaming but keeping the same ID.  If the
      * variable is in use on this block, rerender to show the new name.
+     *
      * @param variable The variable being renamed.
      * @package
      * @override
@@ -334,6 +341,7 @@ const procedureDefUpdateShapeMixin = {
 
   /**
    * Add or remove the statement block from this function definition.
+   *
    * @param hasStatements True if a statement block is needed.
    * @this {Blockly.Block}
    */
@@ -386,6 +394,7 @@ const procedureDefMutator = {
   /**
    * Create XML to represent the argument inputs.
    * Backwards compatible serialization implementation.
+   *
    * @returns XML storage element.
    * @this {Blockly.Block}
    */
@@ -410,6 +419,7 @@ const procedureDefMutator = {
   /**
    * Parse XML to restore the argument inputs.
    * Backwards compatible serialization implementation.
+   *
    * @param xmlElement XML storage element.
    * @this {Blockly.Block}
    */
@@ -433,6 +443,7 @@ const procedureDefMutator = {
 
   /**
    * Returns the state of this block as a JSON serializable object.
+   *
    * @param doFullSerialization Tells the block if it should serialize
    *     its entire state (including data stored in the backing procedure
    *     model). Used for copy-paste.
@@ -465,6 +476,7 @@ const procedureDefMutator = {
 
   /**
    * Applies the given state to this block.
+   *
    * @param state The state to apply to this block, eg the parameters and
    *     statements.
    */
@@ -502,6 +514,7 @@ const procedureDefMutator = {
 
   /**
    * Populate the mutator's dialog with this block's components.
+   *
    * @param workspace Blockly.Mutator's workspace.
    * @returns Root block in mutator.
    * @this {Blockly.Block}
@@ -544,6 +557,7 @@ const procedureDefMutator = {
 
   /**
    * Reconfigure this block based on the mutator dialog's components.
+   *
    * @param containerBlock Root block in mutator.
    * @this {Blockly.Block}
    */
@@ -565,6 +579,7 @@ const procedureDefMutator = {
   /**
    * Deletes any parameters from the procedure model that do not have associated
    * parameter blocks in the mutator.
+   *
    * @param containerBlock Root block in the mutator.
    */
   deleteParamsFromModel_: function (containerBlock) {
@@ -581,6 +596,7 @@ const procedureDefMutator = {
   /**
    * Renames any parameters in the procedure model whose associated parameter
    * blocks have been renamed.
+   *
    * @param containerBlock Root block in the mutator.
    */
   renameParamsInModel_: function (containerBlock) {
@@ -606,6 +622,7 @@ const procedureDefMutator = {
   /**
    * Adds new parameters to the procedure model for any new procedure parameter
    * blocks.
+   *
    * @param containerBlock Root block in the mutator.
    */
   addParamsToModel_: function (containerBlock) {
@@ -643,6 +660,7 @@ Blockly.Extensions.registerMutator(
 const procedureDefContextMenuMixin = {
   /**
    * Add custom menu options to this block's context menu.
+   *
    * @param options List of menu options to add to.
    * @this {Blockly.Block}
    */
@@ -802,6 +820,7 @@ const procedureCallerGetDefMixin = function () {
 
     /**
      * Returns the procedure model associated with this block.
+     *
      * @returns The procedure model associated with this block.
      */
     getProcedureModel() {
@@ -810,6 +829,7 @@ const procedureCallerGetDefMixin = function () {
 
     /**
      * Returns the procedure model tha was found.
+     *
      * @param name The name of the procedure model to find.
      * @param params The param names of the procedure model
      *     to find.
@@ -838,6 +858,7 @@ const procedureCallerGetDefMixin = function () {
     /**
      * Returns the main workspace (i.e. not the flyout workspace) associated
      * with this block.
+     *
      * @returns The main workspace (i.e. not the flyout workspace) associated
      *     with this block.
      */
@@ -850,6 +871,7 @@ const procedureCallerGetDefMixin = function () {
     /**
      * True if this is a procedure definition block, false otherwise (i.e.
      * it is a caller).
+     *
      * @returns False because this is not a procedure definition block.
      */
     isProcedureDef() {
@@ -858,6 +880,7 @@ const procedureCallerGetDefMixin = function () {
 
     /**
      * Return all variables referenced by this block.
+     *
      * @returns List of variable names.
      * @this {Blockly.Block}
      */
@@ -869,6 +892,7 @@ const procedureCallerGetDefMixin = function () {
 
     /**
      * Return all variables referenced by this block.
+     *
      * @returns List of variable models.
      * @this {Blockly.Block}
      */
@@ -893,6 +917,7 @@ const procedureCallerVarMixin = function () {
     /**
      * Notification that a variable is renaming but keeping the same ID.  If the
      * variable is in use on this block, rerender to show the new name.
+     *
      * @param variable The variable being renamed.
      * @package
      * @override
@@ -925,6 +950,7 @@ const procedureCallerMutator = {
   /**
    * Create XML to represent the (non-editable) name and arguments.
    * Backwards compatible serialization implementation.
+   *
    * @returns XML storage element.
    * @this {Blockly.Block}
    */
@@ -945,6 +971,7 @@ const procedureCallerMutator = {
   /**
    * Parse XML to restore the (non-editable) name and parameters.
    * Backwards compatible serialization implementation.
+   *
    * @param xmlElement XML storage element.
    * @this {Blockly.Block}
    */
@@ -961,6 +988,7 @@ const procedureCallerMutator = {
 
   /**
    * Returns the state of this block as a JSON serializable object.
+   *
    * @returns The state of
    *     this block, ie the params and procedure name.
    */
@@ -988,6 +1016,7 @@ const procedureCallerMutator = {
 
   /**
    * Applies the given state to this block.
+   *
    * @param state The state to apply to this block, ie the params and
    *     procedure name.
    */
@@ -997,6 +1026,7 @@ const procedureCallerMutator = {
 
   /**
    * Applies the given name and params from the serialized state to the block.
+   *
    * @param name The name to apply to the block.
    * @param params The parameters to apply to the block.
    */
@@ -1140,6 +1170,7 @@ const procedureCallerUpdateShapeMixin = {
 
   /**
    * Creates all of the parameter inputs to match the state of the data model.
+   *
    * @param params The params to add to the block, or null to
    *     use the params defined in the procedure model.
    */
@@ -1173,6 +1204,7 @@ const procedureCallerUpdateShapeMixin = {
   /**
    * Notification that a procedure is renaming.
    * If the name matches this block's procedure, rename it.
+   *
    * @param oldName Previous name of procedure.
    * @param newName Renamed procedure.
    * @this {Blockly.Block}
@@ -1196,6 +1228,7 @@ const procedureCallerOnChangeMixin = {
   /**
    * Procedure calls cannot exist without the corresponding procedure
    * definition.  Enforce this link whenever an event is fired.
+   *
    * @param event Change event.
    * @this {Blockly.Block}
    */
@@ -1252,6 +1285,7 @@ const procedureCallerOnChangeMixin = {
   /**
    * Returns true if the given def block matches the definition of this caller
    * block.
+   *
    * @param defBlock The definition block to check against.
    * @returns Whether the def block matches or not.
    */
@@ -1267,6 +1301,7 @@ const procedureCallerOnChangeMixin = {
   /**
    * Creates a procedure definition block with the given name and params,
    * and returns the procedure model associated with it.
+   *
    * @param name The name of the procedure to create.
    * @param params The names of the parameters to create.
    * @returns The procedure model associated with the new
@@ -1302,6 +1337,7 @@ Blockly.Extensions.registerMixin(
 const procedureCallerContextMenuMixin = {
   /**
    * Add menu option to find the definition block for this call.
+   *
    * @param options List of menu options to add to.
    * @this {Blockly.Block}
    */

--- a/plugins/block-shareable-procedures/src/events_procedure_base.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_base.ts
@@ -19,6 +19,7 @@ export abstract class ProcedureBase extends Blockly.Events.Abstract {
 
   /**
    * Constructs the base procedure event.
+   *
    * @param workspace The workspace the procedure model exists in.
    * @param procedure The procedure model associated with this event.
    */
@@ -32,6 +33,7 @@ export abstract class ProcedureBase extends Blockly.Events.Abstract {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    */
   toJson(): ProcedureBaseJson {

--- a/plugins/block-shareable-procedures/src/events_procedure_change_return.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_change_return.ts
@@ -21,6 +21,7 @@ export class ProcedureChangeReturn extends ProcedureBase {
 
   /**
    * Constructs the procedure change event.
+   *
    * @param workpace The workspace this change event is associated with.
    * @param procedure The model this change event is associated with.
    * @param oldTypes The type(s) the procedure's return was set to before it
@@ -38,6 +39,7 @@ export class ProcedureChangeReturn extends ProcedureBase {
 
   /**
    * Replays the event in the workspace.
+   *
    * @param forward if true, play the event forward (redo), otherwise play it
    *     backward (undo).
    */
@@ -60,6 +62,7 @@ export class ProcedureChangeReturn extends ProcedureBase {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    */
   toJson(): ProcedureChangeReturnJson {
@@ -70,6 +73,7 @@ export class ProcedureChangeReturn extends ProcedureBase {
 
   /**
    * Deserializes the JSON event.
+   *
    * @param json The JSON representation of a procedure change event.
    * @param workspace The workspace to deserialize the event into.
    * @returns The new procedure change return event.

--- a/plugins/block-shareable-procedures/src/events_procedure_create.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_create.ts
@@ -20,6 +20,7 @@ export class ProcedureCreate extends ProcedureBase {
 
   /**
    * Replays the event in the workspace.
+   *
    * @param forward if true, play the event forward (redo), otherwise play it
    *     backward (undo).
    */
@@ -37,6 +38,7 @@ export class ProcedureCreate extends ProcedureBase {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    */
   toJson(): ProcedureCreateJson {
@@ -49,6 +51,7 @@ export class ProcedureCreate extends ProcedureBase {
 
   /**
    * Deserializes the JSON event.
+   *
    * @param json The JSON representation of a procedure create event.
    * @param workspace The workspace to deserialize the event into.
    * @returns The new procedure create event.

--- a/plugins/block-shareable-procedures/src/events_procedure_delete.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_delete.ts
@@ -18,6 +18,7 @@ export class ProcedureDelete extends ProcedureBase {
 
   /**
    * Replays the event in the workspace.
+   *
    * @param forward if true, play the event forward (redo), otherwise play it
    *     backward (undo).
    */
@@ -35,6 +36,7 @@ export class ProcedureDelete extends ProcedureBase {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    */
   toJson(): ProcedureDeleteJson {
@@ -43,6 +45,7 @@ export class ProcedureDelete extends ProcedureBase {
 
   /**
    * Deserializes the JSON event.
+   *
    * @param json The JSON representation of a procedure delete event.
    * @param workspace The workspace to deserialize the event into.
    * @returns The new procedure delete event.

--- a/plugins/block-shareable-procedures/src/events_procedure_enable.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_enable.ts
@@ -22,6 +22,7 @@ export class ProcedureEnable extends ProcedureBase {
 
   /**
    * Constructs the procedure enable event.
+   *
    * @param workspace The workspace this event is associated with.
    * @param procedure The model this event is associated with.
    * @param newState The (optional) new enabled state of the procedure model.
@@ -46,6 +47,7 @@ export class ProcedureEnable extends ProcedureBase {
 
   /**
    * Replays the event in the workspace.
+   *
    * @param forward if true, play the event forward (redo), otherwise play it
    *     backward (undo).
    */
@@ -68,6 +70,7 @@ export class ProcedureEnable extends ProcedureBase {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    */
   toJson(): ProcedureEnableJson {
@@ -78,6 +81,7 @@ export class ProcedureEnable extends ProcedureBase {
 
   /**
    * Deserializes the JSON event.
+   *
    * @param json The JSON representation of a procedure enable event.
    * @param workspace The workspace to deserialize the event into.
    * @returns The new procedure enable event.

--- a/plugins/block-shareable-procedures/src/events_procedure_parameter_base.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_parameter_base.ts
@@ -18,6 +18,7 @@ export abstract class ProcedureParameterBase extends ProcedureBase {
 
   /**
    * Constructs the procedure parameter base event.
+   *
    * @param workspace The workspace the parameter model exists in.
    * @param procedure The procedure model the parameter model belongs to.
    * @param parameter The parameter model associated with this event.
@@ -34,6 +35,7 @@ export abstract class ProcedureParameterBase extends ProcedureBase {
   /**
    * Finds the parameter with the given ID in the procedure model with the given
    * ID, if both things exist.
+   *
    * @param workspace The workspace to search for the parameter.
    * @param procedureId The ID of the procedure model to search for
    *     the parameter.
@@ -57,6 +59,7 @@ export abstract class ProcedureParameterBase extends ProcedureBase {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    */
   toJson(): ProcedureParameterBaseJson {

--- a/plugins/block-shareable-procedures/src/events_procedure_parameter_create.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_parameter_create.ts
@@ -24,6 +24,7 @@ export class ProcedureParameterCreate extends ProcedureParameterBase {
 
   /**
    * Constructs the procedure parameter create event.js.
+   *
    * @param workspace The workspace this event is associated with.
    * @param procedure The procedure model this event is associated with.
    * @param parameter The parameter model that was just added to the procedure.
@@ -40,6 +41,7 @@ export class ProcedureParameterCreate extends ProcedureParameterBase {
 
   /**
    * Replays the event in the workspace.
+   *
    * @param forward if true, play the event forward (redo), otherwise play it
    *     backward (undo).
    */
@@ -62,6 +64,7 @@ export class ProcedureParameterCreate extends ProcedureParameterBase {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    */
   toJson(): ProcedureParameterCreateJson {
@@ -75,6 +78,7 @@ export class ProcedureParameterCreate extends ProcedureParameterBase {
 
   /**
    * Deserializes the JSON event.
+   *
    * @param json The JSON representation of a procedure parameter create event.
    * @param workspace The workspace to deserialize the event into.
    * @returns The new procedure parameter create event.

--- a/plugins/block-shareable-procedures/src/events_procedure_parameter_delete.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_parameter_delete.ts
@@ -21,6 +21,7 @@ export class ProcedureParameterDelete extends ProcedureParameterBase {
 
   /**
    * Constructs the procedure parameter delete event.
+   *
    * @param workspace The workspace this event is associated with.
    * @param procedure The procedure model this event is associated with.
    * @param parameter The parameter model that was just removed from the
@@ -38,6 +39,7 @@ export class ProcedureParameterDelete extends ProcedureParameterBase {
 
   /**
    * Replays the event in the workspace.
+   *
    * @param forward if true, play the event forward (redo), otherwise play it
    *     backward (undo).
    */
@@ -60,6 +62,7 @@ export class ProcedureParameterDelete extends ProcedureParameterBase {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    */
   toJson(): ProcedureParameterDeleteJson {
@@ -70,6 +73,7 @@ export class ProcedureParameterDelete extends ProcedureParameterBase {
 
   /**
    * Deserializes the JSON event.
+   *
    * @param json The JSON representation of a procedure parameter delete event.
    * @param workspace The workspace to deserialize the event into.
    * @returns The new procedure parameter delete event.

--- a/plugins/block-shareable-procedures/src/events_procedure_parameter_rename.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_parameter_rename.ts
@@ -28,6 +28,7 @@ export class ProcedureParameterRename extends ProcedureParameterBase {
 
   /**
    * Constructs the procedure parameter rename event.
+   *
    * @param workspace The workpace this event is associated with.
    * @param procedure The procedure model this event is associated with.
    * @param parameter The parameter model this event is associated with.
@@ -55,6 +56,7 @@ export class ProcedureParameterRename extends ProcedureParameterBase {
 
   /**
    * Replays the event in the workspace.
+   *
    * @param forward if true, play the event forward (redo), otherwise play it
    *     backward (undo).
    */
@@ -78,6 +80,7 @@ export class ProcedureParameterRename extends ProcedureParameterBase {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    */
   toJson(): ProcedureParameterRenameJson {
@@ -90,6 +93,7 @@ export class ProcedureParameterRename extends ProcedureParameterBase {
 
   /**
    * Deserializes the JSON event.
+   *
    * @param json The JSON representation of a procedure parameter rename event.
    * @param workspace The workspace to deserialize the event into.
    * @returns The new procedure parameter rename event.

--- a/plugins/block-shareable-procedures/src/events_procedure_rename.ts
+++ b/plugins/block-shareable-procedures/src/events_procedure_rename.ts
@@ -18,6 +18,7 @@ export class ProcedureRename extends ProcedureBase {
 
   /**
    * Constructs the procedure rename event.
+   *
    * @param workspace The workspace this event is associated with.
    * @param procedure The model this event is associated with.
    * @param oldName The old name of the procedure model.
@@ -38,6 +39,7 @@ export class ProcedureRename extends ProcedureBase {
 
   /**
    * Replays the event in the workspace.
+   *
    * @param forward if true, play the event forward (redo), otherwise play it
    *     backward (undo).
    */
@@ -62,6 +64,7 @@ export class ProcedureRename extends ProcedureBase {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    */
   toJson(): ProcedureRenameJson {
@@ -73,6 +76,7 @@ export class ProcedureRename extends ProcedureBase {
 
   /**
    * Deserializes the JSON event.
+   *
    * @param json The JSON representation of a procedure rename event.
    * @param workspace The workspace to deserialize the event into.
    * @returns The new procedure rename event.

--- a/plugins/block-shareable-procedures/src/i_procedure_block.ts
+++ b/plugins/block-shareable-procedures/src/i_procedure_block.ts
@@ -17,6 +17,7 @@ export interface IProcedureBlock {
 
 /**
  * A type guard which checks if the given block is a procedure block.
+ *
  * @param block The block to check for procedure-y-ness.
  * @returns Whether this block is a procedure block or not.
  */

--- a/plugins/block-shareable-procedures/src/observable_parameter_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_parameter_model.ts
@@ -19,6 +19,7 @@ export class ObservableParameterModel
 
   /**
    * Constructor for the procedure parameter.
+   *
    * @param workspace The workspace this parameter model exists in.
    * @param name The name of this parameter.
    * @param id The optional unique language-neutral ID of the parameter.
@@ -39,6 +40,7 @@ export class ObservableParameterModel
 
   /**
    * Sets the name of this parameter to the given name.
+   *
    * @param name The string to set the name to.
    * @param id The optional ID the backing variable should have.
    * @returns This parameter model.
@@ -67,6 +69,7 @@ export class ObservableParameterModel
    * Unimplemented. The built-in ParameterModel does not support typing.
    * If you want your procedure blocks to have typed parameters, you need to
    * implement your own ParameterModel.
+   *
    * @param types The types to set this parameter to.
    * @throws Throws for the ObservableParameterModel specifically because this
    *     method is unimplemented.
@@ -95,6 +98,7 @@ export class ObservableParameterModel
   /**
    * Returns the unique language-neutral ID for the parameter. This represents
    * the identity of the variable model which does not change over time.
+   *
    * @returns The unique language-neutral ID for the parameter.
    */
   getId(): string {
@@ -110,6 +114,7 @@ export class ObservableParameterModel
 
   /**
    * Tells the parameter model it should fire events.
+   *
    * @internal
    */
   startPublishing() {
@@ -118,6 +123,7 @@ export class ObservableParameterModel
 
   /**
    * Tells the parameter model it should not fire events.
+   *
    * @internal
    */
   stopPublishing() {
@@ -126,6 +132,7 @@ export class ObservableParameterModel
 
   /**
    * Sets the procedure model this parameter is a part of.
+   *
    * @param model The procedure model this parameter is a part of.
    * @returns This parameter model.
    */

--- a/plugins/block-shareable-procedures/src/observable_procedure_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_procedure_model.ts
@@ -29,6 +29,7 @@ export class ObservableProcedureModel
 
   /**
    * Constructor for the procedure model.
+   *
    * @param workspace The workspace the procedure model is associated with.
    * @param name The name of the new procedure.
    * @param id The (optional) unique language-neutral ID for the procedure.
@@ -44,6 +45,7 @@ export class ObservableProcedureModel
 
   /**
    * Sets the human-readable name of the procedure.
+   *
    * @param name The human-readable name of the procedure.
    * @returns This procedure model.
    */
@@ -61,6 +63,7 @@ export class ObservableProcedureModel
   /**
    * Inserts a parameter into the list of parameters.
    * To move a parameter, first delete it, and then re-insert.
+   *
    * @param parameterModel The parameter model to insert.
    * @param index The index to insert it at.
    * @returns This procedure model.
@@ -102,6 +105,7 @@ export class ObservableProcedureModel
 
   /**
    * Removes the parameter at the given index from the parameter list.
+   *
    * @param index The index of the parameter to remove.
    * @returns This procedure model.
    */
@@ -128,6 +132,7 @@ export class ObservableProcedureModel
    * value (null).
    * This procedure model does not support procedures that have actual
    * return types (i.e. non-empty arrays, e.g. ['number']).
+   *
    * @param types Used to set whether this procedure has a return value
    *     (empty array) or no return value (null).
    * @returns This procedure model.
@@ -155,6 +160,7 @@ export class ObservableProcedureModel
   /**
    * Sets whether this procedure is enabled/disabled. If a procedure is disabled
    * all procedure caller blocks should be disabled as well.
+   *
    * @param enabled Whether this procedure is enabled/disabled.
    * @returns This procedure model.
    */
@@ -171,6 +177,7 @@ export class ObservableProcedureModel
   /**
    * Disables triggering updates to procedure blocks until the endBulkUpdate
    * is called.
+   *
    * @internal
    */
   startBulkUpdate() {
@@ -180,6 +187,7 @@ export class ObservableProcedureModel
   /**
    * Triggers an update to procedure blocks. Should be used with
    * startBulkUpdate.
+   *
    * @internal
    */
   endBulkUpdate() {
@@ -219,6 +227,7 @@ export class ObservableProcedureModel
   /**
    * Returns the return type of the procedure.
    * Null represents a procedure that does not return a value.
+   *
    * @returns the return type of the procedure.
    */
   getReturnTypes(): string[] | null {
@@ -228,6 +237,7 @@ export class ObservableProcedureModel
   /**
    * Returns whether the procedure is enabled/disabled. If a procedure is
    * disabled, all procedure caller blocks should be disabled as well.
+   *
    * @returns Returns whether the procedure is enabled/disabled.
    */
   getEnabled(): boolean {
@@ -236,6 +246,7 @@ export class ObservableProcedureModel
 
   /**
    * Tells the procedure model it should fire events.
+   *
    * @internal
    */
   startPublishing() {
@@ -248,6 +259,7 @@ export class ObservableProcedureModel
 
   /**
    * Tells the procedure model it should not fire events.
+   *
    * @internal
    */
   stopPublishing() {

--- a/plugins/block-shareable-procedures/src/update_procedures.ts
+++ b/plugins/block-shareable-procedures/src/update_procedures.ts
@@ -8,6 +8,7 @@ import * as Blockly from 'blockly/core';
 
 /**
  * Calls the `doProcedureUpdate` method on all blocks which implement it.
+ *
  * @param workspace The workspace within which to trigger block updates.
  * @internal
  */

--- a/plugins/content-highlight/src/index.ts
+++ b/plugins/content-highlight/src/index.ts
@@ -75,12 +75,14 @@ export class ContentHighlight {
 
   /**
    * Constructor for the content highlight plugin.
+   *
    * @param workspace The workspace that the plugin will be added to.
    */
   constructor(protected workspace: Blockly.WorkspaceSvg) {}
 
   /**
    * Initializes the plugin.
+   *
    * @param padding The padding to use for the content area highlight
    *    rectangle, in workspace units.
    */
@@ -173,6 +175,7 @@ export class ContentHighlight {
 
   /**
    * Handles events triggered on the workspace.
+   *
    * @param event The event.
    */
   private onChange(event: Blockly.Events.Abstract) {
@@ -200,6 +203,7 @@ export class ContentHighlight {
   /**
    * Changes opacity of the highlight based on what kind of block drag event
    * is passed.
+   *
    * @param event The BlockDrag event.
    */
   private handleBlockDrag(event: Blockly.Events.BlockDrag) {
@@ -226,6 +230,7 @@ export class ContentHighlight {
 
   /**
    * Resizes the content highlight.
+   *
    * @param contentMetrics The content metrics for the workspace in workspace
    *     coordinates.
    */
@@ -248,6 +253,7 @@ export class ContentHighlight {
 
   /**
    * Positions the highlight on the workspace based on the workspace metrics.
+   *
    * @param contentMetrics The content metrics for the workspace in workspace
    *     coordinates.
    * @param absoluteMetrics The absolute metrics for the workspace.

--- a/plugins/cross-tab-copy-paste/src/index.d.ts
+++ b/plugins/cross-tab-copy-paste/src/index.d.ts
@@ -6,6 +6,7 @@ export class CrossTabCopyPaste {
   /**
    * Initializes the cross tab copy paste plugin. If no options are selected
    * then both context menu items and keyboard shortcuts are added.
+   *
    * @param {{contextMenu: boolean, shortcut: boolean}} options
    * `contextMenu` Register copy and paste in the context menu.
    * `shortcut` Register cut (ctr + x), copy (ctr + c) and paste (ctr + v)

--- a/plugins/dev-create/templates/typescript-block/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-block/template/test/index.ts
@@ -17,6 +17,7 @@ const allBlocks = ['block_template'];
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/dev-create/templates/typescript-field/template/src/index.ts
+++ b/plugins/dev-create/templates/typescript-field/template/src/index.ts
@@ -18,6 +18,7 @@ import * as Blockly from 'blockly/core';
 export class FieldTemplate extends Blockly.Field {
   /**
    * Constructs a FieldTemplate from a JSON arg object.
+   *
    * @param options A JSON object with options.
    * @returns The new field instance.
    * @package

--- a/plugins/dev-create/templates/typescript-field/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-field/template/test/index.ts
@@ -22,6 +22,7 @@ const toolbox = generateFieldTestBlocks('field_template', [
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/dev-create/templates/typescript-plugin/template/src/index.ts
+++ b/plugins/dev-create/templates/typescript-plugin/template/src/index.ts
@@ -19,6 +19,7 @@ export class Plugin {
   protected workspace: Blockly.WorkspaceSvg;
   /**
    * Constructor for ...
+   *
    * @param workspace The workspace that the plugin will
    *     be added to.
    */

--- a/plugins/dev-create/templates/typescript-plugin/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-plugin/template/test/index.ts
@@ -14,6 +14,7 @@ import {Plugin} from '../src/index';
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/dev-create/templates/typescript-theme/template/test/index.ts
+++ b/plugins/dev-create/templates/typescript-theme/template/test/index.ts
@@ -14,6 +14,7 @@ import Theme from '../src/index';
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/dev-tools/src/index.d.ts
+++ b/plugins/dev-tools/src/index.d.ts
@@ -64,6 +64,7 @@ declare namespace DevTools {
 
   /**
    * Create the Blockly playground.
+   *
    * @param container
    * @param createWorkspace
    * @param defaultOptions
@@ -82,6 +83,7 @@ declare namespace DevTools {
 
   /**
    * Use dat.GUI to add controls to adjust configuration of a Blockly workspace.
+   *
    * @param createWorkspace
    * @param defaultOptions
    * @returns The dat.GUI instance.
@@ -94,6 +96,7 @@ declare namespace DevTools {
   /**
    * Generates a number of field testing blocks for a specific field and returns
    * the toolbox xml string.
+   *
    * @param fieldName
    * @param options
    * @returns The toolbox xml string.

--- a/plugins/field-angle/src/field_angle.ts
+++ b/plugins/field-angle/src/field_angle.ts
@@ -285,6 +285,7 @@ export class FieldAngle extends Blockly.FieldNumber {
 
     /**
      * Draw a set of ticks on the gauge.
+     *
      * @param tickAngle Angle between each tick.
      * @param length Length of the tick (minor=5, major=10).
      */
@@ -415,6 +416,7 @@ export class FieldAngle extends Blockly.FieldNumber {
 
   /**
    * Convert an on-screen angle into a value for this field.
+   *
    * @param angle Radians where 0: East, π/2: North, π or -π: West, -π/2: South.
    * @returns Angle value for this field, scaled and offset as specified.
    */
@@ -440,6 +442,7 @@ export class FieldAngle extends Blockly.FieldNumber {
 
   /**
    * Convert a value for this field into an on-screen angle.
+   *
    * @param angle Angle value for this field, scaled and offset as specified.
    * @returns Radians where 0: East, π/2: North, π or -π: West, -π/2: South.
    */
@@ -641,6 +644,7 @@ export class FieldAngle extends Blockly.FieldNumber {
 
   /**
    * Construct a FieldAngle from a JSON arg object.
+   *
    * @param options A JSON object with options
    *     (value, mode, clockwise, offset, min, max, precision).
    * @returns The new field instance.

--- a/plugins/field-angle/test/index.ts
+++ b/plugins/field-angle/test/index.ts
@@ -67,6 +67,7 @@ const toolbox = generateFieldTestBlocks('field_angle', [
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/field-colour-hsv-sliders/src/field_colour_hsv_sliders.ts
+++ b/plugins/field-colour-hsv-sliders/src/field_colour_hsv_sliders.ts
@@ -38,6 +38,7 @@ class RgbColour {
 
   /**
    * The RgbColour constructor.
+   *
    * @param r The initial amount of red. Defaults to 0.
    * @param g The initial amount of green. Defaults to 0.
    * @param b The initial amount of blue. Defaults to 0.
@@ -51,6 +52,7 @@ class RgbColour {
   /**
    * Given a number from 0 to 1, returns a two-digit hexadecimal string from
    * '00' to 'ff'.
+   *
    * @param x The amount of light in a component from 0 to 1.
    * @returns A hexadecimal representation from '00' to 'ff'.
    */
@@ -62,6 +64,7 @@ class RgbColour {
 
   /**
    * Returns a hexadecimal string in the format #rrggbb representing the colour.
+   *
    * @returns A hexadecimal representation of this colour.
    */
   toHex(): string {
@@ -76,6 +79,7 @@ class RgbColour {
   /**
    * Updates the properties of this instance to represent the same colour as the
    * provided string in the hexadecimal format #rrggbb.
+   *
    * @param hex A hexadecimal string in the format '#rrggbb'.
    * @returns This instance after updating it.
    */
@@ -89,6 +93,7 @@ class RgbColour {
   /**
    * Updates the properties of this instance to represent the same colour as the
    * provided HsvColour but in the sRGB colour space.
+   *
    * @param hsv An HSV representation of a colour to copy.
    * @returns This instance after updating it.
    */
@@ -121,6 +126,7 @@ class HsvColour {
 
   /**
    * The HsvColour constructor.
+   *
    * @param h The initial hue of the colour. Defaults to 0.
    * @param s The initial amount of saturation. Defaults to 0.
    * @param v The initial amount of brightness. Defaults to 0.
@@ -134,6 +140,7 @@ class HsvColour {
   /**
    * Updates the properties of this instance to represent the same colour as the
    * provided RgbColour but in the HSV colour space.
+   *
    * @param rgb An RGB representation of a colour to copy.
    * @returns This instance after updating it.
    */
@@ -165,6 +172,7 @@ class HsvColour {
 
   /**
    * Updates the properties of this instance to copy the provided HsvColour.
+   *
    * @param other An HSV representation of a colour to copy.
    * @returns This instance after updating it.
    */
@@ -233,6 +241,7 @@ export class FieldColourHsvSliders extends FieldColour {
   /* eslint-disable @typescript-eslint/naming-convention */
   /**
    * Create and show the colour field's editor.
+   *
    * @override
    */
   protected showEditor_(): void {
@@ -255,6 +264,7 @@ export class FieldColourHsvSliders extends FieldColour {
   /**
    * Creates a row with a slider label and a readout to display the slider
    * value, appends it to the provided container, and returns the readout.
+   *
    * @param name The display name of the slider.
    * @param container Where the row will be inserted.
    * @returns The readout, so that it can be updated.
@@ -276,6 +286,7 @@ export class FieldColourHsvSliders extends FieldColour {
 
   /**
    * Creates a slider, appends it to the provided container, and returns it.
+   *
    * @param max The maximum value of the slider.
    * @param step The minimum step size of the slider.
    * @param container Where the row slider be inserted.
@@ -394,6 +405,7 @@ export class FieldColourHsvSliders extends FieldColour {
    * A helper function that converts a colour, specified by the provided hue,
    * saturation, and brightness parameters, into a hexadecimal string in the
    * format "#rrggbb".
+   *
    * @param hue The hue of the colour.
    * @param saturation The saturation of the colour.
    * @param brightness The brightness of the colour.
@@ -414,6 +426,7 @@ export class FieldColourHsvSliders extends FieldColour {
 
   /**
    * Updates the value of this field based on the editor sliders.
+   *
    * @param event Unused.
    */
   private onSliderChange(event?: Event): void {
@@ -434,6 +447,7 @@ export class FieldColourHsvSliders extends FieldColour {
 
   /**
    * Updates the value of this field and editor sliders using an eyedropper.
+   *
    * @param event Unused.
    */
   private onEyedropperEvent(event?: Event): void {

--- a/plugins/field-colour-hsv-sliders/test/index.ts
+++ b/plugins/field-colour-hsv-sliders/test/index.ts
@@ -23,6 +23,7 @@ const toolbox = generateFieldTestBlocks('field_colour_hsv_sliders', [
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/field-colour/test/index.ts
+++ b/plugins/field-colour/test/index.ts
@@ -44,6 +44,7 @@ const toolbox = generateFieldTestBlocks('field_colour', [
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/field-date/src/field_date.ts
+++ b/plugins/field-date/src/field_date.ts
@@ -28,6 +28,7 @@ export class FieldDate extends Blockly.FieldTextInput {
   /**
    * Class for a date input field. Derived from the Closure library date
    * picker.
+   *
    * @param value The initial value of the field. Should be in
    *    'YYYY-MM-DD' format. Defaults to the current date.
    * @param validator A function that is called to validate
@@ -46,6 +47,7 @@ export class FieldDate extends Blockly.FieldTextInput {
 
   /**
    * Constructs a FieldDate from a JSON arg object.
+   *
    * @param options A JSON object with options (date).
    * @returns The new field instance.
    * @package
@@ -63,6 +65,7 @@ export class FieldDate extends Blockly.FieldTextInput {
    * Ensures that the input value is a valid date. Additionally, if the date
    * string provided includes a time, the time will be removed and the date for
    * relative to the user's timezone will be used.
+   *
    * @param newValue The input value. Ex: '2023-04-28'
    * @returns A valid date string, or null if invalid.
    * @override
@@ -106,6 +109,7 @@ export class FieldDate extends Blockly.FieldTextInput {
   /**
    * Shows the inline free-text editor on top of the text along with the date
    * editor.
+   *
    * @param e Optional mouse event that triggered the field to
    *     open, or undefined if triggered programmatically.
    * @override
@@ -171,6 +175,7 @@ export class FieldDate extends Blockly.FieldTextInput {
 /**
  * NOTE: There are a few minor ways to tweak the datepicker CSS, though they're
  * not consistent across browsers.
+ *
  * @see{@link https://developer.mozilla.org/en-US/docs/Learn/Forms/Property_compatibility_table_for_form_controls#date_pickers}
  *
  * Below are a few ways this can be tweaked on *some* browsers:
@@ -221,6 +226,7 @@ export type FieldDateValidator = Blockly.FieldTextInputValidator;
 
 /**
  * Validate a string value to see if it matches the format.
+ *
  * @param value The value to validate the format for.
  * @returns true if the value is in 'yyyy-mm-dd' format.
  * @example
@@ -236,6 +242,7 @@ export function isISOFormat(value: string): boolean {
 
 /**
  * Convert the date to ISO format for the current timezone.
+ *
  * @param date The date to convert to an ISO string.
  * @returns The string in 'yyyy-mm-dd' format, though for the current timezone.
  * Ex: new Date('2000-02-20')

--- a/plugins/field-date/src/utils.ts
+++ b/plugins/field-date/src/utils.ts
@@ -1,5 +1,6 @@
 /**
  * Get the string formatted locally to the user.
+ *
  * @param dateString A string in the format 'yyyy-mm-dd'
  * @returns the locale date string for the date.
  */

--- a/plugins/field-date/test/index.ts
+++ b/plugins/field-date/test/index.ts
@@ -46,6 +46,7 @@ const toolbox = generateFieldTestBlocks('field_date', [
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/field-dependent-dropdown/src/dependent_dropdown_options_change.ts
+++ b/plugins/field-dependent-dropdown/src/dependent_dropdown_options_change.ts
@@ -15,6 +15,7 @@ import type {FieldDependentDropdown} from './field_dependent_dropdown';
 /**
  * A deep equality comparison between the two provided arrays recursively
  * comparing any child elements that are also arrays.
+ *
  * @param a The first array to compare.
  * @param b The second array to compare.
  * @returns Whether the arrays are deeply equivalent.
@@ -75,6 +76,7 @@ export class DependentDropdownOptionsChange extends Blockly.Events.BlockBase {
 
   /**
    * Construct a new DependentDropdownOptionsChange.
+   *
    * @param block The changed block. Undefined for a blank event.
    * @param name Name of the field affected.
    * @param oldValue Previous value of field.
@@ -113,6 +115,7 @@ export class DependentDropdownOptionsChange extends Blockly.Events.BlockBase {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    */
   toJson(): DependentDropdownOptionsChangeJson {
@@ -139,6 +142,7 @@ export class DependentDropdownOptionsChange extends Blockly.Events.BlockBase {
 
   /**
    * Decode the JSON event.
+   *
    * @param json JSON representation.
    * @param workspace
    * @param event
@@ -164,6 +168,7 @@ export class DependentDropdownOptionsChange extends Blockly.Events.BlockBase {
 
   /**
    * Does this event leave all state as it was before?
+   *
    * @returns False if something changed.
    */
   isNull(): boolean {
@@ -178,6 +183,7 @@ export class DependentDropdownOptionsChange extends Blockly.Events.BlockBase {
 
   /**
    * Run a change event.
+   *
    * @param forward True if run forward, false if run backward (undo).
    */
   run(forward: boolean): void {

--- a/plugins/field-dependent-dropdown/src/field_dependent_dropdown.ts
+++ b/plugins/field-dependent-dropdown/src/field_dependent_dropdown.ts
@@ -92,6 +92,7 @@ export class FieldDependentDropdown extends Blockly.FieldDropdown {
 
   /**
    * Constructs a new FieldDependentDropdown.
+   *
    * @param parentName The name of the parent field whose value determines this
    *    field's available options.
    * @param optionMapping A mapping from the possible values of the parent field
@@ -161,6 +162,7 @@ export class FieldDependentDropdown extends Blockly.FieldDropdown {
 
   /**
    * Constructs a FieldDependentDropdown from a JSON arg object.
+   *
    * @param options A JSON object providing "parentName" and "optionMapping".
    * @returns The new field instance.
    */
@@ -232,6 +234,7 @@ export class FieldDependentDropdown extends Blockly.FieldDropdown {
   /**
    * Updates the options of this child dropdown field based on the new value of
    * the parent field.
+   *
    * @param newValue The newly assigned value.
    */
   private updateOptionsBasedOnNewValue(newValue: string | undefined): void {

--- a/plugins/field-dependent-dropdown/test/index.ts
+++ b/plugins/field-dependent-dropdown/test/index.ts
@@ -39,6 +39,7 @@ const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/field-grid-dropdown/src/index.ts
+++ b/plugins/field-grid-dropdown/src/index.ts
@@ -104,6 +104,7 @@ export class FieldGridDropdown extends Blockly.FieldDropdown {
 
   /**
    * Sets the number of columns on the grid. Updates the styling to reflect.
+   *
    * @param columns The number of columns. Is rounded to
    *    an integer value and must be greater than 0. Invalid
    *    values are ignored.

--- a/plugins/field-grid-dropdown/test/index.ts
+++ b/plugins/field-grid-dropdown/test/index.ts
@@ -224,6 +224,7 @@ const toolbox = generateFieldTestBlocks('field_grid_dropdown', [
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/field-multilineinput/test/index.ts
+++ b/plugins/field-multilineinput/test/index.ts
@@ -36,6 +36,7 @@ All mimsy were the borogoves,
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/field-slider/src/field_slider.ts
+++ b/plugins/field-slider/src/field_slider.ts
@@ -43,6 +43,7 @@ export class FieldSlider extends Blockly.FieldNumber {
 
   /**
    * Class for an number slider field.
+   *
    * @param value The initial value of the field. Should
    *    cast to a number. Defaults to 0.
    * @param min Minimum value.
@@ -69,6 +70,7 @@ export class FieldSlider extends Blockly.FieldNumber {
 
   /**
    * Constructs a FieldSlider from a JSON arg object.
+   *
    * @param options A JSON object with options
    *     (value, min, max, precision).
    * @returns The new field instance.
@@ -91,7 +93,8 @@ export class FieldSlider extends Blockly.FieldNumber {
   /* eslint-disable @typescript-eslint/naming-convention */
   /**
    * Show the inline free-text editor on top of the text along with the slider
-   *    editor.
+   * editor.
+   *
    * @param e Optional mouse event that triggered the field to
    *     open, or undefined if triggered programmatically.
    * @param quietInput Quiet input (prevent focusing on the editor).
@@ -136,6 +139,7 @@ export class FieldSlider extends Blockly.FieldNumber {
 
   /**
    * Creates the slider editor and add event listeners.
+   *
    * @returns The newly created slider.
    */
   private dropdownCreate_(): HTMLElement {

--- a/plugins/field-slider/test/index.ts
+++ b/plugins/field-slider/test/index.ts
@@ -46,6 +46,7 @@ const toolbox = generateFieldTestBlocks('field_slider', [
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/renderer-inline-row-separators/test/index.ts
+++ b/plugins/renderer-inline-row-separators/test/index.ts
@@ -91,6 +91,7 @@ const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/shadow-block-converter/src/shadow_block_converter.ts
+++ b/plugins/shadow-block-converter/src/shadow_block_converter.ts
@@ -38,6 +38,7 @@ export class BlockShadowChange extends Blockly.Events.BlockBase {
 
   /**
    * The constructor for a new BlockShadowChange event.
+   *
    * @param block The changed block. Undefined for a blank event.
    * @param oldValue Previous value of shadow state.
    * @param newValue New value of shadow state.
@@ -56,6 +57,7 @@ export class BlockShadowChange extends Blockly.Events.BlockBase {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    * @override
    */
@@ -68,6 +70,7 @@ export class BlockShadowChange extends Blockly.Events.BlockBase {
 
   /**
    * Decode the JSON event.
+   *
    * @param json JSON representation.
    * @override
    */
@@ -88,6 +91,7 @@ export class BlockShadowChange extends Blockly.Events.BlockBase {
 
   /**
    * Does this event record any change of state?
+   *
    * @returns False if something changed.
    * @override
    */
@@ -97,6 +101,7 @@ export class BlockShadowChange extends Blockly.Events.BlockBase {
 
   /**
    * Run a change event.
+   *
    * @param forward True if run forward, false if run backward (undo).
    * @override
    */

--- a/plugins/shadow-block-converter/test/index.ts
+++ b/plugins/shadow-block-converter/test/index.ts
@@ -113,6 +113,7 @@ const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/toolbox-search/src/block_searcher.ts
+++ b/plugins/toolbox-search/src/block_searcher.ts
@@ -20,6 +20,7 @@ export class BlockSearcher {
    * scenes, it creates a workspace, loads the specified block types on it,
    * indexes their types and human-readable text, and cleans up after
    * itself.
+   *
    * @param blockTypes A list of block types to index.
    */
   indexBlocks(blockTypes: string[]) {
@@ -38,6 +39,7 @@ export class BlockSearcher {
 
   /**
    * Check if the field is a dropdown, and index every text in the option
+   *
    * @param field We need to check the type of field
    * @param blockType The block type to associate the trigrams with.
    */
@@ -55,6 +57,7 @@ export class BlockSearcher {
 
   /**
    * Filters the available blocks based on the current query string.
+   *
    * @param query The text to use to match blocks against.
    * @returns A list of block types matching the query.
    */
@@ -74,6 +77,7 @@ export class BlockSearcher {
   /**
    * Generates trigrams for the given text and associates them with the given
    * block type.
+   *
    * @param text The text to generate trigrams of.
    * @param blockType The block type to associate the trigrams with.
    */
@@ -87,6 +91,7 @@ export class BlockSearcher {
 
   /**
    * Generates a list of trigrams for a given string.
+   *
    * @param input The string to generate trigrams of.
    * @returns A list of trigrams of the given string.
    */
@@ -105,6 +110,7 @@ export class BlockSearcher {
 
   /**
    * Returns the intersection of two sets.
+   *
    * @param a The first set.
    * @param b The second set.
    * @returns The intersection of the two sets.

--- a/plugins/toolbox-search/src/toolbox_search.ts
+++ b/plugins/toolbox-search/src/toolbox_search.ts
@@ -25,6 +25,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
 
   /**
    * Initializes a ToolboxSearchCategory.
+   *
    * @param categoryDef The information needed to create a category in the
    *     toolbox.
    * @param parentToolbox The parent toolbox for the category.
@@ -43,6 +44,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
 
   /**
    * Initializes the search field toolbox category.
+   *
    * @returns The <div> that will be displayed in the toolbox.
    */
   protected override createDom_(): HTMLDivElement {
@@ -67,6 +69,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
 
   /**
    * Returns the numerical position of this category in its parent toolbox.
+   *
    * @returns The zero-based index of this category in its parent toolbox, or -1
    *    if it cannot be determined, e.g. if this is a nested category.
    */
@@ -103,6 +106,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
 
   /**
    * Returns a list of block types that are present in the toolbox definition.
+   *
    * @param schema A toolbox item definition.
    * @param allBlocks The set of all available blocks that have been encountered
    *     so far.
@@ -135,6 +139,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
 
   /**
    * Handles a click on this toolbox category.
+   *
    * @param e The click event.
    */
   override onClick(e: Event) {
@@ -146,6 +151,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
 
   /**
    * Handles changes in the selection state of this category.
+   *
    * @param isSelected Whether or not the category is now selected.
    */
   override setSelected(isSelected: boolean) {

--- a/plugins/toolbox-search/test/index.ts
+++ b/plugins/toolbox-search/test/index.ts
@@ -14,6 +14,7 @@ import '../src/toolbox_search';
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/workspace-backpack/src/backpack.ts
+++ b/plugins/workspace-backpack/src/backpack.ts
@@ -85,6 +85,7 @@ export class Backpack
 
   /**
    * Constructor for a backpack.
+   *
    * @param workspace_ The target workspace that
    *     the backpack will be added to.
    * @param backpackOptions The backpack options to use.
@@ -265,6 +266,7 @@ export class Backpack
 
   /**
    * Helper method for adding an event.
+   *
    * @param node Node upon which to listen.
    * @param name Event name to listen to (e.g. 'mousedown').
    * @param thisObject The value of 'this' in the function.
@@ -282,6 +284,7 @@ export class Backpack
 
   /**
    * Returns the backpack flyout.
+   *
    * @returns The backpack flyout.
    */
   getFlyout(): Blockly.IFlyout | null {
@@ -291,6 +294,7 @@ export class Backpack
   /**
    * Returns the bounding rectangle of the drag target area in pixel units
    * relative to viewport.
+   *
    * @returns The component's bounding box. Null if drag
    *   target area should be ignored.
    */
@@ -310,6 +314,7 @@ export class Backpack
   /**
    * Returns the bounding rectangle of the UI element in pixel units relative to
    * the Blockly injection div.
+   *
    * @returns The component’s bounding box.
    */
   getBoundingRectangle(): Blockly.utils.Rect {
@@ -325,6 +330,7 @@ export class Backpack
    * Positions the backpack.
    * It is positioned in the opposite corner to the corner the
    * categories/toolbox starts at.
+   *
    * @param metrics The workspace metrics.
    * @param savedPositions List of rectangles that
    *     are already on the workspace.
@@ -409,6 +415,7 @@ export class Backpack
 
   /**
    * Returns the count of items in the backpack.
+   *
    * @returns The count of items.
    */
   getCount(): number {
@@ -417,6 +424,7 @@ export class Backpack
 
   /**
    * Returns backpack contents.
+   *
    * @returns The backpack contents.
    */
   getContents(): string[] {
@@ -427,6 +435,7 @@ export class Backpack
   /**
    * Handles when a block or bubble is dropped on this component.
    * Should not handle delete here.
+   *
    * @param dragElement The block or bubble currently
    *   being dragged.
    */
@@ -439,6 +448,7 @@ export class Backpack
   /**
    * Converts the provided block into a JSON string and
    * cleans the JSON of any unnecessary attributes
+   *
    * @param block The block to convert.
    * @returns The JSON object as a string.
    */
@@ -471,6 +481,7 @@ export class Backpack
 
   /**
    * Converts serialized XML to its equivalent serialized JSON string
+   *
    * @param blockXml The XML serialized block.
    * @returns The JSON object as a string.
    */
@@ -493,6 +504,7 @@ export class Backpack
 
   /**
    * Returns whether the backpack contains a duplicate of the provided Block.
+   *
    * @param block The block to check.
    * @returns Whether the backpack contains a duplicate of the
    *     provided block.
@@ -503,6 +515,7 @@ export class Backpack
 
   /**
    * Adds the specified block to backpack.
+   *
    * @param block The block to be added to the backpack.
    */
   addBlock(block: Blockly.Block) {
@@ -511,6 +524,7 @@ export class Backpack
 
   /**
    * Adds the provided blocks to backpack.
+   *
    * @param blocks The blocks to be added to the
    *     backpack.
    */
@@ -520,6 +534,7 @@ export class Backpack
 
   /**
    * Removes the specified block from the backpack.
+   *
    * @param block The block to be removed from the backpack.
    */
   removeBlock(block: Blockly.Block) {
@@ -528,6 +543,7 @@ export class Backpack
 
   /**
    * Adds item to backpack.
+   *
    * @param item Text representing the JSON of a block to add,
    *     cleaned of all unnecessary attributes.
    */
@@ -537,6 +553,7 @@ export class Backpack
 
   /**
    * Adds multiple items to the backpack.
+   *
    * @param items The backpack contents to add.
    */
   addItems(items: string[]) {
@@ -549,6 +566,7 @@ export class Backpack
 
   /**
    * Removes item from the backpack.
+   *
    * @param item Text representing the JSON of a block to remove,
    * cleaned of all unnecessary attributes.
    */
@@ -562,6 +580,7 @@ export class Backpack
 
   /**
    * Sets backpack contents.
+   *
    * @param contents The new backpack contents.
    */
   setContents(contents: string[]) {
@@ -619,6 +638,7 @@ export class Backpack
   /**
    * Returns a filtered list without duplicates within itself and without any
    * shared elements with this.contents_.
+   *
    * @param array The array of items to filter.
    * @returns The filtered list.
    */
@@ -630,6 +650,7 @@ export class Backpack
 
   /**
    * Returns whether the backpack is open-able.
+   *
    * @returns Whether the backpack is open-able.
    */
   protected isOpenable(): boolean {
@@ -640,6 +661,7 @@ export class Backpack
 
   /**
    * Returns whether the backpack is open.
+   *
    * @returns Whether the backpack is open.
    */
   isOpen(): boolean {
@@ -702,6 +724,7 @@ export class Backpack
 
   /**
    * Hides the component. Called in Blockly.hideChaff.
+   *
    * @param onlyClosePopups Whether only popups should be closed.
    *     Flyouts should not be closed if this is true.
    */
@@ -715,6 +738,7 @@ export class Backpack
 
   /**
    * Handle click event.
+   *
    * @param e Mouse event.
    */
   protected onClick(e: MouseEvent) {
@@ -732,6 +756,7 @@ export class Backpack
 
   /**
    * Handles when a cursor with a block or bubble enters this drag target.
+   *
    * @param dragElement The block or bubble currently
    *   being dragged.
    */
@@ -743,6 +768,7 @@ export class Backpack
 
   /**
    * Handles when a cursor with a block or bubble exits this drag target.
+   *
    * @param dragElement The block or bubble currently
    *   being dragged.
    */
@@ -768,6 +794,7 @@ export class Backpack
 
   /**
    * Adds or removes styling to darken the backpack to show it is interactable.
+   *
    * @param addClass True to add styling, false to remove.
    */
   protected updateHoverStying(addClass: boolean) {
@@ -783,6 +810,7 @@ export class Backpack
    * Returns whether the provided block or bubble should not be moved after
    * being dropped on this component. If true, the element will return to where
    * it was when the drag started.
+   *
    * @param dragElement The block or bubble currently
    *   being dragged.
    * @returns Whether the block or bubble provided should be returned
@@ -794,6 +822,7 @@ export class Backpack
 
   /**
    * Prevents a workspace scroll and click event if the backpack is openable.
+   *
    * @param e A mouse down event.
    */
   protected blockMouseDownWhenOpenable(e: MouseEvent) {
@@ -894,6 +923,7 @@ class BackpackSerializer {
 
   /**
    * Saves a target workspace's state to serialized JSON.
+   *
    * @param workspace the workspace to save
    * @returns the serialized JSON if present
    */
@@ -905,6 +935,7 @@ class BackpackSerializer {
 
   /**
    * Loads a serialized state into the target workspace.
+   *
    * @param state the serialized state JSON
    * @param workspace the workspace to load into
    */
@@ -917,6 +948,7 @@ class BackpackSerializer {
 
   /**
    * Resets the state of a workspace.
+   *
    * @param workspace the workspace to reset
    */
   clear(workspace: Blockly.WorkspaceSvg) {

--- a/plugins/workspace-backpack/src/backpack_helpers.ts
+++ b/plugins/workspace-backpack/src/backpack_helpers.ts
@@ -18,6 +18,7 @@ import {BackpackContextMenuOptions} from './options';
 
 /**
  * Registers a context menu option to empty the backpack when right-clicked.
+ *
  * @param workspace The workspace to register the context menu option on.
  */
 function registerEmptyBackpack(workspace: Blockly.WorkspaceSvg) {
@@ -84,6 +85,7 @@ function registerRemoveFromBackpack() {
 
 /**
  * Registers context menu options for adding a block to the backpack.
+ *
  * @param disablePreconditionContainsCheck Whether to disable the
  *   precondition check for whether the backpack contains the block.
  */
@@ -219,6 +221,7 @@ function registerPasteAllBackpack() {
 
 /**
  * Register all context menu options.
+ *
  * @param contextMenuOptions The backpack context menu options.
  * @param workspace The workspace to register the context menu options.
  */

--- a/plugins/workspace-backpack/src/options.ts
+++ b/plugins/workspace-backpack/src/options.ts
@@ -29,6 +29,7 @@ export interface BackpackOptions {
 /**
  * Returns a new options object with all properties set, using default values
  * if not specified in the optional options that were passed in.
+ *
  * @param options The options to use.
  * @returns The created options object.
  */

--- a/plugins/workspace-backpack/src/ui_events.ts
+++ b/plugins/workspace-backpack/src/ui_events.ts
@@ -27,6 +27,7 @@ export class BackpackOpen extends Blockly.Events.UiBase {
 
   /**
    * Class for a backpack open event.
+   *
    * @param isOpen Whether the backpack flyout is opening (false
    *    if closing). Undefined for a blank event.
    * @param workspaceId The workspace identifier for this event.
@@ -41,6 +42,7 @@ export class BackpackOpen extends Blockly.Events.UiBase {
 
   /**
    * Encode the event as JSON.
+   *
    * @returns JSON representation.
    */
   toJson(): BackpackOpenEventJson {
@@ -51,6 +53,7 @@ export class BackpackOpen extends Blockly.Events.UiBase {
 
   /**
    * Decode the JSON event.
+   *
    * @param json JSON representation.
    * @param workspace A workspace to create the event on.
    * @param event an instance of BackpackOpen to deserialize into.

--- a/plugins/workspace-backpack/test/index.ts
+++ b/plugins/workspace-backpack/test/index.ts
@@ -11,6 +11,7 @@ import {Backpack} from '../src/index';
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/workspace-minimap/src/focus_region.ts
+++ b/plugins/workspace-minimap/src/focus_region.ts
@@ -36,6 +36,7 @@ export class FocusRegion {
 
   /**
    * Constructor for the focus region.
+   *
    * @param primaryWorkspace The primary workspaceSvg.
    * @param minimapWorkspace The minimap workspaceSvg.
    */
@@ -141,6 +142,7 @@ export class FocusRegion {
 
   /**
    * Handles events triggered on the primary workspace.
+   *
    * @param event The event.
    */
   private onChange(event: Blockly.Events.Abstract): void {
@@ -192,6 +194,7 @@ export class FocusRegion {
 
   /**
    * Returns whether focus region is initialized or not.
+   *
    * @returns True if focus region is initialized else false.
    */
   isEnabled(): boolean {

--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -39,6 +39,7 @@ export class Minimap {
 
   /**
    * Constructor for a minimap.
+   *
    * @param workspace The workspace to mirror.
    */
   constructor(workspace: Blockly.WorkspaceSvg) {
@@ -136,6 +137,7 @@ export class Minimap {
   /**
    * Creates the mirroring between workspaces. Passes on all desired events
    * to the minimap from the primary workspace.
+   *
    * @param event The primary workspace event.
    */
   private mirror(event: Blockly.Events.Abstract): void {
@@ -163,6 +165,7 @@ export class Minimap {
   /**
    * Converts the coorindates from a mouse event on the minimap
    * into scroll coordinates for the primary viewport.
+   *
    * @param primaryMetrics The metrics from the primary workspace.
    * @param minimapMetrics The metrics from the minimap workspace.
    * @param offsetX The x offset of the mouse event.
@@ -197,6 +200,7 @@ export class Minimap {
 
   /**
    * Scrolls the primary workspace viewport based on a minimap event.
+   *
    * @param event The minimap browser event.
    */
   private primaryScroll(event: PointerEvent): void {
@@ -211,6 +215,7 @@ export class Minimap {
 
   /**
    * Updates the primary workspace viewport based on a click in the minimap.
+   *
    * @param event The minimap browser event.
    */
   private onClickDown(event: PointerEvent): void {
@@ -235,6 +240,7 @@ export class Minimap {
 
   /**
    * Updates the primary workspace viewport based on a drag in the minimap.
+   *
    * @param event The minimap browser event.
    */
   private onMouseMove(event: PointerEvent): void {
@@ -257,6 +263,7 @@ export class Minimap {
 
   /**
    * Returns whether the focus region is enabled.
+   *
    * @returns True if the focus region is enabled.
    */
   isFocusEnabled(): boolean {

--- a/plugins/workspace-minimap/src/positioned_minimap.ts
+++ b/plugins/workspace-minimap/src/positioned_minimap.ts
@@ -30,6 +30,7 @@ export class PositionedMinimap
 
   /**
    * Constructor for a positionable minimap.
+   *
    * @param workspace The workspace to mirror.
    */
   constructor(workspace: Blockly.WorkspaceSvg) {
@@ -58,6 +59,7 @@ export class PositionedMinimap
   /**
    * Returns the bounding rectangle of the UI element in pixel units
    * relative to the Blockly injection div.
+   *
    * @returns The component’s bounding box.
    */
   getBoundingRectangle(): Blockly.utils.Rect {
@@ -71,6 +73,7 @@ export class PositionedMinimap
 
   /**
    * Positions the minimap.
+   *
    * @param metrics The workspace metrics.
    * @param savedPositions List of rectangles already on the workspace.
    */
@@ -85,6 +88,7 @@ export class PositionedMinimap
 
   /**
    * Sizes the minimap.
+   *
    * @internal
    */
   setSize(): void {
@@ -95,6 +99,7 @@ export class PositionedMinimap
 
   /**
    * Calculates the position of the minimap over the primary workspace.
+   *
    * @param metrics The workspace metrics.
    * @param savedPositions List of rectangles already on the workspace.
    * @internal

--- a/plugins/workspace-minimap/test/index.ts
+++ b/plugins/workspace-minimap/test/index.ts
@@ -17,6 +17,7 @@ let workspace = null;
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/workspace-search/src/workspace_search.ts
+++ b/plugins/workspace-search/src/workspace_search.ts
@@ -75,6 +75,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Class for workspace search.
+   *
    * @param workspace The workspace the search bar sits in.
    */
   constructor(private workspace: Blockly.WorkspaceSvg) {}
@@ -188,6 +189,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Helper method for adding an event.
+   *
    * @param node Node upon which to listen.
    * @param name Event name to listen to (e.g. 'mousedown').
    * @param thisObject The value of 'this' in the function.
@@ -211,6 +213,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
   /**
    * Add a button to the action div. This must be called after the init function
    * has been called.
+   *
    * @param btn The button to add the event listener to.
    * @param onClickFn The function to call when the user clicks on
    *     or hits enter on the button.
@@ -222,6 +225,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Creates the text input for the search bar.
+   *
    * @returns A text input for the search bar.
    */
   protected createTextInput(): HTMLInputElement {
@@ -233,6 +237,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Creates the button used to get the next block in the list.
+   *
    * @returns The next button.
    */
   protected createNextBtn(): HTMLButtonElement {
@@ -241,6 +246,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Creates the button used to get the previous block in the list.
+   *
    * @returns The previous button.
    */
   protected createPreviousBtn(): HTMLButtonElement {
@@ -249,6 +255,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Creates the button used for closing the search bar.
+   *
    * @returns A button for closing the search bar.
    */
   protected createCloseBtn(): HTMLButtonElement {
@@ -257,6 +264,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Creates a button for the workspace search bar.
+   *
    * @param className The class name for the button.
    * @param text The text to display to the screen reader.
    * @returns The created button.
@@ -271,6 +279,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Add event listener for clicking and keydown on the given button.
+   *
    * @param btn The button to add the event listener to.
    * @param onClickFn The function to call when the user clicks on
    *      or hits enter on the button.
@@ -296,6 +305,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
   /**
    * Returns the bounding rectangle of the UI element in pixel units relative to
    * the Blockly injection div.
+   *
    * @returns The component’s bounding box. Null in this
    *     case since we don't need other elements to avoid the workspace search
    *     field.
@@ -308,6 +318,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
    * Positions the workspace search field.
    * It is positioned in the opposite corner to the corner the
    * categories/toolbox starts at.
+   *
    * @param metrics The workspace metrics.
    * @param savedPositions List of rectangles that
    *     are already on the workspace.
@@ -342,6 +353,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Handles a key down for the search bar.
+   *
    * @param e The key down event.
    */
   private onKeyDown(e: KeyboardEvent) {
@@ -361,6 +373,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Opens the search bar when Control F or Command F are used on the workspace.
+   *
    * @param e The key down event.
    */
   private onWorkspaceKeyDown(e: KeyboardEvent) {
@@ -388,6 +401,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Sets the placeholder text for the search bar text input.
+   *
    * @param placeholderText The placeholder text.
    */
   setSearchPlaceholder(placeholderText: string) {
@@ -399,6 +413,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Changes the currently "selected" block and adds extra highlight.
+   *
    * @param index Index of block to set as current. Number is wrapped.
    */
   protected setCurrentBlock(index: number) {
@@ -439,6 +454,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Shows or hides the workspace search bar.
+   *
    * @param show Whether to set the search bar as visible.
    */
   private setVisible(show: boolean) {
@@ -448,6 +464,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
   /**
    * Searches the workspace for the current search term and highlights matching
    * blocks.
+   *
    * @param searchText The search text.
    * @param preserveCurrent Whether to preserve the current block
    *    if it is included in the new matching blocks.
@@ -472,6 +489,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Returns pool of blocks to search from.
+   *
    * @param workspace The workspace to get blocks from.
    * @returns The search pool of blocks to use.
    */
@@ -486,6 +504,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Returns whether the given block matches the search text.
+   *
    * @param block The block to check.
    * @param searchText The search text. Note if the search is case
    *    insensitive, this will be passed already converted to lowercase letters.
@@ -518,6 +537,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Returns blocks that match the given search text.
+   *
    * @param workspace The workspace to search.
    * @param searchText The search text.
    * @param caseSensitive Whether the search should be case sensitive.
@@ -557,6 +577,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
   /**
    * Adds "current selection" highlight to the provided block.
    * Highlights the provided block as the "current selection".
+   *
    * @param currentBlock The block to highlight.
    */
   protected highlightCurrentSelection(currentBlock: Blockly.BlockSvg) {
@@ -566,6 +587,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Removes "current selection" highlight from provided block.
+   *
    * @param currentBlock The block to unhighlight.
    */
   protected unhighlightCurrentSelection(currentBlock: Blockly.BlockSvg) {
@@ -575,6 +597,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Adds highlight to the provided blocks.
+   *
    * @param blocks The blocks to highlight.
    */
   protected highlightSearchGroup(blocks: Blockly.BlockSvg[]) {
@@ -586,6 +609,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
   /**
    * Removes highlight from the provided blocks.
+   *
    * @param blocks The blocks to unhighlight.
    */
   protected unhighlightSearchGroup(blocks: Blockly.BlockSvg[]) {

--- a/plugins/workspace-search/test/index.ts
+++ b/plugins/workspace-search/test/index.ts
@@ -16,6 +16,7 @@ import {WorkspaceSearch} from '../src/index';
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.

--- a/plugins/zoom-to-fit/src/index.ts
+++ b/plugins/zoom-to-fit/src/index.ts
@@ -59,6 +59,7 @@ export class ZoomToFitControl implements Blockly.IPositionable {
 
   /**
    * Constructor for zoom-to-fit control.
+   *
    * @param workspace The workspace that the zoom-to-fit
    *     control will be added to.
    */
@@ -140,6 +141,7 @@ export class ZoomToFitControl implements Blockly.IPositionable {
   /**
    * Returns the bounding rectangle of the UI element in pixel units relative to
    * the Blockly injection div.
+   *
    * @returns The component’s bounding box.
    */
   getBoundingRectangle(): Blockly.utils.Rect {
@@ -155,6 +157,7 @@ export class ZoomToFitControl implements Blockly.IPositionable {
    * Positions the zoom-to-fit control.
    * It is positioned in the opposite corner to the corner the
    * categories/toolbox starts at.
+   *
    * @param metrics The workspace metrics.
    * @param savedPositions List of rectangles that
    *     are already on the workspace.

--- a/plugins/zoom-to-fit/test/index.ts
+++ b/plugins/zoom-to-fit/test/index.ts
@@ -15,6 +15,7 @@ import {ZoomToFitControl} from '../src/index';
 
 /**
  * Create a workspace.
+ *
  * @param blocklyDiv The blockly container div.
  * @param options The Blockly options.
  * @returns The created workspace.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #1979 

### Proposed Changes

Enforced a recommended blank line rule preceding only the first tag _(e.g., `@param`)_ in a jsdoc comment.

#### An Example 

>Before:
>```javascript
>/**
>   * Parses XML based on the 'inputs' attribute (non-standard).
>   * @param xmlElement XML storage element.
>   */
>```

>After: 
>```javascript
>/**
>   * Parses XML based on the 'inputs' attribute (non-standard).
>   *
>   * @param xmlElement XML storage element.
>   */
>```

### Reason for Changes

Code changes are made for better readability of jsdoc comments.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

Running `npm run lint` shows 16 warnings but that's being fixed in #2065.