### PR TITLE
fix: Fix but preventing clearing/randomizing nonsquare bitmap fields.

### DIFF
--- a/plugins/field-bitmap/src/field-bitmap.js
+++ b/plugins/field-bitmap/src/field-bitmap.js
@@ -406,9 +406,9 @@ export class FieldBitmap extends Blockly.Field {
    */
   getEmptyArray_() {
     const newVal = [];
-    for (let r = 0; r < this.imgWidth_; r++) {
+    for (let r = 0; r < this.imgHeight_; r++) {
       newVal.push([]);
-      for (let c = 0; c < this.imgHeight_; c++) {
+      for (let c = 0; c < this.imgWidth_; c++) {
         newVal[r].push(0);
       }
     }


### PR DESCRIPTION
## The basics
- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves
Fixes #2223

### Proposed Changes
This PR updates `getEmptyArray_()` to build a grid in [row][column] order, consistent with the rest of the file, instead of [column][row] order like it was doing.

### Reason for Changes
The existing behavior was inconsistent with the rest of the file, so for non-square grids, accessing items outside the smaller of the two dimensions would be out of bounds.

### Test Coverage
I created non-square grids (taller and wider), and ensured that they deserialized identically after making this change. I also manually verified that the randomize and clear buttons work now.