### PR TITLE
fix: remove code of removed colour toolbox

### DIFF
--- a/examples/devsite-demo/script.js
+++ b/examples/devsite-demo/script.js
@@ -71,10 +71,9 @@ function init() {
   toolboxJson['contents'][2].name = getMsg('Math');
   toolboxJson['contents'][3].name = getMsg('Text');
   toolboxJson['contents'][4].name = getMsg('Lists');
-  toolboxJson['contents'][5].name = getMsg('Colour');
   // Separator.
-  toolboxJson['contents'][7].name = getMsg('Variables');
-  toolboxJson['contents'][8].name = getMsg('Procedures');
+  toolboxJson['contents'][6].name = getMsg('Variables');
+  toolboxJson['contents'][7].name = getMsg('Procedures');
 
   // Inject default variable name.
   // https://github.com/google/blockly/issues/5238

--- a/examples/devsite-landing-demo/script.js
+++ b/examples/devsite-landing-demo/script.js
@@ -80,10 +80,9 @@ function init() {
   toolboxJson['contents'][2].name = getMsg('Math');
   toolboxJson['contents'][3].name = getMsg('Text');
   toolboxJson['contents'][4].name = getMsg('Lists');
-  toolboxJson['contents'][5].name = getMsg('Colour');
   // Separator.
-  toolboxJson['contents'][7].name = getMsg('Variables');
-  toolboxJson['contents'][8].name = getMsg('Procedures');
+  toolboxJson['contents'][6].name = getMsg('Variables');
+  toolboxJson['contents'][7].name = getMsg('Procedures');
 
   // Inject default variable name.
   // https://github.com/google/blockly/issues/5238

--- a/examples/devsite-landing-demo/style.css
+++ b/examples/devsite-landing-demo/style.css
@@ -95,15 +95,11 @@ option {
   border-left: 15px solid #4db6ac !important;
 }
 
-#blockly-5 {
-  border-left: 15px solid #ffcdd2 !important;
-}
-
-#blockly-7 {
+#blockly-6 {
   border-left: 15px solid #ef9a9a !important;
 }
 
-#blockly-8 {
+#blockly-7 {
   border-left: 15px solid #d7ccc8 !important;
 }
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes error loading caused by applying changes in #2294.

### Proposed Changes

Remove JavasSript and CSS codes of the removed colour toolbox.
