### PR TITLE
feat: add code header generation for imports and script tags

### DIFF
--- a/examples/developer-tools/src/controller.ts
+++ b/examples/developer-tools/src/controller.ts
@@ -8,6 +8,7 @@ import * as Blockly from 'blockly';
 import {ViewModel} from './view_model';
 import {JavascriptDefinitionGenerator} from './output-generators/javascript_definition_generator';
 import {JsonDefinitionGenerator} from './output-generators/json_definition_generator';
+import {CodeHeaderGenerator} from './output-generators/code_header_generator';
 
 export class Controller {
   constructor(
@@ -16,6 +17,8 @@ export class Controller {
     private viewModel: ViewModel,
     private jsGenerator: JavascriptDefinitionGenerator,
     private jsonGenerator: JsonDefinitionGenerator,
+    private importHeaderGenerator: CodeHeaderGenerator,
+    private scriptHeaderGenerator: CodeHeaderGenerator,
   ) {
     // Add event listeners to update when output config elements are changed
     this.viewModel.outputConfigDiv.addEventListener('change', () => {
@@ -39,6 +42,20 @@ export class Controller {
     this.viewModel.definitionDiv.textContent = blockDefinitionString;
   }
 
+  showImportHeaders() {
+    const headers = this.importHeaderGenerator.workspaceToCode(
+      this.mainWorkspace,
+    );
+    this.viewModel.codeHeadersDiv.textContent = headers;
+  }
+
+  showScriptHeaders() {
+    const headers = this.scriptHeaderGenerator.workspaceToCode(
+      this.mainWorkspace,
+    );
+    this.viewModel.codeHeadersDiv.textContent = headers;
+  }
+
   /**
    * Updates all of the output for the block factory,
    * including the preview, definition, generators, etc.
@@ -48,6 +65,12 @@ export class Controller {
       this.showJsonDefinition();
     } else {
       this.showJavaScriptDefinition();
+    }
+
+    if (this.viewModel.getCodeHeaderStyle() === 'import') {
+      this.showImportHeaders();
+    } else {
+      this.showScriptHeaders();
     }
 
     this.updateBlockPreview();

--- a/examples/developer-tools/src/index.html
+++ b/examples/developer-tools/src/index.html
@@ -56,7 +56,7 @@
             </select>
           </div>
         </div>
-        <div id="code-headers">code headers</div>
+        <pre id="code-headers"><code></code></pre>
         <pre id="block-definition">
                     JSON Definition
                     <code></code>

--- a/examples/developer-tools/src/index.ts
+++ b/examples/developer-tools/src/index.ts
@@ -16,6 +16,10 @@ import 'blockly/blocks';
 import './index.css';
 import {ViewModel} from './view_model';
 import {Controller} from './controller';
+import {
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from './output-generators/code_header_generator';
 
 // Put Blockly in the global scope for easy debugging.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -38,6 +42,8 @@ const controller = new Controller(
   model,
   javascriptDefinitionGenerator,
   jsonDefinitionGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
 );
 
 // Disable orphan blocks on the main workspace

--- a/examples/developer-tools/src/output-generators/code_header_generator.ts
+++ b/examples/developer-tools/src/output-generators/code_header_generator.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly';
+
+/**
+ * A CodeGenerator that generates the code headers.
+ *
+ * None of the blocks currently actually return code strings. They just add header lines,
+ * which will be deduplicated and joined when `workspaceToCode` is called.
+ *
+ * If you add a field which doesn't need any additional imports, just return an empty string
+ * from its generator function for these generators. If your field is in a plugin,
+ * the code generator function for the field should add
+ * the appropriate import/script that will load the field's plugin.
+ */
+export class CodeHeaderGenerator extends Blockly.CodeGenerator {
+  private headerLines = new Set();
+
+  /**
+   * Resets the headers every time workspaceToCode is called.
+   *
+   * @override
+   */
+  init() {
+    this.headerLines = new Set();
+  }
+
+  /**
+   * Adds a line of code that is needed as a code header, such as an import statement.
+   *
+   * @param header
+   */
+  addHeaderLine(header: string) {
+    this.headerLines.add(header);
+  }
+
+  /**
+   * Concatenates code from next blocks.
+   *
+   * @override
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  protected scrub_(
+    block: Blockly.Block,
+    code: string,
+    thisOnly?: boolean,
+  ): string {
+    const nextBlock =
+      block.nextConnection && block.nextConnection.targetBlock();
+    const nextCode = thisOnly ? '' : this.blockToCode(nextBlock);
+    return code + nextCode;
+  }
+
+  /** @override */
+  workspaceToCode(workspace: Blockly.Workspace): string {
+    // This should be an empty string, but it kicks off code generation
+    super.workspaceToCode(workspace);
+    const headers = Array.from(this.headerLines).join('\n');
+    return headers;
+  }
+}
+
+export const importHeaderGenerator = new CodeHeaderGenerator(
+  'importHeaderGenerator',
+);
+export const scriptHeaderGenerator = new CodeHeaderGenerator(
+  'scriptHeaderGenerator',
+);

--- a/examples/developer-tools/src/output-generators/factory_base.ts
+++ b/examples/developer-tools/src/output-generators/factory_base.ts
@@ -15,6 +15,11 @@ import {
   JavascriptDefinitionGenerator,
   javascriptDefinitionGenerator,
 } from './javascript_definition_generator';
+import {
+  CodeHeaderGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from './code_header_generator';
 
 /**
  * Builds the 'message0' part of the JSON block definition.
@@ -199,3 +204,23 @@ Blockly.common.defineBlocks({${blockName}: ${blockName}});`;
 
 javascriptDefinitionGenerator.forBlock['text'] =
   javascriptGenerator.forBlock['text'];
+
+importHeaderGenerator.forBlock['factory_base'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  generator.addHeaderLine(`import * as Blockly from 'blockly/core';`);
+  generator.statementToCode(block, 'INPUTS');
+  return '';
+};
+
+scriptHeaderGenerator.forBlock['factory_base'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  generator.addHeaderLine(
+    `<script src="https://unpkg.com/blockly/blockly_compressed.js"></script>`,
+  );
+  generator.statementToCode(block, 'INPUTS');
+  return '';
+};

--- a/examples/developer-tools/src/output-generators/fields/checkbox.ts
+++ b/examples/developer-tools/src/output-generators/fields/checkbox.ts
@@ -13,6 +13,11 @@ import {
   JavascriptDefinitionGenerator,
   javascriptDefinitionGenerator,
 } from '../javascript_definition_generator';
+import {
+  CodeHeaderGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from '../code_header_generator';
 
 jsonDefinitionGenerator.forBlock['field_checkbox'] = function (
   block: Blockly.Block,
@@ -33,4 +38,18 @@ javascriptDefinitionGenerator.forBlock['field_checkbox'] = function (
   const name = generator.quote_(block.getFieldValue('FIELDNAME'));
   const checked = generator.quote_(block.getFieldValue('CHECKED'));
   return `.appendField(new Blockly.FieldCheckbox(${checked}), ${name})`;
+};
+
+importHeaderGenerator.forBlock['field_checkbox'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
+};
+
+scriptHeaderGenerator.forBlock['field_checkbox'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
 };

--- a/examples/developer-tools/src/output-generators/fields/dropdown.ts
+++ b/examples/developer-tools/src/output-generators/fields/dropdown.ts
@@ -13,6 +13,11 @@ import {
   JavascriptDefinitionGenerator,
   javascriptDefinitionGenerator,
 } from '../javascript_definition_generator';
+import {
+  CodeHeaderGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from '../code_header_generator';
 
 /**
  * Gets the array of human-readable and machine-readable dropdown options.
@@ -97,4 +102,18 @@ ${optionString}
 ${optionsString}
 ${generator.INDENT}]), ${name})`;
   return code;
+};
+
+importHeaderGenerator.forBlock['field_dropdown'] = function (
+  block: FieldDropdownBlock,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
+};
+
+scriptHeaderGenerator.forBlock['field_dropdown'] = function (
+  block: FieldDropdownBlock,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
 };

--- a/examples/developer-tools/src/output-generators/fields/image.ts
+++ b/examples/developer-tools/src/output-generators/fields/image.ts
@@ -13,6 +13,11 @@ import {
   JavascriptDefinitionGenerator,
   javascriptDefinitionGenerator,
 } from '../javascript_definition_generator';
+import {
+  CodeHeaderGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from '../code_header_generator';
 
 jsonDefinitionGenerator.forBlock['field_image'] = function (
   block: Blockly.Block,
@@ -41,4 +46,18 @@ javascriptDefinitionGenerator.forBlock['field_image'] = function (
 
   const code = `.appendField(new Blockly.FieldImage(${src}, ${width}, ${height}, { alt: ${alt}, flipRtl: ${flipRtl}}))`;
   return code;
+};
+
+importHeaderGenerator.forBlock['field_image'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
+};
+
+scriptHeaderGenerator.forBlock['field_image'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
 };

--- a/examples/developer-tools/src/output-generators/fields/label.ts
+++ b/examples/developer-tools/src/output-generators/fields/label.ts
@@ -13,6 +13,11 @@ import {
   JavascriptDefinitionGenerator,
   javascriptDefinitionGenerator,
 } from '../javascript_definition_generator';
+import {
+  CodeHeaderGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from '../code_header_generator';
 
 jsonDefinitionGenerator.forBlock['field_label'] = function (
   block: Blockly.Block,
@@ -32,4 +37,18 @@ javascriptDefinitionGenerator.forBlock['field_label'] = function (
   const text = generator.quote_(block.getFieldValue('TEXT'));
   const code = `.appendField(${text})`;
   return code;
+};
+
+importHeaderGenerator.forBlock['field_label'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
+};
+
+scriptHeaderGenerator.forBlock['field_label'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
 };

--- a/examples/developer-tools/src/output-generators/fields/label_serializable.ts
+++ b/examples/developer-tools/src/output-generators/fields/label_serializable.ts
@@ -13,6 +13,11 @@ import {
   JavascriptDefinitionGenerator,
   javascriptDefinitionGenerator,
 } from '../javascript_definition_generator';
+import {
+  CodeHeaderGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from '../code_header_generator';
 
 jsonDefinitionGenerator.forBlock['field_label_serializable'] = function (
   block: Blockly.Block,
@@ -35,4 +40,18 @@ javascriptDefinitionGenerator.forBlock['field_label_serializable'] = function (
 
   const code = `.appendField(new Blockly.FieldLabelSerializable(${text}), ${name})`;
   return code;
+};
+
+importHeaderGenerator.forBlock['field_label_serializable'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
+};
+
+scriptHeaderGenerator.forBlock['field_label_serializable'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
 };

--- a/examples/developer-tools/src/output-generators/fields/number.ts
+++ b/examples/developer-tools/src/output-generators/fields/number.ts
@@ -13,6 +13,11 @@ import {
   JavascriptDefinitionGenerator,
   javascriptDefinitionGenerator,
 } from '../javascript_definition_generator';
+import {
+  CodeHeaderGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from '../code_header_generator';
 
 jsonDefinitionGenerator.forBlock['field_number'] = function (
   block: Blockly.Block,
@@ -57,4 +62,18 @@ javascriptDefinitionGenerator.forBlock['field_number'] = function (
 
   const code = `.appendField(new Blockly.FieldNumber(${argsString}), ${name})`;
   return code;
+};
+
+importHeaderGenerator.forBlock['field_number'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
+};
+
+scriptHeaderGenerator.forBlock['field_number'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
 };

--- a/examples/developer-tools/src/output-generators/fields/text_input.ts
+++ b/examples/developer-tools/src/output-generators/fields/text_input.ts
@@ -13,6 +13,11 @@ import {
   JavascriptDefinitionGenerator,
   javascriptDefinitionGenerator,
 } from '../javascript_definition_generator';
+import {
+  CodeHeaderGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from '../code_header_generator';
 
 jsonDefinitionGenerator.forBlock['field_input'] = function (
   block: Blockly.Block,
@@ -35,4 +40,18 @@ javascriptDefinitionGenerator.forBlock['field_input'] = function (
 
   const code = `.appendField(new Blockly.FieldTextInput(${text}), ${name})`;
   return code;
+};
+
+importHeaderGenerator.forBlock['field_input'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
+};
+
+scriptHeaderGenerator.forBlock['field_input'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
 };

--- a/examples/developer-tools/src/output-generators/fields/variable.ts
+++ b/examples/developer-tools/src/output-generators/fields/variable.ts
@@ -13,6 +13,11 @@ import {
   JavascriptDefinitionGenerator,
   javascriptDefinitionGenerator,
 } from '../javascript_definition_generator';
+import {
+  CodeHeaderGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from '../code_header_generator';
 
 jsonDefinitionGenerator.forBlock['field_variable'] = function (
   block: Blockly.Block,
@@ -35,4 +40,18 @@ javascriptDefinitionGenerator.forBlock['field_variable'] = function (
 
   const code = `.appendField(new Blockly.FieldVariable(${variable}), ${name})`;
   return code;
+};
+
+importHeaderGenerator.forBlock['field_variable'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
+};
+
+scriptHeaderGenerator.forBlock['field_variable'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  return '';
 };

--- a/examples/developer-tools/src/output-generators/input.ts
+++ b/examples/developer-tools/src/output-generators/input.ts
@@ -15,6 +15,11 @@ import {
 } from './javascript_definition_generator';
 import {Order as JsOrder} from 'blockly/javascript';
 import * as Blockly from 'blockly/core';
+import {
+  CodeHeaderGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from './code_header_generator';
 
 /**
  * JSON definition for the "input" block.
@@ -114,4 +119,22 @@ javascriptDefinitionGenerator.forBlock['input'] = function (
   }${fields};`;
 
   return code;
+};
+
+importHeaderGenerator.forBlock['input'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  // Allow all the fields to add their headers, if they want to
+  generator.statementToCode(block, 'FIELDS');
+  return '';
+};
+
+scriptHeaderGenerator.forBlock['input'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  // Allow all the fields to add their headers, if they want to
+  generator.statementToCode(block, 'FIELDS');
+  return '';
 };

--- a/examples/developer-tools/src/view_model.ts
+++ b/examples/developer-tools/src/view_model.ts
@@ -9,7 +9,7 @@ export class ViewModel {
   previewDiv = document.getElementById('block-preview');
   definitionDiv = document.getElementById('block-definition').firstChild;
   outputConfigDiv = document.getElementById('output-config');
-  codeHeadersDiv = document.getElementById('code-headers');
+  codeHeadersDiv = document.getElementById('code-headers').firstChild;
   generatorStubDiv = document.getElementById('generator-stub');
 
   /**
@@ -36,5 +36,12 @@ export class ViewModel {
       'code-generator-language',
     ) as HTMLInputElement;
     return languageSelector.value;
+  }
+
+  getCodeHeaderStyle(): string {
+    const radioButton = document.getElementById(
+      'import-esm',
+    ) as HTMLInputElement;
+    return radioButton.checked ? 'import' : 'script';
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2289 

### Proposed Changes

Adds a `CodeGenerator` subclass that can do code header generation for developer tools.

Adds block code generator functions for all the fields. Right now, none of the fields require additional code headers. When the plugin fields are added to dev-tools, they'll be able to use these generators to show users how to import their plugin so the field can be used.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Though none of the current fields need additional headers, I did test to make sure that if they did, the output appears correctly.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
