### PR TITLE
feat: add controllers and models to switch between definitions

### DIFF
--- a/examples/developer-tools/src/controller.ts
+++ b/examples/developer-tools/src/controller.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly';
+import {ViewModel} from './view_model';
+import {JavascriptDefinitionGenerator} from './output-generators/javascript_definition_generator';
+import {JsonDefinitionGenerator} from './output-generators/json_definition_generator';
+
+export class Controller {
+  constructor(
+    private mainWorkspace: Blockly.WorkspaceSvg,
+    private previewWorkspace: Blockly.WorkspaceSvg,
+    private viewModel: ViewModel,
+    private jsGenerator: JavascriptDefinitionGenerator,
+    private jsonGenerator: JsonDefinitionGenerator,
+  ) {
+    // Add event listeners to update when output config elements are changed
+    this.viewModel.outputConfigDiv.addEventListener('change', () => {
+      this.updateOutput();
+    });
+  }
+
+  /** Shows the JavaScript definition of the block factory block. */
+  showJavaScriptDefinition() {
+    const blockDefinitionString = this.jsGenerator.workspaceToCode(
+      this.mainWorkspace,
+    );
+    this.viewModel.definitionDiv.textContent = blockDefinitionString;
+  }
+
+  /** Shows the JSON definition of the block factory block. */
+  showJsonDefinition() {
+    const blockDefinitionString = this.jsonGenerator.workspaceToCode(
+      this.mainWorkspace,
+    );
+    this.viewModel.definitionDiv.textContent = blockDefinitionString;
+  }
+
+  /**
+   * Updates all of the output for the block factory,
+   * including the preview, definition, generators, etc.
+   */
+  updateOutput() {
+    if (this.viewModel.getBlockDefinitionFormat() === 'json') {
+      this.showJsonDefinition();
+    } else {
+      this.showJavaScriptDefinition();
+    }
+
+    this.updateBlockPreview();
+  }
+
+  /** Updates the block preview pane. */
+  updateBlockPreview() {
+    this.previewWorkspace.clear();
+    const blockDefinitionString = this.jsonGenerator.workspaceToCode(
+      this.mainWorkspace,
+    );
+    const blockDefinition = JSON.parse(blockDefinitionString);
+    // use a fake name so that we never get conflicts with built-in blocks
+    const blockName = 'blockly_block_factory_preview_block';
+    blockDefinition.type = blockName;
+
+    // delete the old block definition so we don't get warnings about overwriting
+    delete Blockly.Blocks[blockName];
+    Blockly.common.defineBlocks(
+      Blockly.common.createBlockDefinitionsFromJsonArray([blockDefinition]),
+    );
+
+    // TODO: After Blockly v11, won't need to call `initSvg` and `render` directly.
+    const block = this.previewWorkspace.newBlock(blockName);
+    block.initSvg();
+    block.render();
+  }
+}

--- a/examples/developer-tools/src/index.html
+++ b/examples/developer-tools/src/index.html
@@ -10,7 +10,52 @@
       <div id="main-workspace"></div>
       <div id="output-pane">
         <div id="block-preview"></div>
-        <div id="output-config">config</div>
+        <div id="output-config">
+          <div>
+            Block definition format:
+            <input
+              type="radio"
+              id="definition-json"
+              name="block-definition-language"
+              value="json"
+              checked />
+            <label for="definition-json">JSON</label>
+            <input
+              type="radio"
+              id="definition-js"
+              name="block-definition-language"
+              value="js" />
+            <label for="definition-js">JavaScript</label>
+          </div>
+          <div>
+            Blockly import format:
+            <input
+              type="radio"
+              id="import-esm"
+              name="import-format"
+              value="import"
+              checked />
+            <label for="import-esm">Import (esm/cjs)</label>
+            <input
+              type="radio"
+              id="import-script"
+              name="import-format"
+              value="script" />
+            <label for="import-script">Script tags</label>
+          </div>
+          <div>
+            <label for="code-generator-language"
+              >Code generator language:</label
+            >
+            <select name="code-generator-language" id="code-generator-language">
+              <option value="Javascript">JavaScript</option>
+              <option value="Python">Python</option>
+              <option value="Dart">Dart</option>
+              <option value="Php">PHP</option>
+              <option value="Lua">Lua</option>
+            </select>
+          </div>
+        </div>
         <div id="code-headers">code headers</div>
         <pre id="block-definition">
                     JSON Definition

--- a/examples/developer-tools/src/view_model.ts
+++ b/examples/developer-tools/src/view_model.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export class ViewModel {
+  mainWorkspaceDiv = document.getElementById('main-workspace');
+  previewDiv = document.getElementById('block-preview');
+  definitionDiv = document.getElementById('block-definition').firstChild;
+  outputConfigDiv = document.getElementById('output-config');
+  codeHeadersDiv = document.getElementById('code-headers');
+  generatorStubDiv = document.getElementById('generator-stub');
+
+  /**
+   * Gets a string representing the format of the block
+   * definition the user selected.
+   *
+   * @returns Either 'json' or 'js' depending on which radio button is selected.
+   */
+  getBlockDefinitionFormat(): string {
+    const radioButton = document.getElementById(
+      'definition-json',
+    ) as HTMLInputElement;
+    return radioButton.checked ? 'json' : 'js';
+  }
+
+  /**
+   * Gets the name of the code generator language the user selected.
+   *
+   * @returns The generator language name, in the same format as
+   *    used by Blockly, e.g. `Javascript` or `Php`.
+   */
+  getCodeGeneratorLanguage(): string {
+    const languageSelector = document.getElementById(
+      'code-generator-language',
+    ) as HTMLInputElement;
+    return languageSelector.value;
+  }
+}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Works on developer-tools

### Proposed Changes

- Adds UI controls to select the block definition format, import format, and generator language. The latter two don't do anything yet since those code generators haven't been implemented.
- Adds a view model class that contains methods for getting information about the DOM structure
- Adds a controller class that contains methods for updating the UI in response to user actions
- Updates the block definition shown when the user switches formats

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
