### PR TITLE
feat: patch toString to call the llm

### DIFF
--- a/examples/sample-p5-app/src/block_svg_patch.js
+++ b/examples/sample-p5-app/src/block_svg_patch.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {getSummary} from './llm';
+
+const originalToString = Blockly.BlockSvg.prototype.toString;
+/**
+ * If the LLM-generated summary of a block already exists, return
+ * that. If not, return the normal collapsed block string, but
+ * also fetch an LLM-summary and update the block when it returns.
+ * @returns The LLM-generated summary of the block if it exists,
+ *     or else the normal collapsed block string.
+ */
+Blockly.BlockSvg.prototype.toString = function() {
+  if (!this.llmSummary && !this.tryingToGetLlmSummary) {
+    this.tryingToGetLlmSummary = true;
+    getSummary(this).then(summary => {
+      this.tryingToGetLlmSummary = false;
+      this.llmSummary = summary;
+      this.renderEfficiently();
+    }).catch(reason => {
+      this.tryingToGetLlmSummary = false;
+      console.log(reason);
+    });
+  }
+  
+  return this.llmSummary ?? originalToString.call(this);
+};
+
+const originalCollapse = Blockly.BlockSvg.prototype.setCollapsed;
+Blockly.BlockSvg.prototype.setCollapsed = function(collapsed) {
+  // If we're expanding the block, clear its llmSummary because
+  // it might change while it is uncollapsed.
+  if (!collapsed) this.llmSummary = null;
+  originalCollapse.call(this, collapsed);
+};
+

--- a/examples/sample-p5-app/src/index.js
+++ b/examples/sample-p5-app/src/index.js
@@ -14,6 +14,7 @@ import {forBlock} from './generators/javascript';
 import {Multiselect, MultiselectBlockDragger} from '@mit-app-inventor/blockly-plugin-workspace-multiselect';
 import p5 from 'p5';
 import './index.css';
+import './block_svg_patch';
 
 // Register the blocks and generator with Blockly
 Blockly.common.defineBlocks(blocks);
@@ -26,6 +27,7 @@ const outputDiv = document.getElementById('output');
 const blocklyDiv = document.getElementById('blocklyDiv');
 
 const options = {
+  collapse: true,
   toolbox: toolbox,
   plugins: {
     'blockDragger': MultiselectBlockDragger, // Required to work
@@ -98,22 +100,3 @@ ws.addChangeListener((e) => {
   }
   runCode();
 });
-
-const url = `https://generativelanguage.googleapis.com/v1beta3/models/text-bison-001:generateText?key=${AI_TOKEN}`
-
-async function testLLMCall() {
-  const options = {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      "prompt": { "text": "Tell me an animal fact"} 
-    }),
-  };
-   
-  const response = await fetch(url, options);
-  const data = await response.json();
-  console.log(data);
-}
-// testLLMCall();

--- a/examples/sample-p5-app/src/llm.js
+++ b/examples/sample-p5-app/src/llm.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const url = `https://generativelanguage.googleapis.com/v1beta3/models/text-bison-001:generateText?key=${AI_TOKEN}`
+
+export async function testLLMCall() {
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      "prompt": { "text": "Tell me an animal fact"} 
+    }),
+  };
+   
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+}
+// testLLMCall();
+
+export async function getSummary(block) {
+  const options = {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+        "prompt": { "text": `Tell me an animal fact and start your response with "${block.type}"`} 
+    }),
+  };
+      
+  const response = await fetch(url, options);
+  const data = await response.json();
+  console.log(data);
+  return data?.candidates?.[0]?.output;
+}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

Patches the toString method of a block to fetch and show some LLM-generated text. Right now this is an animal fact with the name of the block type, but in the future should be updated to show a summary of the block instead.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
