### PR TITLE
revert: "fix: Use setShadowState instead of setShadow in shadow-block-converter"

### DIFF
--- a/plugins/shadow-block-converter/README.md
+++ b/plugins/shadow-block-converter/README.md
@@ -1,6 +1,6 @@
 # @blockly/shadow-block-converter [![Built on Blockly](https://tinyurl.com/built-on-blockly)](https://github.com/google/blockly)
 
-A [Blockly](https://www.npmjs.com/package/blockly) plugin for automatically converting shadow blocks to regular blocks when the user edits them.
+A [Blockly](https://www.npmjs.com/package/blockly) plugin for automatically converting shadow blocks to real blocks when the user edits them.
 
 ## Installation
 
@@ -19,24 +19,9 @@ npm install @blockly/shadow-block-converter --save
 ## Usage
 
 This plugin exports a function called `shadowBlockConversionChangeListener`. If
-you add it as a change listener to your Blockly workspace then any shadow block
-the user edits will be converted to a regular block. This allows the user to
-move or delete the block, in which case the original shadow block will
-automatically return. With this plugin, shadow blocks behave like a persistent
-default value associated with the parent block (unlike standard Blockly
-behavior, where shadow blocks retain any edits made to them even after a regular
-block is dragged on top of them).
-
-The regular block will be a new block instance, separate from the shadow block
-that was replaced, and will have a different id. It will otherwise have the same
-properties and shape as the original shadow block.
-
-If the shadow block was attached to any ancestor blocks that were also shadows,
-they will be recreated as regular blocks. If the shadow block was attached to
-any descendent blocks, they will be recreated with different ids but will still
-be shadow blocks.
-
-See below for an example using it with a workspace.
+you add it as a change listener to your blockly workspace then any shadow block
+the user edits will be converted to a real block. See below for an example using
+it with a workspace.
 
 ### JavaScript
 

--- a/plugins/shadow-block-converter/test/index.ts
+++ b/plugins/shadow-block-converter/test/index.ts
@@ -17,16 +17,6 @@ const toolbox: Blockly.utils.toolbox.ToolboxDefinition = {
   contents: [
     {
       kind: 'block',
-      type: 'text_reverse',
-      inputs: {
-        TEXT: {
-          shadow: {type: 'text', fields: {TEXT: 'abc'}},
-          block: undefined,
-        },
-      },
-    },
-    {
-      kind: 'block',
       type: 'colour_blend',
       inputs: {
         COLOUR1: {


### PR DESCRIPTION
Reverts google/blockly-samples#2090

It's a breaking change because the BlockShadowChange event was a public exported event type, but was removed (and replaced with a similar but different event type). This change ought to have been recorded as a breaking change. I'll send out a new PR for that.