### PR TITLE
fix: Update index.js DOM text reinterpreted as HTML

### DIFF
--- a/examples/keyboard-navigation-codelab/src/index.js
+++ b/examples/keyboard-navigation-codelab/src/index.js
@@ -43,7 +43,7 @@ const runCode = () => {
   const code = javascriptGenerator.workspaceToCode(ws);
   codeDiv.innerText = code;
 
-  outputDiv.innerText = '';
+  outputDiv.textContent = '';
 
   eval(code);
 };

--- a/examples/keyboard-navigation-codelab/src/index.js
+++ b/examples/keyboard-navigation-codelab/src/index.js
@@ -43,7 +43,7 @@ const runCode = () => {
   const code = javascriptGenerator.workspaceToCode(ws);
   codeDiv.innerText = code;
 
-  outputDiv.innerHTML = '';
+  outputDiv.innerText = '';
 
   eval(code);
 };


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.