### PR TITLE
fix: update screenshot.js DOM text reinterpreted as HTML

### DIFF
--- a/plugins/dev-tools/src/screenshot.js
+++ b/plugins/dev-tools/src/screenshot.js
@@ -58,7 +58,7 @@ function workspaceToSvg_(workspace, callback, customCss) {
   // Go through all text areas and set their value.
   const textAreas = document.getElementsByTagName('textarea');
   for (let i = 0; i < textAreas.length; i++) {
-    textAreas[i].innerHTML = textAreas[i].value;
+    textAreas[i].innerText = textAreas[i].value;
   }
 
   const bBox = workspace.getBlocksBoundingBox();


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.