### PR TITLE
feat: add save, load, and delete functionality to dev-tools

### DIFF
--- a/examples/developer-tools/package-lock.json
+++ b/examples/developer-tools/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@material/web": "^1.4.0",
         "blockly": "^10.4.2"
       },
       "devDependencies": {
@@ -382,6 +383,28 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
+      "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
+    "node_modules/@material/web": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@material/web/-/web-1.4.0.tgz",
+      "integrity": "sha512-+rnQLUc/vsu7vnkr8XxbEhNVEcdkaYxNjykZ18w/nUMrYTEvAi4TRQJAYeEUXMwRcO3mEXBsCKOtHZ+cbmxTLw==",
+      "dependencies": {
+        "lit": "^2.7.4 || ^3.0.0",
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1340,6 +1363,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
     "node_modules/@types/vinyl": {
       "version": "2.0.7",
@@ -4940,6 +4968,34 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/lit": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.2.tgz",
+      "integrity": "sha512-VZx5iAyMtX7CV4K8iTLdCkMaYZ7ipjJZ0JcSdJ0zIdGxxyurjIn7yuuSxNBD7QmjvcNJwr0JS4cAdAtsy7gZ6w==",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.4.tgz",
+      "integrity": "sha512-98CvgulX6eCPs6TyAIQoJZBCQPo80rgXR+dVBs61cstJXqtI+USQZAbA4gFHh6L/mxBx9MrgPLHLsUgDUHAcCQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.2.tgz",
+      "integrity": "sha512-3OBZSUrPnAHoKJ9AMjRL/m01YJxQMf+TMHanNtTHG68ubjnZxK0RFl102DPzsw4mWnHibfZIBJm3LWCZ/LmMvg==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/load-yaml-file": {
       "version": "0.2.0",
@@ -8636,8 +8692,7 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tuf-js": {
       "version": "1.1.7",
@@ -10863,6 +10918,28 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
+    "@lit-labs/ssr-dom-shim": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
+      "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
+    },
+    "@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
+    "@material/web": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@material/web/-/web-1.4.0.tgz",
+      "integrity": "sha512-+rnQLUc/vsu7vnkr8XxbEhNVEcdkaYxNjykZ18w/nUMrYTEvAi4TRQJAYeEUXMwRcO3mEXBsCKOtHZ+cbmxTLw==",
+      "requires": {
+        "lit": "^2.7.4 || ^3.0.0",
+        "tslib": "^2.4.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -11692,6 +11769,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
     "@types/vinyl": {
       "version": "2.0.7",
@@ -14457,6 +14539,34 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "lit": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.2.tgz",
+      "integrity": "sha512-VZx5iAyMtX7CV4K8iTLdCkMaYZ7ipjJZ0JcSdJ0zIdGxxyurjIn7yuuSxNBD7QmjvcNJwr0JS4cAdAtsy7gZ6w==",
+      "requires": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "lit-element": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.4.tgz",
+      "integrity": "sha512-98CvgulX6eCPs6TyAIQoJZBCQPo80rgXR+dVBs61cstJXqtI+USQZAbA4gFHh6L/mxBx9MrgPLHLsUgDUHAcCQ==",
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "lit-html": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.2.tgz",
+      "integrity": "sha512-3OBZSUrPnAHoKJ9AMjRL/m01YJxQMf+TMHanNtTHG68ubjnZxK0RFl102DPzsw4mWnHibfZIBJm3LWCZ/LmMvg==",
+      "requires": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "load-yaml-file": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/load-yaml-file/-/load-yaml-file-0.2.0.tgz",
@@ -17220,8 +17330,7 @@
     "tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tuf-js": {
       "version": "1.1.7",

--- a/examples/developer-tools/package.json
+++ b/examples/developer-tools/package.json
@@ -38,6 +38,7 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
+    "@material/web": "^1.4.0",
     "blockly": "^10.4.2"
   }
 }

--- a/examples/developer-tools/src/blocks/factory_base.ts
+++ b/examples/developer-tools/src/blocks/factory_base.ts
@@ -5,6 +5,7 @@
  */
 
 import * as Blockly from 'blockly/core';
+import * as storage from '../storage';
 
 /** Base of new block. */
 export const factoryBase = {
@@ -12,7 +13,12 @@ export const factoryBase = {
     this.setStyle('base');
     this.appendDummyInput()
       .appendField('name')
-      .appendField(new Blockly.FieldTextInput('block_type'), 'NAME');
+      .appendField(
+        new Blockly.FieldTextInput('block_type', (name) =>
+          this.validateName(name),
+        ),
+        'NAME',
+      );
     this.appendStatementInput('INPUTS').setCheck('Input').appendField('inputs');
     const inputsDropdown = new Blockly.FieldDropdown([
       ['automatic inputs', 'AUTO'],
@@ -104,5 +110,20 @@ export const factoryBase = {
       .setCheck(['ConnectionCheck', 'ConnectionCheckArray'])
       .appendField(label);
     this.moveInputBefore(name, 'COLOUR');
+  },
+  validateName: function (name: string): string | null {
+    // If the name is prohibited then it's never valid
+    if (storage.getProhibitedBlockNames().has(name)) return null;
+
+    // If the name is the currently-being-edited block it's always valid
+    // This most often occurs when loading a block from storage and we're
+    // currently deserializing a block for the first time.
+    if (storage.getLastEditedBlockName() === name) return name;
+
+    // Otherwise, it's invalid if the name is already in storage but it's not
+    // the one we're currently editing
+    if (storage.getAllSavedBlockNames().has(name)) return null;
+
+    return name;
   },
 };

--- a/examples/developer-tools/src/controller.ts
+++ b/examples/developer-tools/src/controller.ts
@@ -11,7 +11,7 @@ import {ViewModel} from './view_model';
 import {JavascriptDefinitionGenerator} from './output-generators/javascript_definition_generator';
 import {JsonDefinitionGenerator} from './output-generators/json_definition_generator';
 import {CodeHeaderGenerator} from './output-generators/code_header_generator';
-import { Menu } from '@material/web/menu/menu';
+import {Menu} from '@material/web/menu/menu';
 
 export class Controller {
   constructor(
@@ -149,7 +149,7 @@ export class Controller {
 
   /**
    * Handles selecting a block from the load menu, whether selected via keyboard or mouse.
-   * 
+   *
    * @param e Custom event fired when the menu is closed.
    */
   private handleLoadSelect(e: Event) {

--- a/examples/developer-tools/src/controller.ts
+++ b/examples/developer-tools/src/controller.ts
@@ -5,10 +5,13 @@
  */
 
 import * as Blockly from 'blockly';
+import * as storage from './storage';
+import {createNewBlock, load} from './serialization';
 import {ViewModel} from './view_model';
 import {JavascriptDefinitionGenerator} from './output-generators/javascript_definition_generator';
 import {JsonDefinitionGenerator} from './output-generators/json_definition_generator';
 import {CodeHeaderGenerator} from './output-generators/code_header_generator';
+import { Menu } from '@material/web/menu/menu';
 
 export class Controller {
   constructor(
@@ -23,6 +26,22 @@ export class Controller {
     // Add event listeners to update when output config elements are changed
     this.viewModel.outputConfigDiv.addEventListener('change', () => {
       this.updateOutput();
+    });
+
+    this.viewModel.createButton.addEventListener('click', () => {
+      this.handleCreateButton();
+    });
+
+    this.viewModel.deleteButton.addEventListener('click', () => {
+      this.handleDeleteButton();
+    });
+
+    this.viewModel.loadMenu.addEventListener('close-menu', (e) => {
+      this.handleLoadSelect(e);
+    });
+
+    this.viewModel.loadButton.addEventListener('click', () => {
+      this.handleLoadButton();
     });
   }
 
@@ -97,5 +116,69 @@ export class Controller {
     const block = this.previewWorkspace.newBlock(blockName);
     block.initSvg();
     block.render();
+  }
+
+  /** Handles a click on the "Create new block" button. */
+  private handleCreateButton() {
+    createNewBlock(this.mainWorkspace);
+  }
+
+  /** Handles a click on the "Delete" button. */
+  private handleDeleteButton() {
+    const blockName = this.mainWorkspace
+      .getBlocksByType('factory_base')[0]
+      .getFieldValue('NAME');
+    Blockly.dialog.confirm(
+      `Are you sure you want to delete block "${blockName}"?`,
+      (ok) => {
+        if (!ok) return;
+        storage.removeBlock(blockName);
+
+        // Loads a previously saved block or creates a new one, so the workspace is never empty
+        load(this.mainWorkspace);
+      },
+    );
+  }
+
+  /** Handles a click on the "Load existing block" button. */
+  private handleLoadButton() {
+    this.populateLoadMenu();
+    const menuEl = this.viewModel.loadMenu as Menu;
+    menuEl.open = !menuEl.open;
+  }
+
+  /**
+   * Handles selecting a block from the load menu, whether selected via keyboard or mouse.
+   * 
+   * @param e Custom event fired when the menu is closed.
+   */
+  private handleLoadSelect(e: Event) {
+    if (e.target && e.target instanceof HTMLElement) {
+      const blockName = e.target.getAttribute('data-id');
+      load(this.mainWorkspace, blockName);
+    }
+  }
+
+  /**
+   * Populates the load menu with the list of blocks.
+   * This is called every time the load menu is opened,
+   * so it's always up-to-date with the name of the blocks,
+   * selected block, and list of currently-existing blocks.
+   */
+  private populateLoadMenu() {
+    const menuEl = this.viewModel.loadMenu;
+    const newItems = Array.from(storage.getAllSavedBlockNames()).map((name) => {
+      const el = document.createElement('md-menu-item');
+      el.setAttribute('data-id', name);
+      const div = document.createElement('div');
+      div.setAttribute('slot', 'headline');
+      if (name === storage.getLastEditedBlockName()) {
+        el.setAttribute('selected', 'true');
+      }
+      div.innerText = name;
+      el.appendChild(div);
+      return el;
+    });
+    menuEl.replaceChildren(...newItems);
   }
 }

--- a/examples/developer-tools/src/controller.ts
+++ b/examples/developer-tools/src/controller.ts
@@ -6,7 +6,7 @@
 
 import * as Blockly from 'blockly';
 import * as storage from './storage';
-import {createNewBlock, load} from './serialization';
+import {createNewBlock, loadBlock} from './serialization';
 import {ViewModel} from './view_model';
 import {JavascriptDefinitionGenerator} from './output-generators/javascript_definition_generator';
 import {JsonDefinitionGenerator} from './output-generators/json_definition_generator';
@@ -135,7 +135,7 @@ export class Controller {
         storage.removeBlock(blockName);
 
         // Loads a previously saved block or creates a new one, so the workspace is never empty
-        load(this.mainWorkspace);
+        loadBlock(this.mainWorkspace);
       },
     );
   }
@@ -155,7 +155,7 @@ export class Controller {
   private handleLoadSelect(e: Event) {
     if (e.target && e.target instanceof HTMLElement) {
       const blockName = e.target.getAttribute('data-id');
-      load(this.mainWorkspace, blockName);
+      loadBlock(this.mainWorkspace, blockName);
     }
   }
 

--- a/examples/developer-tools/src/index.css
+++ b/examples/developer-tools/src/index.css
@@ -2,10 +2,17 @@ body {
   margin: 0;
 }
 
+.page-container {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 #block-factory-container {
   display: flex;
-  height: 100vh;
   box-sizing: border-box;
+  height: 80%;
+  flex-grow: 1;
 }
 
 #main-workspace {
@@ -16,7 +23,7 @@ body {
   min-width: 500px;
 }
 
-#output-pane {
+.panel-container {
   display: flex;
   flex-basis: 0;
   flex-direction: column;
@@ -24,10 +31,15 @@ body {
   overflow-y: scroll;
 }
 
-#output-pane > * {
+.panel-container > * {
   flex-basis: 20%;
   margin: 8px;
   min-height: 100px;
+}
+
+.fit-to-size {
+  flex-basis: auto;
+  min-height: auto;
 }
 
 #block-preview {
@@ -38,7 +50,40 @@ body {
   overflow: scroll;
 }
 
-@media screen and (max-width: 800px) {
+.toolbar {
+  width: 100%;
+  height: 64px;
+  padding: 16px;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  background: #2bb4ca;
+  font-family: 'Google Sans', Roboto, Arial, sans-serif;
+}
+
+.logo {
+  height: 36px;
+  border: 0;
+  box-shadow: none;
+  margin: 0 16px 0 0;
+}
+
+.btn {
+  background-color: #fff;
+  border: 2px solid transparent;
+  border-radius: 3px;
+  color: #3c4043;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 8px 16px;
+  margin: 0 8px;
+}
+
+md-menu {
+  max-height: 430px;
+}
+
+@media screen and (max-width: 900px) {
   #block-factory-container {
     flex-direction: column;
     overflow-y: scroll;

--- a/examples/developer-tools/src/index.html
+++ b/examples/developer-tools/src/index.html
@@ -6,62 +6,80 @@
     <title>Blockly Developer Tools</title>
   </head>
   <body>
-    <div id="block-factory-container">
-      <div id="main-workspace"></div>
-      <div id="output-pane">
-        <div id="block-preview"></div>
-        <div id="output-config">
-          <div>
-            Block definition format:
-            <input
-              type="radio"
-              id="definition-json"
-              name="block-definition-language"
-              value="json"
-              checked />
-            <label for="definition-json">JSON</label>
-            <input
-              type="radio"
-              id="definition-js"
-              name="block-definition-language"
-              value="js" />
-            <label for="definition-js">JavaScript</label>
+    <div class="page-container">
+      <div class="toolbar" aria-role="banner">
+        <a href=""
+          ><img
+            src="https://blocklycodelabs.dev/images/logo_knockout.png"
+            class="logo"
+            alt="Blockly logo"
+        /></a>
+        <button id="create-btn" class="btn">Create new block</button>
+        <span style="position: relative">
+          <button id="load-btn" class="btn">Load block</button>
+          <md-menu id="load-menu" anchor="load-btn"></md-menu>
+        </span>
+        <button id="delete-btn" class="btn">Delete</button>
+      </div>
+      <div id="block-factory-container">
+        <div id="main-workspace"></div>
+        <div id="output-pane" class="panel-container">
+          <div id="block-preview"></div>
+          <div id="output-config" class="fit-to-size">
+            <div>
+              Block definition format:
+              <input
+                type="radio"
+                id="definition-json"
+                name="block-definition-language"
+                value="json"
+                checked />
+              <label for="definition-json">JSON</label>
+              <input
+                type="radio"
+                id="definition-js"
+                name="block-definition-language"
+                value="js" />
+              <label for="definition-js">JavaScript</label>
+            </div>
+            <div>
+              Blockly import format:
+              <input
+                type="radio"
+                id="import-esm"
+                name="import-format"
+                value="import"
+                checked />
+              <label for="import-esm">Import (esm/cjs)</label>
+              <input
+                type="radio"
+                id="import-script"
+                name="import-format"
+                value="script" />
+              <label for="import-script">Script tags</label>
+            </div>
+            <div>
+              <label for="code-generator-language"
+                >Code generator language:</label
+              >
+              <select
+                name="code-generator-language"
+                id="code-generator-language">
+                <option value="Javascript">JavaScript</option>
+                <option value="Python">Python</option>
+                <option value="Dart">Dart</option>
+                <option value="Php">PHP</option>
+                <option value="Lua">Lua</option>
+              </select>
+            </div>
           </div>
-          <div>
-            Blockly import format:
-            <input
-              type="radio"
-              id="import-esm"
-              name="import-format"
-              value="import"
-              checked />
-            <label for="import-esm">Import (esm/cjs)</label>
-            <input
-              type="radio"
-              id="import-script"
-              name="import-format"
-              value="script" />
-            <label for="import-script">Script tags</label>
-          </div>
-          <div>
-            <label for="code-generator-language"
-              >Code generator language:</label
-            >
-            <select name="code-generator-language" id="code-generator-language">
-              <option value="Javascript">JavaScript</option>
-              <option value="Python">Python</option>
-              <option value="Dart">Dart</option>
-              <option value="Php">PHP</option>
-              <option value="Lua">Lua</option>
-            </select>
-          </div>
+          <pre id="code-headers"><code></code></pre>
+          <pre id="block-definition">
+                      JSON Definition
+                      <code></code>
+                  </pre>
+          <div id="generator-stub">generator</div>
         </div>
-        <pre id="code-headers"><code></code></pre>
-        <pre id="block-definition">
-                    JSON Definition
-                    <code></code>
-                </pre>
-        <div id="generator-stub">generator</div>
       </div>
     </div>
   </body>

--- a/examples/developer-tools/src/index.ts
+++ b/examples/developer-tools/src/index.ts
@@ -9,7 +9,7 @@ import * as En from 'blockly/msg/en';
 import {jsonDefinitionGenerator} from './output-generators/json_definition_generator';
 import {javascriptDefinitionGenerator} from './output-generators/javascript_definition_generator';
 import {registerAllBlocks} from './blocks';
-import {save, load} from './serialization';
+import {saveOnChange, load} from './serialization';
 import {toolbox} from './toolbox';
 import {theme} from './theme';
 import 'blockly/blocks';
@@ -65,6 +65,6 @@ mainWorkspace.addChangeListener((e: Blockly.Events.Abstract) => {
     return;
   }
 
-  save(mainWorkspace);
+  saveOnChange(mainWorkspace, e);
   controller.updateOutput();
 });

--- a/examples/developer-tools/src/index.ts
+++ b/examples/developer-tools/src/index.ts
@@ -9,7 +9,7 @@ import * as En from 'blockly/msg/en';
 import {jsonDefinitionGenerator} from './output-generators/json_definition_generator';
 import {javascriptDefinitionGenerator} from './output-generators/javascript_definition_generator';
 import {registerAllBlocks} from './blocks';
-import {saveOnChange, load} from './serialization';
+import {saveOnChange, loadBlock} from './serialization';
 import {toolbox} from './toolbox';
 import {theme} from './theme';
 import 'blockly/blocks';
@@ -50,7 +50,7 @@ const controller = new Controller(
 mainWorkspace.addChangeListener(Blockly.Events.disableOrphans);
 
 // Load either saved state or new state
-load(mainWorkspace);
+loadBlock(mainWorkspace);
 
 // Whenever the workspace changes meaningfully, update the preview.
 mainWorkspace.addChangeListener((e: Blockly.Events.Abstract) => {

--- a/examples/developer-tools/src/serialization.ts
+++ b/examples/developer-tools/src/serialization.ts
@@ -48,7 +48,7 @@ export const saveOnChange = function (
  * @param workspace Blockly workspace to load into.
  * @param blockName Name of saved block to load. If unset, loads the last edited block instead.
  */
-export const load = function (
+export const loadBlock = function (
   workspace: Blockly.Workspace,
   blockName?: string,
 ) {

--- a/examples/developer-tools/src/serialization.ts
+++ b/examples/developer-tools/src/serialization.ts
@@ -5,71 +5,188 @@
  */
 
 import * as Blockly from 'blockly/core';
-
-const storageKey = 'blockFactory';
-
-const startBlocks = {
-  blocks: {
-    languageVersion: 0,
-    blocks: [
-      {
-        type: 'factory_base',
-        deletable: false,
-        x: 53,
-        y: 23,
-        fields: {
-          NAME: 'block_type',
-          INLINE: 'AUTO',
-          CONNECTIONS: 'NONE',
-        },
-        inputs: {
-          TOOLTIP: {
-            block: {
-              type: 'text',
-              deletable: false,
-              movable: false,
-              fields: {
-                TEXT: '',
-              },
-            },
-          },
-          HELPURL: {
-            block: {
-              type: 'text',
-              deletable: false,
-              movable: false,
-              fields: {
-                TEXT: '',
-              },
-            },
-          },
-        },
-      },
-    ],
-  },
-};
+import * as storage from './storage';
 
 /**
  * Saves the state of the workspace to browser's local storage.
  *
  * @param workspace Blockly workspace to save.
+ * @param e Blockly event triggering the save.
  */
-export const save = function (workspace: Blockly.Workspace) {
+export const saveOnChange = function (
+  workspace: Blockly.Workspace,
+  e: Blockly.Events.Abstract,
+) {
+  // Don't save if we're in the middle of updating the block's name.
+  if (isChangingBlockName(workspace, e)) return;
+
+  if (isFinalBlockNameChange(workspace, e)) {
+    // If we've changed the block name, make sure the new name is unused and delete the old name.
+    const event = e as Blockly.Events.BlockChange;
+    const oldName = event.oldValue as string;
+    const newName = event.newValue as string;
+    if (storage.getBlock(newName)) {
+      // This case should only happen if the field name change was actually invalid
+      // This fires an incorrect block_change event due to google/blockly#7966
+      // Don't do anything; the field will revert to the old name if the user presses enter
+      return;
+    }
+    storage.removeBlock(oldName);
+  }
+
   const data = Blockly.serialization.workspaces.save(workspace);
-  window.localStorage?.setItem(storageKey, JSON.stringify(data));
+  const blockName = workspace
+    .getBlocksByType('factory_base')[0]
+    .getFieldValue('NAME');
+  storage.updateBlock(blockName, JSON.stringify(data));
 };
 
 /**
- * Loads saved state from local storage into the given workspace.
+ * Loads saved state from storage into the given workspace.
+ * Creates a new block if there is no state to load.
+ *
+ * @param workspace Blockly workspace to load into.
+ * @param blockName Name of saved block to load. If unset, loads the last edited block instead.
+ */
+export const load = function (
+  workspace: Blockly.Workspace,
+  blockName?: string,
+) {
+  const block = blockName
+    ? storage.getBlock(blockName)
+    : storage.getLastEditedBlock();
+  if (block) {
+    Blockly.serialization.workspaces.load(JSON.parse(block), workspace);
+  } else {
+    createNewBlock(workspace);
+  }
+};
+
+/**
+ * Creates a new block from scratch.
  *
  * @param workspace Blockly workspace to load into.
  */
-export const load = function (workspace: Blockly.Workspace) {
-  const data = window.localStorage?.getItem(storageKey);
-  if (data) {
-    Blockly.serialization.workspaces.load(JSON.parse(data), workspace);
-  } else {
-    // Load starter block
-    Blockly.serialization.workspaces.load(startBlocks, workspace);
+export const createNewBlock = function (workspace: Blockly.Workspace) {
+  // Disable events so we don't save while deleting blocks.
+  Blockly.Events.disable();
+  workspace.clear();
+  Blockly.Events.enable();
+
+  const blockName = getNewUnusedName();
+  const startBlockJson = createStartBlock(blockName);
+  Blockly.serialization.workspaces.load(startBlockJson, workspace);
+};
+
+/**
+ * Finds a name for a block that isn't being used yet.
+ *
+ * @param startName Initial name to propose, or 'my_block' if not set.
+ * @returns An unused name based on the proposed name.
+ */
+const getNewUnusedName = function (startName = 'my_block'): string {
+  let name = startName;
+  let number = 0;
+  while (storage.getAllSavedBlockNames().has(name)) {
+    number += 1;
+    name = startName + number;
   }
+  return name;
+};
+
+/**
+ * Creates the inital block factory block setup with the given name.
+ *
+ * @param name Initial name of the block.
+ * @returns Block JSON representing the factory start blocks.
+ */
+const createStartBlock = function (name: string): object {
+  return {
+    blocks: {
+      languageVersion: 0,
+      blocks: [
+        {
+          type: 'factory_base',
+          deletable: false,
+          x: 53,
+          y: 23,
+          fields: {
+            NAME: name,
+            INLINE: 'AUTO',
+            CONNECTIONS: 'NONE',
+          },
+          inputs: {
+            TOOLTIP: {
+              block: {
+                type: 'text',
+                deletable: false,
+                movable: false,
+                fields: {
+                  TEXT: '',
+                },
+              },
+            },
+            HELPURL: {
+              block: {
+                type: 'text',
+                deletable: false,
+                movable: false,
+                fields: {
+                  TEXT: '',
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+};
+
+/**
+ * Checks if the event represents an in-progress change of a block's name.
+ *
+ * @param workspace Blockly workspace the event was for.
+ * @param e The change event to check.
+ * @returns true if the event is an intermediate field change
+ *    that changes the block's name field, else false.
+ */
+const isChangingBlockName = function (
+  workspace: Blockly.Workspace,
+  e: Blockly.Events.Abstract,
+) {
+  if (e.type === Blockly.Events.BLOCK_FIELD_INTERMEDIATE_CHANGE) {
+    const event = e as Blockly.Events.BlockFieldIntermediateChange;
+    if (
+      workspace.getBlockById(event.blockId)?.type === 'factory_base' &&
+      event.name === 'NAME'
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Checks if the event represents a completed change of a block's name.
+ *
+ * @param workspace Blockly workspace the event was for.
+ * @param e The change event to check.
+ * @returns true ifthe event was a block change event that changes the
+ *    block's name field, else false.
+ */
+const isFinalBlockNameChange = function (
+  workspace: Blockly.Workspace,
+  e: Blockly.Events.Abstract,
+) {
+  if (e.type === Blockly.Events.BLOCK_CHANGE) {
+    const event = e as Blockly.Events.BlockChange;
+    if (
+      workspace.getBlockById(event.blockId)?.type === 'factory_base' &&
+      event.name === 'NAME'
+    ) {
+      return true;
+    }
+  }
+  return false;
 };

--- a/examples/developer-tools/src/storage.ts
+++ b/examples/developer-tools/src/storage.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const lastEditedBlockKey = 'blockFactoryLastEditedBlock';
+const allBlocksKey = 'blockFactoryAllBlocks';
+const allBlocks: Set<string> = new Set(
+  JSON.parse(window.localStorage?.getItem(allBlocksKey)) || [],
+);
+const prohibitedBlockNames = new Set([
+  lastEditedBlockKey,
+  allBlocksKey,
+  'blockly_block_factory_preview_block',
+]);
+
+const localStorage = window.localStorage;
+if (!localStorage) {
+  window.alert(
+    'Local Storage is disabled on this page. Saving and loading stored blocks is not possible. You may need to enable cookies or local storage on this domain.',
+  );
+  throw new Error('Local storage is unavailable');
+}
+
+/**
+ * Adds or updates block in local storage.
+ *
+ * @param name Name of the block.
+ * @param block Stringified JSON representing the block's state.
+ */
+export const updateBlock = function (name: string, block: string) {
+  allBlocks.add(name);
+  localStorage.setItem(allBlocksKey, JSON.stringify(Array.from(allBlocks)));
+  localStorage.setItem(name, block);
+  localStorage.setItem(lastEditedBlockKey, name);
+};
+
+/**
+ * Gets the block data for the given block name from storage.
+ *
+ * @param name Name of the block to get.
+ * @returns Stringified JSON representing the block's state, or null if not found.
+ */
+export const getBlock = function (name: string): string | null {
+  const block = localStorage.getItem(name);
+  if (block) {
+    localStorage.setItem(lastEditedBlockKey, name);
+  }
+  return block;
+};
+
+/**
+ * Removes block data for the given block name from storage.
+ *
+ * @param name Name of the block to remove.
+ */
+export const removeBlock = function (name: string) {
+  allBlocks.delete(name);
+  localStorage.setItem(allBlocksKey, JSON.stringify(Array.from(allBlocks)));
+
+  localStorage.removeItem(name);
+
+  if (localStorage.getItem(lastEditedBlockKey) === name) {
+    localStorage.removeItem(lastEditedBlockKey);
+  }
+};
+
+/**
+ * Gets the name of the last edited block.
+ * A block is set as the last edited block when its data is added, changed, or accessed.
+ *
+ * @returns Name of the last edited block.
+ */
+export const getLastEditedBlockName = function (): string {
+  return localStorage.getItem(lastEditedBlockKey);
+};
+
+/**
+ * Gets the block data for the last edited block.
+ * If there is no last edited block found, it returns the
+ * data for the last block saved in storage instead.
+ *
+ * @returns Stringified JSON reperesenting the block's state,
+ *    or null if there are no blocks.
+ */
+export const getLastEditedBlock = function (): string {
+  const lastEditedName = localStorage.getItem(lastEditedBlockKey);
+  if (lastEditedName) {
+    const lastEditedBlock = getBlock(lastEditedName);
+    if (lastEditedBlock) {
+      return lastEditedBlock;
+    }
+  }
+
+  const allBlocksArr = Array.from(allBlocks);
+  if (allBlocksArr.length > 0) {
+    return getBlock(allBlocksArr[allBlocksArr.length - 1]);
+  }
+
+  return null;
+};
+
+/** Gets the names of all blocks saved in storage. */
+export const getAllSavedBlockNames = function (): Set<string> {
+  return allBlocks;
+};
+
+/**
+ * Gets prohibited names for the blocks.
+ * This includes keys that are already used by this application.
+ */
+export const getProhibitedBlockNames = function (): Set<string> {
+  return prohibitedBlockNames;
+};

--- a/examples/developer-tools/src/view_model.ts
+++ b/examples/developer-tools/src/view_model.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import '@material/web/menu/menu';
+import '@material/web/menu/menu-item';
+
 export class ViewModel {
   mainWorkspaceDiv = document.getElementById('main-workspace');
   previewDiv = document.getElementById('block-preview');
@@ -11,6 +14,11 @@ export class ViewModel {
   outputConfigDiv = document.getElementById('output-config');
   codeHeadersDiv = document.getElementById('code-headers').firstChild;
   generatorStubDiv = document.getElementById('generator-stub');
+
+  createButton = document.getElementById('create-btn');
+  deleteButton = document.getElementById('delete-btn');
+  loadButton = document.getElementById('load-btn');
+  loadMenu = document.getElementById('load-menu');
 
   /**
    * Gets a string representing the format of the block


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes #2287 

### Proposed Changes

- Adds ability to create and save multiple blocks
- Adds create new, load, and delete buttons to access this functionality
    - The button & toolbar CSS was ripped from the plugins site to maintain some visual continuity with that
    - The load menu was taken from material design web components, because that was the quickest way to get something that both
        - matched the material-ish design we're using on plugins site and devsite
        - had full a11y features like keyboard nav without me having to implement that myself

<img width="1353" alt="Screenshot 2024-03-28 at 1 29 04 PM" src="https://github.com/google/blockly-samples/assets/8573958/3a751d5b-8a26-4bae-90e4-a23b79122cee">
<img width="631" alt="Screenshot 2024-03-28 at 1 29 25 PM" src="https://github.com/google/blockly-samples/assets/8573958/16624751-551e-4db4-a93a-90cb5d0af045">


### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Examples still doesn't have infrastructure for running tests. Extensive manual testing performed.

### Documentation

tbd

### Additional Information

<!-- Anything else we should know? -->
