### PR TITLE
fix: When using the toolbox-search, auto select the found dropdown item

### DIFF
--- a/plugins/toolbox-search/CHANGELOG.md
+++ b/plugins/toolbox-search/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.7](https://github.com/google/blockly-samples/compare/@blockly/toolbox-search@1.2.6...@blockly/toolbox-search@1.2.7) (2024-02-23)
+### Bug Fixes
+ * Improved search for drop down
+ * Improved unit tests
+ * Last trigram from a word was never indexed
+
 ## [1.2.6](https://github.com/google/blockly-samples/compare/@blockly/toolbox-search@1.2.5...@blockly/toolbox-search@1.2.6) (2024-02-08)
 
 **Note:** Version bump only for package @blockly/toolbox-search

--- a/plugins/toolbox-search/src/toolbox_search.ts
+++ b/plugins/toolbox-search/src/toolbox_search.ts
@@ -9,6 +9,7 @@
  * in its flyout.
  */
 import * as Blockly from 'blockly/core';
+import {block} from '../node_modules/blockly/core/tooltip';
 import {BlockSearcher} from './block_searcher';
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -171,13 +172,19 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
    */
   private matchBlocks() {
     const query = this.searchField?.value || '';
-
     this.flyoutItems_ = query
-      ? this.blockSearcher.blockTypesMatching(query).map((blockType) => {
-          return {
-            kind: 'block',
-            type: blockType,
-          };
+      ? this.blockSearcher.blockTypesMatching(query).map((blockState) => {
+          if (blockState.fields) {
+            return {
+              kind: 'block',
+              type: blockState.type,
+              fields: blockState.fields,
+            };
+          } else
+            return {
+              kind: 'block',
+              type: blockState.type,
+            };
         })
       : [];
 

--- a/plugins/toolbox-search/test/tests.mocha.js
+++ b/plugins/toolbox-search/test/tests.mocha.js
@@ -14,18 +14,129 @@ suite('Toolbox search', () => {
   });
 });
 
+function allPossibleCombinations(input, length, curstr) {
+  if (curstr.length == length) return [curstr];
+  const ret = [];
+  for (let i = 0; i < input.length; i++) {
+    ret.push(...allPossibleCombinations(input, length, curstr + input[i]));
+  }
+  return ret;
+}
+
+function allThreeLetterCombinations() {
+  const input = [
+    'a',
+    'b',
+    'c',
+    'd',
+    'e',
+    'f',
+    'g',
+    'h',
+    'i',
+    'j',
+    'k',
+    'l',
+    'm',
+    'n',
+    'o',
+    'p',
+    'r',
+    's',
+    't',
+    'u',
+    'v',
+    'z',
+    'x',
+    'y',
+    'z',
+    'w',
+  ];
+  return allPossibleCombinations(input, 3, '');
+}
+
+const searchableBlocks = [
+  'controls_if',
+  'logic_compare',
+  'logic_operation',
+  'logic_negate',
+  'logic_boolean',
+  'logic_null',
+  'logic_ternary',
+  'controls_repeat_ext',
+  'controls_repeat',
+  'controls_whileUntil',
+  'controls_for',
+  'controls_forEach',
+  'controls_flow_statements',
+  'math_number',
+  'math_arithmetic',
+  'math_single',
+  'math_trig',
+  'math_constant',
+  'math_number_property',
+  'math_round',
+  'math_on_list',
+  'math_modulo',
+  'math_constrain',
+  'math_random_int',
+  'math_random_float',
+  'math_atan2',
+  'text',
+  'text_multiline',
+  'text_join',
+  'text_append',
+  'text_length',
+  'text_isEmpty',
+  'text_indexOf',
+  'text_charAt',
+  'text_getSubstring',
+  'text_changeCase',
+  'text_trim',
+  'text_count',
+  'text_replace',
+  'text_reverse',
+  'text_print',
+  'text_prompt_ext',
+  'lists_create_with',
+  'lists_repeat',
+  'lists_length',
+  'lists_isEmpty',
+  'lists_indexOf',
+  'lists_getIndex',
+  'lists_setIndex',
+  'lists_getSublist',
+  'lists_split',
+  'lists_sort',
+  'lists_reverse',
+  'colour_picker',
+  'colour_random',
+  'colour_rgb',
+  'colour_blend',
+];
+
 suite('BlockSearcher', () => {
-  test('indexes the default value of dropdown fields', () => {
+  test('indexes the default value of dropdown fields', async () => {
     const searcher = new BlockSearcher();
+
     // Text on these:
     // lists_sort: sort <numeric> <ascending>
     // lists_split: make <list from text> with delimiter ,
     searcher.indexBlocks(['lists_sort', 'lists_split']);
 
     const numericMatches = searcher.blockTypesMatching('numeric');
-    assert.sameMembers(['lists_sort'], numericMatches);
+    assert.sameMembers(
+      ['lists_sort'],
+      numericMatches.map((item) => item.type),
+    );
+    assert.sameMembers(
+      ['NUMERIC'],
+      numericMatches.map((item) => item.fields['TYPE']),
+    );
 
-    const listFromTextMatches = searcher.blockTypesMatching('list from text');
+    const listFromTextMatches = searcher
+      .blockTypesMatching('list from text')
+      .map((item) => item.type);
     assert.sameMembers(['lists_split'], listFromTextMatches);
   });
 
@@ -33,14 +144,121 @@ suite('BlockSearcher', () => {
     const searcher = new BlockSearcher();
     searcher.indexBlocks(['lists_create_with']);
 
-    const lowercaseMatches = searcher.blockTypesMatching('create list');
+    const lowercaseMatches = searcher
+      .blockTypesMatching('create list')
+      .map((item) => item.type);
     assert.sameMembers(['lists_create_with'], lowercaseMatches);
 
-    const uppercaseMatches = searcher.blockTypesMatching('CREATE LIST');
+    const uppercaseMatches = searcher
+      .blockTypesMatching('CREATE LIST')
+      .map((item) => item.type);
     assert.sameMembers(['lists_create_with'], uppercaseMatches);
 
-    const ransomNoteMatches = searcher.blockTypesMatching('cReATe LiST');
+    const ransomNoteMatches = searcher
+      .blockTypesMatching('cReATe LiST')
+      .map((item) => item.type);
     assert.sameMembers(['lists_create_with'], ransomNoteMatches);
+  });
+
+  test('Check for duplicates', () => {
+    const searcher = new BlockSearcher();
+
+    searcher.indexBlocks(searchableBlocks);
+
+    const combinations = allThreeLetterCombinations();
+    combinations.forEach((element) => {
+      const matches = searcher
+        .blockTypesMatching(element)
+        .map((item) => JSON.stringify(item));
+      const matchesSet = new Set(matches);
+      assert.equal(matches.length, matchesSet.size);
+    });
+  });
+
+  test('Check for false negative', () => {
+    const searcher = new BlockSearcher();
+
+    searcher.indexBlocks(searchableBlocks);
+    const stringInfo = {};
+    searchableBlocks.forEach((element) => {
+      let itemString = element;
+      const blockCreationWorkspace = new Blockly.Workspace();
+      const block = blockCreationWorkspace.newBlock(element);
+      block.inputList.forEach((input) => {
+        input.fieldRow.forEach((field) => {
+          if (field.getText()) {
+            itemString += ' ' + field.getText();
+          }
+          if (field.name) {
+            itemString += ' ' + field.name;
+          }
+          if (field instanceof Blockly.FieldDropdown) {
+            field.getOptions(true).forEach((option) => {
+              // For VAR fields the option[1] is generated randpmly each time the block is created,
+              // we don't want to test for it as we don't count it as a false negative
+              if (field.name != 'VAR' && option[0] != 'i')
+                itemString += ' ' + option[1];
+              itemString += ' ' + option[0];
+            });
+          }
+        });
+      });
+      stringInfo[element] = itemString;
+    });
+
+    const combinations = allThreeLetterCombinations();
+    combinations.forEach((element) => {
+      const matches = searcher.blockTypesMatching(element);
+      for (const key in stringInfo) {
+        if (stringInfo[key].includes(element)) {
+          let found = false;
+          matches.forEach((match) => {
+            if (match.type == key) {
+              found = true;
+            }
+          });
+          if (!found) {
+            assert.equal(found, true);
+          }
+        }
+      }
+    });
+  });
+
+  test('Check for false positives', () => {
+    const searcher = new BlockSearcher();
+
+    searcher.indexBlocks(searchableBlocks);
+    const combinations = allThreeLetterCombinations();
+    combinations.forEach((element) => {
+      const matches = searcher.blockTypesMatching(element);
+      let checkInString = 0;
+      matches.forEach((item) => {
+        const blockCreationWorkspace = new Blockly.Workspace();
+        const block = blockCreationWorkspace.newBlock(item.type);
+        const itemString = JSON.stringify(item);
+        let blockInputList = '';
+        block.inputList.forEach((input) => {
+          input.fieldRow.forEach((field) => {
+            blockInputList += ' ' + field.getText();
+            if (field instanceof Blockly.FieldDropdown) {
+              field.getOptions(true).forEach((option) => {
+                if (item.fields[field.name] == option[1]) {
+                  blockInputList += ' ' + option[0];
+                }
+              });
+            }
+          });
+        });
+        if (
+          !itemString.toLowerCase().includes(element) &&
+          !blockInputList.toLowerCase().includes(element)
+        ) {
+          checkInString += 1;
+        }
+      });
+      assert.equal(checkInString, 0);
+    });
   });
 
   test('returns an empty list when no matches are found', () => {


### PR DESCRIPTION
Fixes: https://github.com/google/blockly-samples/issues/1940

Uses the Block State as suggested here:
https://github.com/google/blockly-samples/pull/2004#issuecomment-1832317907 

Fixes: bug that didn't indexed the last trigram from a word

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics



- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves


Fixes https://github.com/google/blockly-samples/issues/1940
### Proposed Changes

Use block state for efficient indexing

### Reason for Changes

Have the found drop down item automatically selected in the drop down

### Test Coverage

Unit test have been added to cover the false positive, false negative and duplicate cases

### Documentation



### Additional Information


