### PR TITLE
fix: Include disabled block pattern in screenshot.

### DIFF
--- a/plugins/dev-tools/src/screenshot.js
+++ b/plugins/dev-tools/src/screenshot.js
@@ -68,12 +68,12 @@ function workspaceToSvg_(workspace, callback, customCss) {
   const height = bBox.height || bBox.bottom - y;
 
   const blockCanvas = workspace.getCanvas();
-  const clone = blockCanvas.cloneNode(true);
-  clone.removeAttribute('transform');
+  const blockCanvasClone = blockCanvas.cloneNode(true);
+  blockCanvasClone.removeAttribute('transform');
+
 
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-  svg.appendChild(clone);
   svg.setAttribute('viewBox', x + ' ' + y + ' ' + width + ' ' + height);
 
   svg.setAttribute(
@@ -100,7 +100,12 @@ function workspaceToSvg_(workspace, callback, customCss) {
     .join('\n');
   const style = document.createElement('style');
   style.innerHTML = css + '\n' + customCss;
-  svg.insertBefore(style, svg.firstChild);
+
+  svg.appendChild(style);
+  for (const defs of workspace.getSvgGroup().getElementsByTagName('defs')) {
+    svg.appendChild(defs.cloneNode(true));
+  }
+  svg.appendChild(blockCanvasClone);
 
   let svgAsXML = new XMLSerializer().serializeToString(svg);
   svgAsXML = svgAsXML.replace(/&nbsp/g, '&#160');


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes #2157

### Proposed Changes

All SVG defs elements inside the workspace SVG are copied to the screenshot SVG. These elements contain, among other things, the pattern definition referenced by disabled blocks.

### Reason for Changes

Previously disabled blocks had an invisible background in screenshots.

### Test Coverage

I manually tested the screenshot feature.

### Documentation

N/A

### Additional Information

N/A