### PR TITLE
feature: enabled TS strict mode in workspace-backapck, resolved TS errors

### DIFF
--- a/plugins/workspace-backpack/src/backpack.ts
+++ b/plugins/workspace-backpack/src/backpack.ts
@@ -476,7 +476,7 @@ export class Backpack
     const traverseJson = function (json: StateWithIndex, keys: string[]) {
       for (const key in json) {
         if (key) {
-          if (keys.includes(key)) {
+          if (keys.indexOf(key) !== -1) {
             delete json[key];
           }
           if (json[key] && typeof json[key] === 'object') {

--- a/plugins/workspace-backpack/src/backpack.ts
+++ b/plugins/workspace-backpack/src/backpack.ts
@@ -136,7 +136,9 @@ export class Backpack
     this.initFlyout();
     this.createDom();
     this.attachListeners();
-    registerContextMenus(this.options.contextMenu, this.workspace_);
+    if (this.options.contextMenu) {
+      registerContextMenus(this.options.contextMenu, this.workspace_);
+    }
     this.initialized_ = true;
     this.workspace_.resize();
   }
@@ -167,7 +169,8 @@ export class Backpack
       'rtl': this.workspace_.RTL,
       'oneBasedIndex': this.workspace_.options.oneBasedIndex,
       'renderer': this.workspace_.options.renderer,
-      'rendererOverrides': this.workspace_.options.rendererOverrides,
+      'rendererOverrides':
+        this.workspace_.options.rendererOverrides || undefined,
       'move': {
         'scrollbars': true,
       },
@@ -183,7 +186,9 @@ export class Backpack
         this.workspace_.options,
         true,
       );
-      this.flyout_ = new HorizontalFlyout(flyoutWorkspaceOptions);
+      if (HorizontalFlyout) {
+        this.flyout_ = new HorizontalFlyout(flyoutWorkspaceOptions);
+      }
     } else {
       flyoutWorkspaceOptions.toolboxPosition =
         this.workspace_.toolboxPosition === Blockly.utils.toolbox.Position.RIGHT
@@ -194,10 +199,13 @@ export class Backpack
         this.workspace_.options,
         true,
       );
-      this.flyout_ = new VerticalFlyout(flyoutWorkspaceOptions);
+      if (VerticalFlyout) {
+        this.flyout_ = new VerticalFlyout(flyoutWorkspaceOptions);
+      }
     }
     // Add flyout to DOM.
     const parentNode = this.workspace_.getParentSvg().parentNode;
+    if (!parentNode || !this.flyout_) return;
     parentNode.appendChild(this.flyout_.createDom(Blockly.utils.Svg.SVG));
     this.flyout_.init(this.workspace_);
   }
@@ -253,6 +261,7 @@ export class Backpack
    * Attaches event listeners.
    */
   protected attachListeners() {
+    if (!this.svgGroup_) return;
     this.addEvent(
       this.svgGroup_,
       'mousedown',
@@ -407,10 +416,12 @@ export class Backpack
       }
     }
 
-    this.svgGroup_.setAttribute(
-      'transform',
-      `translate(${this.left_},${this.top_})`,
-    );
+    if (this.svgGroup_) {
+      this.svgGroup_.setAttribute(
+        'transform',
+        `translate(${this.left_},${this.top_})`,
+      );
+    }
   }
 
   /**
@@ -462,20 +473,22 @@ export class Backpack
     const keys = ['id', 'height', 'width', 'pinned', 'enabled'];
 
     // Traverse the JSON recursively.
-    const traverseJson = function (json, keys) {
+    const traverseJson = function (json: StateWithIndex, keys: string[]) {
       for (const key in json) {
         if (key) {
           if (keys.includes(key)) {
             delete json[key];
           }
           if (json[key] && typeof json[key] === 'object') {
-            traverseJson(json[key], keys);
+            traverseJson(json[key] as StateWithIndex, keys);
           }
         }
       }
     };
 
-    traverseJson(json, keys);
+    if (json) {
+      traverseJson(json as StateWithIndex, keys);
+    }
     return JSON.stringify(json);
   }
 
@@ -619,7 +632,7 @@ export class Backpack
     this.maybeRefreshFlyoutContents();
     Blockly.Events.fire(new BackpackChange(this.workspace_.id));
 
-    if (!this.options.useFilledBackpackImage) return;
+    if (!this.options.useFilledBackpackImage || !this.svgImg_) return;
     if (this.contents_.length > 0) {
       this.svgImg_.setAttributeNS(
         Blockly.utils.dom.XLINK_NS,
@@ -665,7 +678,7 @@ export class Backpack
    * @returns Whether the backpack is open.
    */
   isOpen(): boolean {
-    return this.flyout_.isVisible();
+    return this.flyout_ ? this.flyout_.isVisible() : false;
   }
 
   /**
@@ -676,7 +689,7 @@ export class Backpack
       return;
     }
     const jsons = this.contents_.map((text) => JSON.parse(text));
-    this.flyout_.show(jsons);
+    if (this.flyout_) this.flyout_.show(jsons);
     // TODO: We can remove the setVisible check when updating from ^10.0.0 to
     //    ^11.
     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -698,7 +711,7 @@ export class Backpack
       return;
     }
     const json = this.contents_.map((text) => JSON.parse(text));
-    this.flyout_.show(json);
+    if (this.flyout_) this.flyout_.show(json);
   }
 
   /**
@@ -708,7 +721,7 @@ export class Backpack
     if (!this.isOpen()) {
       return;
     }
-    this.flyout_.hide();
+    if (this.flyout_) this.flyout_.hide();
     // TODO: We can remove the setVisible check when updating from ^10.0.0 to
     //    ^11.
     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -741,8 +754,8 @@ export class Backpack
    *
    * @param e Mouse event.
    */
-  protected onClick(e: MouseEvent) {
-    if (Blockly.browserEvents.isRightButton(e)) {
+  protected onClick(e: Event) {
+    if (e instanceof MouseEvent && Blockly.browserEvents.isRightButton(e)) {
       return;
     }
     this.open();
@@ -799,10 +812,12 @@ export class Backpack
    */
   protected updateHoverStying(addClass: boolean) {
     const backpackDarken = 'blocklyBackpackDarken';
-    if (addClass) {
-      Blockly.utils.dom.addClass(this.svgImg_, backpackDarken);
-    } else {
-      Blockly.utils.dom.removeClass(this.svgImg_, backpackDarken);
+    if (this.svgImg_) {
+      if (addClass) {
+        Blockly.utils.dom.addClass(this.svgImg_, backpackDarken);
+      } else {
+        Blockly.utils.dom.removeClass(this.svgImg_, backpackDarken);
+      }
     }
   }
 
@@ -825,8 +840,12 @@ export class Backpack
    *
    * @param e A mouse down event.
    */
-  protected blockMouseDownWhenOpenable(e: MouseEvent) {
-    if (!Blockly.browserEvents.isRightButton(e) && this.isOpenable()) {
+  protected blockMouseDownWhenOpenable(e: Event) {
+    if (
+      e instanceof MouseEvent &&
+      !Blockly.browserEvents.isRightButton(e) &&
+      this.isOpenable()
+    ) {
       e.stopPropagation(); // Don't start a workspace scroll.
     }
   }
@@ -956,4 +975,8 @@ class BackpackSerializer {
     const backpack = componentManager.getComponent('backpack') as Backpack;
     backpack?.empty();
   }
+}
+
+interface StateWithIndex extends Blockly.serialization.blocks.State {
+  [key: string]: unknown;
 }

--- a/plugins/workspace-backpack/src/backpack.ts
+++ b/plugins/workspace-backpack/src/backpack.ts
@@ -204,7 +204,7 @@ export class Backpack
       if (VerticalFlyout) {
         this.flyout_ = new VerticalFlyout(flyoutWorkspaceOptions);
       } else {
-        throw new Error("VerticalFlyout does not found");
+        throw new Error('VerticalFlyout does not exist');
       }
     }
     // Add flyout to DOM.

--- a/plugins/workspace-backpack/src/backpack.ts
+++ b/plugins/workspace-backpack/src/backpack.ts
@@ -188,6 +188,8 @@ export class Backpack
       );
       if (HorizontalFlyout) {
         this.flyout_ = new HorizontalFlyout(flyoutWorkspaceOptions);
+      } else {
+        throw new Error('HorizontalFlyout does not exist');
       }
     } else {
       flyoutWorkspaceOptions.toolboxPosition =
@@ -201,12 +203,13 @@ export class Backpack
       );
       if (VerticalFlyout) {
         this.flyout_ = new VerticalFlyout(flyoutWorkspaceOptions);
+      } else {
+        throw new Error("VerticalFlyout does not found");
       }
     }
     // Add flyout to DOM.
     const parentNode = this.workspace_.getParentSvg().parentNode;
-    if (!parentNode || !this.flyout_) return;
-    parentNode.appendChild(this.flyout_.createDom(Blockly.utils.Svg.SVG));
+    parentNode?.appendChild(this.flyout_?.createDom(Blockly.utils.Svg.SVG));
     this.flyout_.init(this.workspace_);
   }
 
@@ -689,7 +692,7 @@ export class Backpack
       return;
     }
     const jsons = this.contents_.map((text) => JSON.parse(text));
-    if (this.flyout_) this.flyout_.show(jsons);
+    this.flyout_?.show(jsons);
     // TODO: We can remove the setVisible check when updating from ^10.0.0 to
     //    ^11.
     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -711,7 +714,7 @@ export class Backpack
       return;
     }
     const json = this.contents_.map((text) => JSON.parse(text));
-    if (this.flyout_) this.flyout_.show(json);
+    this.flyout_?.show(json);
   }
 
   /**
@@ -721,7 +724,7 @@ export class Backpack
     if (!this.isOpen()) {
       return;
     }
-    if (this.flyout_) this.flyout_.hide();
+    this.flyout_?.hide();
     // TODO: We can remove the setVisible check when updating from ^10.0.0 to
     //    ^11.
     /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/plugins/workspace-backpack/src/backpack_helpers.ts
+++ b/plugins/workspace-backpack/src/backpack_helpers.ts
@@ -23,14 +23,17 @@ import {BackpackContextMenuOptions} from './options';
  */
 function registerEmptyBackpack(workspace: Blockly.WorkspaceSvg) {
   const prevConfigureContextMenu = workspace.configureContextMenu;
-  workspace.configureContextMenu = (menuOptions, e: PointerEvent) => {
+  workspace.configureContextMenu = (menuOptions, e: Event) => {
     const backpack = workspace
       .getComponentManager()
       .getComponent('backpack') as Backpack;
-    if (!backpack || !backpack.getClientRect().contains(e.clientX, e.clientY)) {
-      prevConfigureContextMenu &&
-        prevConfigureContextMenu.call(null, menuOptions, e);
-      return;
+    const backpackClientRect = backpack && backpack.getClientRect();
+    if (e instanceof PointerEvent && backpackClientRect !== null) {
+      if (!backpack || !backpackClientRect.contains(e.clientX, e.clientY)) {
+        prevConfigureContextMenu &&
+          prevConfigureContextMenu.call(null, menuOptions, e);
+        return;
+      }
     }
     menuOptions.length = 0;
     const backpackOptions = {
@@ -58,18 +61,26 @@ function registerRemoveFromBackpack() {
   const removeFromBackpack = {
     displayText: Blockly.Msg['REMOVE_FROM_BACKPACK'],
     preconditionFn: function (scope: Blockly.ContextMenuRegistry.Scope) {
-      const ws = scope.block.workspace;
-      if (ws.isFlyout && ws.targetWorkspace) {
-        const backpack = ws.targetWorkspace
-          .getComponentManager()
-          .getComponent('backpack') as Backpack;
-        if (backpack && backpack.getFlyout().getWorkspace().id === ws.id) {
-          return 'enabled';
+      if (scope.block) {
+        const ws = scope.block.workspace;
+        if (ws.isFlyout && ws.targetWorkspace) {
+          const backpack = ws.targetWorkspace
+            .getComponentManager()
+            .getComponent('backpack') as Backpack;
+          const backpackFlyout = backpack && backpack.getFlyout();
+          if (
+            backpack &&
+            backpackFlyout &&
+            backpackFlyout.getWorkspace().id === ws.id
+          ) {
+            return 'enabled';
+          }
         }
       }
       return 'hidden';
     },
     callback: function (scope: Blockly.ContextMenuRegistry.Scope) {
+      if (!scope.block || !scope.block.workspace.targetWorkspace) return;
       const backpack = scope.block.workspace.targetWorkspace
         .getComponentManager()
         .getComponent('backpack') as Backpack;
@@ -96,7 +107,7 @@ function registerCopyToBackpack(disablePreconditionContainsCheck: boolean) {
   const copyToBackpack = {
     displayText: function (scope: Blockly.ContextMenuRegistry.Scope) {
       if (!scope.block) {
-        return;
+        return '';
       }
       const backpack = scope.block.workspace
         .getComponentManager()
@@ -105,21 +116,24 @@ function registerCopyToBackpack(disablePreconditionContainsCheck: boolean) {
       return `${Blockly.Msg['COPY_TO_BACKPACK']} (${backpackCount})`;
     },
     preconditionFn: function (scope: Blockly.ContextMenuRegistry.Scope) {
-      const ws = scope.block.workspace;
-      if (!ws.isFlyout) {
-        const backpack = ws
-          .getComponentManager()
-          .getComponent('backpack') as Backpack;
-        if (backpack) {
-          if (disablePreconditionContainsCheck) {
-            return 'enabled';
+      if (scope.block) {
+        const ws = scope.block.workspace;
+        if (!ws.isFlyout) {
+          const backpack = ws
+            .getComponentManager()
+            .getComponent('backpack') as Backpack;
+          if (backpack) {
+            if (disablePreconditionContainsCheck) {
+              return 'enabled';
+            }
+            return backpack.containsBlock(scope.block) ? 'disabled' : 'enabled';
           }
-          return backpack.containsBlock(scope.block) ? 'disabled' : 'enabled';
         }
       }
       return 'hidden';
     },
     callback: function (scope: Blockly.ContextMenuRegistry.Scope) {
+      if (!scope.block) return;
       const backpack = scope.block.workspace
         .getComponentManager()
         .getComponent('backpack') as Backpack;
@@ -145,7 +159,7 @@ function registerCopyAllBackpack() {
     displayText: Blockly.Msg['COPY_ALL_TO_BACKPACK'],
     preconditionFn: function (scope: Blockly.ContextMenuRegistry.Scope) {
       const ws = scope.workspace;
-      if (!ws.isFlyout) {
+      if (ws && !ws.isFlyout) {
         const backpack = ws.getComponentManager().getComponent('backpack');
         if (backpack) {
           return 'enabled';
@@ -155,6 +169,7 @@ function registerCopyAllBackpack() {
     },
     callback: function (scope: Blockly.ContextMenuRegistry.Scope) {
       const ws = scope.workspace;
+      if (!ws) return;
       const backpack = ws
         .getComponentManager()
         .getComponent('backpack') as Backpack;
@@ -179,7 +194,7 @@ function registerPasteAllBackpack() {
   const pasteAllFromBackpack = {
     displayText: function (scope: Blockly.ContextMenuRegistry.Scope) {
       if (!scope.workspace) {
-        return;
+        return '';
       }
       const backpack = scope.workspace
         .getComponentManager()
@@ -189,7 +204,7 @@ function registerPasteAllBackpack() {
     },
     preconditionFn: function (scope: Blockly.ContextMenuRegistry.Scope) {
       const ws = scope.workspace;
-      if (!ws.isFlyout) {
+      if (ws && !ws.isFlyout) {
         const backpack = ws.getComponentManager().getComponent('backpack');
         if (backpack) {
           return 'enabled';
@@ -199,6 +214,7 @@ function registerPasteAllBackpack() {
     },
     callback: function (scope: Blockly.ContextMenuRegistry.Scope) {
       const ws = scope.workspace;
+      if (!ws) return;
       const backpack = ws
         .getComponentManager()
         .getComponent('backpack') as Backpack;
@@ -236,7 +252,9 @@ export function registerContextMenus(
     registerRemoveFromBackpack();
   }
   if (contextMenuOptions.copyToBackpack) {
-    registerCopyToBackpack(contextMenuOptions.disablePreconditionChecks);
+    registerCopyToBackpack(
+      contextMenuOptions.disablePreconditionChecks ?? false,
+    );
   }
   if (contextMenuOptions.copyAllToBackpack) {
     registerCopyAllBackpack();

--- a/plugins/workspace-backpack/src/backpack_helpers.ts
+++ b/plugins/workspace-backpack/src/backpack_helpers.ts
@@ -28,7 +28,7 @@ function registerEmptyBackpack(workspace: Blockly.WorkspaceSvg) {
       .getComponentManager()
       .getComponent('backpack') as Backpack;
     const backpackClientRect = backpack && backpack.getClientRect();
-    if (e instanceof PointerEvent && backpackClientRect !== null) {
+    if (e instanceof PointerEvent && backpackClientRect) {
       if (!backpack || !backpackClientRect.contains(e.clientX, e.clientY)) {
         prevConfigureContextMenu &&
           prevConfigureContextMenu.call(null, menuOptions, e);

--- a/plugins/workspace-backpack/src/backpack_helpers.ts
+++ b/plugins/workspace-backpack/src/backpack_helpers.ts
@@ -61,20 +61,19 @@ function registerRemoveFromBackpack() {
   const removeFromBackpack = {
     displayText: Blockly.Msg['REMOVE_FROM_BACKPACK'],
     preconditionFn: function (scope: Blockly.ContextMenuRegistry.Scope) {
-      if (scope.block) {
-        const ws = scope.block.workspace;
-        if (ws.isFlyout && ws.targetWorkspace) {
-          const backpack = ws.targetWorkspace
-            .getComponentManager()
-            .getComponent('backpack') as Backpack;
-          const backpackFlyout = backpack && backpack.getFlyout();
-          if (
-            backpack &&
-            backpackFlyout &&
-            backpackFlyout.getWorkspace().id === ws.id
-          ) {
-            return 'enabled';
-          }
+      if (!scope.block) return 'hidden';
+      const ws = scope.block.workspace;
+      if (ws.isFlyout && ws.targetWorkspace) {
+        const backpack = ws.targetWorkspace
+          .getComponentManager()
+          .getComponent('backpack') as Backpack;
+        const backpackFlyout = backpack && backpack.getFlyout();
+        if (
+          backpack &&
+          backpackFlyout &&
+          backpackFlyout.getWorkspace().id === ws.id
+        ) {
+          return 'enabled';
         }
       }
       return 'hidden';
@@ -116,18 +115,17 @@ function registerCopyToBackpack(disablePreconditionContainsCheck: boolean) {
       return `${Blockly.Msg['COPY_TO_BACKPACK']} (${backpackCount})`;
     },
     preconditionFn: function (scope: Blockly.ContextMenuRegistry.Scope) {
-      if (scope.block) {
-        const ws = scope.block.workspace;
-        if (!ws.isFlyout) {
-          const backpack = ws
-            .getComponentManager()
-            .getComponent('backpack') as Backpack;
-          if (backpack) {
-            if (disablePreconditionContainsCheck) {
-              return 'enabled';
-            }
-            return backpack.containsBlock(scope.block) ? 'disabled' : 'enabled';
+      if (!scope.block) return 'hidden';
+      const ws = scope.block.workspace;
+      if (!ws.isFlyout) {
+        const backpack = ws
+          .getComponentManager()
+          .getComponent('backpack') as Backpack;
+        if (backpack) {
+          if (disablePreconditionContainsCheck) {
+            return 'enabled';
           }
+          return backpack.containsBlock(scope.block) ? 'disabled' : 'enabled';
         }
       }
       return 'hidden';

--- a/plugins/workspace-backpack/src/ui_events.ts
+++ b/plugins/workspace-backpack/src/ui_events.ts
@@ -46,7 +46,7 @@ export class BackpackOpen extends Blockly.Events.UiBase {
    * @returns JSON representation.
    */
   toJson(): BackpackOpenEventJson {
-    const json = super.toJson();
+    const json = super.toJson() as BackpackOpenEventJson;
     json['isOpen'] = this.isOpen;
     return json;
   }

--- a/plugins/workspace-backpack/test/index.ts
+++ b/plugins/workspace-backpack/test/index.ts
@@ -32,9 +32,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const defaultOptions = {
     toolbox: toolboxCategories,
   };
-  createPlayground(
-    document.getElementById('root'),
-    createWorkspace,
-    defaultOptions,
-  );
+  const rootElement = document.getElementById('root');
+  if (rootElement instanceof HTMLElement) {
+    createPlayground(rootElement, createWorkspace, defaultOptions);
+  }
 });

--- a/plugins/workspace-backpack/tsconfig.json
+++ b/plugins/workspace-backpack/tsconfig.json
@@ -8,7 +8,7 @@
     "module": "es2015",
     "moduleResolution": "bundler",
     "target": "es6",
-    "strict": false,
+    "strict": true,
     // Point at the local Blockly. See #1934. Remove if we add hoisting.
     "paths": {
       "blockly/*": ["node_modules/blockly/*"]


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2030 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
* Enabled strict mode for TS code.

* Fixed TS errors include _(a lot of the errors were repetitive for different pieces of code)_:
   ```Javascript
   TS2345: Argument of type 'BackpackContextMenuOptions | undefined' is not assignable to parameter of type 'BackpackContextMenuOptions'.
  Type 'undefined' is not assignable to type 'BackpackContextMenuOptions'.
   ```
   ```Javascript
   TS2322: Type '{ [rendererConstant: string]: any; } | null' is not assignable to type '{ [rendererConstant: string]: any; } | undefined'.
  Type 'null' is not assignable to type '{ [rendererConstant: string]: any; } | undefined'.
   ```
   ```Javascript
   TS18047: 'HorizontalFlyout' is possibly 'null'.
   ```
   ```Javascript
   TS18047: 'VerticalFlyout' is possibly 'null'.
   ```
   ```Javascript
   TS18047: 'parentNode' is possibly 'null'.
   ```
   ```Javascript
   TS2345: Argument of type 'SVGElement | null' is not assignable to parameter of type 'Element'.
  Type 'null' is not assignable to type 'Element'.
   ```
   ```Javascript
    TS2531: Object is possibly 'null'.
   ```
   ```Javascript
   TS7006: Parameter 'json' implicitly has an 'any' type.
   ```
   ```Javascript
   TS7006: Parameter 'keys' implicitly has an 'any' type.
   ```
   ```Javascript
   TS2322: Type '(menuOptions: ContextMenuOption[], e: PointerEvent) => void' is not assignable to type '(menuOptions: ContextMenuOption[], e: Event) => void'.
  Types of parameters 'e' and 'e' are incompatible.
    Type 'Event' is missing the following properties from type 'PointerEvent': height, isPrimary, pointerId, pointerType, and 33 more.
   ```
   ```Javascript
   TS18048: 'scope.block' is possibly 'undefined'.
   ```
   ```Javascript
   TS18047: 'scope.block.workspace.targetWorkspace' is possibly 'null'.
   ```
   ```Javascript
   TS2345: Argument of type 'BlockSvg | undefined' is not assignable to parameter of type 'Block'.
  Type 'undefined' is not assignable to type 'Block'.
   ```
   ```Javascript
   TS2345: Argument of type '{ displayText: (scope: Scope) => string | undefined; preconditionFn: (scope: Scope) => "enabled" | "hidden" | "disabled"; callback: (scope: Scope) => void; scopeType: ScopeType; id: string; weight: number; }' is not assignable to parameter of type 'RegistryItem'.
  Types of property 'displayText' are incompatible.
    Type '(scope: Scope) => string | undefined' is not assignable to type 'string | ((p1: Scope) => string)'.
      Type '(scope: Scope) => string | undefined' is not assignable to type '(p1: Scope) => string'.
        Type 'string | undefined' is not assignable to type 'string'.
          Type 'undefined' is not assignable to type 'string'.
   ```
   ```Javascript
    TS18048: 'ws' is possibly 'undefined'.
   ```
   ```Javascript
   TS2345: Argument of type 'WorkspaceSvg | undefined' is not assignable to parameter of type 'Workspace'.
  Type 'undefined' is not assignable to type 'Workspace'.
   ```
   ```Javascript
   TS2345: Argument of type 'boolean | undefined' is not assignable to parameter of type 'boolean'.
  Type 'undefined' is not assignable to type 'boolean'.
   ```
   ```Javascript
   TS7053: Element implicitly has an 'any' type because expression of type '"isOpen"' can't be used to index type 'AbstractEventJson'.
  Property 'isOpen' does not exist on type 'AbstractEventJson'.
   ```

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
To enhance compile-time type checking built-in with TS to avoid potential errors during runtime.

* `npm run lint` results: 
   >![image](https://github.com/google/blockly-samples/assets/71615163/fc815ce0-01c2-4105-859f-088752a8f920)
* `npm run build` results:
   >![image](https://github.com/google/blockly-samples/assets/71615163/5c9980d3-3409-4bbd-b616-030172a84a85)
* `npm run test` results:
   No tests found for workspace-backpack plugin

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->

* I'm unsure if [creating a new interface StateWithIndex](https://github.com/google/blockly-samples/pull/2080/files#diff-363096547bdd4e0d53f88eab1dd90badc5858e2d18f792b008abb42d94e375b1R979-R982) for [traverseJson()](https://github.com/google/blockly-samples/pull/2080/files#diff-363096547bdd4e0d53f88eab1dd90badc5858e2d18f792b008abb42d94e375b1R476) is correct.

* I'm unsure if what I did here for [L35-38](https://github.com/google/blockly-samples/pull/2080/files#diff-b16cffb4b7eeee54214122fd1dfce42cd0e8b01cc6bde072cdb4661e98f98d39R35-R38) is correct!
