### PR TITLE
feat: Add `blocksToString()` function

### DIFF
--- a/examples/sample-p5-app/src/block_svg_patch.js
+++ b/examples/sample-p5-app/src/block_svg_patch.js
@@ -27,7 +27,7 @@ Blockly.BlockSvg.prototype.toString = function() {
       console.log(reason);
     });
   }
-  
+
   return this.llmSummary ?? originalToString.call(this);
 };
 

--- a/examples/sample-p5-app/src/blocks_to_string.js
+++ b/examples/sample-p5-app/src/blocks_to_string.js
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+import * as Blockly from 'blockly/core';
+
+/**
+ * Create a human-readable text representation of a stack of blocks and their
+ * children.
+ *
+ * @param {!Block} block Top block of stack.
+ * @param {string} indent Whitespace or other text to indent statements from
+ *     statement inputs by.
+ * @param {string} emptyToken The placeholder string used to denote an empty
+ *     input.
+ * @returns {string} Text describing blocks.
+ */
+export function blocksToString(
+    block, opt_maxLength, indent = '  ', emptyToken = '<unspecified>') {
+
+  const NEWLINE = Symbol();
+  const INDENT = Symbol();
+  const OUTDENT = Symbol();
+
+  const tokens = [];
+
+  /**
+   * Converts stack starting at given block to tokens.  Pushes tokens onto
+   * tokens array.
+   */
+  function blocksToTokens(block) {
+    /**
+     * Whether or not to add parentheses around an input.
+     *
+     * @param connection The connection.
+     * @returns True if we should add parentheses around the input.
+     */
+    function shouldAddParentheses(connection) {
+      let checks =
+          connection.getCheck() ?? connection.targetConnection?.getCheck();
+      return checks?.includes('Boolean') || checks?.includes('Number');
+    }
+
+    for (const input of block.inputList) {
+      if (input.name == Blockly.constants.COLLAPSED_INPUT_NAME) {
+        continue;
+      }
+      tokens.push(...input.fieldRow.map(field => field.getText()));
+
+      if (input.connection) {
+        const child = input.connection.targetBlock();
+        if (input.type === Blockly.inputTypes.STATEMENT) {
+          tokens.push(NEWLINE);
+          tokens.push(INDENT);
+        }
+        if (child) {
+          const shouldAddParens = shouldAddParentheses(input.connection);
+          if (shouldAddParens) tokens.push('(');
+          blocksToTokens(child);
+          if (shouldAddParens) tokens.push(')');
+        } else {
+          tokens.push(emptyToken);
+        }
+        if (input.type === Blockly.inputTypes.STATEMENT) {
+          tokens.push(OUTDENT);
+        }
+      }
+    }
+    const nextBlock = block.getNextBlock();
+    if (nextBlock) {
+      tokens.push(NEWLINE);
+      blocksToTokens(nextBlock);
+    }
+  }
+
+  blocksToTokens(block);
+
+  // Run through our tokens array and simplify expression to remove
+  // parentheses around single field blocks.
+  // E.g. ['repeat', '(', '10', ')', 'times', 'do', '?']
+  for (let i = 2; i < tokens.length; i++) {
+    if (tokens[i - 2] === '(' && tokens[i] === ')' &&
+        typeof tokens[i - 1] === 'string') {
+      tokens[i - 2] = tokens[i - 1];
+      tokens.splice(i - 1, 2);
+    }
+  }
+
+  // Join the text array, adding indentation as requested.
+  let text = '';
+  let depth = 0;
+  let prev = undefined;
+  for (const token of tokens) {
+    if (token === NEWLINE) {
+        text += '\n' + indent.repeat(depth);
+    } else if (token === INDENT) {
+      depth++;
+      text += indent;
+    } else if (token === OUTDENT) {
+      depth--;
+    } else {
+      // Skip spaces inside parens.
+      text += (prev === '(' || token === ')' ? '' : ' ') + token;
+    }
+    prev = token;
+  }
+  return text;
+}

--- a/examples/sample-p5-app/src/index.js
+++ b/examples/sample-p5-app/src/index.js
@@ -78,7 +78,7 @@ const runCode = () => {
 // Disable blocks that aren't inside the setup or draw loops.
 ws.addChangeListener(Blockly.Events.disableOrphans);
 
-const getContiguousOption = 
+const getContiguousOption =
 {
     callback: function(scope) {
       console.log(combineBlocks(scope.block.workspace, blockSelectionWeakMap.get(scope.block.workspace)));
@@ -123,8 +123,7 @@ const getStringification = {
     const stack = combineBlocks(ws, blockSelectionWeakMap.get(ws))[0];
     let str = '';
     for (const block of stack.blockList) {
-      // TODO: Replace with new toString function!!!
-      str += block.toString();
+      str += blocksToString(block);
     }
     // Output to the console.
     console.log(str);

--- a/examples/sample-p5-app/src/index.js
+++ b/examples/sample-p5-app/src/index.js
@@ -10,6 +10,7 @@ import {javascriptGenerator} from 'blockly/javascript';
 import {save, load} from './serialization';
 import {toolbox} from './toolbox';
 import {blocks} from './blocks/p5';
+import {blocksToString} from './blocks_to_string.js';
 import {forBlock} from './generators/javascript';
 import {Multiselect, MultiselectBlockDragger, blockSelectionWeakMap} from '@mit-app-inventor/blockly-plugin-workspace-multiselect';
 import { combineBlocks } from './contiguous.ts';
@@ -193,3 +194,7 @@ ws.addChangeListener((e) => {
   }
   runCode();
 });
+
+
+// Add some things to the global namespace for hacking convenience.
+Object.assign(globalThis, {Blockly, blocksToString});

--- a/examples/sample-p5-app/src/llm.js
+++ b/examples/sample-p5-app/src/llm.js
@@ -13,10 +13,10 @@ export async function testLLMCall() {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      "prompt": { "text": "Tell me an animal fact"} 
+      "prompt": { "text": "Tell me an animal fact"}
     }),
   };
-   
+
   const response = await fetch(url, options);
   const data = await response.json();
   console.log(data);
@@ -30,10 +30,10 @@ export async function getSummary(block) {
         'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-        "prompt": { "text": `Tell me an animal fact and start your response with "${block.type}"`} 
+        "prompt": { "text": `Tell me an animal fact and start your response with "${block.type}"`}
     }),
   };
-      
+
   const response = await fetch(url, options);
   const data = await response.json();
   console.log(data);


### PR DESCRIPTION
## The basics

- [ ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/orgs/google/projects/109/views/1?pane=issue&itemId=45223090

### Proposed Changes

* Add `src/blocks_to_string.js` exporting `blocksToString` function.
* Have `src/index.js` put both `Blockly` and `blocksToString` in the global scope, for console convenience.
* Hook up `getStringification` to `blocksToString`
* Whitespace removal.

### Test Coverage

As if I tested this.

(N.B. while not testing I notice that the "Generate Code Text" context menu is disabled for some reason.)