### PR TITLE
fix: Use the referencesVariables() method to identify variable-related fields instead of checking their type.

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousFlyout.js
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.js
@@ -245,7 +245,7 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
     for (const input of block.inputList) {
       for (const field of input.fieldRow) {
         // No variables.
-        if (field instanceof Blockly.FieldVariable) {
+        if (field.referencesVariables()) {
           return false;
         }
         if (field instanceof Blockly.FieldDropdown) {


### PR DESCRIPTION
The continuous toolbox's flyout enables block recycling for performance. It exempts variable-related blocks, but currently does this by checking if their fields inherit from FieldVariable. Scratch's variable field (and perhaps others) do not inherit from FieldVariable, and the base Field class already provides a `referencesVariables()` instance method that subclasses may override. This PR updates the continuous flyout to use this method to identify variable-related blocks, which should be more reliable and flexible since it makes no assumptions about the inheritance hierarchy.