### PR TITLE
feat: add basic saving and loading and start block state

### DIFF
--- a/examples/developer-tools/src/index.ts
+++ b/examples/developer-tools/src/index.ts
@@ -7,6 +7,7 @@
 import * as Blockly from 'blockly/core';
 import * as En from 'blockly/msg/en';
 import {registerAllBlocks} from './blocks';
+import {save, load} from './serialization';
 import {toolbox} from './toolbox';
 import {theme} from './theme';
 import 'blockly/blocks';
@@ -28,3 +29,26 @@ const definitionDiv = document.getElementById('block-definition').firstChild;
 
 const previewWorkspace = Blockly.inject(previewDiv, {});
 const mainWorkspace = Blockly.inject(mainWorkspaceDiv, {theme, toolbox});
+
+// Disable orphan blocks on the main workspace
+mainWorkspace.addChangeListener(Blockly.Events.disableOrphans);
+
+// Load either saved state or new state
+load(mainWorkspace);
+
+// Whenever the workspace changes meaningfully, update the preview.
+mainWorkspace.addChangeListener((e: Blockly.Events.Abstract) => {
+  // Don't run the code when the workspace finishes loading; we're
+  // already running it once when the application starts.
+  // Don't run the code during drags; we might have invalid state.
+  if (
+    e.isUiEvent ||
+    e.type == Blockly.Events.FINISHED_LOADING ||
+    mainWorkspace.isDragging()
+  ) {
+    return;
+  }
+
+  save(mainWorkspace);
+  previewWorkspace.clear();
+});

--- a/examples/developer-tools/src/serialization.ts
+++ b/examples/developer-tools/src/serialization.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+
+const storageKey = 'blockFactory';
+
+const startBlocks = {
+  blocks: {
+    languageVersion: 0,
+    blocks: [
+      {
+        type: 'factory_base',
+        deletable: false,
+        x: 53,
+        y: 23,
+        fields: {
+          NAME: 'block_type',
+          INLINE: 'AUTO',
+          CONNECTIONS: 'NONE',
+        },
+        inputs: {
+          TOOLTIP: {
+            block: {
+              type: 'text',
+              deletable: false,
+              movable: false,
+              fields: {
+                TEXT: '',
+              },
+            },
+          },
+          HELPURL: {
+            block: {
+              type: 'text',
+              deletable: false,
+              movable: false,
+              fields: {
+                TEXT: '',
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+
+/**
+ * Saves the state of the workspace to browser's local storage.
+ *
+ * @param workspace Blockly workspace to save.
+ */
+export const save = function (workspace: Blockly.Workspace) {
+  const data = Blockly.serialization.workspaces.save(workspace);
+  window.localStorage?.setItem(storageKey, JSON.stringify(data));
+};
+
+/**
+ * Loads saved state from local storage into the given workspace.
+ *
+ * @param workspace Blockly workspace to load into.
+ */
+export const load = function (workspace: Blockly.Workspace) {
+  const data = window.localStorage?.getItem(storageKey);
+  if (data) {
+    Blockly.serialization.workspaces.load(JSON.parse(data), workspace);
+  } else {
+    // Load starter block
+    Blockly.serialization.workspaces.load(startBlocks, workspace);
+  }
+};


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Works on block factory

### Proposed Changes

Adds basic saving and loading on change, and adds the start block to the workspace if there's no previous data

The comment on the change listener is slightly optimistic but my next PR will finish implementing what the comment says it does :)

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
