### PR TITLE
fix: Include padding above category labels when jumping to a category.

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousFlyout.js
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.js
@@ -89,7 +89,9 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
       if (button.isLabel()) {
         const position = button.getPosition();
         const adjustedPosition = new Blockly.utils.Coordinate(
-          position.x, position.y - this.labelGaps[index]);
+          position.x,
+          position.y - this.labelGaps[index],
+        );
         this.scrollPositions.push({
           name: button.getButtonText(),
           position: adjustedPosition,
@@ -290,12 +292,12 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
   setRecyclingEnabled(isEnabled) {
     this.recyclingEnabled_ = isEnabled;
   }
-  
+
   /**
    * Lay out the blocks in the flyout.
    * @param {Array<Blockly.Flyout.FlyoutItem>} contents The blocks and buttons to lay out.
    * @param {Array<number>} gaps The visible gaps between blocks.
-   */  
+   */
   layout_(contents, gaps) {
     super.layout_(contents, gaps);
     this.labelGaps = [];

--- a/plugins/continuous-toolbox/src/ContinuousFlyout.js
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.js
@@ -291,6 +291,11 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
     this.recyclingEnabled_ = isEnabled;
   }
   
+  /**
+   * Lay out the blocks in the flyout.
+   * @param {Array<Blockly.Flyout.FlyoutItem>} contents The blocks and buttons to lay out.
+   * @param {Array<number>} gaps The visible gaps between blocks.
+   */  
   layout_(contents, gaps) {
     super.layout_(contents, gaps);
     this.labelGaps = [];

--- a/plugins/continuous-toolbox/src/ContinuousFlyout.js
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.js
@@ -85,11 +85,14 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
         button.isLabel() &&
         this.getParentToolbox_().getCategoryByName(button.getButtonText()),
     );
-    for (const button of categoryLabels) {
+    for (const [index, button] of categoryLabels.entries()) {
       if (button.isLabel()) {
+        const position = button.getPosition();
+        const adjustedPosition = new Blockly.utils.Coordinate(
+          position.x, position.y - this.labelGaps[index]);
         this.scrollPositions.push({
           name: button.getButtonText(),
-          position: button.getPosition(),
+          position: adjustedPosition,
         });
       }
     }
@@ -120,7 +123,7 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
   selectCategoryByScrollPosition_(position) {
     // If we are currently auto-scrolling, due to selecting a category by
     // clicking on it, do not update the category selection.
-    if (this.scrollTarget) {
+    if (this.scrollTarget !== null) {
       return;
     }
     const scaledPosition = Math.round(position / this.workspace_.scale);
@@ -137,7 +140,7 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
 
   /**
    * Scrolls flyout to given position.
-   * @param {number} position The x coordinate to scroll to.
+   * @param {number} position The Y coordinate to scroll to.
    */
   scrollTo(position) {
     // Set the scroll target to either the scaled position or the lowest
@@ -157,7 +160,7 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
    * @private
    */
   stepScrollAnimation_() {
-    if (!this.scrollTarget) {
+    if (this.scrollTarget === null) {
       return;
     }
 
@@ -219,6 +222,7 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
     super.show(flyoutDef);
     this.recordScrollPositions();
     this.workspace_.resizeContents();
+    this.selectCategoryByScrollPosition_(0);
   }
 
   /**
@@ -285,5 +289,15 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
    */
   setRecyclingEnabled(isEnabled) {
     this.recyclingEnabled_ = isEnabled;
+  }
+  
+  layout_(contents, gaps) {
+    super.layout_(contents, gaps);
+    this.labelGaps = [];
+    for (const [index, item] of contents.entries()) {
+      if (item.type === 'button' && item.button.isLabel()) {
+        this.labelGaps.push(gaps[index - 1] ?? this.MARGIN);
+      }
+    }
   }
 }


### PR DESCRIPTION
## The basics
- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves
Fixes #2207

### Proposed Changes
When a category is clicked in the continuous flyout's left portion, the padding above the category label is displayed in the flyout, instead of putting the text directly at the top of the flyout.

This change also pre-selects the first category when `show()` is called.

### Reason for Changes
Gives the text some room to breathe/looks better and aligns with Scratch's behavior.