### PR TITLE
fix: procedure parameter serialization

### DIFF
--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -495,9 +495,11 @@ const procedureDefMutator = {
     const newParams = state['params'] ?? [];
     const newIds = new Set(newParams.map((p) => p.id));
     const currParams = model.getParameters();
-    for (let i = currParams.length - 1; i >= 0; i--) {
-      if (!newIds.has(currParams[i].getId)) {
-        model.deleteParameter(i);
+    if (state['fullSerialization']) {
+      for (let i = currParams.length - 1; i >= 0; i--) {
+        if (!newIds.has(currParams[i].getId)) {
+          model.deleteParameter(i);
+        }
       }
     }
     for (let i = 0; i < newParams.length; i++) {

--- a/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
+++ b/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
@@ -20,7 +20,10 @@ const {testHelpers} = require('@blockly/dev-tools');
 const {ObservableParameterModel} = require('../src/observable_parameter_model');
 const {ObservableProcedureModel} = require('../src/observable_procedure_model');
 const {blocks} = require('../src/blocks');
-const {unregisterProcedureBlocks, registerProcedureSerializer} = require('../src/index');
+const {
+  unregisterProcedureBlocks,
+  registerProcedureSerializer,
+} = require('../src/index');
 const {ProcedureDelete} = require('../src/events_procedure_delete');
 const {ProcedureCreate} = require('../src/events_procedure_create');
 

--- a/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
+++ b/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
@@ -20,7 +20,7 @@ const {testHelpers} = require('@blockly/dev-tools');
 const {ObservableParameterModel} = require('../src/observable_parameter_model');
 const {ObservableProcedureModel} = require('../src/observable_procedure_model');
 const {blocks} = require('../src/blocks');
-const {unregisterProcedureBlocks} = require('../src/index');
+const {unregisterProcedureBlocks, registerProcedureSerializer} = require('../src/index');
 const {ProcedureDelete} = require('../src/events_procedure_delete');
 const {ProcedureCreate} = require('../src/events_procedure_create');
 
@@ -36,6 +36,8 @@ suite('Procedures', function () {
 
     unregisterProcedureBlocks();
     Blockly.common.defineBlocks(blocks);
+
+    registerProcedureSerializer();
 
     this.workspace = Blockly.inject('blocklyDiv', {});
 
@@ -1969,13 +1971,6 @@ suite('Procedures', function () {
                 type: 'procedures_defnoreturn',
                 extraState: {
                   procedureId: 'procId',
-                  params: [
-                    {
-                      name: 'x',
-                      id: 'varId',
-                      paramId: 'paramId',
-                    },
-                  ],
                 },
                 fields: {
                   NAME: 'do something',
@@ -2012,67 +2007,6 @@ suite('Procedures', function () {
         ['varId'],
       );
     });
-
-    test(
-      'multiple definitions pointing to the same model end up with ' +
-        'different models',
-      function () {
-        Blockly.serialization.workspaces.load(
-          {
-            blocks: {
-              languageVersion: 0,
-              blocks: [
-                {
-                  type: 'procedures_defnoreturn',
-                  extraState: {
-                    procedureId: 'procId',
-                  },
-                  fields: {
-                    NAME: 'do something',
-                  },
-                },
-                {
-                  type: 'procedures_defnoreturn',
-                  y: 10,
-                  extraState: {
-                    procedureId: 'procId',
-                  },
-                  fields: {
-                    NAME: 'do something',
-                  },
-                },
-              ],
-            },
-            procedures: [
-              {
-                id: 'procId',
-                name: 'do something',
-                returnTypes: null,
-              },
-            ],
-          },
-          this.workspace,
-        );
-        const def1 = this.workspace.getTopBlocks(true)[0];
-        const def2 = this.workspace.getTopBlocks(true)[1];
-        chai.assert.equal(
-          def1.getProcedureModel().getName(),
-          'do something',
-          'Expected the first procedure definition to have the ' +
-            'name in XML',
-        );
-        chai.assert.equal(
-          def2.getProcedureModel().getName(),
-          'do something2',
-          'Expected the second procedure definition to be renamed',
-        );
-        chai.assert.notEqual(
-          def1.getProcedureModel(),
-          def2.getProcedureModel(),
-          'Expected the procedures to have different models',
-        );
-      },
-    );
   });
 
   suite('getDefinition', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2124

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so procedure parameters are only deleted from the procedure model if `doFullSerialization` was true.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Currently parameters are getting deleted when loading from a save =(

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
There was a test for this... the test data was just broken. Now it has been fixed.

Also tested that mirroring continues to work. https://github.com/google/blockly-samples/issues/1873

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
Deleted a test for checking that procedure definition blocks referencing the same model get different procedure models.

This was never supported, the test was just broken because the procedure serializer wasn't registered.
