### PR TITLE
fix: shareable procedures v11

### DIFF
--- a/plugins/block-shareable-procedures/package-lock.json
+++ b/plugins/block-shareable-procedures/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^10.2.0",
+        "blockly": "^11.0.0-beta.2",
         "chai": "^4.3.7",
         "jsdom": "^16.4.0",
         "jsdom-global": "^3.0.2",
@@ -20,7 +20,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^10.2.0"
+        "blockly": "^11.0.0-beta.2"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -132,21 +132,27 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.2.0.tgz",
-      "integrity": "sha512-9jPGdiU3/pzyc2abyqoWcG+ddQwLBixb8HHr5QH2oSn+HialbaR94hS0hqgKXptMr7eD5/ZwEqVK+ptq8Gxe0A==",
+      "version": "11.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.2.tgz",
+      "integrity": "sha512-/XFrb0BmDSYrTf0ktoP3dIGP68x0YgUx5EFj1cafXbSQW66cEsa5WX1FAXKMoTGArM7uIyl9Jh89yZinPqJw6g==",
       "dev": true,
       "dependencies": {
-        "jsdom": "22.1.0"
+        "jsdom": "23.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
-    "node_modules/blockly/node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+    "node_modules/blockly/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 14"
       }
     },
     "node_modules/blockly/node_modules/cssstyle": {
@@ -162,29 +168,16 @@
       }
     },
     "node_modules/blockly/node_modules/data-urls": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-4.0.0.tgz",
-      "integrity": "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
       "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^12.0.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/blockly/node_modules/domexception": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "dev": true,
-      "dependencies": {
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/blockly/node_modules/form-data": {
@@ -202,66 +195,76 @@
       }
     },
     "node_modules/blockly/node_modules/html-encoding-sniffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
       "dependencies": {
-        "whatwg-encoding": "^2.0.0"
+        "whatwg-encoding": "^3.1.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/blockly/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
       "dev": true,
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/blockly/node_modules/https-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/blockly/node_modules/jsdom": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
-      "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.0.0.tgz",
+      "integrity": "sha512-cbL/UCtohJguhFC7c2/hgW6BeZCNvP7URQGnx9tSJRYKCdnfbfWOrtuLTMfiB2VxKsx5wPHVsh/J0aBy9lIIhQ==",
       "dev": true,
       "dependencies": {
-        "abab": "^2.0.6",
         "cssstyle": "^3.0.0",
-        "data-urls": "^4.0.0",
+        "data-urls": "^5.0.0",
         "decimal.js": "^10.4.3",
-        "domexception": "^4.0.0",
         "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.4",
+        "nwsapi": "^2.2.7",
         "parse5": "^7.1.2",
         "rrweb-cssom": "^0.6.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^12.0.1",
-        "ws": "^8.13.0",
-        "xml-name-validator": "^4.0.0"
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.14.2",
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.5.0"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -294,27 +297,27 @@
       }
     },
     "node_modules/blockly/node_modules/tr46": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
       "dev": true,
       "dependencies": {
-        "punycode": "^2.3.0"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/blockly/node_modules/w3c-xmlserializer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "dependencies": {
-        "xml-name-validator": "^4.0.0"
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/blockly/node_modules/webidl-conversions": {
@@ -327,46 +330,46 @@
       }
     },
     "node_modules/blockly/node_modules/whatwg-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "dev": true,
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/blockly/node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/blockly/node_modules/whatwg-url": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-12.0.1.tgz",
-      "integrity": "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
       "dev": true,
       "dependencies": {
-        "tr46": "^4.1.1",
+        "tr46": "^5.0.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/blockly/node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -905,9 +908,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.5.tgz",
-      "integrity": "sha512-6xpotnECFy/og7tKSBVmUNft7J3jyXAka4XvG6AUhFWRz+Q/Ljus7znJAA3bxColfQLdS+XsjoodtJfCgeTEFQ==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
       "dev": true
     },
     "node_modules/parse5": {
@@ -941,9 +944,9 @@
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -1181,9 +1184,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"

--- a/plugins/block-shareable-procedures/package-lock.json
+++ b/plugins/block-shareable-procedures/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.2",
+        "blockly": "^11.0.0-beta.3",
         "chai": "^4.3.7",
         "jsdom": "^16.4.0",
         "jsdom-global": "^3.0.2",
@@ -20,7 +20,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.2"
+        "blockly": "^11.0.0-beta.3"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -132,9 +132,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.2.tgz",
-      "integrity": "sha512-/XFrb0BmDSYrTf0ktoP3dIGP68x0YgUx5EFj1cafXbSQW66cEsa5WX1FAXKMoTGArM7uIyl9Jh89yZinPqJw6g==",
+      "version": "11.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.3.tgz",
+      "integrity": "sha512-bNVOhzOHVAWMQMzvWD31qdm1ArbuTkb4Ib8ZDYMYd42S8SMoIdOsWd5/qxfaXxFZdaP4kc/Cm8cHNZFB5vJIlA==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"

--- a/plugins/block-shareable-procedures/package.json
+++ b/plugins/block-shareable-procedures/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.5",
-    "blockly": "^10.2.0",
+    "blockly": "^11.0.0-beta.2",
     "chai": "^4.3.7",
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",
@@ -51,7 +51,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "blockly": "^10.2.0"
+    "blockly": "^11.0.0-beta.2"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/block-shareable-procedures/package.json
+++ b/plugins/block-shareable-procedures/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.5",
-    "blockly": "^11.0.0-beta.2",
+    "blockly": "^11.0.0-beta.3",
     "chai": "^4.3.7",
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",
@@ -51,7 +51,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.2"
+    "blockly": "^11.0.0-beta.3"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -1185,7 +1185,7 @@ const procedureCallerUpdateShapeMixin = {
     for (const [i, p] of params.entries()) {
       this.appendValueInput(`ARG${i}`)
         .appendField(new Blockly.FieldLabel(p), `ARGNAME${i}`)
-        .setAlign(Blockly.Input.Align.RIGHT);
+        .setAlign(Blockly.inputs.Align.RIGHT);
     }
   },
 

--- a/plugins/block-shareable-procedures/src/observable_parameter_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_parameter_model.ts
@@ -157,7 +157,7 @@ export class ObservableParameterModel
   }
 
   /** Serializes the state of this parameter to JSON.
-   * 
+   *
    * @returns JSON serializable state of the parameter.
    */
   saveState(): Blockly.serialization.procedures.ParameterState {
@@ -175,11 +175,7 @@ export class ObservableParameterModel
     state: Blockly.serialization.procedures.ParameterState,
     workspace: Blockly.Workspace,
   ): ObservableParameterModel {
-    const model = new ObservableParameterModel(
-      workspace,
-      state.name,
-      state.id,
-    );
+    const model = new ObservableParameterModel(workspace, state.name, state.id);
     if (state.types) model.setTypes(state.types);
     return model;
   }

--- a/plugins/block-shareable-procedures/src/observable_parameter_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_parameter_model.ts
@@ -169,4 +169,18 @@ export class ObservableParameterModel
     state.types = this.getTypes();
     return state;
   }
+
+  /** Returns a new parameter model with the given state. */
+  static loadState(
+    state: Blockly.serialization.procedures.ParameterState,
+    workspace: Blockly.Workspace,
+  ): ObservableParameterModel {
+    const model = new ObservableParameterModel(
+      workspace,
+      state.name,
+      state.id,
+    );
+    if (state.types) model.setTypes(state.types);
+    return model;
+  }
 }

--- a/plugins/block-shareable-procedures/src/observable_parameter_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_parameter_model.ts
@@ -155,4 +155,18 @@ export class ObservableParameterModel
     this.procedureModel = model;
     return this;
   }
+
+  /** Serializes the state of this parameter to JSON.
+   * 
+   * @returns JSON serializable state of the parameter.
+   */
+  saveState(): Blockly.serialization.procedures.ParameterState {
+    const state: Blockly.serialization.procedures.ParameterState = {
+      id: this.getId(),
+      name: this.getName(),
+    };
+    if (!this.getTypes().length) return state;
+    state.types = this.getTypes();
+    return state;
+  }
 }

--- a/plugins/block-shareable-procedures/src/observable_parameter_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_parameter_model.ts
@@ -156,7 +156,8 @@ export class ObservableParameterModel
     return this;
   }
 
-  /** Serializes the state of this parameter to JSON.
+  /**
+   * Serializes the state of this parameter to JSON.
    *
    * @returns JSON serializable state of the parameter.
    */
@@ -170,7 +171,13 @@ export class ObservableParameterModel
     return state;
   }
 
-  /** Returns a new parameter model with the given state. */
+  /**
+   * Returns a new parameter model with the given state.
+   *
+   * @param state The state of the parameter to load.
+   * @param workspace The workspace to load the parameter into.
+   * @returns The loaded parameter model.
+   */
   static loadState(
     state: Blockly.serialization.procedures.ParameterState,
     workspace: Blockly.Workspace,

--- a/plugins/block-shareable-procedures/src/observable_procedure_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_procedure_model.ts
@@ -287,7 +287,7 @@ export class ObservableProcedureModel
 
   /**
    * Returns a new procedure model with the given state.
-   * 
+   *
    * @param state The state of the procedure to load.
    * @param workspace The workspace to load the procedure into.
    * @returns The loaded procedure model.

--- a/plugins/block-shareable-procedures/src/observable_procedure_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_procedure_model.ts
@@ -285,7 +285,13 @@ export class ObservableProcedureModel
     };
   }
 
-  /** Returns a new procedure model with the given state. */
+  /**
+   * Returns a new procedure model with the given state.
+   * 
+   * @param state The state of the procedure to load.
+   * @param workspace The workspace to load the procedure into.
+   * @returns The loaded procedure model.
+   */
   static loadState(
     state: Blockly.serialization.procedures.State,
     workspace: Blockly.Workspace,

--- a/plugins/block-shareable-procedures/src/observable_procedure_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_procedure_model.ts
@@ -16,9 +16,7 @@ import {ProcedureRename} from './events_procedure_rename';
 import {triggerProceduresUpdate} from './update_procedures';
 
 /** Represents a procedure signature. */
-export class ObservableProcedureModel
-  implements Blockly.procedures.IProcedureModel
-{
+export class ObservableProcedureModel implements Blockly.procedures.IProcedureModel {
   private id: string;
   private name: string;
   private parameters: ObservableParameterModel[] = [];
@@ -268,6 +266,20 @@ export class ObservableProcedureModel
     this.shouldFireEvents = false;
     for (const param of this.parameters) {
       if (Blockly.isObservable(param)) param.stopPublishing();
+    }
+  }
+
+  /**
+   * Serializes the state of the procedure to JSON.
+   *
+   * @returns JSON serializable state of the procedure.
+   */
+  saveState(): Blockly.serialization.procedures.State {
+    // Parameter state is serialized by core.
+    return {
+      id: this.getId(),
+      name: this.getName(),
+      returnTypes: this.getReturnTypes(),
     }
   }
 }

--- a/plugins/block-shareable-procedures/src/observable_procedure_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_procedure_model.ts
@@ -16,7 +16,9 @@ import {ProcedureRename} from './events_procedure_rename';
 import {triggerProceduresUpdate} from './update_procedures';
 
 /** Represents a procedure signature. */
-export class ObservableProcedureModel implements Blockly.procedures.IProcedureModel {
+export class ObservableProcedureModel
+  implements Blockly.procedures.IProcedureModel
+{
   private id: string;
   private name: string;
   private parameters: ObservableParameterModel[] = [];
@@ -280,6 +282,18 @@ export class ObservableProcedureModel implements Blockly.procedures.IProcedureMo
       id: this.getId(),
       name: this.getName(),
       returnTypes: this.getReturnTypes(),
-    }
+    };
+  }
+
+  /** Returns a new procedure model with the given state. */
+  static loadState(
+    state: Blockly.serialization.procedures.State,
+    workspace: Blockly.Workspace,
+  ): ObservableProcedureModel {
+    return new ObservableProcedureModel(
+      workspace,
+      state.name,
+      state.id,
+    ).setReturnTypes(state.returnTypes);
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2164 

### Proposed Changes + Reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Updates the shareable procedures plugin to be compatible with v11. Updates references to inputs, and procedure hooks.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A - Should be no user-facing change in behavior.

### Additional Information

<!-- Anything else we should know? -->
Previously procedures were serialized by procedure serializers in core, but we found that it took too much effort to register new procedure serializers when you were defining new procedure models, so now we've bundled the procedure serialization with the procedure models themselves.

Parameter models are serialized separately by the core procedure serializer and the state is appended to the procedure model state so that procedure models don't have to be tightly coupled to their parameter model classes.
