### PR TITLE
fix: insertion markers destroying procedure models for block-shareable-procedures in v11

### DIFF
--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -215,7 +215,11 @@ const procedureDefGetDefMixin = function () {
      * disposed.
      */
     destroy: function () {
-      this.workspace.getProcedureMap().delete(this.getProcedureModel().getId());
+      if (!this.isInsertionMarker()) {
+        this.workspace
+          .getProcedureMap()
+          .delete(this.getProcedureModel().getId());
+      }
     },
   };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Found that with the new v11 beta the insertion marker managers for procedure definitions were destroying the procedure models when they are destroyed. This is because insertion markers now do the non-full erialization (since they should just reference the model of whatever block they're shadowing).


### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Fix buggies. This was causing mirroring events into other workspaces to break.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested. Confirmed that tests pass.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
I'll update the description of https://github.com/google/blockly/pull/7730 to reflect this break as well.

### Additional Information

<!-- Anything else we should know? -->
N/A
