### PR TITLE
chore: remove uses of the multiline block or field in other plugins

### DIFF
--- a/examples/backpack-demo/index.js
+++ b/examples/backpack-demo/index.js
@@ -136,10 +136,6 @@ const toolbox = {
           type: 'text',
         },
         {
-          kind: 'block',
-          type: 'text_multiline',
-        },
-        {
           'kind': 'label',
           'text': 'Input/Output:',
           'web-class': 'ioLabel',

--- a/examples/custom-renderer-codelab/src/toolbox.js
+++ b/examples/custom-renderer-codelab/src/toolbox.js
@@ -330,10 +330,6 @@ export const toolbox = {
         },
         {
           kind: 'block',
-          type: 'text_multiline',
-        },
-        {
-          kind: 'block',
           type: 'text_join',
         },
         {

--- a/examples/custom-toolbox-codelab/complete-code/index.html
+++ b/examples/custom-toolbox-codelab/complete-code/index.html
@@ -193,7 +193,6 @@
       </category>
       <category name="Text" categorystyle="text_category">
         <block type="text"></block>
-        <block type="text_multiline"></block>
         <block type="text_join"></block>
         <block type="text_append">
           <value name="TEXT">

--- a/examples/custom-toolbox-codelab/starter-code/index.html
+++ b/examples/custom-toolbox-codelab/starter-code/index.html
@@ -183,7 +183,6 @@
       </category>
       <category name="Text" categorystyle="text_category">
         <block type="text"></block>
-        <block type="text_multiline"></block>
         <block type="text_join"></block>
         <block type="text_append">
           <value name="TEXT">

--- a/examples/devsite-demo/toolbox.js
+++ b/examples/devsite-demo/toolbox.js
@@ -279,10 +279,6 @@ const toolboxJson = {
         },
         {
           kind: 'BLOCK',
-          type: 'text_multiline',
-        },
-        {
-          kind: 'BLOCK',
           type: 'text_join',
           extraState: {itemCount: 2},
         },

--- a/examples/devsite-landing-demo/toolbox.js
+++ b/examples/devsite-landing-demo/toolbox.js
@@ -280,10 +280,6 @@ let toolboxJson = {
         },
         {
           kind: 'BLOCK',
-          type: 'text_multiline',
-        },
-        {
-          kind: 'BLOCK',
           type: 'text_join',
           extraState: {itemCount: 2},
         },

--- a/examples/keyboard-navigation-codelab/src/toolbox.js
+++ b/examples/keyboard-navigation-codelab/src/toolbox.js
@@ -330,10 +330,6 @@ export const toolbox = {
         },
         {
           kind: 'block',
-          type: 'text_multiline',
-        },
-        {
-          kind: 'block',
           type: 'text_join',
         },
         {

--- a/examples/sample-app-ts/src/toolbox.ts
+++ b/examples/sample-app-ts/src/toolbox.ts
@@ -330,10 +330,6 @@ export const toolbox = {
         },
         {
           kind: 'block',
-          type: 'text_multiline',
-        },
-        {
-          kind: 'block',
           type: 'text_join',
         },
         {

--- a/examples/sample-app/src/toolbox.js
+++ b/examples/sample-app/src/toolbox.js
@@ -330,10 +330,6 @@ export const toolbox = {
         },
         {
           kind: 'block',
-          type: 'text_multiline',
-        },
-        {
-          kind: 'block',
           type: 'text_join',
         },
         {

--- a/plugins/block-test/src/fields/defaults.js
+++ b/plugins/block-test/src/fields/defaults.js
@@ -59,19 +59,6 @@ Blockly.defineBlocksWithJsonArray([
     output: 'String',
   },
   {
-    type: 'test_fields_multilinetext',
-    message0: 'code %1',
-    args0: [
-      {
-        type: 'field_multilinetext',
-        name: 'CODE',
-        text: 'default1\ndefault2',
-      },
-    ],
-    style: 'math_blocks',
-    tooltip: 'test tooltip',
-  },
-  {
     type: 'test_fields_checkbox',
     message0: 'checkbox %1',
     args0: [
@@ -245,10 +232,6 @@ export const category = {
     {
       kind: 'BLOCK',
       type: 'test_fields_only_text_input',
-    },
-    {
-      kind: 'BLOCK',
-      type: 'test_fields_multilinetext',
     },
     {
       kind: 'BLOCK',

--- a/plugins/dev-tools/src/toolboxCategories.js
+++ b/plugins/dev-tools/src/toolboxCategories.js
@@ -368,13 +368,6 @@ export default {
           },
         },
         {
-          type: 'text_multiline',
-          kind: 'block',
-          fields: {
-            TEXT: '',
-          },
-        },
-        {
           type: 'text_join',
           kind: 'block',
         },

--- a/plugins/strict-connection-checker/src/toolboxCategories.js
+++ b/plugins/strict-connection-checker/src/toolboxCategories.js
@@ -368,13 +368,6 @@ export default {
           },
         },
         {
-          type: 'text_multiline',
-          kind: 'block',
-          fields: {
-            TEXT: '',
-          },
-        },
-        {
           type: 'text_join',
           kind: 'block',
         },

--- a/plugins/theme-dark/test/index.js
+++ b/plugins/theme-dark/test/index.js
@@ -381,13 +381,6 @@ const toolbox = {
           },
         },
         {
-          type: 'text_multiline',
-          kind: 'block',
-          fields: {
-            TEXT: '',
-          },
-        },
-        {
           type: 'text_join',
           kind: 'block',
         },

--- a/plugins/theme-deuteranopia/test/index.js
+++ b/plugins/theme-deuteranopia/test/index.js
@@ -381,13 +381,6 @@ const toolbox = {
           },
         },
         {
-          type: 'text_multiline',
-          kind: 'block',
-          fields: {
-            TEXT: '',
-          },
-        },
-        {
           type: 'text_join',
           kind: 'block',
         },

--- a/plugins/theme-highcontrast/test/index.js
+++ b/plugins/theme-highcontrast/test/index.js
@@ -381,13 +381,6 @@ const toolbox = {
           },
         },
         {
-          type: 'text_multiline',
-          kind: 'block',
-          fields: {
-            TEXT: '',
-          },
-        },
-        {
           type: 'text_join',
           kind: 'block',
         },

--- a/plugins/theme-modern/test/index.js
+++ b/plugins/theme-modern/test/index.js
@@ -381,13 +381,6 @@ const toolbox = {
           },
         },
         {
-          type: 'text_multiline',
-          kind: 'block',
-          fields: {
-            TEXT: '',
-          },
-        },
-        {
           type: 'text_join',
           kind: 'block',
         },

--- a/plugins/theme-tritanopia/test/index.js
+++ b/plugins/theme-tritanopia/test/index.js
@@ -381,13 +381,6 @@ const toolbox = {
           },
         },
         {
-          type: 'text_multiline',
-          kind: 'block',
-          fields: {
-            TEXT: '',
-          },
-        },
-        {
           type: 'text_join',
           kind: 'block',
         },


### PR DESCRIPTION
## The basics


- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Part of https://github.com/google/blockly-samples/issues/2194

### Proposed Changes

Delete uses of the multiline field or related block in other plugins and examples.

### Reason for Changes
These are no longer provided as part of core, so we would need to depend on the field-multilineinput plugin to include them in tests and demos. They are not being used actively in tests, so I prefer to delete them.
