### PR TITLE
chore: stop testing on node 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
Replaces #2273 with a properly formatted commit.
### Resolves
### Proposed Changes

Stop testing on node 16 in github workflows.
### Reason for Changes

Node 16 is now out of LTS and we are no longer testing against it in core. https://nodejs.org/en/about/previous-releases.