### PR TITLE
chore: update codelab to say context menus accept html

### DIFF
--- a/codelabs/context_menu_option/context_menu_option.md
+++ b/codelabs/context_menu_option/context_menu_option.md
@@ -67,7 +67,7 @@ Each menu option in the registry has several properties:
 
 - `callback`: A function called when the menu option is clicked.
 - `scopeType`: An enum indicating when this option should be shown.
-- `displayText`: The text to show in the menu. Either a string or a function that returns a string.
+- `displayText`: The text to show in the menu. Either a string, or HTML, or a function that returns either of the former.
 - `preconditionFn`: Function that returns one of `'enabled'`, `'disabled'`, or `'hidden'` to determine whether and how the menu option should be rendered.
 - `weight`: A number that determines the sort order of the option. Options with higher weights appear later in the context menu.
 - `id`: A unique string id for the option.
@@ -282,7 +282,7 @@ callback: function(scope) {
 
 ## Display text
 
-So far the `displayText` has always been a simple string, but it can also be a function that returns a string. This can be useful when you want a context-dependent message.
+So far the `displayText` has always been a simple string, but it can also be HTML, or a function that returns either of the former. Using a function can be useful when you want a context-dependent message.
 
 When defined as a function `displayText` accepts a `scope` argument, just like `callback` and `preconditionFn`.
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Updates the context menu codelab to specify that context menu options can be or return HTML. 

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
App Inventor has bugged me about the docs being out of date twice now so I'm fixing it.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
N/A

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
This is docs silly!

### Additional Information

<!-- Anything else we should know? -->
N/A
