### PR TITLE
Update screenshot.js DOM text reinterpreted as HTML 

### DIFF
--- a/plugins/dev-tools/src/screenshot.js
+++ b/plugins/dev-tools/src/screenshot.js
@@ -99,7 +99,7 @@ function workspaceToSvg_(workspace, callback, customCss) {
     })
     .join('\n');
   const style = document.createElement('style');
-  style.innerText = css + '\n' + customCss;
+  style.textContent = css + '\n' + customCss;
   svg.insertBefore(style, svg.firstChild);
 
   let svgAsXML = new XMLSerializer().serializeToString(svg);

--- a/plugins/dev-tools/src/screenshot.js
+++ b/plugins/dev-tools/src/screenshot.js
@@ -99,7 +99,7 @@ function workspaceToSvg_(workspace, callback, customCss) {
     })
     .join('\n');
   const style = document.createElement('style');
-  style.innerHTML = css + '\n' + customCss;
+  style.innerText = css + '\n' + customCss;
   svg.insertBefore(style, svg.firstChild);
 
   let svgAsXML = new XMLSerializer().serializeToString(svg);


### PR DESCRIPTION
By using textContent, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.