### PR TITLE
fix: make scroll options compatible with v11

### DIFF
--- a/plugins/scroll-options/src/ScrollBlockDragger.js
+++ b/plugins/scroll-options/src/ScrollBlockDragger.js
@@ -117,8 +117,6 @@ export class ScrollBlockDragger extends Blockly.BlockDragger {
     // Make the block stay under the cursor.
     this.draggingBlock_.moveDuringDrag(newLoc);
 
-    this.dragIcons_(totalDelta);
-
     // As we scroll, show the insertion markers.
     this.draggedConnectionManager_.update(
       new Blockly.utils.Coordinate(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2178 

### Proposed Changes + Reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Removes the reference to `dragIcons_` which no longer exists in v11.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Manually tested, and plugin seems to work now.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
