### PR TITLE
feat: add generator tests for the text_multiline block

### DIFF
--- a/plugins/field-multilineinput/src/blocks/textMultiline.ts
+++ b/plugins/field-multilineinput/src/blocks/textMultiline.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {Block, common as BlocklyCommon} from 'blockly';
+import {Block, common as BlocklyCommon} from 'blockly/core';
 import {
   JavascriptGenerator,
   Order as JavascriptOrder,

--- a/plugins/field-multilineinput/test/block_test.mocha.js
+++ b/plugins/field-multilineinput/test/block_test.mocha.js
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs';
+import * as Blockly from 'blockly/core';
+import * as en from 'blockly/msg/en';
+import 'blockly/blocks';
+
+import {javascriptGenerator} from 'blockly/javascript';
+import {dartGenerator} from 'blockly/dart';
+import {phpGenerator} from 'blockly/php';
+import {pythonGenerator} from 'blockly/python';
+import {luaGenerator} from 'blockly/lua';
+import {installAllBlocks} from '../src/index';
+import {BLOCK_NAME} from '../src/blocks/textMultiline';
+import {assert} from 'chai';
+
+const blockJson = {
+  blocks: {
+    languageVersion: 0,
+    blocks: [
+      {
+        type: 'text_print',
+        inputs: {
+          TEXT: {
+            block: {
+              type: 'text_multiline',
+              fields: {
+                TEXT: '’Twas brillig, and the slithy toves\n  Did gyre and gimble in the wabe:\nAll mimsy were the borogoves,\n  And the mome raths outgrabe.',
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+
+/**
+ * Uninstall old blocks and generators, since they come pre-installed
+ * with Blockly.
+ * TODO(#2194): Delete this function and calls to it.
+ */
+function uninstallBlocks() {
+  delete Blockly.Blocks[BLOCK_NAME];
+
+  delete javascriptGenerator.forBlock[BLOCK_NAME];
+  delete dartGenerator.forBlock[BLOCK_NAME];
+  delete luaGenerator.forBlock[BLOCK_NAME];
+  delete pythonGenerator.forBlock[BLOCK_NAME];
+  delete phpGenerator.forBlock[BLOCK_NAME];
+}
+
+/**
+ * Assert that the generated code matches the golden code for the specified
+ * language.
+ * @param {string} suffix The suffix of the golden file.
+ * @param {string} generated The generated code to compare against the
+ *     golden file.
+ */
+function checkResult(suffix, generated) {
+  const fileName = `test/golden/golden.${suffix}`;
+  const goldenContents = fs.readFileSync(fileName);
+  // Normalize the line feeds.
+  const normalized = goldenContents.toString().replace(/(?:\r\n|\r|\n)/g, '\n');
+  assert.equal(generated, normalized);
+}
+
+suite('Multiline Text Block Generators', function () {
+  suiteSetup(function () {
+    Blockly.setLocale(en);
+    uninstallBlocks();
+    installAllBlocks({
+      javascript: javascriptGenerator,
+      dart: dartGenerator,
+      lua: luaGenerator,
+      python: pythonGenerator,
+      php: phpGenerator,
+    });
+  });
+  setup(function () {
+    this.workspace = new Blockly.Workspace();
+    Blockly.serialization.workspaces.load(blockJson, this.workspace);
+  });
+  test('JavaScript', function () {
+    const generated = javascriptGenerator.workspaceToCode(this.workspace);
+    checkResult('js', generated);
+  });
+  test('Dart', function () {
+    const generated = dartGenerator.workspaceToCode(this.workspace);
+    checkResult('dart', generated);
+  });
+  test('Lua', function () {
+    const generated = luaGenerator.workspaceToCode(this.workspace);
+    checkResult('lua', generated);
+  });
+  test('Python', function () {
+    const generated = pythonGenerator.workspaceToCode(this.workspace);
+    checkResult('py', generated);
+  });
+  test('PHP', function () {
+    const generated = phpGenerator.workspaceToCode(this.workspace);
+    checkResult('php', generated);
+  });
+  teardown(function () {
+    this.workspace.dispose();
+  });
+  suiteTeardown(function () {
+    uninstallBlocks();
+  });
+});

--- a/plugins/field-multilineinput/test/block_test.mocha.js
+++ b/plugins/field-multilineinput/test/block_test.mocha.js
@@ -29,7 +29,7 @@ const blockJson = {
             block: {
               type: 'text_multiline',
               fields: {
-                TEXT: '’Twas brillig, and the slithy toves\n  Did gyre and gimble in the wabe:\nAll mimsy were the borogoves,\n  And the mome raths outgrabe.',
+                TEXT: 'Picard said, "Beam me up!".\nO\'Brien made it so.',
               },
             },
           },

--- a/plugins/field-multilineinput/test/golden/golden.dart
+++ b/plugins/field-multilineinput/test/golden/golden.dart
@@ -1,0 +1,6 @@
+main() {
+  print('’Twas brillig, and the slithy toves' + '\n' +
+  '  Did gyre and gimble in the wabe:' + '\n' +
+  'All mimsy were the borogoves,' + '\n' +
+  '  And the mome raths outgrabe.');
+}

--- a/plugins/field-multilineinput/test/golden/golden.dart
+++ b/plugins/field-multilineinput/test/golden/golden.dart
@@ -1,6 +1,4 @@
 main() {
-  print('’Twas brillig, and the slithy toves' + '\n' +
-  '  Did gyre and gimble in the wabe:' + '\n' +
-  'All mimsy were the borogoves,' + '\n' +
-  '  And the mome raths outgrabe.');
+  print('Picard said, "Beam me up!".' + '\n' +
+  'O\'Brien made it so.');
 }

--- a/plugins/field-multilineinput/test/golden/golden.js
+++ b/plugins/field-multilineinput/test/golden/golden.js
@@ -1,4 +1,2 @@
-window.alert('’Twas brillig, and the slithy toves' + '\n' +
-'  Did gyre and gimble in the wabe:' + '\n' +
-'All mimsy were the borogoves,' + '\n' +
-'  And the mome raths outgrabe.');
+window.alert('Picard said, "Beam me up!".' + '\n' +
+'O\'Brien made it so.');

--- a/plugins/field-multilineinput/test/golden/golden.js
+++ b/plugins/field-multilineinput/test/golden/golden.js
@@ -1,0 +1,4 @@
+window.alert('’Twas brillig, and the slithy toves' + '\n' +
+'  Did gyre and gimble in the wabe:' + '\n' +
+'All mimsy were the borogoves,' + '\n' +
+'  And the mome raths outgrabe.');

--- a/plugins/field-multilineinput/test/golden/golden.lua
+++ b/plugins/field-multilineinput/test/golden/golden.lua
@@ -1,0 +1,4 @@
+print('’Twas brillig, and the slithy toves' .. '\n' ..
+'  Did gyre and gimble in the wabe:' .. '\n' ..
+'All mimsy were the borogoves,' .. '\n' ..
+'  And the mome raths outgrabe.')

--- a/plugins/field-multilineinput/test/golden/golden.lua
+++ b/plugins/field-multilineinput/test/golden/golden.lua
@@ -1,4 +1,2 @@
-print('’Twas brillig, and the slithy toves' .. '\n' ..
-'  Did gyre and gimble in the wabe:' .. '\n' ..
-'All mimsy were the borogoves,' .. '\n' ..
-'  And the mome raths outgrabe.')
+print('Picard said, "Beam me up!".' .. '\n' ..
+'O\'Brien made it so.')

--- a/plugins/field-multilineinput/test/golden/golden.php
+++ b/plugins/field-multilineinput/test/golden/golden.php
@@ -1,0 +1,4 @@
+print('’Twas brillig, and the slithy toves' . "\n" .
+'  Did gyre and gimble in the wabe:' . "\n" .
+'All mimsy were the borogoves,' . "\n" .
+'  And the mome raths outgrabe.');

--- a/plugins/field-multilineinput/test/golden/golden.php
+++ b/plugins/field-multilineinput/test/golden/golden.php
@@ -1,4 +1,2 @@
-print('’Twas brillig, and the slithy toves' . "\n" .
-'  Did gyre and gimble in the wabe:' . "\n" .
-'All mimsy were the borogoves,' . "\n" .
-'  And the mome raths outgrabe.');
+print('Picard said, "Beam me up!".' . "\n" .
+'O\'Brien made it so.');

--- a/plugins/field-multilineinput/test/golden/golden.py
+++ b/plugins/field-multilineinput/test/golden/golden.py
@@ -1,0 +1,4 @@
+print('’Twas brillig, and the slithy toves' + '\n' +
+'  Did gyre and gimble in the wabe:' + '\n' +
+'All mimsy were the borogoves,' + '\n' +
+'  And the mome raths outgrabe.')

--- a/plugins/field-multilineinput/test/golden/golden.py
+++ b/plugins/field-multilineinput/test/golden/golden.py
@@ -1,4 +1,2 @@
-print('’Twas brillig, and the slithy toves' + '\n' +
-'  Did gyre and gimble in the wabe:' + '\n' +
-'All mimsy were the borogoves,' + '\n' +
-'  And the mome raths outgrabe.')
+print('Picard said, "Beam me up!".' + '\n' +
+"O'Brien made it so.")


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves
Part of #2154

### Proposed Changes

Clean up imports to import from `blockly/core` wherever possible, to reduce unnecessary imports and provide example code for writing plugins.

Add generator tests to field multiline input plugin.

The test:
- Uninstall old blocks and generators.
- Install new blocks and generators.
- Load a specific set of blocks (provided as JSON).
- Run each language generator in turn.
- Compare the generated code to a golden file for each language.
  - I created the golden file by running the old generators in the playground.

### Reason for Changes

Verify that generators are the same after moving them from core to samples. This is primarily change detection in case of later cleanup.

### Test Coverage

Added tests in `plugins/field-multilineinput/test/blocks-test.mocha`
