### PR TITLE
feat: add shadow blocks for connection checks and real colour block

### DIFF
--- a/examples/developer-tools/src/blocks/input.ts
+++ b/examples/developer-tools/src/blocks/input.ts
@@ -47,10 +47,16 @@ const updateTypeInputs = function (
 ): undefined {
   if (inputsWithConnectionCheckInputs.has(value)) {
     if (!this.getInput('CHECK')) {
-      this.appendValueInput('CHECK')
+      const input = this.appendValueInput('CHECK')
         .setCheck(['ConnectionCheckArray', 'ConnectionCheck'])
         .setAlign(Blockly.inputs.Align.RIGHT)
         .appendField('connection check');
+      input.connection.setShadowState({
+        type: 'connection_check',
+        fields: {
+          CHECKDROPDOWN: 'null',
+        },
+      });
     }
   } else {
     this.removeInput('CHECK', true);

--- a/examples/developer-tools/src/serialization.ts
+++ b/examples/developer-tools/src/serialization.ts
@@ -133,6 +133,14 @@ function createStartBlock(name: string): object {
                 },
               },
             },
+            COLOUR: {
+              block: {
+                type: 'colour_hue',
+                fields: {
+                  HUE: 230,
+                },
+              },
+            },
           },
         },
       ],


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2301 

### Proposed Changes

- Adds shadow blocks for "value" and "statement" blocks (automatically adds shadow state if you change the dropdown value to one of these)
- Spawns a real colour block when creating a new block. See issue for rationale of real vs shadow here

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->

<img width="422" alt="Screenshot 2024-04-03 at 3 34 35 PM" src="https://github.com/google/blockly-samples/assets/8573958/8548d83e-f048-444a-abfa-d74f6085eda9">

The new shadow blocks are in the blue "input" blocks. If the dropdown is set to "value" or "statement" this PR adds the shadow blocks. If the dropdown is set to "dummy" or "end-row" those types of inputs do not have connections, therefore they do not have the connection check input on the block and don't get the new shadow state.

The new colour block is connected to the "colour" input on the factory base block, at the very bottom of this screenshot