### PR TITLE
fix: Enables strict mode for toolbox-search

### DIFF
--- a/plugins/toolbox-search/src/toolbox_search.ts
+++ b/plugins/toolbox-search/src/toolbox_search.ts
@@ -131,7 +131,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
    */
   private initBlockSearcher() {
     const availableBlocks = new Set<string>();
-    this.workspace_.options.languageTree?.contents?.map((item) =>
+    this.workspace_.options.languageTree?.contents?.forEach((item) =>
       this.getAvailableBlocks(item, availableBlocks),
     );
     this.blockSearcher.indexBlocks([...availableBlocks]);
@@ -156,15 +156,13 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
    */
   override setSelected(isSelected: boolean) {
     super.setSelected(isSelected);
+    if (!this.searchField) return;
     if (isSelected) {
-      this.searchField?.focus();
+      this.searchField.focus();
       this.matchBlocks();
     } else {
-      const searchField = this.searchField
-      if(searchField){
-        searchField.value = '';
-      }
-      this.searchField?.blur();
+      this.searchField.value = '';
+      this.searchField.blur();
     }
   }
 

--- a/plugins/toolbox-search/src/toolbox_search.ts
+++ b/plugins/toolbox-search/src/toolbox_search.ts
@@ -63,7 +63,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
 
       this.matchBlocks();
     });
-    this.rowContents_.replaceChildren(this.searchField);
+    this.rowContents_?.replaceChildren(this.searchField);
     return dom;
   }
 
@@ -74,7 +74,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
    *    if it cannot be determined, e.g. if this is a nested category.
    */
   private getPosition() {
-    const categories = this.workspace_.options.languageTree.contents;
+    const categories = this.workspace_.options.languageTree?.contents || [];
     for (let i = 0; i < categories.length; i++) {
       if (categories[i].kind === ToolboxSearchCategory.SEARCH_CATEGORY_KIND) {
         return i;
@@ -131,7 +131,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
    */
   private initBlockSearcher() {
     const availableBlocks = new Set<string>();
-    this.workspace_.options.languageTree.contents.map((item) =>
+    this.workspace_.options.languageTree?.contents?.map((item) =>
       this.getAvailableBlocks(item, availableBlocks),
     );
     this.blockSearcher.indexBlocks([...availableBlocks]);
@@ -157,11 +157,14 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
   override setSelected(isSelected: boolean) {
     super.setSelected(isSelected);
     if (isSelected) {
-      this.searchField.focus();
+      this.searchField?.focus();
       this.matchBlocks();
     } else {
-      this.searchField.value = '';
-      this.searchField.blur();
+      const searchField = this.searchField
+      if(searchField){
+        searchField.value = '';
+      }
+      this.searchField?.blur();
     }
   }
 
@@ -169,7 +172,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
    * Filters the available blocks based on the current query string.
    */
   private matchBlocks() {
-    const query = this.searchField.value;
+    const query = this.searchField?.value || '';
 
     this.flyoutItems_ = query
       ? this.blockSearcher.blockTypesMatching(query).map((blockType) => {

--- a/plugins/toolbox-search/tsconfig.json
+++ b/plugins/toolbox-search/tsconfig.json
@@ -9,7 +9,7 @@
     "moduleResolution": "bundler",
     "target": "es6",
     "lib": ["es2021", "dom"],
-    "strict": false,
+    "strict": true,
     // Point at the local Blockly. See #1934. Remove if we add hoisting.
     "paths": {
       "blockly/*": ["node_modules/blockly/*"]


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Closes #2029 

### Proposed Changes

Enables strict mode for the toolbox-search plugin by configuring "strict":true in tsconfig.json.

Typescript errors that arose as a result:
![TS_Errors](https://github.com/google/blockly-samples/assets/69362333/2826fde0-400c-4780-9d58-342580167f7e)

Solved by making necessary changes to the toolbox_search.ts file:
![Solved_Err_TS](https://github.com/google/blockly-samples/assets/69362333/18e0ecf4-cb75-43ab-85db-167df0c8ded9)


### Reason for Changes

Enables strict mode and carries out checks for null or possibly undefined objects.


### Additional Information

Ran npm run lint to ensure no errors! Let me know if there are any changes required.

**Note**: Was using this StackOverflow [discussion](https://stackoverflow.com/a/72404011/22548352) as reference earlier but this seems to be a forbidden non-null assertion as we are telling typescript the object exists. 
