### PR TITLE
fix: Fix TS errors in plugins/toolbox-search

### DIFF
--- a/plugins/dev-tools/src/index.d.ts
+++ b/plugins/dev-tools/src/index.d.ts
@@ -109,12 +109,12 @@ declare namespace DevTools {
   /**
    * A toolbox xml with built-in blocks split into categories.
    */
-  const toolboxCategories: string;
+  const toolboxCategories: Blockly.utils.toolbox.ToolboxInfo;
 
   /**
    * A simple toolbox xml with built-in blocks and no categories.
    */
-  const toolboxSimple: string;
+  const toolboxSimple: Blockly.utils.toolbox.ToolboxInfo;
 }
 
 export = DevTools;

--- a/plugins/toolbox-search/test/index.ts
+++ b/plugins/toolbox-search/test/index.ts
@@ -36,9 +36,11 @@ document.addEventListener('DOMContentLoaded', function () {
   const defaultOptions: Blockly.BlocklyOptions = {
     toolbox,
   };
-  createPlayground(
-    document.getElementById('root')!,
-    createWorkspace,
-    defaultOptions,
-  );
+
+  const root = document.getElementById('root');
+  if (!root) {
+    throw new Error('Root element is missing');
+  }
+
+  createPlayground(root, createWorkspace, defaultOptions);
 });

--- a/plugins/toolbox-search/test/index.ts
+++ b/plugins/toolbox-search/test/index.ts
@@ -27,7 +27,7 @@ function createWorkspace(
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  const toolbox = Object.assign({}, toolboxCategories);
+  const toolbox = Object.assign({}, toolboxCategories) as unknown as Blockly.utils.toolbox.ToolboxInfo;
   toolbox['contents'].push({
     'kind': 'search',
     'name': 'Search',
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', function () {
     toolbox,
   };
   createPlayground(
-    document.getElementById('root'),
+    document.getElementById('root')!,
     createWorkspace,
     defaultOptions,
   );

--- a/plugins/toolbox-search/test/index.ts
+++ b/plugins/toolbox-search/test/index.ts
@@ -27,7 +27,7 @@ function createWorkspace(
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  const toolbox = Object.assign({}, toolboxCategories) as unknown as Blockly.utils.toolbox.ToolboxInfo;
+  const toolbox = {...toolboxCategories};
   toolbox['contents'].push({
     'kind': 'search',
     'name': 'Search',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

This PR fixes the TypeScript errors shown when running the `plugins/toolbox-search` using tsc `5.0.4`.
