### PR TITLE
fix: code style in generators for field colour blocks

### DIFF
--- a/plugins/field-colour/src/blocks/colourBlend.ts
+++ b/plugins/field-colour/src/blocks/colourBlend.ts
@@ -92,8 +92,7 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(c1, c2, ratio) {
 }
 `,
   );
-  const code =
-    functionName + '(' + colour1 + ', ' + colour2 + ', ' + ratio + ')';
+  const code = `${functionName}(${colour1}, ${colour2}, ${ratio})`;
   return [code, JavascriptOrder.FUNCTION_CALL];
 }
 
@@ -147,8 +146,7 @@ String ${generator.FUNCTION_NAME_PLACEHOLDER_}(String c1, String c2, num ratio) 
 }
 `,
   );
-  const code =
-    functionName + '(' + colour1 + ', ' + colour2 + ', ' + ratio + ')';
+  const code = `${functionName}(${colour1}, ${colour2}, ${ratio})`;
   return [code, DartOrder.UNARY_POSTFIX];
 }
 
@@ -187,8 +185,7 @@ end
   const colour2 =
     generator.valueToCode(block, 'COLOUR2', LuaOrder.NONE) || "'#000000'";
   const ratio = generator.valueToCode(block, 'RATIO', LuaOrder.NONE) || 0;
-  const code =
-    functionName + '(' + colour1 + ', ' + colour2 + ', ' + ratio + ')';
+  const code = `${functionName}(${colour1}, ${colour2}, ${ratio})`;
   return [code, LuaOrder.HIGH];
 }
 
@@ -231,8 +228,7 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}($c1, $c2, $ratio) {
 }
 `,
   );
-  const code =
-    functionName + '(' + colour1 + ', ' + colour2 + ', ' + ratio + ')';
+  const code = `${functionName}(${colour1}, ${colour2}, ${ratio})`;
   return [code, PhpOrder.FUNCTION_CALL];
 }
 
@@ -267,8 +263,7 @@ def ${generator.FUNCTION_NAME_PLACEHOLDER_}(colour1, colour2, ratio):
   const colour2 =
     generator.valueToCode(block, 'COLOUR2', PythonOrder.NONE) || "'#000000'";
   const ratio = generator.valueToCode(block, 'RATIO', PythonOrder.NONE) || 0;
-  const code =
-    functionName + '(' + colour1 + ', ' + colour2 + ', ' + ratio + ')';
+  const code = `${functionName}(${colour1}, ${colour2}, ${ratio})`;
   return [code, PythonOrder.FUNCTION_CALL];
 }
 

--- a/plugins/field-colour/src/blocks/colourRandom.ts
+++ b/plugins/field-colour/src/blocks/colourRandom.ts
@@ -45,7 +45,7 @@ export function toJavascript(
     'colourRandom',
     `
 function ${generator.FUNCTION_NAME_PLACEHOLDER_}() {
-  var num = Math.floor(Math.random() * Math.pow(2, 24));
+  var num = Math.floor(Math.random() * 0x1000000);
   return '#' + ('00000' + num.toString(16)).substr(-6);
 }
 `,

--- a/plugins/field-colour/src/blocks/colourRgb.ts
+++ b/plugins/field-colour/src/blocks/colourRgb.ts
@@ -80,7 +80,7 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}(r, g, b) {
 }
 `,
   );
-  const code = functionName + '(' + red + ', ' + green + ', ' + blue + ')';
+  const code = `${functionName}(${red}, ${green}, ${blue})`;
   return [code, JavascriptOrder.FUNCTION_CALL];
 }
 
@@ -125,7 +125,7 @@ String ${generator.FUNCTION_NAME_PLACEHOLDER_}(num r, num g, num b) {
 }
 `,
   );
-  const code = functionName + '(' + red + ', ' + green + ', ' + blue + ')';
+  const code = `${functionName}(${red}, ${green}, ${blue})`;
   return [code, DartOrder.UNARY_POSTFIX];
 }
 
@@ -155,7 +155,7 @@ end
   const red = generator.valueToCode(block, 'RED', LuaOrder.NONE) || 0;
   const green = generator.valueToCode(block, 'GREEN', LuaOrder.NONE) || 0;
   const blue = generator.valueToCode(block, 'BLUE', LuaOrder.NONE) || 0;
-  const code = functionName + '(' + red + ', ' + green + ', ' + blue + ')';
+  const code = `${functionName}(${red}, ${green}, ${blue})`;
   return [code, LuaOrder.HIGH];
 }
 
@@ -189,7 +189,7 @@ function ${generator.FUNCTION_NAME_PLACEHOLDER_}($r, $g, $b) {
 }
 `,
   );
-  const code = functionName + '(' + red + ', ' + green + ', ' + blue + ')';
+  const code = `${functionName}(${red}, ${green}, ${blue})`;
   return [code, PhpOrder.FUNCTION_CALL];
 }
 

--- a/plugins/field-colour/test/golden/golden.js
+++ b/plugins/field-colour/test/golden/golden.js
@@ -1,5 +1,5 @@
 function colourRandom() {
-  var num = Math.floor(Math.random() * Math.pow(2, 24));
+  var num = Math.floor(Math.random() * 0x1000000);
   return '#' + ('00000' + num.toString(16)).substr(-6);
 }
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes #2198

### Proposed Changes

Code style fixes in generators. Only one change impacts the generated code (`Math.pow(2,24)` -> `0x1000000`), which also caused a corresponding change in the generated files.

### Reason for Changes

Cleanup since I was already touching this code.

### Test Coverage
Generator tests cover this!
