### PR TITLE
fix: enables strict mode for content-highlight

### DIFF
--- a/plugins/content-highlight/src/index.ts
+++ b/plugins/content-highlight/src/index.ts
@@ -71,7 +71,7 @@ export class ContentHighlight {
   private svgGroup?: SVGGElement;
   private rect?: SVGRectElement;
   private background?: SVGRectElement;
-  private onChangeWrapper?: () => void;
+  private onChangeWrapper?: (event: Blockly.Events.Abstract) => void;
 
   /**
    * Constructor for the content highlight plugin.
@@ -189,7 +189,9 @@ export class ContentHighlight {
         this.resize(this.cachedContentMetrics);
       }
       const absoluteMetrics = metricsManager.getAbsoluteMetrics();
-      this.position(this.cachedContentMetrics, absoluteMetrics);
+      if (this.cachedContentMetrics) {
+        this.position(this.cachedContentMetrics, absoluteMetrics);
+      }
     } else if (event.type === Blockly.Events.BLOCK_DRAG) {
       this.handleBlockDrag(event as Blockly.Events.BlockDrag);
     } else if (event.type === Blockly.Events.BLOCK_CHANGE) {
@@ -208,7 +210,7 @@ export class ContentHighlight {
    */
   private handleBlockDrag(event: Blockly.Events.BlockDrag) {
     const opacity = event.isStart ? '0' : '1';
-    this.svgGroup.setAttribute('opacity', opacity);
+    this.svgGroup?.setAttribute('opacity', opacity);
   }
 
   /**
@@ -225,7 +227,8 @@ export class ContentHighlight {
       bgColor === '#ffffff' || bgColor === '#fff'
         ? colorDarkened
         : colorLightened;
-    this.background.setAttribute('fill', color);
+    if (!color) return;
+    this.background?.setAttribute('fill', color);
   }
 
   /**
@@ -243,11 +246,11 @@ export class ContentHighlight {
       : 0;
     if (width !== this.width) {
       this.width = width;
-      this.rect.setAttribute('width', `${width}`);
+      this.rect?.setAttribute('width', `${width}`);
     }
     if (height !== this.height) {
       this.height = height;
-      this.rect.setAttribute('height', `${height}`);
+      this.rect?.setAttribute('height', `${height}`);
     }
   }
 
@@ -281,7 +284,7 @@ export class ContentHighlight {
       this.top = top;
       this.left = left;
       this.lastScale = scale;
-      this.rect.setAttribute(
+      this.rect?.setAttribute(
         'transform',
         `translate(${left}, ${top}) scale(${scale})`,
       );

--- a/plugins/content-highlight/tsconfig.json
+++ b/plugins/content-highlight/tsconfig.json
@@ -8,7 +8,7 @@
     "module": "es2015",
     "moduleResolution": "bundler",
     "target": "es6",
-    "strict": false,
+    "strict": true,
     // Point at the local Blockly. See #1934. Remove if we add hoisting.
     "paths": {
       "blockly/*": ["node_modules/blockly/*"]


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Closes #2028 

### Proposed Changes

Enables strict mode for the content-highlight plugin 

Typescript errors that arose as a result:
![CH_TS_Errors](https://github.com/google/blockly-samples/assets/69362333/89305271-9061-448b-b56c-4748745803d5)

Solved after making changes to src/index.ts:
![CH_TS_Fixed](https://github.com/google/blockly-samples/assets/69362333/5f4b1cb1-387a-445d-9e9f-c0540859c614)


### Reason for Changes

To enable strict mode for the plugin.

### Additional Information

Ran npm run lint to ensure no errors and npm run format at the root! Let me know if there are any changes required.
