### PR TITLE
feat: add javascript definition generators for blocks

### DIFF
--- a/examples/developer-tools/package-lock.json
+++ b/examples/developer-tools/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "blockly": "^10.3.0"
+        "blockly": "^10.4.2"
       },
       "devDependencies": {
         "@webpack-cli/generators": "^3.0.7",
@@ -2009,9 +2009,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.3.0.tgz",
-      "integrity": "sha512-+95241EVK5o80F3b/iDP61+LfwKwueqscRyh/JfGKPRA4Tlcg8nngu1DdMhOyVCy8Z58AyXuFJ+96+QlCFx5MQ==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.4.2.tgz",
+      "integrity": "sha512-oCJkHZD1HEPYPwnMk/sbmMmhW6UFe+3iH5yvDn3hy3HSVzCOunkw9H1Crb/MmlhhFdvjB5uWgGzQNAa2eWAV6A==",
       "dependencies": {
         "jsdom": "22.1.0"
       }
@@ -12222,9 +12222,9 @@
       }
     },
     "blockly": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.3.0.tgz",
-      "integrity": "sha512-+95241EVK5o80F3b/iDP61+LfwKwueqscRyh/JfGKPRA4Tlcg8nngu1DdMhOyVCy8Z58AyXuFJ+96+QlCFx5MQ==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.4.2.tgz",
+      "integrity": "sha512-oCJkHZD1HEPYPwnMk/sbmMmhW6UFe+3iH5yvDn3hy3HSVzCOunkw9H1Crb/MmlhhFdvjB5uWgGzQNAa2eWAV6A==",
       "requires": {
         "jsdom": "22.1.0"
       }

--- a/examples/developer-tools/package.json
+++ b/examples/developer-tools/package.json
@@ -38,6 +38,6 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
-    "blockly": "^10.3.0"
+    "blockly": "^10.4.2"
   }
 }

--- a/examples/developer-tools/src/blocks/input.ts
+++ b/examples/developer-tools/src/blocks/input.ts
@@ -106,7 +106,7 @@ export const input = {
     this.setNextStatement(true, 'Input');
     this.setStyle('input');
     this.setTooltip((): string => {
-      const value = this.getFieldValue('INPUT_TYPE');
+      const value = this.getFieldValue('INPUTTYPE');
       return tooltip[value];
     });
     this.setHelpUrl('https://www.youtube.com/watch?v=s2_xaEvcVI0#t=71');

--- a/examples/developer-tools/src/output-generators/colour.ts
+++ b/examples/developer-tools/src/output-generators/colour.ts
@@ -6,13 +6,18 @@
 
 import {
   JsonDefinitionGenerator,
-  Order,
+  Order as JsonOrder,
   jsonDefinitionGenerator,
 } from './json_definition_generator';
+import {
+  JavascriptDefinitionGenerator,
+  javascriptDefinitionGenerator,
+} from './javascript_definition_generator';
+import {Order as JsOrder} from 'blockly/javascript';
 import * as Blockly from 'blockly/core';
 
 /**
- * JSON definition for the "input" block.
+ * JSON definition for the "colour_hue" block.
  *
  * @param block
  * @param generator
@@ -25,5 +30,19 @@ jsonDefinitionGenerator.forBlock['colour_hue'] = function (
   block: Blockly.Block,
   generator: JsonDefinitionGenerator,
 ): [string, number] {
-  return [this.getFieldValue('HUE').toString(), Order.ATOMIC];
+  return [this.getFieldValue('HUE').toString(), JsonOrder.ATOMIC];
+};
+
+/**
+ * JavaScript definition for the "colour_hue" block.
+ *
+ * @param block
+ * @param generator
+ * @returns The value of the colour field, as a string.
+ */
+javascriptDefinitionGenerator.forBlock['colour_hue'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+): [string, number] {
+  return [this.getFieldValue('HUE').toString(), JsOrder.ATOMIC];
 };

--- a/examples/developer-tools/src/output-generators/connection_check.ts
+++ b/examples/developer-tools/src/output-generators/connection_check.ts
@@ -7,9 +7,39 @@
 import * as Blockly from 'blockly/core';
 import {
   JsonDefinitionGenerator,
-  Order,
+  Order as JsonOrder,
   jsonDefinitionGenerator,
 } from './json_definition_generator';
+import {
+  javascriptDefinitionGenerator,
+  JavascriptDefinitionGenerator,
+} from './javascript_definition_generator';
+import {Order as JsOrder} from 'blockly/javascript';
+
+/**
+ * Gets the selected check from the block.
+ *
+ * @param selected Dropdown option selected.
+ * @param block Connection check block.
+ * @returns A custom option the user has typed in, the selected dropdown option,
+ * or null if `any` or a blank custom option is chosen.
+ */
+function getSelectedCheck(
+  selected: string,
+  block: Blockly.Block,
+): string | null {
+  switch (selected) {
+    case 'null': {
+      return null;
+    }
+    case 'CUSTOM': {
+      return block.getFieldValue('CUSTOMCHECK') || null;
+    }
+    default: {
+      return selected;
+    }
+  }
+}
 
 /**
  * JSON definition for a single "connection_check" block.
@@ -24,26 +54,13 @@ jsonDefinitionGenerator.forBlock['connection_check'] = function (
   generator: JsonDefinitionGenerator,
 ): [string, number] {
   const selected = block.getFieldValue('CHECKDROPDOWN');
-  let output = '';
-  switch (selected) {
-    case 'null': {
-      output = null;
-      break;
-    }
-    case 'CUSTOM': {
-      output = block.getFieldValue('CUSTOMCHECK') || null;
-      break;
-    }
-    default: {
-      output = selected;
-    }
-  }
+  const output = getSelectedCheck(selected, block);
 
-  return [JSON.stringify(output), Order.ATOMIC];
+  return [JSON.stringify(output), JsonOrder.ATOMIC];
 };
 
 /**
- * JSON Definition for the "any of" check block.
+ * JSON definition for the "any of" check block.
  *
  * @param block
  * @param generator
@@ -58,24 +75,79 @@ jsonDefinitionGenerator.forBlock['connection_check_group'] = function (
 ): [string, number] {
   const checks = new Set<string>();
   for (const input of block.inputList) {
-    const value = generator.valueToCode(block, input.name, Order.ATOMIC);
+    const value = generator.valueToCode(block, input.name, JsonOrder.ATOMIC);
     if (!value) continue; // No block connected to this input
     const check = JSON.parse(value) || '';
     if (check === null) {
       // If the list contains 'any' then the check is simplified to 'any'
-      return [JSON.stringify(null), Order.ATOMIC];
+      return [JSON.stringify(null), JsonOrder.ATOMIC];
     }
     if (check) checks.add(check);
   }
 
   if (checks.size === 0) {
     // No checks were connected to the block.
-    return [JSON.stringify(null), Order.ATOMIC];
+    return [JSON.stringify(null), JsonOrder.ATOMIC];
   }
   if (checks.size === 1) {
     // If there's only one check, we return it directly instead of
     // returning an array with one member.
-    return [JSON.stringify(Array.from(checks)[0]), Order.ATOMIC];
+    return [JSON.stringify(Array.from(checks)[0]), JsonOrder.ATOMIC];
   }
-  return [JSON.stringify(Array.from(checks)), Order.ATOMIC];
+  return [JSON.stringify(Array.from(checks)), JsonOrder.ATOMIC];
+};
+
+/**
+ * JavaScript definition for a single "connection_check" block.
+ *
+ * @param block
+ * @param generator
+ * @returns A connection check string corresponding to the option chosen.
+ *    If custom option is chosen and not specified, returns null.
+ */
+javascriptDefinitionGenerator.forBlock['connection_check'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+): [string, number] {
+  const selected = block.getFieldValue('CHECKDROPDOWN');
+  const output = getSelectedCheck(selected, block);
+
+  return [output ? generator.quote_(output) : 'null', JsOrder.ATOMIC];
+};
+
+/**
+ * JavaScript definition for the "any of" check block.
+ *
+ * @param block
+ * @param generator
+ * @returns one of:
+ *     - null if the list is empty or contains the "any" check
+ *     - a single check string if that is the only check present in the list
+ *     - an array of all checks in the list, deduplicated
+ */
+javascriptDefinitionGenerator.forBlock['connection_check_group'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+): [string, number] {
+  const checks = new Set<string>();
+  for (const input of block.inputList) {
+    const value = generator.valueToCode(block, input.name, JsOrder.ATOMIC);
+    if (!value) continue; // No block connected to this input
+    if (value === 'null') {
+      // If the list contains 'any' then the check is simplified to 'any'
+      return ['null', JsOrder.ATOMIC];
+    }
+    if (value) checks.add(value);
+  }
+
+  if (checks.size === 0) {
+    // No checks were connected to the block.
+    return ['null', JsOrder.ATOMIC];
+  }
+  if (checks.size === 1) {
+    // If there's only one check, we return it directly instead of
+    // returning an array with one member.
+    return [Array.from(checks)[0], JsOrder.ATOMIC];
+  }
+  return [`[${Array.from(checks).join(', ')}]`, JsOrder.ATOMIC];
 };

--- a/examples/developer-tools/src/output-generators/connection_check.ts
+++ b/examples/developer-tools/src/output-generators/connection_check.ts
@@ -29,15 +29,12 @@ function getSelectedCheck(
   block: Blockly.Block,
 ): string | null {
   switch (selected) {
-    case 'null': {
+    case 'null':
       return null;
-    }
-    case 'CUSTOM': {
+    case 'CUSTOM':
       return block.getFieldValue('CUSTOMCHECK') || null;
-    }
-    default: {
+    default:
       return selected;
-    }
   }
 }
 

--- a/examples/developer-tools/src/output-generators/factory_base.ts
+++ b/examples/developer-tools/src/output-generators/factory_base.ts
@@ -5,10 +5,7 @@
  */
 
 import * as Blockly from 'blockly/core';
-import {
-  javascriptGenerator,
-  Order as JsOrder,
-} from 'blockly/javascript';
+import {javascriptGenerator, Order as JsOrder} from 'blockly/javascript';
 import {
   JsonDefinitionGenerator,
   jsonDefinitionGenerator,

--- a/examples/developer-tools/src/output-generators/factory_base.ts
+++ b/examples/developer-tools/src/output-generators/factory_base.ts
@@ -5,12 +5,19 @@
  */
 
 import * as Blockly from 'blockly/core';
-import {javascriptGenerator} from 'blockly/javascript';
+import {
+  javascriptGenerator,
+  Order as JsOrder,
+} from 'blockly/javascript';
 import {
   JsonDefinitionGenerator,
   jsonDefinitionGenerator,
-  Order,
+  Order as JsonOrder,
 } from './json_definition_generator';
+import {
+  JavascriptDefinitionGenerator,
+  javascriptDefinitionGenerator,
+} from './javascript_definition_generator';
 
 /**
  * Builds the 'message0' part of the JSON block definition.
@@ -53,10 +60,10 @@ jsonDefinitionGenerator.forBlock['factory_base'] = function (
   const blockName = block.getFieldValue('NAME');
   // Tooltip and Helpurl string blocks can't be removed, so we don't care what happens if the block doesn't exist
   const tooltip = JSON.parse(
-    generator.valueToCode(block, 'TOOLTIP', Order.ATOMIC),
+    generator.valueToCode(block, 'TOOLTIP', JsonOrder.ATOMIC),
   );
   const helpUrl = JSON.parse(
-    generator.valueToCode(block, 'HELPURL', Order.ATOMIC),
+    generator.valueToCode(block, 'HELPURL', JsonOrder.ATOMIC),
   );
 
   const code: {[key: string]: unknown} = {
@@ -89,8 +96,8 @@ jsonDefinitionGenerator.forBlock['factory_base'] = function (
    */
   const setConnectionChecks = (inputName: string, connectionName: string) => {
     if (this.getInput(inputName)) {
-      // If there is no set type, we still need to add 'null` to the check
-      const output = generator.valueToCode(block, inputName, Order.ATOMIC);
+      // If there is no set type, we still need to add 'null' to the check
+      const output = generator.valueToCode(block, inputName, JsonOrder.ATOMIC);
       code[connectionName] = output ? JSON.parse(output) : null;
     }
   };
@@ -99,7 +106,7 @@ jsonDefinitionGenerator.forBlock['factory_base'] = function (
   setConnectionChecks('TOPCHECK', 'previousStatement');
   setConnectionChecks('BOTTOMCHECK', 'nextStatement');
 
-  const colour = generator.valueToCode(block, 'COLOUR', Order.ATOMIC);
+  const colour = generator.valueToCode(block, 'COLOUR', JsonOrder.ATOMIC);
   if (colour !== '') {
     code.colour = JSON.parse(colour);
   }
@@ -123,3 +130,75 @@ jsonDefinitionGenerator.forBlock['factory_base'] = function (
 };
 
 jsonDefinitionGenerator.forBlock['text'] = javascriptGenerator.forBlock['text'];
+
+javascriptDefinitionGenerator.forBlock['factory_base'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+) {
+  // TODO: Get a JavaScript-legal name for the block
+  const blockName = block.getFieldValue('NAME');
+  const inputsValue = generator.statementToCode(block, 'INPUTS');
+  const inputs = inputsValue
+    ? generator.prefixLines(inputsValue, generator.INDENT) + '\n'
+    : '';
+
+  const alignInputsValue = block.getFieldValue('INLINE');
+  let alignInputs = '';
+  if (alignInputsValue === 'EXT') {
+    alignInputs = 'this.setInputsInline(false)';
+  } else if (alignInputsValue === 'INT') {
+    alignInputs = 'this.setInputsInline(true)';
+  }
+
+  const createConnectionChecks = function (
+    inputName: string,
+    connectionName: string,
+  ): string {
+    if (block.getInput(inputName)) {
+      const check = generator.valueToCode(
+        block,
+        inputName,
+        JsOrder.FUNCTION_CALL,
+      );
+      return `this.set${connectionName}(true, ${check});`;
+    }
+    return '';
+  };
+  const connectionsList = [];
+  connectionsList.push(createConnectionChecks('OUTPUTCHECK', 'Output'));
+  connectionsList.push(createConnectionChecks('TOPCHECK', 'PreviousStatement'));
+  connectionsList.push(createConnectionChecks('BOTTOMCHECK', 'NextStatement'));
+  const connections = connectionsList
+    .filter((value) => value !== '')
+    .join('\n');
+
+  const tooltip = `this.setTooltip(${
+    generator.valueToCode(block, 'TOOLTIP', JsOrder.ATOMIC) || "''"
+  });`;
+  const helpUrl = `this.setHelpUrl(${
+    generator.valueToCode(block, 'HELPURL', JsOrder.ATOMIC) || "''"
+  });`;
+
+  const colourValue = generator.valueToCode(block, 'COLOUR', JsOrder.ATOMIC);
+  const colour = colourValue !== '' ? `this.setColour(${colourValue});` : '';
+
+  // Filter out empty code string pieces, join them all with newlines, and indent them twice.
+  // Inputs code is already indented once automatically by the generator
+  // since it's in a statement input, so it's not included here.
+  const codeStringPieces = generator.prefixLines(
+    [alignInputs, connections, tooltip, helpUrl, colour]
+      .filter((value) => value !== '')
+      .join('\n'),
+    generator.INDENT + generator.INDENT,
+  );
+  const code = `const ${blockName} = {
+  init: function() {
+${inputs}${codeStringPieces}
+  }
+};
+Blockly.common.defineBlocks({${blockName}: ${blockName}});`;
+  return code;
+};
+
+javascriptDefinitionGenerator.forBlock['text'] =
+  javascriptGenerator.forBlock['text'];

--- a/examples/developer-tools/src/output-generators/fields/checkbox.ts
+++ b/examples/developer-tools/src/output-generators/fields/checkbox.ts
@@ -9,6 +9,10 @@ import {
   JsonDefinitionGenerator,
   jsonDefinitionGenerator,
 } from '../json_definition_generator';
+import {
+  JavascriptDefinitionGenerator,
+  javascriptDefinitionGenerator,
+} from '../javascript_definition_generator';
 
 jsonDefinitionGenerator.forBlock['field_checkbox'] = function (
   block: Blockly.Block,
@@ -20,4 +24,13 @@ jsonDefinitionGenerator.forBlock['field_checkbox'] = function (
     checked: block.getFieldValue('CHECKED'),
   };
   return JSON.stringify(code);
+};
+
+javascriptDefinitionGenerator.forBlock['field_checkbox'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+): string {
+  const name = generator.quote_(block.getFieldValue('FIELDNAME'));
+  const checked = generator.quote_(block.getFieldValue('CHECKED'));
+  return `.appendField(new Blockly.FieldCheckbox(${checked}), ${name})`;
 };

--- a/examples/developer-tools/src/output-generators/fields/dropdown.ts
+++ b/examples/developer-tools/src/output-generators/fields/dropdown.ts
@@ -60,13 +60,41 @@ javascriptDefinitionGenerator.forBlock['field_dropdown'] = function (
     return '';
   }
 
-  let optionsCode = '';
+  const formatImgOption = function (option: DropdownOptionData) {
+    if (typeof option === 'string') return;
+    const optionString = generator.prefixLines(
+      `src: ${generator.quote_(option.src)},
+height: ${generator.quote_(option.height.toString())},
+width: ${generator.quote_(option.width.toString())},
+alt: ${generator.quote_(option.alt)},`,
+      generator.INDENT,
+    );
+    return `{
+${optionString}
+}`;
+  };
+
+  let optionsCode = [];
   for (const option of options) {
-    optionsCode += `[${generator.quote_(option[0])}, ${generator.quote_(
-      option[1],
-    )}], `;
+    if (typeof option[0] === 'string') {
+      // text option
+      optionsCode.push(
+        `[${generator.quote_(option[0])}, ${generator.quote_(option[1])}]`,
+      );
+    } else {
+      // image option
+      optionsCode.push(
+        `[${formatImgOption(option[0])}, ${generator.quote_(option[1])}]`,
+      );
+    }
   }
 
-  const code = `.appendField(new Blockly.FieldDropdown([${optionsCode}]), ${name})`;
+  const optionsString = generator.prefixLines(
+    optionsCode.join(',\n'),
+    generator.INDENT + generator.INDENT,
+  );
+  const code = `.appendField(new Blockly.FieldDropdown([
+${optionsString}
+${generator.INDENT}]), ${name})`;
   return code;
 };

--- a/examples/developer-tools/src/output-generators/fields/dropdown.ts
+++ b/examples/developer-tools/src/output-generators/fields/dropdown.ts
@@ -74,7 +74,7 @@ ${optionString}
 }`;
   };
 
-  let optionsCode = [];
+  const optionsCode = [];
   for (const option of options) {
     if (typeof option[0] === 'string') {
       // text option

--- a/examples/developer-tools/src/output-generators/fields/image.ts
+++ b/examples/developer-tools/src/output-generators/fields/image.ts
@@ -9,6 +9,10 @@ import {
   JsonDefinitionGenerator,
   jsonDefinitionGenerator,
 } from '../json_definition_generator';
+import {
+  JavascriptDefinitionGenerator,
+  javascriptDefinitionGenerator,
+} from '../javascript_definition_generator';
 
 jsonDefinitionGenerator.forBlock['field_image'] = function (
   block: Blockly.Block,
@@ -23,4 +27,18 @@ jsonDefinitionGenerator.forBlock['field_image'] = function (
     flipRtl: block.getFieldValue('FLIP_RTL'),
   };
   return JSON.stringify(code);
+};
+
+javascriptDefinitionGenerator.forBlock['field_image'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+) {
+  const src = generator.quote_(block.getFieldValue('SRC'));
+  const width = block.getFieldValue('WIDTH');
+  const height = block.getFieldValue('HEIGHT');
+  const alt = generator.quote_(block.getFieldValue('ALT'));
+  const flipRtl = generator.quote_(block.getFieldValue('FLIP_RTL'));
+
+  const code = `.appendField(new Blockly.FieldImage(${src}, ${width}, ${height}, { alt: ${alt}, flipRtl: ${flipRtl}}))`;
+  return code;
 };

--- a/examples/developer-tools/src/output-generators/fields/label.ts
+++ b/examples/developer-tools/src/output-generators/fields/label.ts
@@ -9,6 +9,10 @@ import {
   JsonDefinitionGenerator,
   jsonDefinitionGenerator,
 } from '../json_definition_generator';
+import {
+  JavascriptDefinitionGenerator,
+  javascriptDefinitionGenerator,
+} from '../javascript_definition_generator';
 
 jsonDefinitionGenerator.forBlock['field_label'] = function (
   block: Blockly.Block,
@@ -19,4 +23,13 @@ jsonDefinitionGenerator.forBlock['field_label'] = function (
     text: block.getFieldValue('TEXT'),
   };
   return JSON.stringify(code);
+};
+
+javascriptDefinitionGenerator.forBlock['field_label'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+): string {
+  const text = generator.quote_(block.getFieldValue('TEXT'));
+  const code = `.appendField(${text})`;
+  return code;
 };

--- a/examples/developer-tools/src/output-generators/fields/label_serializable.ts
+++ b/examples/developer-tools/src/output-generators/fields/label_serializable.ts
@@ -9,6 +9,10 @@ import {
   JsonDefinitionGenerator,
   jsonDefinitionGenerator,
 } from '../json_definition_generator';
+import {
+  JavascriptDefinitionGenerator,
+  javascriptDefinitionGenerator,
+} from '../javascript_definition_generator';
 
 jsonDefinitionGenerator.forBlock['field_label_serializable'] = function (
   block: Blockly.Block,
@@ -20,4 +24,15 @@ jsonDefinitionGenerator.forBlock['field_label_serializable'] = function (
     name: block.getFieldValue('FIELDNAME'),
   };
   return JSON.stringify(code);
+};
+
+javascriptDefinitionGenerator.forBlock['field_label_serializable'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+): string {
+  const name = generator.quote_(block.getFieldValue('FIELDNAME'));
+  const text = generator.quote_(block.getFieldValue('TEXT'));
+
+  const code = `.appendField(new Blockly.FieldLabelSerializable(${text}), ${name})`;
+  return code;
 };

--- a/examples/developer-tools/src/output-generators/fields/number.ts
+++ b/examples/developer-tools/src/output-generators/fields/number.ts
@@ -9,6 +9,10 @@ import {
   JsonDefinitionGenerator,
   jsonDefinitionGenerator,
 } from '../json_definition_generator';
+import {
+  JavascriptDefinitionGenerator,
+  javascriptDefinitionGenerator,
+} from '../javascript_definition_generator';
 
 jsonDefinitionGenerator.forBlock['field_number'] = function (
   block: Blockly.Block,
@@ -26,4 +30,31 @@ jsonDefinitionGenerator.forBlock['field_number'] = function (
   if (max !== Infinity) code.max = max;
   if (precision !== 0) code.precision = precision;
   return JSON.stringify(code);
+};
+
+javascriptDefinitionGenerator.forBlock['field_number'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+): string {
+  const name = generator.quote_(block.getFieldValue('FIELDNAME'));
+  const value = block.getFieldValue('VALUE');
+  const min = block.getFieldValue('MIN');
+  const max = block.getFieldValue('MAX');
+  const precision = block.getFieldValue('PRECISION');
+  const args = [value, min, max, precision];
+
+  // Remove trailing useless arguments if needed
+  if (precision === 0) {
+    args.pop();
+    if (max === Infinity) {
+      args.pop();
+      if (min === -Infinity) {
+        args.pop();
+      }
+    }
+  }
+  const argsString = args.join(', ');
+
+  const code = `.appendField(new Blockly.FieldNumber(${argsString}), ${name})`;
+  return code;
 };

--- a/examples/developer-tools/src/output-generators/fields/text_input.ts
+++ b/examples/developer-tools/src/output-generators/fields/text_input.ts
@@ -9,6 +9,10 @@ import {
   JsonDefinitionGenerator,
   jsonDefinitionGenerator,
 } from '../json_definition_generator';
+import {
+  JavascriptDefinitionGenerator,
+  javascriptDefinitionGenerator,
+} from '../javascript_definition_generator';
 
 jsonDefinitionGenerator.forBlock['field_input'] = function (
   block: Blockly.Block,
@@ -20,4 +24,15 @@ jsonDefinitionGenerator.forBlock['field_input'] = function (
     text: block.getFieldValue('TEXT'),
   };
   return JSON.stringify(code);
+};
+
+javascriptDefinitionGenerator.forBlock['field_input'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+): string {
+  const name = generator.quote_(block.getFieldValue('FIELDNAME'));
+  const text = generator.quote_(block.getFieldValue('TEXT'));
+
+  const code = `.appendField(new Blockly.FieldTextInput(${text}), ${name})`;
+  return code;
 };

--- a/examples/developer-tools/src/output-generators/fields/variable.ts
+++ b/examples/developer-tools/src/output-generators/fields/variable.ts
@@ -9,6 +9,10 @@ import {
   JsonDefinitionGenerator,
   jsonDefinitionGenerator,
 } from '../json_definition_generator';
+import {
+  JavascriptDefinitionGenerator,
+  javascriptDefinitionGenerator,
+} from '../javascript_definition_generator';
 
 jsonDefinitionGenerator.forBlock['field_variable'] = function (
   block: Blockly.Block,
@@ -20,4 +24,15 @@ jsonDefinitionGenerator.forBlock['field_variable'] = function (
     variable: block.getFieldValue('TEXT'),
   };
   return JSON.stringify(code);
+};
+
+javascriptDefinitionGenerator.forBlock['field_variable'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+): string {
+  const name = generator.quote_(block.getFieldValue('FIELDNAME'));
+  const variable = generator.quote_(block.getFieldValue('TEXT'));
+
+  const code = `.appendField(new Blockly.FieldVariable(${variable}), ${name})`;
+  return code;
 };

--- a/examples/developer-tools/src/output-generators/javascript_definition_generator.ts
+++ b/examples/developer-tools/src/output-generators/javascript_definition_generator.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly';
+import {JavascriptGenerator} from 'blockly/javascript';
+
+export class JavascriptDefinitionGenerator extends JavascriptGenerator {
+  /**
+   * Scrub handles concatenating "next" connection blocks.
+   * This is a copy of the regular scrub_ function for JS, but
+   * we also add newlines between next blocks.
+   *
+   * @override
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  scrub_(block: Blockly.Block, code: string, thisOnly = false): string {
+    let commentCode = '';
+    // Only collect comments for blocks that aren't inline.
+    if (!block.outputConnection || !block.outputConnection.targetConnection) {
+      // Collect comment for this block.
+      let comment = block.getCommentText();
+      if (comment) {
+        comment = Blockly.utils.string.wrap(comment, this.COMMENT_WRAP - 3);
+        commentCode += this.prefixLines(comment + '\n', '// ');
+      }
+      // Collect comments for all value arguments.
+      // Don't collect comments for nested statements.
+      for (let i = 0; i < block.inputList.length; i++) {
+        if (block.inputList[i].type === Blockly.inputs.inputTypes.VALUE) {
+          const childBlock = block.inputList[i].connection.targetBlock();
+          if (childBlock) {
+            comment = this.allNestedComments(childBlock);
+            if (comment) {
+              commentCode += this.prefixLines(comment, '// ');
+            }
+          }
+        }
+      }
+    }
+    const nextBlock =
+      block.nextConnection && block.nextConnection.targetBlock();
+    const nextCode = thisOnly ? '' : this.blockToCode(nextBlock);
+    const newLine = nextCode ? '\n' : '';
+    return commentCode + code + newLine + nextCode;
+  }
+}
+
+export const javascriptDefinitionGenerator =
+  new JavascriptDefinitionGenerator();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details

### Proposed Changes

- Adds JavaScript block definition code generators for block factory blocks
Here's an example of the code generated:


```
const block_type = {
  init: function() {
    // test comment
    this.appendEndRowInput('NAME')
      .appendField('neiou')
      .appendField(new Blockly.FieldLabelSerializable('hi'), 'NAME')
      .appendField(new Blockly.FieldTextInput('default'), 'NAME')
      .appendField(new Blockly.FieldNumber(0), 'NAME');
    this.appendEndRowInput('NAME')
      // dropdown comment
      .appendField(new Blockly.FieldDropdown([['option', 'OPTIONNAME'], ['option', 'OPTIONNAME'], ['option', 'OPTIONNAME'], ]), 'NAME')
      .appendField(new Blockly.FieldCheckbox('TRUE'), 'NAME')
      .appendField(new Blockly.FieldVariable('item'), 'NAME');
    this.setPreviousStatement(true, ['Boolean', 'String']);
    this.setNextStatement(true, null);
    this.setTooltip('tooltip text');
    this.setHelpUrl('');
    this.setColour(160);
  }
};
Blockly.common.defineBlocks({block_type: block_type});
```

### Reason for Changes

Works on block factory.

### Test Coverage

Manual testing for now, I'll add generator tests in a follow up PR because there is currently no test infrastructure for running tests in `examples/`

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

- This code relies on an upcoming change in Blockly 10.4, so for now I've been using a locally linked build of blockly. CI doesn't test that examples run so this doesn't affect automated tests. I'll update the code to point at 10.4 when it's released.
- Right now there is no way to switch the block factory to show you the generated js code. That will be coming soon :)
