### PR TITLE
feat: add generator stubs to block factory

### DIFF
--- a/examples/developer-tools/src/controller.ts
+++ b/examples/developer-tools/src/controller.ts
@@ -14,6 +14,10 @@ import {CodeHeaderGenerator} from './output-generators/code_header_generator';
 import {Menu} from '@material/web/menu/menu';
 import {GeneratorStubGenerator} from './output-generators/generator_stub_generator';
 
+/**
+ * This class handles updating the UI output, including refreshing the block preview,
+ * updating the generator output, etc.
+ */
 export class Controller {
   constructor(
     private mainWorkspace: Blockly.WorkspaceSvg,
@@ -63,6 +67,7 @@ export class Controller {
     this.viewModel.definitionDiv.textContent = blockDefinitionString;
   }
 
+  /** Shows code headers for loading Blockly and other deps using imports. */
   showImportHeaders() {
     this.importHeaderGenerator.setLanguage(
       this.viewModel.getCodeGeneratorLanguage(),
@@ -73,6 +78,7 @@ export class Controller {
     this.viewModel.codeHeadersDiv.textContent = headers;
   }
 
+  /** Shows code headers for loading Blockly and other deps using script tags. */
   showScriptHeaders() {
     this.scriptHeaderGenerator.setLanguage(
       this.viewModel.getCodeGeneratorLanguage(),
@@ -83,6 +89,10 @@ export class Controller {
     this.viewModel.codeHeadersDiv.textContent = headers;
   }
 
+  /**
+   * Shows the code generator stub for the currently selected programming
+   * language and import style.
+   */
   updateGeneratorStub() {
     const scriptMode = this.viewModel.getCodeHeaderStyle() === 'script';
     this.generatorStubGenerator.setScriptMode(scriptMode);

--- a/examples/developer-tools/src/controller.ts
+++ b/examples/developer-tools/src/controller.ts
@@ -12,6 +12,7 @@ import {JavascriptDefinitionGenerator} from './output-generators/javascript_defi
 import {JsonDefinitionGenerator} from './output-generators/json_definition_generator';
 import {CodeHeaderGenerator} from './output-generators/code_header_generator';
 import {Menu} from '@material/web/menu/menu';
+import {GeneratorStubGenerator} from './output-generators/generator_stub_generator';
 
 export class Controller {
   constructor(
@@ -22,6 +23,7 @@ export class Controller {
     private jsonGenerator: JsonDefinitionGenerator,
     private importHeaderGenerator: CodeHeaderGenerator,
     private scriptHeaderGenerator: CodeHeaderGenerator,
+    private generatorStubGenerator: GeneratorStubGenerator,
   ) {
     // Add event listeners to update when output config elements are changed
     this.viewModel.outputConfigDiv.addEventListener('change', () => {
@@ -75,6 +77,19 @@ export class Controller {
     this.viewModel.codeHeadersDiv.textContent = headers;
   }
 
+  updateGeneratorStub() {
+    const scriptMode = this.viewModel.getCodeHeaderStyle() === 'script';
+    this.generatorStubGenerator.setScriptMode(scriptMode);
+    this.generatorStubGenerator.setLanguage(
+      this.viewModel.getCodeGeneratorLanguage(),
+    );
+
+    const generatorStub = this.generatorStubGenerator.workspaceToCode(
+      this.mainWorkspace,
+    );
+    this.viewModel.generatorStubDiv.textContent = generatorStub;
+  }
+
   /**
    * Updates all of the output for the block factory,
    * including the preview, definition, generators, etc.
@@ -91,6 +106,8 @@ export class Controller {
     } else {
       this.showScriptHeaders();
     }
+
+    this.updateGeneratorStub();
 
     this.updateBlockPreview();
   }

--- a/examples/developer-tools/src/controller.ts
+++ b/examples/developer-tools/src/controller.ts
@@ -64,6 +64,9 @@ export class Controller {
   }
 
   showImportHeaders() {
+    this.importHeaderGenerator.setLanguage(
+      this.viewModel.getCodeGeneratorLanguage(),
+    );
     const headers = this.importHeaderGenerator.workspaceToCode(
       this.mainWorkspace,
     );
@@ -71,6 +74,9 @@ export class Controller {
   }
 
   showScriptHeaders() {
+    this.scriptHeaderGenerator.setLanguage(
+      this.viewModel.getCodeGeneratorLanguage(),
+    );
     const headers = this.scriptHeaderGenerator.workspaceToCode(
       this.mainWorkspace,
     );

--- a/examples/developer-tools/src/index.css
+++ b/examples/developer-tools/src/index.css
@@ -46,7 +46,7 @@ body {
   min-height: 200px;
 }
 
-#block-definition {
+pre {
   overflow: scroll;
 }
 

--- a/examples/developer-tools/src/index.html
+++ b/examples/developer-tools/src/index.html
@@ -65,11 +65,11 @@
               <select
                 name="code-generator-language"
                 id="code-generator-language">
-                <option value="Javascript">JavaScript</option>
-                <option value="Python">Python</option>
-                <option value="Dart">Dart</option>
-                <option value="Php">PHP</option>
-                <option value="Lua">Lua</option>
+                <option value="javascript">JavaScript</option>
+                <option value="python">Python</option>
+                <option value="dart">Dart</option>
+                <option value="php">PHP</option>
+                <option value="lua">Lua</option>
               </select>
             </div>
           </div>
@@ -78,7 +78,7 @@
                       JSON Definition
                       <code></code>
                   </pre>
-          <div id="generator-stub">generator</div>
+          <pre id="generator-stub"><code></code></pre>
         </div>
       </div>
     </div>

--- a/examples/developer-tools/src/index.ts
+++ b/examples/developer-tools/src/index.ts
@@ -20,6 +20,7 @@ import {
   importHeaderGenerator,
   scriptHeaderGenerator,
 } from './output-generators/code_header_generator';
+import {generatorStubGenerator} from './output-generators/generator_stub_generator';
 
 // Put Blockly in the global scope for easy debugging.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -44,6 +45,7 @@ const controller = new Controller(
   jsonDefinitionGenerator,
   importHeaderGenerator,
   scriptHeaderGenerator,
+  generatorStubGenerator,
 );
 
 // Disable orphan blocks on the main workspace

--- a/examples/developer-tools/src/output-generators/code_header_generator.ts
+++ b/examples/developer-tools/src/output-generators/code_header_generator.ts
@@ -19,6 +19,7 @@ import * as Blockly from 'blockly';
  */
 export class CodeHeaderGenerator extends Blockly.CodeGenerator {
   private headerLines = new Set();
+  private language = 'javascript';
 
   /**
    * Resets the headers every time workspaceToCode is called.
@@ -36,6 +37,14 @@ export class CodeHeaderGenerator extends Blockly.CodeGenerator {
    */
   addHeaderLine(header: string) {
     this.headerLines.add(header);
+  }
+
+  setLanguage(language: string) {
+    this.language = language;
+  }
+
+  getLanguage(): string {
+    return this.language;
   }
 
   /**

--- a/examples/developer-tools/src/output-generators/factory_base.ts
+++ b/examples/developer-tools/src/output-generators/factory_base.ts
@@ -20,6 +20,10 @@ import {
   importHeaderGenerator,
   scriptHeaderGenerator,
 } from './code_header_generator';
+import {
+  GeneratorStubGenerator,
+  generatorStubGenerator,
+} from './generator_stub_generator';
 
 /**
  * Builds the 'message0' part of the JSON block definition.
@@ -223,4 +227,26 @@ scriptHeaderGenerator.forBlock['factory_base'] = function (
   );
   generator.statementToCode(block, 'INPUTS');
   return '';
+};
+
+generatorStubGenerator.forBlock['factory_base'] = function (
+  block: Blockly.Block,
+  generator: GeneratorStubGenerator,
+): string {
+  const lang = generator.getLanguage();
+  const blockName = block.getFieldValue('NAME');
+  const inputs = generator.statementToCode(block, 'INPUTS');
+  const hasOutput = !!block.getInput('OUTPUTCHECK');
+  const returnIfOutput = `// TODO: Change Order.NONE to the correct operator precedence strength
+  return [code, ${generator.getScriptMode() ? lang + '.' : ''}Order.NONE];`;
+  const returnIfNoOutput = `return code;`;
+
+  return `${
+    generator.getScriptMode() ? lang + '.' : ''
+  }${lang}Generator.forBlock[${generator.quote_(blockName)}] = function() {
+${inputs}
+  // TODO: Assemble ${lang} into the code variable.
+  const code = '...';
+  ${hasOutput ? returnIfOutput : returnIfNoOutput}
+}`;
 };

--- a/examples/developer-tools/src/output-generators/factory_base.ts
+++ b/examples/developer-tools/src/output-generators/factory_base.ts
@@ -244,14 +244,15 @@ generatorStubGenerator.forBlock['factory_base'] = function (
   const lang = generator.getLanguage();
   const blockName = block.getFieldValue('NAME');
   const inputs = generator.statementToCode(block, 'INPUTS');
+  const scriptPrefix = generator.getScriptMode() ? lang + '.' : '';
   const hasOutput = !!block.getInput('OUTPUTCHECK');
   const returnIfOutput = `// TODO: Change Order.NONE to the correct operator precedence strength
-  return [code, ${generator.getScriptMode() ? lang + '.' : ''}Order.NONE];`;
+  return [code, ${scriptPrefix}Order.NONE];`;
   const returnIfNoOutput = `return code;`;
 
-  return `${
-    generator.getScriptMode() ? lang + '.' : ''
-  }${lang}Generator.forBlock[${generator.quote_(blockName)}] = function() {
+  return `${scriptPrefix}${lang}Generator.forBlock[${generator.quote_(
+    blockName,
+  )}] = function() {
 ${inputs}
   // TODO: Assemble ${lang} into the code variable.
   const code = '...';

--- a/examples/developer-tools/src/output-generators/factory_base.ts
+++ b/examples/developer-tools/src/output-generators/factory_base.ts
@@ -213,7 +213,11 @@ importHeaderGenerator.forBlock['factory_base'] = function (
   block: Blockly.Block,
   generator: CodeHeaderGenerator,
 ): string {
+  const language = generator.getLanguage();
   generator.addHeaderLine(`import * as Blockly from 'blockly/core';`);
+  generator.addHeaderLine(
+    `import {${language}Generator, Order} from 'blockly/${language}';`,
+  );
   generator.statementToCode(block, 'INPUTS');
   return '';
 };
@@ -222,8 +226,12 @@ scriptHeaderGenerator.forBlock['factory_base'] = function (
   block: Blockly.Block,
   generator: CodeHeaderGenerator,
 ): string {
+  const language = generator.getLanguage();
   generator.addHeaderLine(
     `<script src="https://unpkg.com/blockly/blockly_compressed.js"></script>`,
+  );
+  generator.addHeaderLine(
+    `<script src="https://unpkg.com/blockly/${language}_compressed.js"></script>`,
   );
   generator.statementToCode(block, 'INPUTS');
   return '';

--- a/examples/developer-tools/src/output-generators/fields/checkbox.ts
+++ b/examples/developer-tools/src/output-generators/fields/checkbox.ts
@@ -18,6 +18,10 @@ import {
   importHeaderGenerator,
   scriptHeaderGenerator,
 } from '../code_header_generator';
+import {
+  GeneratorStubGenerator,
+  generatorStubGenerator,
+} from '../generator_stub_generator';
 
 jsonDefinitionGenerator.forBlock['field_checkbox'] = function (
   block: Blockly.Block,
@@ -52,4 +56,15 @@ scriptHeaderGenerator.forBlock['field_checkbox'] = function (
   generator: CodeHeaderGenerator,
 ): string {
   return '';
+};
+
+generatorStubGenerator.forBlock['field_checkbox'] = function (
+  block: Blockly.Block,
+  generator: GeneratorStubGenerator,
+): string {
+  const name = block.getFieldValue('FIELDNAME');
+  const fieldVar = generator.createVariableName('checkbox', name);
+  return `const ${fieldVar} = block.getFieldValue(${generator.quote_(
+    name,
+  )});\n`;
 };

--- a/examples/developer-tools/src/output-generators/fields/dropdown.ts
+++ b/examples/developer-tools/src/output-generators/fields/dropdown.ts
@@ -18,6 +18,10 @@ import {
   importHeaderGenerator,
   scriptHeaderGenerator,
 } from '../code_header_generator';
+import {
+  GeneratorStubGenerator,
+  generatorStubGenerator,
+} from '../generator_stub_generator';
 
 /**
  * Gets the array of human-readable and machine-readable dropdown options.
@@ -116,4 +120,15 @@ scriptHeaderGenerator.forBlock['field_dropdown'] = function (
   generator: CodeHeaderGenerator,
 ): string {
   return '';
+};
+
+generatorStubGenerator.forBlock['field_dropdown'] = function (
+  block: FieldDropdownBlock,
+  generator: GeneratorStubGenerator,
+): string {
+  const name = block.getFieldValue('FIELDNAME');
+  const fieldVar = generator.createVariableName('dropdown', name);
+  return `const ${fieldVar} = block.getFieldValue(${generator.quote_(
+    name,
+  )});\n`;
 };

--- a/examples/developer-tools/src/output-generators/fields/image.ts
+++ b/examples/developer-tools/src/output-generators/fields/image.ts
@@ -18,6 +18,10 @@ import {
   importHeaderGenerator,
   scriptHeaderGenerator,
 } from '../code_header_generator';
+import {
+  GeneratorStubGenerator,
+  generatorStubGenerator,
+} from '../generator_stub_generator';
 
 jsonDefinitionGenerator.forBlock['field_image'] = function (
   block: Blockly.Block,
@@ -59,5 +63,13 @@ scriptHeaderGenerator.forBlock['field_image'] = function (
   block: Blockly.Block,
   generator: CodeHeaderGenerator,
 ): string {
+  return '';
+};
+
+generatorStubGenerator.forBlock['field_image'] = function (
+  block: Blockly.Block,
+  generator: GeneratorStubGenerator,
+): string {
+  // Images don't have a value that would typically appear in a block-code generator
   return '';
 };

--- a/examples/developer-tools/src/output-generators/fields/label.ts
+++ b/examples/developer-tools/src/output-generators/fields/label.ts
@@ -18,6 +18,10 @@ import {
   importHeaderGenerator,
   scriptHeaderGenerator,
 } from '../code_header_generator';
+import {
+  GeneratorStubGenerator,
+  generatorStubGenerator,
+} from '../generator_stub_generator';
 
 jsonDefinitionGenerator.forBlock['field_label'] = function (
   block: Blockly.Block,
@@ -50,5 +54,13 @@ scriptHeaderGenerator.forBlock['field_label'] = function (
   block: Blockly.Block,
   generator: CodeHeaderGenerator,
 ): string {
+  return '';
+};
+
+generatorStubGenerator.forBlock['field_label'] = function (
+  block: Blockly.Block,
+  generator: GeneratorStubGenerator,
+): string {
+  // Labels don't have a value that would typically appear in a block-code generator
   return '';
 };

--- a/examples/developer-tools/src/output-generators/fields/label_serializable.ts
+++ b/examples/developer-tools/src/output-generators/fields/label_serializable.ts
@@ -18,6 +18,10 @@ import {
   importHeaderGenerator,
   scriptHeaderGenerator,
 } from '../code_header_generator';
+import {
+  GeneratorStubGenerator,
+  generatorStubGenerator,
+} from '../generator_stub_generator';
 
 jsonDefinitionGenerator.forBlock['field_label_serializable'] = function (
   block: Blockly.Block,
@@ -53,5 +57,13 @@ scriptHeaderGenerator.forBlock['field_label_serializable'] = function (
   block: Blockly.Block,
   generator: CodeHeaderGenerator,
 ): string {
+  return '';
+};
+
+generatorStubGenerator.forBlock['field_label_serializable'] = function (
+  block: Blockly.Block,
+  generator: GeneratorStubGenerator,
+): string {
+  // Labels don't have a value that would typically appear in a block-code generator
   return '';
 };

--- a/examples/developer-tools/src/output-generators/fields/number.ts
+++ b/examples/developer-tools/src/output-generators/fields/number.ts
@@ -18,6 +18,10 @@ import {
   importHeaderGenerator,
   scriptHeaderGenerator,
 } from '../code_header_generator';
+import {
+  GeneratorStubGenerator,
+  generatorStubGenerator,
+} from '../generator_stub_generator';
 
 jsonDefinitionGenerator.forBlock['field_number'] = function (
   block: Blockly.Block,
@@ -76,4 +80,15 @@ scriptHeaderGenerator.forBlock['field_number'] = function (
   generator: CodeHeaderGenerator,
 ): string {
   return '';
+};
+
+generatorStubGenerator.forBlock['field_number'] = function (
+  block: Blockly.Block,
+  generator: GeneratorStubGenerator,
+): string {
+  const name = block.getFieldValue('FIELDNAME');
+  const fieldVar = generator.createVariableName('number', name);
+  return `const ${fieldVar} = block.getFieldValue(${generator.quote_(
+    name,
+  )});\n`;
 };

--- a/examples/developer-tools/src/output-generators/fields/text_input.ts
+++ b/examples/developer-tools/src/output-generators/fields/text_input.ts
@@ -18,6 +18,10 @@ import {
   importHeaderGenerator,
   scriptHeaderGenerator,
 } from '../code_header_generator';
+import {
+  GeneratorStubGenerator,
+  generatorStubGenerator,
+} from '../generator_stub_generator';
 
 jsonDefinitionGenerator.forBlock['field_input'] = function (
   block: Blockly.Block,
@@ -54,4 +58,15 @@ scriptHeaderGenerator.forBlock['field_input'] = function (
   generator: CodeHeaderGenerator,
 ): string {
   return '';
+};
+
+generatorStubGenerator.forBlock['field_input'] = function (
+  block: Blockly.Block,
+  generator: GeneratorStubGenerator,
+): string {
+  const name = block.getFieldValue('FIELDNAME');
+  const fieldVar = generator.createVariableName('text', name);
+  return `const ${fieldVar} = block.getFieldValue(${generator.quote_(
+    name,
+  )});\n`;
 };

--- a/examples/developer-tools/src/output-generators/fields/variable.ts
+++ b/examples/developer-tools/src/output-generators/fields/variable.ts
@@ -18,6 +18,10 @@ import {
   importHeaderGenerator,
   scriptHeaderGenerator,
 } from '../code_header_generator';
+import {
+  GeneratorStubGenerator,
+  generatorStubGenerator,
+} from '../generator_stub_generator';
 
 jsonDefinitionGenerator.forBlock['field_variable'] = function (
   block: Blockly.Block,
@@ -54,4 +58,15 @@ scriptHeaderGenerator.forBlock['field_variable'] = function (
   generator: CodeHeaderGenerator,
 ): string {
   return '';
+};
+
+generatorStubGenerator.forBlock['field_variable'] = function (
+  block: Blockly.Block,
+  generator: GeneratorStubGenerator,
+): string {
+  const name = block.getFieldValue('FIELDNAME');
+  const fieldVar = generator.createVariableName('variable', name);
+  return `const ${fieldVar} = generator.getVariableName(block.getFieldValue(${generator.quote_(
+    name,
+  )}));\n`;
 };

--- a/examples/developer-tools/src/output-generators/generator_stub_generator.ts
+++ b/examples/developer-tools/src/output-generators/generator_stub_generator.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {JavascriptGenerator} from 'blockly/javascript';
+
+/**
+ * This generator creates the "Generator Stub" output for block factory.
+ * The generated code is the same for each language we support, so we use
+ * the same generator for each programming language and control the output
+ * with a variable, which is set by the block factory controls.
+ */
+export class GeneratorStubGenerator extends JavascriptGenerator {
+  private language = 'javascript';
+  private scriptMode = false;
+  // Don't automatically indent statement inputs.
+  override INDENT = '';
+
+  setLanguage(language: string) {
+    this.language = language;
+  }
+
+  getLanguage(): string {
+    return this.language;
+  }
+
+  setScriptMode(scriptMode: boolean) {
+    this.scriptMode = scriptMode;
+  }
+
+  getScriptMode(): boolean {
+    return this.scriptMode;
+  }
+
+  /**
+   * Creates a variable name for the input or field to be used in the
+   * generator stub output. The type is lowercased and the name is made legal
+   * (no spaces or quotes and encode special characters).
+   *
+   * @param type The type of field or input such as 'checkbox' or 'statement'
+   * @param name The name of the field or input
+   * @returns A valid JavaScript variable name as a string like 'checkbox_name'
+   */
+  createVariableName(type: string, name: string): string {
+    name = encodeURI(
+      name.toLowerCase().replace(/ /g, '_').replace(/[^\w]/g, ''),
+    );
+    return `${type.toLowerCase()}_${name}`;
+  }
+}
+
+export const generatorStubGenerator = new GeneratorStubGenerator();

--- a/examples/developer-tools/src/output-generators/input.ts
+++ b/examples/developer-tools/src/output-generators/input.ts
@@ -151,6 +151,9 @@ generatorStubGenerator.forBlock['input'] = function (
   const inputName = block.getFieldValue('INPUTNAME');
   const inputVar = generator.createVariableName(inputType, inputName);
   const fields = generator.statementToCode(block, 'FIELDS');
+  const orderPrefix = generator.getScriptMode()
+    ? generator.getLanguage() + '.'
+    : '';
   const codeLines = [];
 
   if (inputType === 'Value') {
@@ -160,9 +163,7 @@ generatorStubGenerator.forBlock['input'] = function (
     codeLines.push(
       `const ${inputVar} = generator.valueToCode(block, ${generator.quote_(
         inputName,
-      )}, ${
-        generator.getScriptMode() ? generator.getLanguage() + '.' : ''
-      }Order.ATOMIC);`,
+      )}, ${orderPrefix}Order.ATOMIC);`,
     );
   } else if (inputType === 'Statement') {
     codeLines.push(

--- a/examples/developer-tools/src/output-generators/input.ts
+++ b/examples/developer-tools/src/output-generators/input.ts
@@ -20,6 +20,10 @@ import {
   importHeaderGenerator,
   scriptHeaderGenerator,
 } from './code_header_generator';
+import {
+  GeneratorStubGenerator,
+  generatorStubGenerator,
+} from './generator_stub_generator';
 
 /**
  * JSON definition for the "input" block.
@@ -137,4 +141,41 @@ scriptHeaderGenerator.forBlock['input'] = function (
   // Allow all the fields to add their headers, if they want to
   generator.statementToCode(block, 'FIELDS');
   return '';
+};
+
+generatorStubGenerator.forBlock['input'] = function (
+  block: Blockly.Block,
+  generator: GeneratorStubGenerator,
+): string {
+  const inputType = inputDropdownToJsName[block.getFieldValue('INPUTTYPE')];
+  const inputName = block.getFieldValue('INPUTNAME');
+  const inputVar = generator.createVariableName(inputType, inputName);
+  const fields = generator.statementToCode(block, 'FIELDS');
+  const codeLines = [];
+
+  if (inputType === 'Value') {
+    codeLines.push(
+      '// TODO: change Order.ATOMIC to the correct operator precedence strength',
+    );
+    codeLines.push(
+      `const ${inputVar} = generator.valueToCode(block, ${generator.quote_(
+        inputName,
+      )}, ${
+        generator.getScriptMode() ? generator.getLanguage() + '.' : ''
+      }Order.ATOMIC);`,
+    );
+  } else if (inputType === 'Statement') {
+    codeLines.push(
+      `const ${inputVar} = generator.statementToCode(block, ${generator.quote_(
+        inputName,
+      )});`,
+    );
+  }
+
+  if (!fields && !codeLines.length) return '';
+
+  // Add 1 extra new line always, and 1 more if this isn't the last input in the stack
+  codeLines.push('');
+  if (block.getNextBlock()) codeLines.push('');
+  return generator.prefixLines(fields + codeLines.join('\n'), '  ');
 };

--- a/examples/developer-tools/src/view_model.ts
+++ b/examples/developer-tools/src/view_model.ts
@@ -13,7 +13,7 @@ export class ViewModel {
   definitionDiv = document.getElementById('block-definition').firstChild;
   outputConfigDiv = document.getElementById('output-config');
   codeHeadersDiv = document.getElementById('code-headers').firstChild;
-  generatorStubDiv = document.getElementById('generator-stub');
+  generatorStubDiv = document.getElementById('generator-stub').firstChild;
 
   createButton = document.getElementById('create-btn');
   deleteButton = document.getElementById('delete-btn');
@@ -37,7 +37,7 @@ export class ViewModel {
    * Gets the name of the code generator language the user selected.
    *
    * @returns The generator language name, in the same format as
-   *    used by Blockly, e.g. `Javascript` or `Php`.
+   *    used by Blockly, e.g. `javascript` or `php`.
    */
   getCodeGeneratorLanguage(): string {
     const languageSelector = document.getElementById(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2288

### Proposed Changes

- Adds generator stubs for each of the 5 blockly languages
- Adds the import or script headers for generators to the code headers section

The generated code is largely what is found in the old tool but it fixes several problems where the old tool:
- only showed you script-style `javascript.javascriptGenerator` which is incorrect if you're using imports
- used `Blockly.javascript.ORDER_NONE` in some places which is incorrect as of v10
- used `var` instead of const
- used `generator.nameDB_` instead of `generator.getVariableName`
- did not have newlines between input groups, which I found hard to read
- only had TODOs around fixing the `Order` value in one of the places `Order` is used

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

Note to reviewer: if I manually added quotes around where I'm calling `generator.getFieldValue` such as 

```
`const code = blah('${generator.getFieldValue('FIELDNAME')}');`
```

 that is an error. I should be using `generator.quote_` to add quotes instead (only around field values specifically). I think I fixed them all but would appreciate you double-checking :)
