### PR TITLE
fix(migration): Ignore non-renamed modules

### DIFF
--- a/plugins/migration/bin/rename.js
+++ b/plugins/migration/bin/rename.js
@@ -192,8 +192,11 @@ class VersionRenamer {
       //   moduleA.exportA -> moduleC.exportB
       // And we performed the module rename first, we wouldn't be able to detect
       // the export rename.
-      this.renamings_.push({old: oldModulePath, new: newModulePath});
+      if (newModulePath !== oldModulePath) {
+        this.renamings_.push({old: oldModulePath, new: newModulePath});
+      }
     }
+    console.log(this.renamings_);
   }
 
   /**

--- a/plugins/migration/bin/rename.js
+++ b/plugins/migration/bin/rename.js
@@ -196,7 +196,6 @@ class VersionRenamer {
         this.renamings_.push({old: oldModulePath, new: newModulePath});
       }
     }
-    console.log(this.renamings_);
   }
 
   /**

--- a/plugins/migration/test/rename.mocha.js
+++ b/plugins/migration/test/rename.mocha.js
@@ -18,6 +18,10 @@ suite('Rename', function () {
     const database = {
       '1.0.0': [
         {
+          oldName: 'Blockly',
+          exports: {}
+        },
+        {
           oldName: 'Blockly.moduleA',
           newName: 'Blockly.newModuleA',
           exports: {


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes #2171.

### Proposed Changes

Don't create a renaming entry for modules that haven't been renamed.

Add  an entry to the test renamings that replicates the situation describe in #2171, and which causes multiple test failures without the aforementioned fix.

### Additional Information

We should _probably_ do a prefix sort on `.renamings_` (or even just sort by length descending), so that more specific entries precede less-specific ones, but after thinking quite hard about the possible consequences of this I wasn't 100% sure that this wouldn't have unforeseen consequences due to the (arguably excessive) complexity of how renamings are specified.

Since the renaming file (and therefore script) is due for a rethink anyway—since it is keyed on `goog.module` IDs that no longer actually exist in the Blockly sourcecode—I think doing the simplest possible thing for now is probably the best approach.