### PR TITLE
feat: move backpack to use interface for backpackability

### DIFF
--- a/plugins/workspace-backpack/README.md
+++ b/plugins/workspace-backpack/README.md
@@ -153,6 +153,11 @@ Blockly.Msg['EMPTY_BACKPACK'] = 'Opróżnij plecak'; // Polish
 - `addBlock`: Adds Block to backpack.
 - `addBlocks`: Adds Blocks to backpack.
 - `removeBlock`: Removes Block to backpack.
+- `containsBlock`: Returns whether the Block is in the backpack.
+- `addBackpackable`: Adds Backpackable to backpack.
+- `addBackpackables`: Adds Backpackable to backpack.
+- `removeBackpackable`: Removes Backpackable to backpack.
+- `containsBackpackable`: Returns whether the Backpackable is in the backpack.
 - `addItem`: Adds item to backpack.
 - `removeItem`: Removes item from the backpack.
 - `setContents`: Sets backpack contents.
@@ -201,6 +206,17 @@ The Backpack Flyout uses the registered Flyout for either
 for `Blockly.Trashcan`. If a custom class is registered for either of these
 types, then the Backpack Flyout may need to be tested for compatibility.
 
+### Draggables
+
+If you have a custom draggable object, you can make it possible to add it to
+the backpack by implementing the [`Backpackable`][backpackable] interface.
+
+This interface requires the draggable to have a method that converts it into
+[`FlyoutItemInfo`][flyout-info]. As of 2024-04-08 flyouts only support displaying blocks, buttons, and labels.
+
 ## License
 
 Apache 2.0
+
+[flyout-info]: https://developers.google.com/blockly/reference/js/blockly.utils_namespace.toolbox_namespace.flyoutiteminfo_typealias.md
+[backpackable]: https://github.com/google/blockly-samples/blob/master/plugins/workspace-backpack/src/backpack.ts

--- a/plugins/workspace-backpack/README.md
+++ b/plugins/workspace-backpack/README.md
@@ -212,7 +212,7 @@ If you have a custom draggable object, you can make it possible to add it to
 the backpack by implementing the [`Backpackable`][backpackable] interface.
 
 This interface requires the draggable to have a method that converts it into
-[`FlyoutItemInfo`][flyout-info]. As of 2024-04-08 flyouts only support displaying blocks, buttons, and labels.
+[`FlyoutItemInfo`][flyout-info]. As of Blockly core v11 flyouts only support displaying blocks, buttons, and labels.
 
 ## License
 

--- a/plugins/workspace-backpack/src/backpack.ts
+++ b/plugins/workspace-backpack/src/backpack.ts
@@ -526,7 +526,11 @@ export class Backpack
    *     provided block.
    */
   containsBlock(block: Blockly.Block): boolean {
-    return isBackpackable(block) && this.containsBackpackable(block);
+    if (isBackpackable(block)) {
+      return this.containsBackpackable(block);
+    } else {
+      return this.contents_.indexOf(this.blockToJsonString(block)) !== -1;
+    }
   }
 
   /**
@@ -535,7 +539,11 @@ export class Backpack
    * @param block The block to be added to the backpack.
    */
   addBlock(block: Blockly.Block) {
-    if (isBackpackable(block)) this.addBackpackable(block);
+    if (isBackpackable(block)) {
+      this.addBackpackable(block);
+    } else {
+      this.addItem(this.blockToJsonString(block));
+    }
   }
 
   /**
@@ -546,7 +554,11 @@ export class Backpack
    */
   addBlocks(blocks: Blockly.Block[]) {
     for (const block of blocks) {
-      if (isBackpackable(block)) this.addBackpackable(block);
+      if (isBackpackable(block)) {
+        this.addBackpackable(block);
+      } else {
+        this.addItem(this.blockToJsonString(block));
+      }
     }
   }
 
@@ -556,37 +568,45 @@ export class Backpack
    * @param block The block to be removed from the backpack.
    */
   removeBlock(block: Blockly.Block) {
-    if (isBackpackable(block)) this.removeBackpackable(block);
+    if (isBackpackable(block)) {
+      this.removeBackpackable(block);
+    } else {
+      this.removeItem(this.blockToJsonString(block));
+    }
   }
 
   /**
-   * Returns whether the backpack contains a duplicate of the provided
-   * backpackable.
+   * @param backpackable The backpackable we want to check for existance within
+   *     the backpack.
+   * @return whether the backpack contains a duplicate of the provided
+   *     backpackable.
    */
   containsBackpackable(backpackable: Backpackable) {
     return backpackable
-      .toFlyoutData()
+      .toFlyoutInfo()
       .every((info) => this.contents_.indexOf(JSON.stringify(info)) !== -1);
   }
 
-  /** Adds the given backpackable to the backpack. */
+  /**
+   * @param backpackable The backpackable to add to the backpack.
+   */
   addBackpackable(backpackable: Backpackable) {
     this.addBackpackables([backpackable]);
   }
 
-  /** Adds the given backpackables to the backpack. */
+  /** @param backpackables The backpackables to add to the backpack. */
   addBackpackables(backpackables: Backpackable[]) {
     this.addItems(
       backpackables
-        .map((b) => b.toFlyoutData())
+        .map((b) => b.toFlyoutInfo())
         .reduce((acc, curr) => [...acc, ...curr])
         .map((info) => JSON.stringify(info)),
     );
   }
 
-  /** Removes the given backpackable from the backpack, if it exists. */
+  /** @param backpackable The backpackable to remove from the backpack. */
   removeBackpackable(backpackable: Backpackable) {
-    for (const info of backpackable.toFlyoutData()) {
+    for (const info of backpackable.toFlyoutInfo()) {
       this.removeItem(JSON.stringify(info));
     }
   }

--- a/plugins/workspace-backpack/src/backpack.ts
+++ b/plugins/workspace-backpack/src/backpack.ts
@@ -576,12 +576,12 @@ export class Backpack
   }
 
   /**
-   * @param backpackable The backpackable we want to check for existance within
+   * @param backpackable The backpackable we want to check for existence within
    *     the backpack.
    * @return whether the backpack contains a duplicate of the provided
    *     backpackable.
    */
-  containsBackpackable(backpackable: Backpackable) {
+  containsBackpackable(backpackable: Backpackable): boolean {
     return backpackable
       .toFlyoutInfo()
       .every((info) => this.contents_.indexOf(JSON.stringify(info)) !== -1);

--- a/plugins/workspace-backpack/src/backpackable.ts
+++ b/plugins/workspace-backpack/src/backpackable.ts
@@ -9,16 +9,20 @@ import * as Blockly from 'blockly/core';
 /** Defines if an object can be added to the backpack. */
 export interface Backpackable {
   /**
-   * Returns a representation of this object as a FlyoutItemInfo array, so that
+   * @return A representation of this object as a FlyoutItemInfo array, so that
    * it can be displayed in the backpack.
    *
    * This method should remove any unique or useless state data (e.g. IDs or
    * coordinates).
    */
-  toFlyoutData(): Blockly.utils.toolbox.FlyoutItemInfo[];
+  toFlyoutInfo(): Blockly.utils.toolbox.FlyoutItemInfo[];
 }
 
-/** Checks whether the given object conforms to the Backpackable interface. */
+/**
+ * @param obj The object we want to check is a Backpackable or not.
+ * @return Whether the given object conforms to the Backpackable interface.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isBackpackable(obj: any): obj is Backpackable {
-  return obj.toFlyoutData !== undefined;
+  return obj.toFlyoutInfo !== undefined;
 }

--- a/plugins/workspace-backpack/src/backpackable.ts
+++ b/plugins/workspace-backpack/src/backpackable.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+
+/** Defines if an object can be added to the backpack. */
+export interface Backpackable {
+  /**
+   * Returns a representation of this object as a FlyoutItemInfo array, so that
+   * it can be displayed in the backpack.
+   *
+   * This method should remove any unique or useless state data (e.g. IDs or
+   * coordinates).
+   */
+  toFlyoutData(): Blockly.utils.toolbox.FlyoutItemInfo[];
+}
+
+/** Checks whether the given object conforms to the Backpackable interface. */
+export function isBackpackable(obj: any): obj is Backpackable {
+  return obj.toFlyoutData !== undefined;
+}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2311 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Makes it so the backpack uses an interfaces for adding things to itself instead of hard coding to only work with blocks.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Manually tested that blocks still get added to the backpack.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Should be documented somewhere?? Would love opinions! Worst case I'll add it to the dragger docs?

### Additional Information

<!-- Anything else we should know? -->
N/A
