### PR TITLE
chore: add example llm call

### DIFF
--- a/examples/sample-p5-app/src/index.js
+++ b/examples/sample-p5-app/src/index.js
@@ -69,3 +69,22 @@ ws.addChangeListener((e) => {
   }
   runCode();
 });
+
+const url = `https://generativelanguage.googleapis.com/v1beta3/models/text-bison-001:generateText?key=${AI_TOKEN}`
+
+async function testLLMCall() {
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      "prompt": { "text": "Tell me an animal fact"} 
+    }),
+  };
+   
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+}
+// testLLMCall();

--- a/examples/sample-p5-app/webpack.config.js
+++ b/examples/sample-p5-app/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
 
 // Base config that applies to either development or production mode.
 const config = {
@@ -29,6 +30,10 @@ const config = {
     // created above added in a script tag.
     new HtmlWebpackPlugin({
       template: 'src/index.html',
+    }),
+    // Insert the AI_TOKEN from your local environment.
+    new webpack.DefinePlugin({
+      AI_TOKEN: JSON.stringify(process.env.AI_TOKEN),
     }),
   ],
 };


### PR DESCRIPTION
Adds an example call to an LLM.

If you assign AI_TOKEN in your local environment to a [valid token](https://valentine.corp.google.com/#/show/1701384324176491?tab=metadata), and uncomment the `testLLMCall()` line, you will see an animal fact in the browser console when you run `npm run start`.