### PR TITLE
fix: dynamic blocks erroring on workspace dispose

### DIFF
--- a/plugins/block-dynamic-connection/src/dynamic_if.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_if.ts
@@ -69,12 +69,14 @@ const DYNAMIC_IF_MIXIN = {
    * @returns XML storage element.
    */
   mutationToDom(this: DynamicIfBlock): Element | null {
-    // If we call finalizeConnections here without disabling events, we get into
-    // an event loop.
-    Blockly.Events.disable();
-    this.finalizeConnections();
-    if (this instanceof Blockly.BlockSvg) this.initSvg();
-    Blockly.Events.enable();
+    if (!this.isDeadOrDying()) {
+      // If we call finalizeConnections here without disabling events, we get into
+      // an event loop.
+      Blockly.Events.disable();
+      this.finalizeConnections();
+      if (this instanceof Blockly.BlockSvg) this.initSvg();
+      Blockly.Events.enable();
+    }
 
     if (!this.elseifCount && !this.elseCount) return null;
 
@@ -162,7 +164,7 @@ const DYNAMIC_IF_MIXIN = {
    * @returns The state of this block, ie the else if count and else state.
    */
   saveExtraState: function (this: DynamicIfBlock): IfExtraState | null {
-    if (!this.isCorrectlyFormatted()) {
+    if (!this.isDeadOrDying() && !this.isCorrectlyFormatted()) {
       // If we call finalizeConnections here without disabling events, we get into
       // an event loop.
       Blockly.Events.disable();

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -48,12 +48,14 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    * @returns XML storage element.
    */
   mutationToDom(this: DynamicListCreateBlock): Element {
-    // If we call finalizeConnections here without disabling events, we get into
-    // an event loop.
-    Blockly.Events.disable();
-    this.finalizeConnections();
-    if (this instanceof Blockly.BlockSvg) this.initSvg();
-    Blockly.Events.enable();
+    if (!this.isDeadOrDying()) {
+      // If we call finalizeConnections here without disabling events, we get into
+      // an event loop.
+      Blockly.Events.disable();
+      this.finalizeConnections();
+      if (this instanceof Blockly.BlockSvg) this.initSvg();
+      Blockly.Events.enable();
+    }
 
     const container = Blockly.utils.xml.createElement('mutation');
     container.setAttribute('items', `${this.itemCount}`);
@@ -112,7 +114,7 @@ const DYNAMIC_LIST_CREATE_MIXIN = {
    * @returns The state of this block, ie the item count.
    */
   saveExtraState: function (this: DynamicListCreateBlock): {itemCount: number} {
-    if (!this.isCorrectlyFormatted()) {
+    if (!this.isDeadOrDying() && !this.isCorrectlyFormatted()) {
       // If we call finalizeConnections here without disabling events, we get
       // into an event loop.
       Blockly.Events.disable();

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -46,12 +46,14 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * @returns XML storage element.
    */
   mutationToDom(this: DynamicTextJoinBlock): Element {
-    // If we call finalizeConnections here without disabling events, we get into
-    // an event loop.
-    Blockly.Events.disable();
-    this.finalizeConnections();
-    if (this instanceof Blockly.BlockSvg) this.initSvg();
-    Blockly.Events.enable();
+    if (!this.isDeadOrDying()) {
+      // If we call finalizeConnections here without disabling events, we get into
+      // an event loop.
+      Blockly.Events.disable();
+      this.finalizeConnections();
+      if (this instanceof Blockly.BlockSvg) this.initSvg();
+      Blockly.Events.enable();
+    }
 
     const container = Blockly.utils.xml.createElement('mutation');
     container.setAttribute('items', `${this.itemCount}`);
@@ -108,7 +110,7 @@ const DYNAMIC_TEXT_JOIN_MIXIN = {
    * @returns The state of this block, ie the item count.
    */
   saveExtraState: function (this: DynamicTextJoinBlock): {itemCount: number} {
-    if (!this.isCorrectlyFormatted()) {
+    if (!this.isDeadOrDying() && !this.isCorrectlyFormatted()) {
       // If we call finalizeConnections here without disabling events, we get into
       // an event loop.
       Blockly.Events.disable();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Related to  https://github.com/google/blockly/issues/7864

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so that the dynamic connection blocks check whether they are being disposed before reconstructing the block during serialization.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This is only necessary because of a long string of cleanup we're having to do because we originally gave the dynamic connection blocks a different serialization format than the blocks in core. The blocks had different input names in core vs in the plugin, so we had to normalize them. The only valid place to do that was during serialization. But normalizing them there caused errors if the workspace is being disposed.

Hopefully this is the last cleanup we need to do from that original bug.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested that you can dispose of the workspace while it has dynamic blocks in it by switching the theme in the advanced playground. (Any switching of options causes the workspace to be disposed and ~reinfected~ reinjected).

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
