### PR TITLE
feat: add json definition generator functions

### DIFF
--- a/examples/developer-tools/src/blocks/connection_check.ts
+++ b/examples/developer-tools/src/blocks/connection_check.ts
@@ -201,6 +201,7 @@ export const connectionCheck = {
     if (this.getField('CUSTOMCHECK')) {
       return {customCheck: this.getFieldValue('CUSTOMCHECK')};
     }
+    return {};
   },
   loadExtraState: function (state: ConnectionCheckState) {
     this.customCheck = state?.customCheck;

--- a/examples/developer-tools/src/blocks/index.ts
+++ b/examples/developer-tools/src/blocks/index.ts
@@ -12,7 +12,7 @@ import {
   connectionCheckGroup,
   connectionCheckContainer,
   connectionCheckItem,
-} from './type';
+} from './connection_check';
 import {
   fieldCheckbox,
   fieldDropdown,
@@ -27,6 +27,20 @@ import {
   fieldVariable,
 } from './fields';
 import {colourHue} from './colour';
+
+// import for side effects for now
+import '../output-generators/factory_base';
+import '../output-generators/input';
+import '../output-generators/connection_check';
+import '../output-generators/fields/text_input';
+import '../output-generators/fields/dropdown';
+import '../output-generators/fields/number';
+import '../output-generators/fields/label';
+import '../output-generators/fields/label_serializable';
+import '../output-generators/fields/checkbox';
+import '../output-generators/fields/image';
+import '../output-generators/fields/variable';
+import '../output-generators/colour';
 
 /* eslint-disable @typescript-eslint/naming-convention
  -- Blockly convention is to use snake_case for block names

--- a/examples/developer-tools/src/index.ts
+++ b/examples/developer-tools/src/index.ts
@@ -6,6 +6,7 @@
 
 import * as Blockly from 'blockly/core';
 import * as En from 'blockly/msg/en';
+import {jsonDefinitionGenerator} from './output-generators/json_definition_generator';
 import {registerAllBlocks} from './blocks';
 import {save, load} from './serialization';
 import {toolbox} from './toolbox';
@@ -37,6 +38,7 @@ mainWorkspace.addChangeListener(Blockly.Events.disableOrphans);
 load(mainWorkspace);
 
 // Whenever the workspace changes meaningfully, update the preview.
+let blockName = '';
 mainWorkspace.addChangeListener((e: Blockly.Events.Abstract) => {
   // Don't run the code when the workspace finishes loading; we're
   // already running it once when the application starts.
@@ -51,4 +53,22 @@ mainWorkspace.addChangeListener((e: Blockly.Events.Abstract) => {
 
   save(mainWorkspace);
   previewWorkspace.clear();
+
+  // If we previously had a block registered, delete it.
+  if (blockName) {
+    delete Blockly.Blocks[blockName];
+  }
+  const blockDefinitionString =
+    jsonDefinitionGenerator.workspaceToCode(mainWorkspace);
+  definitionDiv.textContent = blockDefinitionString;
+  const blockDefinition = JSON.parse(blockDefinitionString);
+  blockName = blockDefinition.type;
+  Blockly.common.defineBlocks(
+    Blockly.common.createBlockDefinitionsFromJsonArray([blockDefinition]),
+  );
+
+  // TODO: After Blockly v11, won't need to call `initSvg` and `render` directly.
+  const block = previewWorkspace.newBlock(blockName);
+  block.initSvg();
+  block.render();
 });

--- a/examples/developer-tools/src/output-generators/colour.ts
+++ b/examples/developer-tools/src/output-generators/colour.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  JsonDefinitionGenerator,
+  Order,
+  jsonDefinitionGenerator,
+} from './json_definition_generator';
+import * as Blockly from 'blockly/core';
+
+/**
+ * JSON definition for the "input" block.
+ *
+ * @param block
+ * @param generator
+ * @returns The stringified JSON representing the stack of input blocks.
+ *    The entire stack will be returned due to the `scrub_` function.
+ *    The JSON returned here should be part of the `args0` of the JSON
+ *    in the final block definition.
+ */
+jsonDefinitionGenerator.forBlock['colour_hue'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): [string, number] {
+  return [this.getFieldValue('HUE').toString(), Order.ATOMIC];
+};

--- a/examples/developer-tools/src/output-generators/connection_check.ts
+++ b/examples/developer-tools/src/output-generators/connection_check.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {
+  JsonDefinitionGenerator,
+  Order,
+  jsonDefinitionGenerator,
+} from './json_definition_generator';
+
+/**
+ * JSON definition for a single "connection_check" block.
+ *
+ * @param block
+ * @param generator
+ * @returns A connection check string corresponding to the option chosen.
+ *    If custom option is chosen and not specified, returns null.
+ */
+jsonDefinitionGenerator.forBlock['connection_check'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): [string, number] {
+  const selected = block.getFieldValue('CHECKDROPDOWN');
+  let output = '';
+  switch (selected) {
+    case 'null': {
+      output = null;
+      break;
+    }
+    case 'CUSTOM': {
+      output = block.getFieldValue('CUSTOMCHECK') || null;
+      break;
+    }
+    default: {
+      output = selected;
+    }
+  }
+
+  return [JSON.stringify(output), Order.ATOMIC];
+};
+
+/**
+ * JSON Definition for the "any of" check block.
+ *
+ * @param block
+ * @param generator
+ * @returns stringified version of:
+ *     - null if the list is empty or contains the "any" check
+ *     - a single check string if that is the only check present in the list
+ *     - an array of all checks in the list, deduplicated
+ */
+jsonDefinitionGenerator.forBlock['connection_check_group'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): [string, number] {
+  const checks = new Set<string>();
+  for (const input of block.inputList) {
+    const value = generator.valueToCode(block, input.name, Order.ATOMIC);
+    if (!value) continue; // No block connected to this input
+    const check = JSON.parse(value) || '';
+    if (check === null) {
+      // If the list contains 'any' then the check is simplified to 'any'
+      return [JSON.stringify(null), Order.ATOMIC];
+    }
+    if (check) checks.add(check);
+  }
+
+  if (checks.size === 0) {
+    // No checks were connected to the block.
+    return [JSON.stringify(null), Order.ATOMIC];
+  }
+  if (checks.size === 1) {
+    // If there's only one check, we return it directly instead of
+    // returning an array with one member.
+    return [JSON.stringify(Array.from(checks)[0]), Order.ATOMIC];
+  }
+  return [JSON.stringify(Array.from(checks)), Order.ATOMIC];
+};

--- a/examples/developer-tools/src/output-generators/factory_base.ts
+++ b/examples/developer-tools/src/output-generators/factory_base.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {javascriptGenerator} from 'blockly/javascript';
+import {
+  JsonDefinitionGenerator,
+  jsonDefinitionGenerator,
+  Order,
+} from './json_definition_generator';
+
+/**
+ * Builds the 'message0' part of the JSON block definition.
+ * The message should have label fields' text inlined into the message.
+ * Doing so makes the message more translatable as fields can be moved around.
+ *
+ * @param argsList The list of fields and inputs generated from the input stack.
+ * @returns An object containing:
+ *    - a message string with one placeholder '%i`
+ *      for each field and input in the block
+ *    - the new args list, with label fields removed
+ */
+const buildMessageString = function (argsList: Array<Record<string, unknown>>) {
+  let i = 0;
+  let messageString = '';
+  const newArgs = [];
+  for (const arg of argsList) {
+    if (arg.type === 'field_label') {
+      // Label fields get added directly to the message string.
+      // They are removed from the arg list so they don't appear twice.
+      messageString += `${arg.text} `;
+    } else {
+      i++;
+      messageString += `%${i} `;
+      newArgs.push(arg);
+    }
+  }
+
+  return {
+    message: messageString.trim(),
+    args: newArgs,
+  };
+};
+
+jsonDefinitionGenerator.forBlock['factory_base'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): string {
+  // TODO: Get a JSON-legal name for the block
+  const blockName = block.getFieldValue('NAME');
+  // Tooltip and Helpurl string blocks can't be removed, so we don't care what happens if the block doesn't exist
+  const tooltip = JSON.parse(
+    generator.valueToCode(block, 'TOOLTIP', Order.ATOMIC),
+  );
+  const helpUrl = JSON.parse(
+    generator.valueToCode(block, 'HELPURL', Order.ATOMIC),
+  );
+
+  const code: {[key: string]: unknown} = {
+    type: blockName,
+    tooltip: tooltip,
+    helpUrl: helpUrl,
+  };
+
+  const inputsStack = generator.statementToCode(block, 'INPUTS');
+  if (inputsStack) {
+    // If there is a stack, they come back as the inner pieces of an array
+    // Can possibly fix this in scrub?
+    const args0 = JSON.parse(`[${inputsStack}]`);
+    const {args, message} = buildMessageString(args0);
+    code.message0 = message;
+    code.args0 = args;
+  } else {
+    code.message0 = '';
+  }
+
+  /**
+   * Sets the connection check for the given input, if present. If the input exists
+   * but doesn't have a block attached or a value, the connection property is
+   * still added to the output with a check of 'null'. If the input doesn't
+   * exist, that means the block should not have that type of connection, and no
+   * property is added to the output.
+   *
+   * @param inputName The name of the input that would contain the type check.
+   * @param connectionName The name of the connection in the definition output.
+   */
+  const setConnectionChecks = (inputName: string, connectionName: string) => {
+    if (this.getInput(inputName)) {
+      // If there is no set type, we still need to add 'null` to the check
+      const output = generator.valueToCode(block, inputName, Order.ATOMIC);
+      code[connectionName] = output ? JSON.parse(output) : null;
+    }
+  };
+
+  setConnectionChecks('OUTPUTCHECK', 'output');
+  setConnectionChecks('TOPCHECK', 'previousStatement');
+  setConnectionChecks('BOTTOMCHECK', 'nextStatement');
+
+  const colour = generator.valueToCode(block, 'COLOUR', Order.ATOMIC);
+  if (colour !== '') {
+    code.colour = JSON.parse(colour);
+  }
+
+  const inputsAlign = block.getFieldValue('INLINE');
+  switch (inputsAlign) {
+    case 'EXT': {
+      code.inputsInline = false;
+      break;
+    }
+    case 'INT': {
+      code.inputsInline = true;
+      break;
+    }
+    default: {
+      // Don't add anything for "auto".
+    }
+  }
+
+  return JSON.stringify(code, undefined, 2);
+};
+
+jsonDefinitionGenerator.forBlock['text'] = javascriptGenerator.forBlock['text'];

--- a/examples/developer-tools/src/output-generators/fields/checkbox.ts
+++ b/examples/developer-tools/src/output-generators/fields/checkbox.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {
+  JsonDefinitionGenerator,
+  jsonDefinitionGenerator,
+} from '../json_definition_generator';
+
+jsonDefinitionGenerator.forBlock['field_checkbox'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): string {
+  const code = {
+    type: 'field_checkbox',
+    name: block.getFieldValue('FIELDNAME'),
+    checked: block.getFieldValue('CHECKED'),
+  };
+  return JSON.stringify(code);
+};

--- a/examples/developer-tools/src/output-generators/fields/dropdown.ts
+++ b/examples/developer-tools/src/output-generators/fields/dropdown.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  JsonDefinitionGenerator,
+  jsonDefinitionGenerator,
+} from '../json_definition_generator';
+import {DropdownOptionData, FieldDropdownBlock} from '../../blocks/fields';
+
+jsonDefinitionGenerator.forBlock['field_dropdown'] = function (
+  block: FieldDropdownBlock,
+  generator: JsonDefinitionGenerator,
+): string {
+  const code: Record<string, string | Array<[DropdownOptionData, string]>> = {
+    type: 'field_dropdown',
+    name: block.getFieldValue('FIELDNAME'),
+  };
+  const options: Array<[DropdownOptionData, string]> = [];
+  for (let i = 0; i < block.optionList.length; i++) {
+    options.push([block.getUserData(i), block.getFieldValue('CPU' + i)]);
+  }
+
+  if (options.length === 0) {
+    // If there are no options in the dropdown, the field isn't valid.
+    // Remove it from the list of fields by returning an empty string.
+    return '';
+  }
+
+  code.options = options;
+  return JSON.stringify(code);
+};

--- a/examples/developer-tools/src/output-generators/fields/image.ts
+++ b/examples/developer-tools/src/output-generators/fields/image.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {
+  JsonDefinitionGenerator,
+  jsonDefinitionGenerator,
+} from '../json_definition_generator';
+
+jsonDefinitionGenerator.forBlock['field_image'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): string {
+  const code = {
+    type: 'field_image',
+    src: block.getFieldValue('SRC'),
+    width: block.getFieldValue('WIDTH'),
+    height: block.getFieldValue('HEIGHT'),
+    alt: block.getFieldValue('ALT'),
+    flipRtl: block.getFieldValue('FLIP_RTL'),
+  };
+  return JSON.stringify(code);
+};

--- a/examples/developer-tools/src/output-generators/fields/label.ts
+++ b/examples/developer-tools/src/output-generators/fields/label.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {
+  JsonDefinitionGenerator,
+  jsonDefinitionGenerator,
+} from '../json_definition_generator';
+
+jsonDefinitionGenerator.forBlock['field_label'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): string {
+  const code = {
+    type: 'field_label',
+    text: block.getFieldValue('TEXT'),
+  };
+  return JSON.stringify(code);
+};

--- a/examples/developer-tools/src/output-generators/fields/label_serializable.ts
+++ b/examples/developer-tools/src/output-generators/fields/label_serializable.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {
+  JsonDefinitionGenerator,
+  jsonDefinitionGenerator,
+} from '../json_definition_generator';
+
+jsonDefinitionGenerator.forBlock['field_label_serializable'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): string {
+  const code = {
+    type: 'field_label_serializable',
+    text: block.getFieldValue('TEXT'),
+    name: block.getFieldValue('FIELDNAME'),
+  };
+  return JSON.stringify(code);
+};

--- a/examples/developer-tools/src/output-generators/fields/number.ts
+++ b/examples/developer-tools/src/output-generators/fields/number.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {
+  JsonDefinitionGenerator,
+  jsonDefinitionGenerator,
+} from '../json_definition_generator';
+
+jsonDefinitionGenerator.forBlock['field_number'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): string {
+  const code: Record<string, string | number> = {
+    type: 'field_number',
+    name: block.getFieldValue('FIELDNAME'),
+    value: block.getFieldValue('VALUE'),
+  };
+  const min = block.getFieldValue('MIN');
+  const max = block.getFieldValue('MAX');
+  const precision = block.getFieldValue('PRECISION');
+  if (min !== -Infinity) code.min = min;
+  if (max !== Infinity) code.max = max;
+  if (precision !== 0) code.precision = precision;
+  return JSON.stringify(code);
+};

--- a/examples/developer-tools/src/output-generators/fields/text_input.ts
+++ b/examples/developer-tools/src/output-generators/fields/text_input.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {
+  JsonDefinitionGenerator,
+  jsonDefinitionGenerator,
+} from '../json_definition_generator';
+
+jsonDefinitionGenerator.forBlock['field_input'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): string {
+  const code = {
+    type: 'field_input',
+    name: block.getFieldValue('FIELDNAME'),
+    text: block.getFieldValue('TEXT'),
+  };
+  return JSON.stringify(code);
+};

--- a/examples/developer-tools/src/output-generators/fields/variable.ts
+++ b/examples/developer-tools/src/output-generators/fields/variable.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {
+  JsonDefinitionGenerator,
+  jsonDefinitionGenerator,
+} from '../json_definition_generator';
+
+jsonDefinitionGenerator.forBlock['field_variable'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): string {
+  const code = {
+    type: 'field_variable',
+    name: block.getFieldValue('FIELDNAME'),
+    variable: block.getFieldValue('TEXT'),
+  };
+  return JSON.stringify(code);
+};

--- a/examples/developer-tools/src/output-generators/input.ts
+++ b/examples/developer-tools/src/output-generators/input.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  JsonDefinitionGenerator,
+  Order,
+  jsonDefinitionGenerator,
+} from './json_definition_generator';
+import * as Blockly from 'blockly/core';
+
+/**
+ * JSON definition for the "input" block.
+ *
+ * @param block
+ * @param generator
+ * @returns The stringified JSON representing the stack of input blocks.
+ *    The entire stack will be returned due to the `scrub_` function.
+ *    The JSON returned here should be part of the `args0` of the JSON
+ *    in the final block definition.
+ */
+jsonDefinitionGenerator.forBlock['input'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): string {
+  const name = block.getFieldValue('INPUTNAME');
+  const inputType = block.getFieldValue('INPUTTYPE');
+
+  const code: {[key: string]: unknown} = {
+    type: inputType,
+    name: name,
+  };
+
+  const align = block.getFieldValue('ALIGNMENT');
+  if (align !== 'LEFT') {
+    code.align = align;
+  }
+
+  const connectionCheckValue = generator.valueToCode(
+    block,
+    'CHECK',
+    Order.ATOMIC,
+  );
+  if (connectionCheckValue && connectionCheckValue !== 'null') {
+    // If the connectionCheckValue is null, it doesn't get included in the input def.
+    code.check = JSON.parse(connectionCheckValue);
+  }
+
+  // All fields associated with an input are in the argument list just
+  // ahead of their input, so prepend the field code to the final
+  // input code.
+  const fields = generator.statementToCode(block, 'FIELDS');
+
+  return fields + (fields ? ',\n' : '') + JSON.stringify(code);
+};

--- a/examples/developer-tools/src/output-generators/json_definition_generator.ts
+++ b/examples/developer-tools/src/output-generators/json_definition_generator.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+
+/**
+ * We will never need parentheses for the JSON definition, so
+ * order precedence can be ignored.
+ */
+export const Order = {
+  ATOMIC: 0,
+};
+
+/**
+ * A CodeGenerator that generates a JSON block definition for a block defined
+ * in the Block Factory.
+ */
+export class JsonDefinitionGenerator extends Blockly.CodeGenerator {
+  /**
+   * Creates a new JsonDefinitionGenerator.
+   *
+   * @param name Registered name for the generator.
+   */
+  constructor(name = 'JsonBlockDefinition') {
+    super(name);
+    // this.isInitialized = false;
+
+    // TODO: List any reserved words.
+    // this.addReservedWords();
+  }
+
+  /**
+   * Initialise the database of variable names.
+   *
+   * @param workspace Workspace to generate code from.
+   */
+  init(workspace: Blockly.Workspace) {
+    // super.init(workspace);
+    // if (!this.nameDB_) {
+    //   this.nameDB_ = new Names(this.RESERVED_WORDS_);
+    // } else {
+    //   this.nameDB_.reset();
+    // }
+    // this.nameDB_.setVariableMap(workspace.getVariableMap());
+    // this.nameDB_.populateVariables(workspace);
+    // this.nameDB_.populateProcedures(workspace);
+    // const defvars = [];
+    // // Add developer variables (not created or named by the user).
+    // const devVarList = Variables.allDeveloperVariables(workspace);
+    // for (let i = 0; i < devVarList.length; i++) {
+    //   defvars.push(
+    //       this.nameDB_.getName(devVarList[i], NameType.DEVELOPER_VARIABLE));
+    // }
+    // // Add user variables, but only ones that are being used.
+    // const variables = Variables.allUsedVarModels(workspace);
+    // for (let i = 0; i < variables.length; i++) {
+    //   defvars.push(
+    //       this.nameDB_.getName(variables[i].getId(), NameType.VARIABLE));
+    // }
+    // // Declare all of the variables.
+    // if (defvars.length) {
+    //   this.definitions_['variables'] = 'var ' + defvars.join(', ') + ';';
+    // }
+    // this.isInitialized = true;
+  }
+
+  /**
+   * Prepend the generated code with the variable definitions.
+   *
+   * @param code Generated code.
+   * @returns Completed code.
+   */
+  // finish(code) {
+  //   // Convert the definitions dictionary into a list.
+  //   const definitions = Object.values(this.definitions_);
+  //   // Call Blockly.CodeGenerator's finish.
+  //   super.finish(code);
+  //   this.isInitialized = false;
+
+  //   this.nameDB_.reset();
+  //   return definitions.join('\n\n') + '\n\n\n' + code;
+  // }
+
+  /**
+   * Naked values are top-level blocks with outputs that aren't plugged into
+   * anything. These are not legal, so nothing should be returned.
+   *
+   * @param line Line of generated code.
+   * @returns Empty string.
+   */
+  scrubNakedValue(line: string) {
+    return '';
+  }
+
+  /**
+   * Encode a string as a properly escaped JSON string, complete with
+   * quotes.
+   *
+   * @param string Text to encode.
+   * @returns JSON string.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  quote_(string: string) {
+    // Can't use goog.string.quote since Google's style guide recommends
+    // JS string literals use single quotes.
+    string = string
+      .replace(/\\/g, '\\\\')
+      .replace(/\n/g, '\\\n')
+      // .replace(/'/g, '\\\'')
+      .replace(/"/g, '\\"');
+    return '"' + string + '"';
+  }
+
+  /**
+   * There are no multiline strings in JSON, so we probably shouldn't use this.
+   *
+   * @param string Text to encode.
+   * @return JavaScript string.
+   */
+  // multiline_quote_(string) {
+  //   // Can't use goog.string.quote since Google's style guide recommends
+  //   // JS string literals use single quotes.
+  //   // const lines = string.split(/\n/g).map(this.quote_);
+  //   // return lines.join(' + \'\\n\' +\n');
+  // }
+
+  /**
+   * Common tasks for generating JSON block definitions from blocks.
+   * Calls any statements following this block.
+   *
+   * @param block The current block.
+   * @param code The JSON code created for this block.
+   * @param thisOnly True to generate code for only this
+   *     statement.
+   * @returns JSON block definition with subsequent blocks added.
+   * @protected
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  scrub_(block: Blockly.Block, code: string, thisOnly = false) {
+    const nextBlock =
+      block.nextConnection && block.nextConnection.targetBlock();
+    let nextCode = thisOnly ? '' : this.blockToCode(nextBlock);
+    if (nextCode) {
+      nextCode = ',\n  ' + nextCode;
+    }
+    return code + nextCode;
+  }
+}
+
+export const jsonDefinitionGenerator = new JsonDefinitionGenerator();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Works on Block Factory

### Proposed Changes

- Adds JSON Definition Generator functions for each of the block factory blocks
- Adds a change listener to the main workspace that shows the block preview using the json definition
- Renames the `blocks/type.ts` file to `blocks/connection_check.ts` to match the new name which was renamed in a previous PR

This PR depends on #2187 , but only barely. It's only the changes in `index.ts` and I'm adding to the change listener that was added in that PR. So you can still review this PR for content and I'll rebase when that PR goes in. The bulk of this PR is not dependent on that one.

Note that many parts of the `JsonDefinitionGenerator` are commented out. I plan to clean this up once I've written a) the other types of generators and b) implemented checking the block name doesn't conflict with a different block name and is a valid json identifier, which I am hoping to use the machinery for valid names in generators to do so. So I will need parts that are currently commented out and others I am not sure about yet. I got the bulk of this code from copying the `javascriptGenerator` from core and modifying as needed.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Manual testing. I've started working on an automated test that would exercise this generator but there's no mechanism for running tests in `examples/` right now so that's a bigger project and in a different PR.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
