### PR TITLE
fix: Display rounded number in field angle.

### DIFF
--- a/plugins/field-angle/src/field_angle.ts
+++ b/plugins/field-angle/src/field_angle.ts
@@ -484,7 +484,7 @@ export class FieldAngle extends Blockly.FieldNumber {
       // normal block change events, and instead report them as special
       // intermediate changes that do not get recorded in undo history.
       const oldValue = this.value_;
-      this.setEditorValue_(angle, false);
+      this.setEditorValue_(validAngle, false);
       if (
         this.sourceBlock_ &&
         Blockly.Events.isEnabled() &&


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes #2094

### Proposed Changes

Use the correctly rounded angle instead of the unrounded angle in the editor display.

### Reason for Changes

The unrounded angle numbers were being displayed accidentally (but this did not impact the actual value assigned to the field).

### Test Coverage

Tested manually.

### Documentation

N/A

### Additional Information

N/A