### PR TITLE
fix: dynamic blocks finalizing connections when children are deleted

### DIFF
--- a/plugins/block-dynamic-connection/README.md
+++ b/plugins/block-dynamic-connection/README.md
@@ -15,7 +15,7 @@ npm install @blockly/block-dynamic-connection --save
 import * as Blockly from 'blockly';
 import * as BlockDynamicConnection from '@blockly/block-dynamic-connection';
 
-const ws = Blockly.inject({
+const myWorkspace = Blockly.inject({
     // options...
     plugins: {
       connectionPreviewer:
@@ -26,6 +26,9 @@ const ws = Blockly.inject({
         ),
     },
   };
+
+// Add the change listener so connections will be finalized on deletion.
+workspace.addChangeListener(BlockDynamicConnection.finalizeConnections);
 ```
 
 ## API

--- a/plugins/block-dynamic-connection/src/connection_previewer.ts
+++ b/plugins/block-dynamic-connection/src/connection_previewer.ts
@@ -15,6 +15,10 @@ interface DynamicBlock extends Blockly.BlockSvg {
   finalizeConnections(): void;
 }
 
+/**
+ * A type guard that checks if the given block fulfills the DynamicBlock
+ * interface.
+ */
 export function blockIsDynamic(block: Blockly.BlockSvg): block is DynamicBlock {
   return (
     (block as DynamicBlock)['onPendingConnection'] !== undefined &&

--- a/plugins/block-dynamic-connection/src/connection_previewer.ts
+++ b/plugins/block-dynamic-connection/src/connection_previewer.ts
@@ -15,7 +15,7 @@ interface DynamicBlock extends Blockly.BlockSvg {
   finalizeConnections(): void;
 }
 
-function blockIsDynamic(block: Blockly.BlockSvg): block is DynamicBlock {
+export function blockIsDynamic(block: Blockly.BlockSvg): block is DynamicBlock {
   return (
     (block as DynamicBlock)['onPendingConnection'] !== undefined &&
     (block as DynamicBlock)['finalizeConnections'] !== undefined

--- a/plugins/block-dynamic-connection/src/index.ts
+++ b/plugins/block-dynamic-connection/src/index.ts
@@ -13,12 +13,28 @@ import * as Blockly from 'blockly/core';
 import './dynamic_if';
 import './dynamic_text_join';
 import './dynamic_list_create';
-import {decoratePreviewer} from './connection_previewer';
+import {decoratePreviewer, blockIsDynamic} from './connection_previewer';
 
-export {decoratePreviewer};
+export {decoratePreviewer, blockIsDynamic};
 
 export const overrideOldBlockDefinitions = function (): void {
   Blockly.Blocks['lists_create_with'] = Blockly.Blocks['dynamic_list_create'];
   Blockly.Blocks['text_join'] = Blockly.Blocks['dynamic_text_join'];
   Blockly.Blocks['controls_if'] = Blockly.Blocks['dynamic_if'];
 };
+
+/**
+ * Finalizes connections when certain events (such as block deletion) are
+ * detected.
+ */
+export function finalizeConnections(e: Blockly.Events.Abstract) {
+  if (e.type === Blockly.Events.BLOCK_DELETE) {
+    const ws = Blockly.Workspace.getById(e.workspaceId ?? '');
+    if (!ws) return;
+    for (const block of ws.getAllBlocks() as Blockly.BlockSvg[]) {
+      if (blockIsDynamic(block)) {
+        block.finalizeConnections();
+      }
+    }
+  }
+}

--- a/plugins/block-dynamic-connection/test/index.ts
+++ b/plugins/block-dynamic-connection/test/index.ts
@@ -23,7 +23,9 @@ function createWorkspace(
   blocklyDiv: HTMLElement,
   options: Blockly.BlocklyOptions,
 ): Blockly.WorkspaceSvg {
-  return Blockly.inject(blocklyDiv, options);
+  const ws = Blockly.inject(blocklyDiv, options);
+  ws.addChangeListener(BlockDynamicConnection.finalizeConnections);
+  return ws;
 }
 
 document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes + Reasons

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
While writing https://github.com/google/blockly-samples/pull/2190 I discovered that delete events were not removing connections on dynamic blocks.

Previously this bug was hidden in the playground because we were finalizing connections during serialization, which triggered on every event. So delete events /were/ kind of triggering finalization, in that they were triggering serialization which triggered finalization. But when I made it so that serialization only finalized events if the inputs weren't in escalating order, the bug was revealed

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Manually tested that deletion triggers connections to be finalized (assuming you've properly added the change listener).

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
