### PR TITLE
chore: fix keyboard nav tests for v10.3

### DIFF
--- a/plugins/keyboard-navigation/test/shortcuts_test.mocha.js
+++ b/plugins/keyboard-navigation/test/shortcuts_test.mocha.js
@@ -46,10 +46,10 @@ suite('Shortcut Tests', function () {
 
   teardown(function () {
     window.cancelAnimationFrame = undefined;
-    this.jsdomCleanup();
     this.controller.dispose();
-    delete Blockly.Blocks['basic_block'];
     this.workspace.dispose();
+    this.jsdomCleanup();
+    delete Blockly.Blocks['basic_block'];
   });
 
   suite('Deleting blocks', function () {


### PR DESCRIPTION
Realized https://github.com/google/blockly-samples/pull/2097 actually needed to be against master so we don't accidentally bump the version number when doing the other q4 changes.