### PR TITLE
feat: add angle and colour fields to block factory

### DIFF
--- a/examples/developer-tools/package-lock.json
+++ b/examples/developer-tools/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@blockly/field-angle": "^4.0.1",
+        "@blockly/field-colour": "^4.0.1",
         "@material/web": "^1.4.0",
         "blockly": "^10.4.2"
       },
@@ -201,6 +203,28 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@blockly/field-angle": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/field-angle/-/field-angle-4.0.1.tgz",
+      "integrity": "sha512-tChPImRydd5qppgPlUArxI22g88Zlm2ZRdk7Ly9sIDskpciC9RItilnuOqWKPFfuE00GMV4yHb25scegBGxCZQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "blockly": "^10.0.0"
+      }
+    },
+    "node_modules/@blockly/field-colour": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/field-colour/-/field-colour-4.0.1.tgz",
+      "integrity": "sha512-IcQwjdbjoUdJXLYm7JVg8vhTdPl8uEDh7hLsfbaxJ5OyJsiTloSPoGfQpqfB8y+xz6PCmE+HxseTmD2193TibQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "blockly": "^10.4.3"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2037,9 +2061,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.4.2.tgz",
-      "integrity": "sha512-oCJkHZD1HEPYPwnMk/sbmMmhW6UFe+3iH5yvDn3hy3HSVzCOunkw9H1Crb/MmlhhFdvjB5uWgGzQNAa2eWAV6A==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.4.3.tgz",
+      "integrity": "sha512-+opfBmQnSiv7vTiY/TkDEBOslxUyfj8luS3S+qs1NnQKjInC+Waf2l9cNsMh9J8BMkmiCIT+Ed/3mmjIaL9wug==",
       "dependencies": {
         "jsdom": "22.1.0"
       }
@@ -10780,6 +10804,18 @@
         }
       }
     },
+    "@blockly/field-angle": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/field-angle/-/field-angle-4.0.1.tgz",
+      "integrity": "sha512-tChPImRydd5qppgPlUArxI22g88Zlm2ZRdk7Ly9sIDskpciC9RItilnuOqWKPFfuE00GMV4yHb25scegBGxCZQ==",
+      "requires": {}
+    },
+    "@blockly/field-colour": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/field-colour/-/field-colour-4.0.1.tgz",
+      "integrity": "sha512-IcQwjdbjoUdJXLYm7JVg8vhTdPl8uEDh7hLsfbaxJ5OyJsiTloSPoGfQpqfB8y+xz6PCmE+HxseTmD2193TibQ==",
+      "requires": {}
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -12304,9 +12340,9 @@
       }
     },
     "blockly": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.4.2.tgz",
-      "integrity": "sha512-oCJkHZD1HEPYPwnMk/sbmMmhW6UFe+3iH5yvDn3hy3HSVzCOunkw9H1Crb/MmlhhFdvjB5uWgGzQNAa2eWAV6A==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.4.3.tgz",
+      "integrity": "sha512-+opfBmQnSiv7vTiY/TkDEBOslxUyfj8luS3S+qs1NnQKjInC+Waf2l9cNsMh9J8BMkmiCIT+Ed/3mmjIaL9wug==",
       "requires": {
         "jsdom": "22.1.0"
       }

--- a/examples/developer-tools/package.json
+++ b/examples/developer-tools/package.json
@@ -38,6 +38,8 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
+    "@blockly/field-angle": "^4.0.1",
+    "@blockly/field-colour": "^4.0.1",
     "@material/web": "^1.4.0",
     "blockly": "^10.4.2"
   }

--- a/examples/developer-tools/src/blocks/colour.ts
+++ b/examples/developer-tools/src/blocks/colour.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
+import {FieldAngle} from '@blockly/field-angle';
 
 /**
  * A hue-picker to set the colour of a block.
@@ -14,7 +14,7 @@ export const colourHue = {
   init: function () {
     this.appendDummyInput()
       .appendField('hue:')
-      .appendField(new Blockly.FieldAngle('0', this.updateBlockColour), 'HUE');
+      .appendField(new FieldAngle('0', this.updateBlockColour), 'HUE');
     this.setOutput(true, 'Colour');
     this.setTooltip('Paint the block with this colour.');
     this.setHelpUrl('https://www.youtube.com/watch?v=s2_xaEvcVI0#t=55');

--- a/examples/developer-tools/src/blocks/fields.ts
+++ b/examples/developer-tools/src/blocks/fields.ts
@@ -5,6 +5,8 @@
  */
 
 import * as Blockly from 'blockly/core';
+import {FieldAngle} from '@blockly/field-angle';
+import {FieldColour} from '@blockly/field-colour';
 
 /** The default source to use as prepopulated text in image fields. */
 const defaultImageSrc =
@@ -439,5 +441,43 @@ export const fieldDropdownOptionImage = {
     this.setTooltip('Add a new image option to the dropdown menu.');
     this.setHelpUrl('https://www.youtube.com/watch?v=s2_xaEvcVI0#t=386');
     this.contextMenu = false;
+  },
+};
+
+/** Angle field. */
+export const fieldAngle = {
+  init: function () {
+    this.setStyle('field');
+    this.appendDummyInput()
+      .appendField('angle')
+      .appendField(new FieldAngle('90'), 'ANGLE')
+      .appendField(',')
+      .appendField(new Blockly.FieldTextInput('NAME'), 'FIELDNAME');
+    this.setPreviousStatement(true, 'Field');
+    this.setNextStatement(true, 'Field');
+    this.setTooltip('A field for the user to enter an angle.');
+    this.setHelpUrl('https://www.youtube.com/watch?v=s2_xaEvcVI0#t=372');
+  },
+  onchange: function () {
+    checkNameConflicts(this);
+  },
+};
+
+/** Colour field. */
+export const fieldColour = {
+  init: function () {
+    this.setStyle('field');
+    this.appendDummyInput()
+      .appendField('colour')
+      .appendField(new FieldColour('#ff0000'), 'COLOUR')
+      .appendField(',')
+      .appendField(new Blockly.FieldTextInput('NAME'), 'FIELDNAME');
+    this.setPreviousStatement(true, 'Field');
+    this.setNextStatement(true, 'Field');
+    this.setTooltip('Colour field.');
+    this.setHelpUrl('https://www.youtube.com/watch?v=s2_xaEvcVI0#t=495');
+  },
+  onchange: function () {
+    checkNameConflicts(this);
   },
 };

--- a/examples/developer-tools/src/blocks/index.ts
+++ b/examples/developer-tools/src/blocks/index.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {registerFieldAngle} from '@blockly/field-angle';
+import {registerFieldColour} from '@blockly/field-colour';
+
 import {factoryBase} from './factory_base';
 import * as Blockly from 'blockly/core';
 import {input} from './input';
@@ -14,7 +17,9 @@ import {
   connectionCheckItem,
 } from './connection_check';
 import {
+  fieldAngle,
   fieldCheckbox,
+  fieldColour,
   fieldDropdown,
   fieldDropdownContainer,
   fieldDropdownOptionImage,
@@ -40,12 +45,18 @@ import '../output-generators/fields/label_serializable';
 import '../output-generators/fields/checkbox';
 import '../output-generators/fields/image';
 import '../output-generators/fields/variable';
+import '../output-generators/fields/angle';
+import '../output-generators/fields/colour';
 import '../output-generators/colour';
 
 /* eslint-disable @typescript-eslint/naming-convention
  -- Blockly convention is to use snake_case for block names
 */
 export const registerAllBlocks = function () {
+  // Register the plugin fields before using them in blocks.
+  registerFieldAngle();
+  registerFieldColour();
+
   Blockly.common.defineBlocks({
     factory_base: factoryBase,
     input: input,
@@ -60,6 +71,8 @@ export const registerAllBlocks = function () {
     field_checkbox: fieldCheckbox,
     field_variable: fieldVariable,
     field_image: fieldImage,
+    field_angle: fieldAngle,
+    field_colour: fieldColour,
     connection_check_group: connectionCheckGroup,
     connection_check_group_container: connectionCheckContainer,
     connection_check_group_item: connectionCheckItem,

--- a/examples/developer-tools/src/output-generators/fields/angle.ts
+++ b/examples/developer-tools/src/output-generators/fields/angle.ts
@@ -62,6 +62,7 @@ scriptHeaderGenerator.forBlock['field_angle'] = function (
   generator.addHeaderLine(
     `<script src="https://unpkg.com/@blockly/field-angle"></script>`,
   );
+  generator.addHeaderLine(`registerFieldAngle();`);
   return '';
 };
 

--- a/examples/developer-tools/src/output-generators/fields/angle.ts
+++ b/examples/developer-tools/src/output-generators/fields/angle.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {
+  JsonDefinitionGenerator,
+  jsonDefinitionGenerator,
+} from '../json_definition_generator';
+import {
+  JavascriptDefinitionGenerator,
+  javascriptDefinitionGenerator,
+} from '../javascript_definition_generator';
+import {
+  CodeHeaderGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from '../code_header_generator';
+import {
+  GeneratorStubGenerator,
+  generatorStubGenerator,
+} from '../generator_stub_generator';
+
+jsonDefinitionGenerator.forBlock['field_angle'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): string {
+  const code = {
+    type: 'field_angle',
+    name: block.getFieldValue('FIELDNAME'),
+    angle: block.getFieldValue('ANGLE'),
+  };
+  return JSON.stringify(code);
+};
+
+javascriptDefinitionGenerator.forBlock['field_angle'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+): string {
+  const name = generator.quote_(block.getFieldValue('FIELDNAME'));
+  const angle = block.getFieldValue('ANGLE');
+  return `.appendField(new FieldAngle(${angle}), ${name})`;
+};
+
+importHeaderGenerator.forBlock['field_angle'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  generator.addHeaderLine(
+    `import {registerFieldAngle, FieldAngle} from '@blockly/field-angle';`,
+  );
+  generator.addHeaderLine(`registerFieldAngle();`);
+  return '';
+};
+
+scriptHeaderGenerator.forBlock['field_angle'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  generator.addHeaderLine(
+    `<script src="https://unpkg.com/@blockly/field-angle"></script>`,
+  );
+  return '';
+};
+
+generatorStubGenerator.forBlock['field_angle'] = function (
+  block: Blockly.Block,
+  generator: GeneratorStubGenerator,
+): string {
+  const name = block.getFieldValue('FIELDNAME');
+  const fieldVar = generator.createVariableName('angle', name);
+  return `const ${fieldVar} = block.getFieldValue(${generator.quote_(
+    name,
+  )});\n`;
+};

--- a/examples/developer-tools/src/output-generators/fields/colour.ts
+++ b/examples/developer-tools/src/output-generators/fields/colour.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {
+  JsonDefinitionGenerator,
+  jsonDefinitionGenerator,
+} from '../json_definition_generator';
+import {
+  JavascriptDefinitionGenerator,
+  javascriptDefinitionGenerator,
+} from '../javascript_definition_generator';
+import {
+  CodeHeaderGenerator,
+  importHeaderGenerator,
+  scriptHeaderGenerator,
+} from '../code_header_generator';
+import {
+  GeneratorStubGenerator,
+  generatorStubGenerator,
+} from '../generator_stub_generator';
+
+jsonDefinitionGenerator.forBlock['field_colour'] = function (
+  block: Blockly.Block,
+  generator: JsonDefinitionGenerator,
+): string {
+  const code = {
+    type: 'field_colour',
+    name: block.getFieldValue('FIELDNAME'),
+    colour: block.getFieldValue('COLOUR'),
+  };
+  return JSON.stringify(code);
+};
+
+javascriptDefinitionGenerator.forBlock['field_colour'] = function (
+  block: Blockly.Block,
+  generator: JavascriptDefinitionGenerator,
+): string {
+  const name = generator.quote_(block.getFieldValue('FIELDNAME'));
+  const colour = generator.quote_(block.getFieldValue('COLOUR'));
+  return `.appendField(new FieldColour(${colour}), ${name})`;
+};
+
+importHeaderGenerator.forBlock['field_colour'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  generator.addHeaderLine(
+    `import {registerFieldColour, FieldColour} from '@blockly/field-colour';`,
+  );
+  generator.addHeaderLine(`registerFieldColour();`);
+  return '';
+};
+
+scriptHeaderGenerator.forBlock['field_colour'] = function (
+  block: Blockly.Block,
+  generator: CodeHeaderGenerator,
+): string {
+  generator.addHeaderLine(
+    `<script src="https://unpkg.com/@blockly/field-colour"></script>`,
+  );
+  return '';
+};
+
+generatorStubGenerator.forBlock['field_colour'] = function (
+  block: Blockly.Block,
+  generator: GeneratorStubGenerator,
+): string {
+  const name = block.getFieldValue('FIELDNAME');
+  const fieldVar = generator.createVariableName('colour', name);
+  return `const ${fieldVar} = block.getFieldValue(${generator.quote_(
+    name,
+  )});\n`;
+};

--- a/examples/developer-tools/src/output-generators/fields/colour.ts
+++ b/examples/developer-tools/src/output-generators/fields/colour.ts
@@ -62,6 +62,7 @@ scriptHeaderGenerator.forBlock['field_colour'] = function (
   generator.addHeaderLine(
     `<script src="https://unpkg.com/@blockly/field-colour"></script>`,
   );
+  generator.addHeaderLine(`registerFieldColour();`);
   return '';
 };
 

--- a/examples/developer-tools/src/toolbox.ts
+++ b/examples/developer-tools/src/toolbox.ts
@@ -79,6 +79,14 @@ export const toolbox = {
           kind: 'block',
           type: 'field_image',
         },
+        {
+          kind: 'block',
+          type: 'field_angle',
+        },
+        {
+          kind: 'block',
+          type: 'field_colour',
+        },
       ],
     },
     {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes google/blockly#2159 

### Proposed Changes

- Adds colour and angle blocks to field blocks
- Uses plugin angle field for the colour block used to color the block factory block
- Does not add the multiline text since that's not in the original block factory either

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
