### PR TITLE
fix: updated field multiline to have enough width

### DIFF
--- a/plugins/field-multilineinput/src/field_multilineinput.ts
+++ b/plugins/field-multilineinput/src/field_multilineinput.ts
@@ -362,7 +362,10 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
     }
     if (this.borderRect_) {
       totalHeight += constants.FIELD_BORDER_RECT_Y_PADDING * 2;
-      totalWidth += constants.FIELD_BORDER_RECT_X_PADDING * 2;
+      // NOTE: Adding 1 extra px to prevent wrapping. Based on browser zoom,
+      // the rounding of the calculated value can result in the line wrapping
+      // unintentionally.
+      totalWidth += (constants.FIELD_BORDER_RECT_X_PADDING + 1) * 2;
       this.borderRect_.setAttribute('width', `${totalWidth}`);
       this.borderRect_.setAttribute('height', `${totalHeight}`);
     }

--- a/plugins/field-multilineinput/src/field_multilineinput.ts
+++ b/plugins/field-multilineinput/src/field_multilineinput.ts
@@ -365,7 +365,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
       // NOTE: Adding 1 extra px to prevent wrapping. Based on browser zoom,
       // the rounding of the calculated value can result in the line wrapping
       // unintentionally.
-      totalWidth += (constants.FIELD_BORDER_RECT_X_PADDING + 1) * 2;
+      totalWidth += constants.FIELD_BORDER_RECT_X_PADDING * 2 + 1;
       this.borderRect_.setAttribute('width', `${totalWidth}`);
       this.borderRect_.setAttribute('height', `${totalHeight}`);
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly-samples/issues/2095

### Proposed Changes

Updated the width to have 1px extra on each side.

### Reason for Changes

From what I can tell, this issue is created by rounding in the browser in different contexts. With Zoom = 100%, this worked as intended for me before the fix. Zooming in, though, I noticed the calculated component ended up as `?.06` and the text area ended up as `?.05`. Essentially, there's *barely* not enough space for the content, so it wraps to the next line. (See screenshots below.)

### Test Coverage

No unit tests needed, though here's what I manually tested:
- Various zoom levels (from <100% to >100%)
- Various string lengths
   - **Note:** See my comment in **Additional Information**.

**Before at 125% zoom:** (Note: the last character wraps to a new line)
![Screenshot 2024-02-16 6 50 47 PM](https://github.com/google/blockly-samples/assets/49404493/7df1a793-180a-419a-b0af-361f54216329)

**After at 125% zoom:**
![Screenshot 2024-02-16 7 05 17 PM](https://github.com/google/blockly-samples/assets/49404493/63b42782-4d04-4986-bbcf-4a5c14864e6d)

### Documentation

N/A

### Additional Information

**What's the expected behavior when the text is long enough to produce an ellipsis?** It seems like it wrapping to a new line when the text is too wide in this context might be expected.

**Long text with "...":**
![5G9LHa25gupstxd](https://github.com/google/blockly-samples/assets/49404493/f22ae9c7-2e02-4ce1-96b5-2185ec97b2b5)

**Corresponding long input text wrapping:**
![AH3zxgiiWrkyNSK](https://github.com/google/blockly-samples/assets/49404493/5519cc51-51c8-4e61-ae58-788c49a106ba)


