### PR TITLE
fix: fire finished loading event in suggested blocks test page

### DIFF
--- a/plugins/suggested-blocks/README.md
+++ b/plugins/suggested-blocks/README.md
@@ -19,7 +19,7 @@ npm install @blockly/suggested-blocks --save
 ## Usage
 
 ```js
-import * as Blockly from 'blockly';
+import * as Blockly from 'blockly/core';
 import * as SuggestedBlocks from '@blockly/suggested-blocks';
 
 const toolbox = {
@@ -70,7 +70,10 @@ SuggestedBlocks.init(workspace);
     firing while you load the initial state of the workspace, you'll need to set
     this to `false`, or the plugin will never place blocks in either category.
     By default, this value is `true`, so that events fired while loading initial
-    serialized state do not affect the statistics.
+    serialized state do not affect the statistics. If you leave this value as `true`,
+    you need to ensure the `FinishedLoading` event is always fired; if you don't call
+    `Blockly.serialization.workspaces.load` when there is no saved state to load, you'll
+    need to fire it yourself for this plugin to work correctly.
 
 ## License
 

--- a/plugins/suggested-blocks/src/index.js
+++ b/plugins/suggested-blocks/src/index.js
@@ -9,11 +9,7 @@
  */
 'use strict';
 
-/**
- * Utility functions for handling block suggestions.
- * @namespace Blockly.SuggestedBlocks
- */
-import * as Blockly from 'blockly';
+import * as Blockly from 'blockly/core';
 
 /** Map from workspaces to BlockSuggestor objects. */
 const suggestorLookup = new WeakMap();

--- a/plugins/suggested-blocks/test/index.js
+++ b/plugins/suggested-blocks/test/index.js
@@ -37,7 +37,7 @@ const customTheme = Blockly.Theme.defineTheme('classic_with_suggestions', {
   startHats: null,
 });
 
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', async function () {
   // Insert two new categories
   toolboxCategories['contents'].push({
     kind: 'category',
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   toolboxCategories['contents'].push({
     kind: 'category',
-    name: 'Recentlty Used',
+    name: 'Recently Used',
     custom: 'RECENTLY_USED',
     categorystyle: 'recently_used_category',
   });
@@ -55,9 +55,17 @@ document.addEventListener('DOMContentLoaded', function () {
     toolbox: toolboxCategories,
     theme: customTheme,
   };
-  createPlayground(
+  const playground = await createPlayground(
     document.getElementById('root'),
     createWorkspace,
     defaultOptions,
+  );
+  // Fire a FINISHED_LOADING event again after the playground loads.
+  // This may be fired if there is saved JSON in the advanced playground.
+  // But we need it to fire even if there's no saved JSON and therefore deserialization was never called.
+  Blockly.Events.fire(
+    new (Blockly.Events.get(Blockly.Events.FINISHED_LOADING))(
+      playground.getWorkspace(),
+    ),
   );
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #1445 

### Proposed Changes

- Fires a (possibly redundant) `FINISHED_LOADING` event when the advanced playground is done loading. This only affects the plugin's test page.
- Updates the documentation to instruct the user to ensure they fire this event.
- Fixes a typo in the category name.
- Removes an incorrect JsDoc comment.
- Imports from `blockly/core` instead of `blockly` in both the test page and documentation.

### Reason for Changes

The bug in #1445 occurs if the `FINISHED_LOADING` event is never heard. That event is fired in `Blockly.serialization.workspaces.load`. The bug happens in the advanced playground because we don't try to call the serializer if there's no saved state in local storage. I fixed this for the demo page, and updated the documentation for anyone who might also skip calling `load` if there's no saved data.

### Test Coverage

Manual testing. Difficult to test this in unit tests since we're using node.

### Documentation

Updated in this PR.

### Additional Information

<!-- Anything else we should know? -->
