### PR TITLE
fix: Move away from using innerHTML

### DIFF
--- a/examples/custom-renderer-codelab/src/index.js
+++ b/examples/custom-renderer-codelab/src/index.js
@@ -32,7 +32,6 @@ const ws = Blockly.inject(blocklyDiv, {
 const runCode = () => {
   const code = javascriptGenerator.workspaceToCode(ws);
   codeDiv.innerText = code;
-
   outputDiv.textContent = '';
 
   eval(code);


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.