### PR TITLE
chore: allow const variables to have UPPER_CASE names

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -230,6 +230,11 @@ module.exports = [
             match: false,
           },
         },
+        {
+          selector: 'variable',
+          modifiers: ['const'],
+          format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+        },
       ],
       '@typescript-eslint/consistent-type-assertions': 'error',
 

--- a/plugins/block-dynamic-connection/src/dynamic_if.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_if.ts
@@ -35,7 +35,6 @@ interface IfExtraState {
   hasElse?: boolean;
 }
 
-/* eslint-disable @typescript-eslint/naming-convention */
 const DYNAMIC_IF_MIXIN = {
   /**
    * Minimum number of inputs for this block.

--- a/plugins/block-dynamic-connection/src/dynamic_list_create.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_list_create.ts
@@ -19,9 +19,7 @@ interface DynamicListCreateMixin extends DynamicListCreateMixinType {}
 /* eslint-enable @typescript-eslint/no-empty-interface */
 type DynamicListCreateMixinType = typeof DYNAMIC_LIST_CREATE_MIXIN;
 
-/* eslint-disable @typescript-eslint/naming-convention */
 const DYNAMIC_LIST_CREATE_MIXIN = {
-  /* eslint-enable @typescript-eslint/naming-convention */
   /** Minimum number of inputs for this block. */
   minInputs: 2,
 

--- a/plugins/block-dynamic-connection/src/dynamic_text_join.ts
+++ b/plugins/block-dynamic-connection/src/dynamic_text_join.ts
@@ -19,9 +19,7 @@ interface DynamicTextJoinMixin extends DynamicTextJoinMixinType {}
 /* eslint-enable @typescript-eslint/no-empty-interface */
 type DynamicTextJoinMixinType = typeof DYNAMIC_TEXT_JOIN_MIXIN;
 
-/* eslint-disable @typescript-eslint/naming-convention */
 const DYNAMIC_TEXT_JOIN_MIXIN = {
-  /* eslint-enable @typescript-eslint/naming-convention */
   /** Minimum number of inputs for this block. */
   minInputs: 2,
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Reason for change
Necessary for block definition change.

Fixes https://github.com/google/blockly-samples/issues/2298