### PR TITLE
chore: fix svelte example

### DIFF
--- a/examples/blockly-svelte/package-lock.json
+++ b/examples/blockly-svelte/package-lock.json
@@ -17,7 +17,7 @@
         "rollup-plugin-commonjs": "^10.0.0",
         "rollup-plugin-livereload": "^1.3.0",
         "rollup-plugin-node-resolve": "^5.2.0",
-        "rollup-plugin-svelte": "^5.2.3",
+        "rollup-plugin-svelte": "^6.1.1",
         "rollup-plugin-terser": "^5.3.1",
         "svelte": "^3.49.0"
       }
@@ -1250,14 +1250,18 @@
       }
     },
     "node_modules/rollup-plugin-svelte": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-5.2.3.tgz",
-      "integrity": "sha512-513vOht9A93OV7fvmpIq8mD1JFgTZ5LidmpULKM2Od9P1l8oI5KwvO32fwCnASuVJS1EkRfvCnS7vKQ8DF4srg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-6.1.1.tgz",
+      "integrity": "sha512-ijnm0pH1ScrY4uxwaNXBpNVejVzpL2769hIEbAlnqNUWZrffLspu5/k9/l/Wsj3NrEHLQ6wCKGagVJonyfN7ow==",
       "dev": true,
       "dependencies": {
         "require-relative": "^0.8.7",
         "rollup-pluginutils": "^2.8.2",
         "sourcemap-codec": "^1.4.8"
+      },
+      "peerDependencies": {
+        "rollup": ">=1.19.2",
+        "svelte": "*"
       }
     },
     "node_modules/rollup-plugin-svelte/node_modules/sourcemap-codec": {
@@ -2721,9 +2725,9 @@
       }
     },
     "rollup-plugin-svelte": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-5.2.3.tgz",
-      "integrity": "sha512-513vOht9A93OV7fvmpIq8mD1JFgTZ5LidmpULKM2Od9P1l8oI5KwvO32fwCnASuVJS1EkRfvCnS7vKQ8DF4srg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-6.1.1.tgz",
+      "integrity": "sha512-ijnm0pH1ScrY4uxwaNXBpNVejVzpL2769hIEbAlnqNUWZrffLspu5/k9/l/Wsj3NrEHLQ6wCKGagVJonyfN7ow==",
       "dev": true,
       "requires": {
         "require-relative": "^0.8.7",

--- a/examples/blockly-svelte/package.json
+++ b/examples/blockly-svelte/package.json
@@ -8,7 +8,7 @@
     "rollup-plugin-commonjs": "^10.0.0",
     "rollup-plugin-livereload": "^1.3.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-svelte": "^5.2.3",
+    "rollup-plugin-svelte": "^6.1.1",
     "rollup-plugin-terser": "^5.3.1",
     "svelte": "^3.49.0"
   },

--- a/examples/blockly-svelte/rollup.config.js
+++ b/examples/blockly-svelte/rollup.config.js
@@ -45,7 +45,7 @@ export default {
       // we'll extract any component CSS out into
       // a separate file — better for performance
       css: css => {
-        css.write('public/bundle.css');
+        css.write('bundle.css');
       }
     }),
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

Fix svelte example

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details


### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
#1679 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

Currently the svelte demo doesn't start.  You'd get an error like:
```
[!] Error: Package subpath './compiler.js' is not defined by "exports" in /workspaces/blockly-samples/examples/blockly-svelte/node_modules/svelte/package.json
Error: Package subpath './compiler.js' is not defined by "exports" in /workspaces/blockly-samples/examples/blockly-svelte/node_modules/svelte/package.json
    at new NodeError (node:internal/errors:405:5)
    at exportsNotFound (node:internal/modules/esm/resolve:259:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:589:9)
    at resolveExports (node:internal/modules/cjs/loader:547:36)
    at Function.Module._findPath (node:internal/modules/cjs/loader:621:31)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1034:27)
    at Function.Module._load (node:internal/modules/cjs/loader:901:27)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18)
    at Object.<anonymous> (/workspaces/blockly-samples/examples/blockly-svelte/node_modules/rollup-plugin-svelte/index.js:11:4)
```

  The version bump was necessary to get it running again.
  The build config for css is also broken.  bundle.css was getting written into `public/public/bundle.css` which is incorrect.

### Test Coverage

ran demo

### Documentation

N/A

### Additional Information
cc @BeksOmega 

