### PR TITLE
fix: Prevent advanced playground OOMing when scrolling aggressively

### DIFF
--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -371,7 +371,7 @@ export function createPlayground(
 
           updateEditor();
           workspace.addChangeListener((e) => {
-            if (e.type !== 'ui') {
+            if (e.type !== 'ui' && e.type !== 'viewport_change') {
               updateEditor();
             }
           });


### PR DESCRIPTION
## The basics
- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves
Fixes #750

### Proposed Changes
Don't regenerate serialized workspace state in response to viewport change events.

### Reason for Changes
When scrolling aggressively, lots of viewport change events are fired, and the generation/display (with syntax highlighting) of the serialized workspace state can result in the tab crashing.