### PR TITLE
fix: input suggested-block plugin into demo site

### DIFF
--- a/gh-pages/_index.html
+++ b/gh-pages/_index.html
@@ -380,6 +380,16 @@
       </p>
     </div>
   </a>
+  <a class="card" href="plugins/suggested-blocks/test/index.html">
+    <div>
+      <h4>
+        Suggested Blocks
+      </h4>
+      <p>
+        A Blockly plugin that suggests blocks for the user based on which blocks they've used already in the workspace.
+      </p>
+    </div>
+  </a>
 </div>
 
 <h3 id="themes">


### PR DESCRIPTION
Input the suggested-block plugin into toolbox category and got rid of video section since there wasn't anything in the media.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #1444 
Fills in the missing demo for suggested-blocks plugin. 
### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information
I didn't put in a video because I wasn't sure whether it was needed. If it is I will take care of it and get rid of this note
<!-- Anything else we should know? -->
