### PR TITLE
feat!: Add registration function to field_angle and make it no longer install on file load

### DIFF
--- a/plugins/field-angle/README.md
+++ b/plugins/field-angle/README.md
@@ -18,6 +18,14 @@ npm install @blockly/field-angle --save
 
 ## Usage
 
+### Installation
+
+You must register this field with Blockly. You can do this by calling
+`registerFieldAngle` before instantiating your blocks. If another field is
+registered under the same name, this field will overwrite it.
+
+### Parameters
+
 This field accepts up to 9 parameters, in addition to the 4 accepted by the
 [number field][number-field]:
 
@@ -60,7 +68,9 @@ This field accepts up to 9 parameters, in addition to the 4 accepted by the
 
 ```js
 import * as Blockly from 'blockly';
-import {FieldAngle} from '@blockly/field-angle';
+import {registerFieldAngle} from '@blockly/field-angle';
+
+registerFieldAngle();
 Blockly.Blocks['test_field_angle'] = {
   init: function () {
     this.appendDummyInput()
@@ -74,7 +84,9 @@ Blockly.Blocks['test_field_angle'] = {
 
 ```js
 import * as Blockly from 'blockly';
-import '@blockly/field-angle';
+import {registerFieldAngle} from '@blockly/field-angle';
+
+registerFieldAngle();
 Blockly.defineBlocksWithJsonArray([
   {
     type: 'test_field_angle',

--- a/plugins/field-angle/src/field_angle.ts
+++ b/plugins/field-angle/src/field_angle.ts
@@ -658,9 +658,7 @@ export class FieldAngle extends Blockly.FieldNumber {
   }
 }
 
-/**
- * Register the field and any dependencies.
- */
+/** Register the field and any dependencies. */
 export function registerFieldAngle() {
   // Unregister legacy field_angle that was in core.
   // TODO(#2194): Delete this once core Blockly no longer defines field_angle.

--- a/plugins/field-angle/src/field_angle.ts
+++ b/plugins/field-angle/src/field_angle.ts
@@ -658,12 +658,17 @@ export class FieldAngle extends Blockly.FieldNumber {
   }
 }
 
-// Unregister legacy field_angle that was in core.  Delete this once
-// core Blockly no longer defines field_angle.
-// If field_angle is not defined in core, this generates a console warning.
-Blockly.fieldRegistry.unregister('field_angle');
+/**
+ * Register the field and any dependencies.
+ */
+export function registerFieldAngle() {
+  // Unregister legacy field_angle that was in core.
+  // TODO(#2194): Delete this once core Blockly no longer defines field_angle.
+  // If field_angle is not defined in core, this generates a console warning.
+  Blockly.fieldRegistry.unregister('field_angle');
 
-Blockly.fieldRegistry.register('field_angle', FieldAngle);
+  Blockly.fieldRegistry.register('field_angle', FieldAngle);
+}
 
 FieldAngle.prototype.DEFAULT_VALUE = 0;
 

--- a/plugins/field-angle/test/field_angle_test.mocha.js
+++ b/plugins/field-angle/test/field_angle_test.mocha.js
@@ -5,7 +5,7 @@
  */
 
 const {testHelpers} = require('@blockly/dev-tools');
-const {FieldAngle} = require('../src/index');
+const {FieldAngle, registerFieldAngle} = require('../src/index');
 const {assert} = require('chai');
 
 const {
@@ -18,6 +18,10 @@ const {
 } = testHelpers;
 
 suite('FieldAngle', function () {
+  setup(function () {
+    registerFieldAngle();
+  });
+
   /**
    * Configuration for field tests with invalid values.
    * @type {Array<FieldCreationTestCase>}

--- a/plugins/field-angle/test/index.ts
+++ b/plugins/field-angle/test/index.ts
@@ -10,7 +10,7 @@
 
 import * as Blockly from 'blockly';
 import {generateFieldTestBlocks, createPlayground} from '@blockly/dev-tools';
-import '../src/index';
+import {registerFieldAngle} from '../src/index';
 
 const toolbox = generateFieldTestBlocks('field_angle', [
   {
@@ -81,6 +81,7 @@ function createWorkspace(
 }
 
 document.addEventListener('DOMContentLoaded', function () {
+  registerFieldAngle();
   const defaultOptions: Blockly.BlocklyOptions = {
     toolbox,
   };


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly-samples/issues/2153

### Proposed Changes

- Update the angle field plugin to no longer install on file load.
- Instead, export a `registerFieldAngle` function.
- Update tests to guarantee that the correct field is being tested.
- Update usage section in README.
- 
BREAKING CHANGE: The angle field no longer registers itself on load. The developer must manually register the field. This is part of a move to have no side effects in field and block definitions, so that tree-shaking can remove unwanted fields and blocks.


### Reason for Changes

Match the behaviour of the colour and multiline text field plugins.
There are no blocks in the core library that use this field, so no blocks need to be ported. A useful follow-up would be to add the angle blocks that are used in Blockly Games.

### Test Coverage

Tested in the playground and in tests.
Confirmed that registration is actually happening by verifying failures if `registerFieldAngle` unregisters the old field but doesn't reregister the new field.

### Documentation

README updated in this PR.
