### PR TITLE
fix: add missing import to scroll-options plugin

### DIFF
--- a/plugins/scroll-options/src/utils.js
+++ b/plugins/scroll-options/src/utils.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as Blockly from 'blockly/core';
+
 /**
  * Gets the current location of the workspace considering
  * when there's no drag surface.


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)


## The details
### Resolves

Fixes https://github.com/google/blockly-samples/issues/2224

### Proposed Changes

Adds a missing import to the utils.js file in the scroll-options plugin

### Reason for Changes

I was trying to add this plugin to MakeCode but was getting an exception from this file as there is no global Blockly defined (we browserify our code)

### Test Coverage

None

### Documentation

Nope

### Additional Information

I'm curious how the sample is working with this error. Does the playground inject Blockly into the window or something?
