### PR TITLE
feat: save block factory settings

### DIFF
--- a/examples/developer-tools/src/controller.ts
+++ b/examples/developer-tools/src/controller.ts
@@ -31,6 +31,7 @@ export class Controller {
   ) {
     // Add event listeners to update when output config elements are changed
     this.viewModel.outputConfigDiv.addEventListener('change', () => {
+      this.saveBlockFactorySettings();
       this.updateOutput();
     });
 
@@ -49,6 +50,27 @@ export class Controller {
     this.viewModel.loadButton.addEventListener('click', () => {
       this.handleLoadButton();
     });
+
+    // Load previously-saved settings once on page load
+    this.loadBlockFactorySettings();
+  }
+
+  private saveBlockFactorySettings() {
+    const settings = {
+      blockDefinitionFormat: this.viewModel.getBlockDefinitionFormat(),
+      codeGeneratorLanguage: this.viewModel.getCodeGeneratorLanguage(),
+      codeHeaderStyle: this.viewModel.getCodeHeaderStyle(),
+    };
+    storage.saveBlockFactorySettings(settings);
+  }
+
+  private loadBlockFactorySettings() {
+    const settings = storage.loadBlockFactorySettings();
+    if (settings) {
+      this.viewModel.setBlockDefinitionFormat(settings.blockDefinitionFormat);
+      this.viewModel.setCodeGeneratorLanguage(settings.codeGeneratorLanguage);
+      this.viewModel.setCodeHeaderStyle(settings.codeHeaderStyle);
+    }
   }
 
   /** Shows the JavaScript definition of the block factory block. */

--- a/examples/developer-tools/src/serialization.ts
+++ b/examples/developer-tools/src/serialization.ts
@@ -13,7 +13,7 @@ import * as storage from './storage';
  * @param workspace Blockly workspace to save.
  * @param e Blockly event triggering the save.
  */
-export const saveOnChange = function (
+export function saveOnChange(
   workspace: Blockly.Workspace,
   e: Blockly.Events.Abstract,
 ) {
@@ -39,7 +39,7 @@ export const saveOnChange = function (
     .getBlocksByType('factory_base')[0]
     .getFieldValue('NAME');
   storage.updateBlock(blockName, JSON.stringify(data));
-};
+}
 
 /**
  * Loads saved state from storage into the given workspace.
@@ -48,10 +48,7 @@ export const saveOnChange = function (
  * @param workspace Blockly workspace to load into.
  * @param blockName Name of saved block to load. If unset, loads the last edited block instead.
  */
-export const loadBlock = function (
-  workspace: Blockly.Workspace,
-  blockName?: string,
-) {
+export function loadBlock(workspace: Blockly.Workspace, blockName?: string) {
   const block = blockName
     ? storage.getBlock(blockName)
     : storage.getLastEditedBlock();
@@ -60,14 +57,14 @@ export const loadBlock = function (
   } else {
     createNewBlock(workspace);
   }
-};
+}
 
 /**
  * Creates a new block from scratch.
  *
  * @param workspace Blockly workspace to load into.
  */
-export const createNewBlock = function (workspace: Blockly.Workspace) {
+export function createNewBlock(workspace: Blockly.Workspace) {
   // Disable events so we don't save while deleting blocks.
   Blockly.Events.disable();
   workspace.clear();
@@ -76,7 +73,7 @@ export const createNewBlock = function (workspace: Blockly.Workspace) {
   const blockName = getNewUnusedName();
   const startBlockJson = createStartBlock(blockName);
   Blockly.serialization.workspaces.load(startBlockJson, workspace);
-};
+}
 
 /**
  * Finds a name for a block that isn't being used yet.
@@ -84,7 +81,7 @@ export const createNewBlock = function (workspace: Blockly.Workspace) {
  * @param startName Initial name to propose, or 'my_block' if not set.
  * @returns An unused name based on the proposed name.
  */
-const getNewUnusedName = function (startName = 'my_block'): string {
+function getNewUnusedName(startName = 'my_block'): string {
   let name = startName;
   let number = 0;
   while (storage.getAllSavedBlockNames().has(name)) {
@@ -92,7 +89,7 @@ const getNewUnusedName = function (startName = 'my_block'): string {
     name = startName + number;
   }
   return name;
-};
+}
 
 /**
  * Creates the inital block factory block setup with the given name.
@@ -100,7 +97,7 @@ const getNewUnusedName = function (startName = 'my_block'): string {
  * @param name Initial name of the block.
  * @returns Block JSON representing the factory start blocks.
  */
-const createStartBlock = function (name: string): object {
+function createStartBlock(name: string): object {
   return {
     blocks: {
       languageVersion: 0,
@@ -141,7 +138,7 @@ const createStartBlock = function (name: string): object {
       ],
     },
   };
-};
+}
 
 /**
  * Checks if the event represents an in-progress change of a block's name.
@@ -151,7 +148,7 @@ const createStartBlock = function (name: string): object {
  * @returns true if the event is an intermediate field change
  *    that changes the block's name field, else false.
  */
-const isChangingBlockName = function (
+function isChangingBlockName(
   workspace: Blockly.Workspace,
   e: Blockly.Events.Abstract,
 ) {
@@ -165,7 +162,7 @@ const isChangingBlockName = function (
     }
   }
   return false;
-};
+}
 
 /**
  * Checks if the event represents a completed change of a block's name.
@@ -175,7 +172,7 @@ const isChangingBlockName = function (
  * @returns true ifthe event was a block change event that changes the
  *    block's name field, else false.
  */
-const isFinalBlockNameChange = function (
+function isFinalBlockNameChange(
   workspace: Blockly.Workspace,
   e: Blockly.Events.Abstract,
 ) {
@@ -189,4 +186,4 @@ const isFinalBlockNameChange = function (
     }
   }
   return false;
-};
+}

--- a/examples/developer-tools/src/storage.ts
+++ b/examples/developer-tools/src/storage.ts
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+const settingsKey = 'blockFactorySettings';
 const lastEditedBlockKey = 'blockFactoryLastEditedBlock';
 const allBlocksKey = 'blockFactoryAllBlocks';
 const allBlocks: Set<string> = new Set(
   JSON.parse(window.localStorage?.getItem(allBlocksKey)) || [],
 );
 const prohibitedBlockNames = new Set([
+  settingsKey,
   lastEditedBlockKey,
   allBlocksKey,
   'blockly_block_factory_preview_block',
@@ -113,3 +115,22 @@ export const getAllSavedBlockNames = function (): Set<string> {
 export const getProhibitedBlockNames = function (): Set<string> {
   return prohibitedBlockNames;
 };
+
+export interface BlockFactorySettings {
+  blockDefinitionFormat: string;
+  codeHeaderStyle: string;
+  codeGeneratorLanguage: string;
+}
+
+export const saveBlockFactorySettings = function (
+  settings: BlockFactorySettings,
+) {
+  localStorage.setItem(settingsKey, JSON.stringify(settings));
+};
+
+export const loadBlockFactorySettings =
+  function (): BlockFactorySettings | null {
+    const settings = localStorage.getItem(settingsKey);
+    if (!settings) return null;
+    return JSON.parse(settings);
+  };

--- a/examples/developer-tools/src/storage.ts
+++ b/examples/developer-tools/src/storage.ts
@@ -31,12 +31,12 @@ if (!localStorage) {
  * @param name Name of the block.
  * @param block Stringified JSON representing the block's state.
  */
-export const updateBlock = function (name: string, block: string) {
+export function updateBlock(name: string, block: string) {
   allBlocks.add(name);
   localStorage.setItem(allBlocksKey, JSON.stringify(Array.from(allBlocks)));
   localStorage.setItem(name, block);
   localStorage.setItem(lastEditedBlockKey, name);
-};
+}
 
 /**
  * Gets the block data for the given block name from storage.
@@ -44,20 +44,20 @@ export const updateBlock = function (name: string, block: string) {
  * @param name Name of the block to get.
  * @returns Stringified JSON representing the block's state, or null if not found.
  */
-export const getBlock = function (name: string): string | null {
+export function getBlock(name: string): string | null {
   const block = localStorage.getItem(name);
   if (block) {
     localStorage.setItem(lastEditedBlockKey, name);
   }
   return block;
-};
+}
 
 /**
  * Removes block data for the given block name from storage.
  *
  * @param name Name of the block to remove.
  */
-export const removeBlock = function (name: string) {
+export function removeBlock(name: string) {
   allBlocks.delete(name);
   localStorage.setItem(allBlocksKey, JSON.stringify(Array.from(allBlocks)));
 
@@ -66,7 +66,7 @@ export const removeBlock = function (name: string) {
   if (localStorage.getItem(lastEditedBlockKey) === name) {
     localStorage.removeItem(lastEditedBlockKey);
   }
-};
+}
 
 /**
  * Gets the name of the last edited block.
@@ -74,9 +74,9 @@ export const removeBlock = function (name: string) {
  *
  * @returns Name of the last edited block.
  */
-export const getLastEditedBlockName = function (): string {
+export function getLastEditedBlockName(): string {
   return localStorage.getItem(lastEditedBlockKey);
-};
+}
 
 /**
  * Gets the block data for the last edited block.
@@ -86,7 +86,7 @@ export const getLastEditedBlockName = function (): string {
  * @returns Stringified JSON reperesenting the block's state,
  *    or null if there are no blocks.
  */
-export const getLastEditedBlock = function (): string {
+export function getLastEditedBlock(): string {
   const lastEditedName = localStorage.getItem(lastEditedBlockKey);
   if (lastEditedName) {
     const lastEditedBlock = getBlock(lastEditedName);
@@ -101,20 +101,20 @@ export const getLastEditedBlock = function (): string {
   }
 
   return null;
-};
+}
 
 /** Gets the names of all blocks saved in storage. */
-export const getAllSavedBlockNames = function (): Set<string> {
+export function getAllSavedBlockNames(): Set<string> {
   return allBlocks;
-};
+}
 
 /**
  * Gets prohibited names for the blocks.
  * This includes keys that are already used by this application.
  */
-export const getProhibitedBlockNames = function (): Set<string> {
+export function getProhibitedBlockNames(): Set<string> {
   return prohibitedBlockNames;
-};
+}
 
 export interface BlockFactorySettings {
   blockDefinitionFormat: string;
@@ -122,15 +122,18 @@ export interface BlockFactorySettings {
   codeGeneratorLanguage: string;
 }
 
-export const saveBlockFactorySettings = function (
-  settings: BlockFactorySettings,
-) {
+/**
+ * Saves block factory settings in local storage.
+ *
+ * @param settings Object with settings to save.
+ */
+export function saveBlockFactorySettings(settings: BlockFactorySettings) {
   localStorage.setItem(settingsKey, JSON.stringify(settings));
-};
+}
 
-export const loadBlockFactorySettings =
-  function (): BlockFactorySettings | null {
-    const settings = localStorage.getItem(settingsKey);
-    if (!settings) return null;
-    return JSON.parse(settings);
-  };
+/** Returns block factory settings that were saved in local storage, or null if none. */
+export function loadBlockFactorySettings(): BlockFactorySettings | null {
+  const settings = localStorage.getItem(settingsKey);
+  if (!settings) return null;
+  return JSON.parse(settings);
+}

--- a/examples/developer-tools/src/view_model.ts
+++ b/examples/developer-tools/src/view_model.ts
@@ -34,6 +34,21 @@ export class ViewModel {
   }
 
   /**
+   * Sets the format of the block definition.
+   *
+   * @param format Either 'json' or 'js'
+   */
+  setBlockDefinitionFormat(format: string) {
+    const jsonButton = document.getElementById(
+      'definition-json',
+    ) as HTMLInputElement;
+    const jsButton = document.getElementById(
+      'definition-js',
+    ) as HTMLInputElement;
+    format === 'json' ? (jsonButton.checked = true) : (jsButton.checked = true);
+  }
+
+  /**
    * Gets the name of the code generator language the user selected.
    *
    * @returns The generator language name, in the same format as
@@ -46,10 +61,35 @@ export class ViewModel {
     return languageSelector.value;
   }
 
+  /**
+   * Sets the name of the code generator language dropdown.
+   *
+   * @param language The generator language name, in the same format as
+   *    used by Blockly, e.g. `javascript` or `php`.
+   */
+  setCodeGeneratorLanguage(language: string) {
+    const languageSelector = document.getElementById(
+      'code-generator-language',
+    ) as HTMLInputElement;
+    languageSelector.value = language;
+  }
+
   getCodeHeaderStyle(): string {
     const radioButton = document.getElementById(
       'import-esm',
     ) as HTMLInputElement;
     return radioButton.checked ? 'import' : 'script';
+  }
+
+  setCodeHeaderStyle(style: string) {
+    const importButton = document.getElementById(
+      'import-esm',
+    ) as HTMLInputElement;
+    const scriptButton = document.getElementById(
+      'import-script',
+    ) as HTMLInputElement;
+    style === 'import'
+      ? (importButton.checked = true)
+      : (scriptButton.checked = true);
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

- Saves the state of the various block factory output settings between page loads

### Reason for Changes

I was annoyed by clicking the same options every time the page refreshed

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
