### PR TITLE
fix: Call blocks handle both manual disabling and disabled defs

### DIFF
--- a/plugins/block-dynamic-connection/package-lock.json
+++ b/plugins/block-dynamic-connection/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.2.0",
         "mocha": "^10.2.0",
         "typescript": "^5.2.2"
@@ -18,7 +18,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -1516,9 +1516,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -42,13 +42,13 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.2.0",
     "mocha": "^10.2.0",
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/block-plus-minus/package-lock.json
+++ b/plugins/block-plus-minus/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.0.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.2.0",
         "mocha": "^10.2.0",
         "sinon": "^9.0.1"
@@ -18,7 +18,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -122,9 +122,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -1628,9 +1628,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/block-plus-minus/package.json
+++ b/plugins/block-plus-minus/package.json
@@ -41,13 +41,13 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.2.0",
     "mocha": "^10.2.0",
     "sinon": "^9.0.1"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/block-shareable-procedures/package-lock.json
+++ b/plugins/block-shareable-procedures/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.3.7",
         "jsdom": "^16.4.0",
         "jsdom-global": "^3.0.2",
@@ -20,7 +20,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -132,9 +132,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"

--- a/plugins/block-shareable-procedures/package.json
+++ b/plugins/block-shareable-procedures/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.3.7",
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",
@@ -51,7 +51,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -745,7 +745,7 @@ const procedureDefOnChangeMixin = {
       e.blockId === this.id &&
       e.element === 'disabled'
     ) {
-      this.getProcedureModel().setEnabled(!e.newValue);
+      this.getProcedureModel().setEnabled(this.isEnabled());
     }
   },
 };
@@ -949,8 +949,6 @@ Blockly.Extensions.register(
 );
 
 const procedureCallerMutator = {
-  previousEnabledState_: true,
-
   paramsFromSerializedState_: [],
 
   /**
@@ -1053,6 +1051,8 @@ Blockly.Extensions.registerMutator(
   procedureCallerMutator,
 );
 
+const PROCEDURE_MODEL_DISABLED_REASON = 'PROCEDURE_MODEL_DISABLED';
+
 const procedureCallerUpdateShapeMixin = {
   /**
    * Renders the block for the first time based on the procedure model.
@@ -1094,12 +1094,10 @@ const procedureCallerUpdateShapeMixin = {
    *     model.
    */
   updateEnabled_: function () {
-    if (!this.getProcedureModel().getEnabled()) {
-      this.previousEnabledState_ = this.isEnabled();
-      this.setEnabled(false);
-    } else {
-      this.setEnabled(this.previousEnabledState_);
-    }
+    this.setDisabledReason(
+      !this.getProcedureModel().getEnabled(),
+      PROCEDURE_MODEL_DISABLED_REASON,
+    );
   },
 
   /**

--- a/plugins/block-test/package-lock.json
+++ b/plugins/block-test/package-lock.json
@@ -9,13 +9,13 @@
       "version": "5.1.0",
       "license": "Apache 2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -37,9 +37,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -496,9 +496,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/block-test/package.json
+++ b/plugins/block-test/package.json
@@ -40,10 +40,10 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/content-highlight/package-lock.json
+++ b/plugins/content-highlight/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.12",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -38,9 +38,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -510,9 +510,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -45,11 +45,11 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/continuous-toolbox/package-lock.json
+++ b/plugins/continuous-toolbox/package-lock.json
@@ -9,13 +9,13 @@
       "version": "5.0.13",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -37,9 +37,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -496,9 +496,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -41,10 +41,10 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/cross-tab-copy-paste/package-lock.json
+++ b/plugins/cross-tab-copy-paste/package-lock.json
@@ -9,13 +9,13 @@
       "version": "5.0.6",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -37,9 +37,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -496,9 +496,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -42,10 +42,10 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/dev-create/package-lock.json
+++ b/plugins/dev-create/package-lock.json
@@ -17,7 +17,7 @@
         "create-package": "bin/create.js"
       },
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -632,9 +632,9 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/dev-create/package.json
+++ b/plugins/dev-create/package.json
@@ -43,6 +43,6 @@
     "node": ">=14.0.0"
   },
   "devDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   }
 }

--- a/plugins/dev-scripts/package-lock.json
+++ b/plugins/dev-scripts/package-lock.json
@@ -26,7 +26,7 @@
         "blockly-scripts": "bin/blockly-scripts.js"
       },
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "typescript": "^5.0.4"
       },
       "engines": {
@@ -881,9 +881,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"

--- a/plugins/dev-scripts/package.json
+++ b/plugins/dev-scripts/package.json
@@ -55,7 +55,7 @@
     "node": ">=8.0.0"
   },
   "devDependencies": {
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "typescript": "^5.0.4"
   }
 }

--- a/plugins/dev-tools/package-lock.json
+++ b/plugins/dev-tools/package-lock.json
@@ -18,13 +18,13 @@
       },
       "devDependencies": {
         "@types/dat.gui": "^0.7.5",
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -91,9 +91,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -759,9 +759,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -53,10 +53,10 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@types/dat.gui": "^0.7.5",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/disable-top-blocks/package-lock.json
+++ b/plugins/disable-top-blocks/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.4.10",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -37,9 +37,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -496,9 +496,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -40,10 +40,10 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/eslint-config/package-lock.json
+++ b/plugins/eslint-config/package-lock.json
@@ -16,7 +16,7 @@
         "eslint-plugin-jsdoc": "^46.8.0"
       },
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -690,9 +690,9 @@
       "peer": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -3061,9 +3061,9 @@
       "peer": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/eslint-config/package.json
+++ b/plugins/eslint-config/package.json
@@ -40,6 +40,6 @@
     "node": ">=10.0.0"
   },
   "devDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   }
 }

--- a/plugins/field-angle/package-lock.json
+++ b/plugins/field-angle/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.12",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.2.0",
         "sinon": "^9.0.1",
         "typescript": "^5.0.4"
@@ -18,7 +18,7 @@
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -84,9 +84,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -760,9 +760,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/field-angle/package.json
+++ b/plugins/field-angle/package.json
@@ -42,13 +42,13 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-bitmap/package-lock.json
+++ b/plugins/field-bitmap/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.13",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.3.6",
         "mocha": "^9.2.1"
       },
@@ -17,7 +17,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -1563,9 +1563,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/field-bitmap/package.json
+++ b/plugins/field-bitmap/package.json
@@ -42,12 +42,12 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.3.6",
     "mocha": "^9.2.1"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-colour-hsv-sliders/package-lock.json
+++ b/plugins/field-colour-hsv-sliders/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -38,9 +38,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -510,9 +510,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/field-colour-hsv-sliders/package.json
+++ b/plugins/field-colour-hsv-sliders/package.json
@@ -46,11 +46,11 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-colour/package-lock.json
+++ b/plugins/field-colour/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@typescript-eslint/parser": "^5.59.5",
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.2.0",
         "sinon": "^9.0.1",
         "typescript": "^5.0.4"
@@ -19,7 +19,7 @@
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -515,9 +515,9 @@
       "peer": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -2773,9 +2773,9 @@
       "peer": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/field-colour/package.json
+++ b/plugins/field-colour/package.json
@@ -43,13 +43,13 @@
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
     "@typescript-eslint/parser": "^5.59.5",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-date/package-lock.json
+++ b/plugins/field-date/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.0.12",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.2.0",
         "sinon": "^9.0.1",
         "typescript": "^5.2.2"
@@ -18,7 +18,7 @@
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -84,9 +84,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -760,9 +760,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -44,13 +44,13 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-dependent-dropdown/package-lock.json
+++ b/plugins/field-dependent-dropdown/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.12",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.2.0",
         "sinon": "^9.0.1",
         "typescript": "^5.2.2"
@@ -18,7 +18,7 @@
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -84,9 +84,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"

--- a/plugins/field-dependent-dropdown/package.json
+++ b/plugins/field-dependent-dropdown/package.json
@@ -43,13 +43,13 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-grid-dropdown/package-lock.json
+++ b/plugins/field-grid-dropdown/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.11",
       "license": "Apache 2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -38,9 +38,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -510,9 +510,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -41,11 +41,11 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-multilineinput/package-lock.json
+++ b/plugins/field-multilineinput/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.13",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.2.0",
         "sinon": "^9.0.1",
         "typescript": "^5.0.4"
@@ -18,7 +18,7 @@
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -84,9 +84,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -760,9 +760,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/field-multilineinput/package.json
+++ b/plugins/field-multilineinput/package.json
@@ -42,13 +42,13 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-slider/package-lock.json
+++ b/plugins/field-slider/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.1.5",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.2.0",
         "sinon": "^9.0.1",
         "typescript": "^5.2.2"
@@ -18,7 +18,7 @@
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -84,9 +84,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -760,9 +760,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -41,13 +41,13 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/fixed-edges/package-lock.json
+++ b/plugins/fixed-edges/package-lock.json
@@ -9,13 +9,13 @@
       "version": "4.0.11",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -37,9 +37,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -496,9 +496,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -40,10 +40,10 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/keyboard-navigation/package-lock.json
+++ b/plugins/keyboard-navigation/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.8",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.2.0",
         "jsdom": "^16.4.0",
         "jsdom-global": "^3.0.2",
@@ -20,7 +20,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -257,23 +257,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/blockly/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/blockly/node_modules/form-data": {
@@ -2801,9 +2784,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"
@@ -2835,15 +2818,6 @@
           "requires": {
             "whatwg-mimetype": "^4.0.0",
             "whatwg-url": "^14.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
           }
         },
         "form-data": {

--- a/plugins/keyboard-navigation/package.json
+++ b/plugins/keyboard-navigation/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.2.0",
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",
@@ -49,7 +49,7 @@
     "sinon": "^9.0.1"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/migration/package-lock.json
+++ b/plugins/migration/package-lock.json
@@ -20,7 +20,7 @@
       },
       "devDependencies": {
         "@types/mocha": "^9.1.0",
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.3.6",
         "mocha": "^9.2.1",
         "sinon": "^13.0.1"
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -1906,9 +1906,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/migration/package.json
+++ b/plugins/migration/package.json
@@ -41,7 +41,7 @@
   "type": "module",
   "devDependencies": {
     "@types/mocha": "^9.1.0",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.3.6",
     "mocha": "^9.2.1",
     "sinon": "^13.0.1"

--- a/plugins/modal/package-lock.json
+++ b/plugins/modal/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.10",
       "license": "Apache 2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "jsdom": "^19.0.0",
         "jsdom-global": "3.0.2",
         "mocha": "^10.1.0",
@@ -19,7 +19,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -193,9 +193,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -2160,9 +2160,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -41,14 +41,14 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",
     "mocha": "^10.1.0",
     "sinon": "7.5.0"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/scroll-options/package-lock.json
+++ b/plugins/scroll-options/package-lock.json
@@ -9,13 +9,13 @@
       "version": "5.0.12",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -37,9 +37,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -496,9 +496,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -41,10 +41,10 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/shadow-block-converter/package-lock.json
+++ b/plugins/shadow-block-converter/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.2.0",
         "sinon": "^9.0.1",
         "typescript": "^5.2.2"
@@ -18,7 +18,7 @@
         "node": ">=8.0.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -84,9 +84,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -761,9 +761,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/shadow-block-converter/package.json
+++ b/plugins/shadow-block-converter/package.json
@@ -41,13 +41,13 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/strict-connection-checker/package-lock.json
+++ b/plugins/strict-connection-checker/package-lock.json
@@ -9,14 +9,14 @@
       "version": "4.0.11",
       "license": "Apache 2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.2.0"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -47,9 +47,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -587,9 +587,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -42,11 +42,11 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.2.0"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/suggested-blocks/package-lock.json
+++ b/plugins/suggested-blocks/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.6",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.3.6",
         "sinon": "^14.0.0"
       },
@@ -17,7 +17,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -78,9 +78,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -718,9 +718,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/suggested-blocks/package.json
+++ b/plugins/suggested-blocks/package.json
@@ -42,12 +42,12 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.3.6",
     "sinon": "^14.0.0"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/theme-dark/package-lock.json
+++ b/plugins/theme-dark/package-lock.json
@@ -9,13 +9,13 @@
       "version": "6.0.5",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -37,9 +37,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -496,9 +496,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -41,10 +41,10 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/theme-deuteranopia/package-lock.json
+++ b/plugins/theme-deuteranopia/package-lock.json
@@ -9,13 +9,13 @@
       "version": "5.0.5",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -37,9 +37,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -496,9 +496,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/theme-deuteranopia/package.json
+++ b/plugins/theme-deuteranopia/package.json
@@ -41,10 +41,10 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/theme-hackermode/package-lock.json
+++ b/plugins/theme-hackermode/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "../block-test": {
@@ -191,9 +191,9 @@
       "license": "MIT"
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"

--- a/plugins/theme-hackermode/package.json
+++ b/plugins/theme-hackermode/package.json
@@ -43,10 +43,10 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.0",
     "@blockly/dev-tools": "^7.1.3",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/theme-highcontrast/package-lock.json
+++ b/plugins/theme-highcontrast/package-lock.json
@@ -9,13 +9,13 @@
       "version": "5.0.5",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -37,9 +37,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -496,9 +496,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/theme-highcontrast/package.json
+++ b/plugins/theme-highcontrast/package.json
@@ -41,10 +41,10 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/theme-modern/package-lock.json
+++ b/plugins/theme-modern/package-lock.json
@@ -9,13 +9,13 @@
       "version": "5.0.5",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -37,9 +37,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -496,9 +496,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -41,10 +41,10 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/theme-tritanopia/package-lock.json
+++ b/plugins/theme-tritanopia/package-lock.json
@@ -9,13 +9,13 @@
       "version": "5.0.5",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -37,9 +37,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -496,9 +496,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/theme-tritanopia/package.json
+++ b/plugins/theme-tritanopia/package.json
@@ -41,10 +41,10 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/toolbox-search/package-lock.json
+++ b/plugins/toolbox-search/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.2.6",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.3.7",
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -45,9 +45,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -598,9 +598,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/toolbox-search/package.json
+++ b/plugins/toolbox-search/package.json
@@ -42,12 +42,12 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.3.7",
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/typed-variable-modal/package-lock.json
+++ b/plugins/typed-variable-modal/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.0.10",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "jsdom": "^19.0.0",
         "jsdom-global": "3.0.2",
         "mocha": "^10.1.0",
@@ -19,7 +19,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -193,9 +193,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -2160,9 +2160,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -41,14 +41,14 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",
     "mocha": "^10.1.0",
     "sinon": "7.5.0"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "dependencies": {
     "@blockly/plugin-modal": "^6.0.10"

--- a/plugins/workspace-backpack/package-lock.json
+++ b/plugins/workspace-backpack/package-lock.json
@@ -9,14 +9,14 @@
       "version": "5.3.4",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -38,9 +38,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -510,9 +510,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -42,11 +42,11 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/workspace-minimap/package-lock.json
+++ b/plugins/workspace-minimap/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.1.14",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "chai": "^4.2.0",
         "typescript": "^5.1.3"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -45,9 +45,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"

--- a/plugins/workspace-minimap/package.json
+++ b/plugins/workspace-minimap/package.json
@@ -41,12 +41,12 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "chai": "^4.2.0",
     "typescript": "^5.1.3"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/workspace-search/package-lock.json
+++ b/plugins/workspace-search/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "jsdom": "^19.0.0",
         "jsdom-global": "3.0.2",
         "sinon": "^9.0.1",
@@ -19,7 +19,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -134,9 +134,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -1171,9 +1171,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -41,14 +41,14 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",
     "sinon": "^9.0.1",
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/zoom-to-fit/package-lock.json
+++ b/plugins/zoom-to-fit/package-lock.json
@@ -9,14 +9,14 @@
       "version": "5.0.13",
       "license": "Apache-2.0",
       "devDependencies": {
-        "blockly": "^11.0.0-beta.7",
+        "blockly": "^11.0.0-beta.9",
         "typescript": "^5.1.6"
       },
       "engines": {
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^11.0.0-beta.7"
+        "blockly": "^11.0.0-beta.9"
       }
     },
     "node_modules/agent-base": {
@@ -38,9 +38,9 @@
       "dev": true
     },
     "node_modules/blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "dependencies": {
         "jsdom": "23.0.0"
@@ -510,9 +510,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "11.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.7.tgz",
-      "integrity": "sha512-JQ/EGIQLPgzopVYH6Vj7H88Y5jnWzRQT028Eg+zXCCWe1CNFyBDrB94SGhTV585E22b9RWW4IKqX/2EHj5eI1A==",
+      "version": "11.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-11.0.0-beta.9.tgz",
+      "integrity": "sha512-Zc8O0d5mwusZbYIydi80tlRK2F1rMkPrIup96v88cD4q6n+jecsVMsTfxeZkB3HzVzblfBChgSDEIAYSilOD4A==",
       "dev": true,
       "requires": {
         "jsdom": "23.0.0"

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -40,11 +40,11 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^3.1.1",
     "@blockly/dev-tools": "^7.1.6",
-    "blockly": "^11.0.0-beta.7",
+    "blockly": "^11.0.0-beta.9",
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0-beta.7"
+    "blockly": "^11.0.0-beta.9"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/2035

### Proposed Changes

https://github.com/google/blockly/pull/7958 makes the core Blockly system for disabling blocks more advanced, allowing a block to be simultaneously disabled for multiple independent reasons (such as manually disabling from the context menu, or being disabled because the block is not valid). Removing one of these reasons doesn't affect the others, and the block as a whole is only considered to be enabled if it doesn't have any disabled reasons. This PR takes advantage of that system to allow shared procedure call blocks to have a unique reason for being disabled when the corresponding procedure model is disabled.

Also, I updated all plugins to depend on the latest blockly beta: `11.0.0-beta.9`.

### Reason for Changes

Previously, if the user manually disabled a procedure call block, then edited the name of the procedure, the call block would be re-enabled (because the call block was updated to match the procedure model). Also, a call block that had been disabled by the model could be manually re-enabled.

### Test Coverage

I tested manually. (with `npm run start` in the plugin directory.) All bugs I'm aware of have been fixed.

There are existing tests to ensure that call blocks get disabled/enabled when the corresponding def is changed, and these still pass. I don't think there are any tests related to disabling from the context menu though.

### Documentation

N/A

### Additional Information

In `procedureDefUpdateShapeMixin.doProcedureUpdate()`, there's the following line:
```
    this.setEnabled(this.getProcedureModel().getEnabled());
```
This is using the deprecated Block method `setEnabled` which only updates the `MANUALLY_DISABLED` reason. If the def block is disabled for other reasons, then the procedure model can't fully enable the def block. This sounds like an unlikely scenario (what else would be disabling a def block? what would cause the model to become enabled when the def block is disabled?) but if we want to robustly handle this situation, then the procedure model should probably fully represent all of the procedure's disabled reasons, instead of just a boolean indicating whether there are any disabled reasons, so that it can properly sync the def with the model.