### PR TITLE
feat: add chameleon test block

### DIFF
--- a/plugins/block-test/src/chameleon.js
+++ b/plugins/block-test/src/chameleon.js
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+'use strict';
+
+/**
+ * @fileoverview Blocks that have both a previous connection and an output
+ *     connection while they are being dragged.
+ */
+
+import * as Blockly from 'blockly/core';
+
+Blockly.Blocks['test_chameleon'] = {
+  hasOutput: true,
+  hasPrevious: true,
+
+  init: function () {
+    this.appendDummyInput().appendField('chameleon');
+    this.setColour(120);
+    this.updateShape();
+  },
+
+  onchange: function (e) {
+    if (e.type === Blockly.Events.BLOCK_DRAG) {
+      console.log('got drag event');
+      this.hasPrevious =
+        !this.outputConnection || !this.outputConnection.targetBlock();
+      this.hasOutput = !this.getPreviousBlock();
+      this.updateShape();
+    }
+  },
+
+  updateShape: function () {
+    this.setPreviousStatement(this.hasPrevious);
+    this.setOutput(this.hasOutput);
+  },
+};
+
+/**
+ * The Chameleon Category.
+ */
+export const category = {
+  kind: 'CATEGORY',
+  name: 'Chameleon',
+  contents: [
+    {
+      kind: 'BLOCK',
+      type: 'test_chameleon',
+    },
+  ],
+};
+
+/**
+ * Initialize this toolbox category.
+ * @param {!Blockly.WorkspaceSvg} workspace The Blockly workspace.
+ */
+export function onInit(workspace) {
+  // NOP
+}

--- a/plugins/block-test/src/index.js
+++ b/plugins/block-test/src/index.js
@@ -15,6 +15,10 @@ import * as Blockly from 'blockly/core';
 import {category as alignCategory, onInit as initAlign} from './align';
 import {category as basicCategory, onInit as initBasic} from './basic';
 import {
+  category as chameleonCategory,
+  onInit as initChameleon,
+} from './chameleon';
+import {
   category as connectionsCategory,
   onInit as initConnections,
 } from './connections';
@@ -34,6 +38,7 @@ export const toolboxTestBlocks = {
   contents: [
     alignCategory,
     basicCategory,
+    chameleonCategory,
     connectionsCategory,
     dragCategory,
     fieldsCategory,
@@ -50,6 +55,7 @@ export const toolboxTestBlocks = {
 export function toolboxTestBlocksInit(workspace) {
   initAlign(workspace);
   initBasic(workspace);
+  initChameleon(workspace);
   initConnections(workspace);
   initDrag(workspace);
   initFields(workspace);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a chameleon test block to the block-test plugin. A chameleon block is a block that has an output and a previous connection when it is dragging, but only one or the other once it is dropped and connected to a parent block (so that we don't get cycles).

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
We support this behavior but didn't have any way to test it before.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
This is tests silly!

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
