### PR TITLE
fix: Align zoom-to-fit event handling with zoom_controls

### DIFF
--- a/plugins/zoom-to-fit/src/index.ts
+++ b/plugins/zoom-to-fit/src/index.ts
@@ -119,7 +119,7 @@ export class ZoomToFitControl implements Blockly.IPositionable {
     // Attach listener.
     this.onZoomToFitWrapper = Blockly.browserEvents.conditionalBind(
       this.svgGroup,
-      'mousedown',
+      'pointerdown',
       null,
       this.onClick.bind(this),
     );
@@ -127,8 +127,10 @@ export class ZoomToFitControl implements Blockly.IPositionable {
 
   /**
    * Handle click event.
+   *
+   * @param e A pointer down event.
    */
-  private onClick() {
+  private onClick(e: PointerEvent) {
     this.workspace.zoomToFit();
     const uiEvent = new (Blockly.Events.get(Blockly.Events.CLICK))(
       null,
@@ -136,6 +138,8 @@ export class ZoomToFitControl implements Blockly.IPositionable {
       'zoom_reset_control',
     );
     Blockly.Events.fire(uiEvent);
+    e.stopPropagation(); // avoid to also fire workspace click event
+    e.preventDefault();
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

The zoom-to-fit plugin is not stopping the event propagation which results in 2 events being fired when clicking the reset zoom button: one with targetType `zoom_reset_control` and one with targetType `workspace`. The core zoom_controls implementation does however stop the event propagation.

### Proposed Changes

This PR aligns the event handling in zoom-to-fit plugin with the core zoom_controls implementation.
It does 2 things:
 - switches the event listener to `pointerdown`
 - adds `e.stopPropagation();` and `e.preventDefault();` to the event handler.

### Reason for Changes

The change aligns the behavior of zoom related controls making sure that users listening to workspace events get the same behavior across all zoom related actions.
