### PR TITLE
feat: support uploading file from old block factory

### DIFF
--- a/examples/developer-tools/src/controller.ts
+++ b/examples/developer-tools/src/controller.ts
@@ -6,7 +6,7 @@
 
 import * as Blockly from 'blockly';
 import * as storage from './storage';
-import {createNewBlock, loadBlock, loadBlockFromData} from './serialization';
+import {createNewBlock, loadBlock} from './serialization';
 import {ViewModel} from './view_model';
 import {JavascriptDefinitionGenerator} from './output-generators/javascript_definition_generator';
 import {JsonDefinitionGenerator} from './output-generators/json_definition_generator';
@@ -16,6 +16,14 @@ import {GeneratorStubGenerator} from './output-generators/generator_stub_generat
 import {convertBaseBlock} from './backwards_compatibility';
 
 const IMPORT_BLOCK_FACTORY_ID = 'Import from block factory...';
+
+/**
+ * A map where the keys are the names of a file that was uploaded,
+ * and the value is an object with two properties:
+ *     successes - an array of successfully saved block names
+ *     fails - the number of blocks that failed to parse from that file
+ */
+type UploadResults = Map<string, {successes: string[]; fails: number}>;
 
 /**
  * This class handles updating the UI output, including refreshing the block preview,
@@ -56,6 +64,10 @@ export class Controller {
 
     this.viewModel.fileModalCloseButton.addEventListener('click', () => {
       this.viewModel.toggleFileUploadModal(false);
+    });
+
+    this.viewModel.uploadResultsCloseButton.addEventListener('click', () => {
+      this.viewModel.toggleUploadResultsModal(false);
     });
 
     this.viewModel.fileDropZone.addEventListener('drop', (e) => {
@@ -266,7 +278,7 @@ export class Controller {
       if (name === storage.getLastEditedBlockName()) {
         el.setAttribute('selected', 'true');
       }
-      div.innerText = name;
+      div.textContent = name;
       el.appendChild(div);
       return el;
     });
@@ -275,13 +287,14 @@ export class Controller {
 
   /** Shows the file upload modal when the user selects that option from the load menu. */
   private handleLoadFromFile() {
+    this.viewModel.toggleFileUploadWarning(false);
     this.viewModel.toggleFileUploadModal(true);
   }
 
   /**
    * Handles the drag event that occurs when a user drops a file onto the file upload
-   * drag-n-drop zone. Gets the first file of the type we want and attempts to load it
-   * into the block factory editor.
+   * drag-n-drop zone. Loads all of the blocks that it can into storage, then shows
+   * the results of the file upload.
    *
    * @param e drop event
    */
@@ -295,18 +308,25 @@ export class Controller {
 
     if (!e.dataTransfer.items) return;
 
-    const firstItem = [...e.dataTransfer.items].find((item) => {
-      // Get the first plain text file, in case the user uploaded multiple
+    const allResults: UploadResults = new Map();
+    const allPromises: Array<Promise<void>> = [];
+
+    [...e.dataTransfer.items].forEach((item) => {
+      // Only consider plain text files
       if (item.kind === 'file' && item.type === 'text/plain') {
-        return true;
+        const file = item.getAsFile();
+        allPromises.push(
+          this.loadFromFile(file).then((results) => {
+            allResults.set(file.name, results);
+          }),
+        );
       }
     });
 
-    if (!firstItem) {
-      this.viewModel.toggleFileUploadWarning(true);
-      return;
-    }
-    this.loadFromFile(firstItem.getAsFile());
+    // Wait for all the files to be processed, then display results
+    Promise.all(allPromises).then(() => {
+      this.displayLoadResults(allResults);
+    });
   }
 
   /**
@@ -318,27 +338,117 @@ export class Controller {
     const input = this.viewModel.fileUploadInput as HTMLInputElement;
     const file = input.files[0];
     if (!file) return;
-    this.loadFromFile(file);
+    this.loadFromFile(file).then(({successes, fails}) => {
+      const results: UploadResults = new Map();
+      results.set(file.name, {successes, fails});
+      this.displayLoadResults(results);
+    });
+
+    // Reset the file input value
+    input.value = null;
+  }
+
+  /**
+   * Shows the results of a file upload/drop.
+   * If there are no succeses, we keep the file upload modal open so user can try again.
+   * If there are mixed successes and failures, we do our best to show what exactly happened.
+   * If there are no failures, we show a success message.
+   * If any block successfully loads, we show the first one in the block editor.
+   *
+   * @param results Map of filename to upload results.
+   */
+  private displayLoadResults(results: UploadResults) {
+    let firstSuccessfulBlock;
+    const messages = document.createElement('ul');
+
+    for (const file of results.keys()) {
+      const messageDiv = document.createElement('li');
+      const {successes, fails} = results.get(file);
+      if (successes.length === 0) {
+        // File couldn't be parsed at all.
+        messageDiv.textContent = `${file}: could not be parsed.`;
+        messageDiv.classList.add('warning-message');
+      } else if (successes.length === 1 && fails === 0) {
+        messageDiv.textContent = `${file}: Successfully loaded one block named ${successes[0]}.`;
+        if (!firstSuccessfulBlock) firstSuccessfulBlock = successes[0];
+      } else if (fails === 0) {
+        // Multiple blocks loaded and no failures. Load the first one,
+        // and display the names of other blocks successfully loaded
+        messageDiv.textContent = `${file}: Successfully loaded blocks named ${successes.join(
+          ', ',
+        )}.`;
+        if (!firstSuccessfulBlock) firstSuccessfulBlock = successes[0];
+      } else {
+        // Some success and some failure. Load the first success,
+        // and display the names of blocks that succeeded and failed to load.
+        messageDiv.textContent = `${file}: Successully loaded blocks named ${successes.join(
+          ', ',
+        )}, but failed to parse ${fails} blocks.`;
+        messageDiv.classList.add('warning-message');
+        if (!firstSuccessfulBlock) firstSuccessfulBlock = successes[0];
+      }
+
+      messages.appendChild(messageDiv);
+    }
+    if (firstSuccessfulBlock) {
+      loadBlock(this.mainWorkspace, firstSuccessfulBlock);
+    } else {
+      // No blocks were successfully parsed at all, so keep the file upload modal open
+      this.viewModel.toggleFileUploadWarning(true);
+      return;
+    }
+
+    this.viewModel.toggleFileUploadModal(false);
+    this.viewModel.toggleUploadResultsModal(true, messages);
   }
 
   /**
    * Given a file, tries to run it through our backwards-compatibility converter
-   * and load the block into block factory. If there's an error at any point,
-   * we show a warning and allow the user to try the upload again.
+   * and save the blocks in block factory.
    *
-   * @param file File containing the block json to load. This should be the file
-   *    downloaded directly from the old block factory tool.
+   * @param file File containing an array of block json to load. This should
+   * be the file downloaded directly from the old block factory tool.
+   * @returns a promise resolving to an object containing an array of successfully
+   * converted block names and the number of blocks that failed to load.
    */
-  private loadFromFile(file: File) {
-    file
-      .text()
-      .then((contents) => {
-        const fixedBlockData = convertBaseBlock(JSON.parse(contents));
-        loadBlockFromData(this.mainWorkspace, fixedBlockData);
-        this.viewModel.toggleFileUploadModal(false);
-      })
-      .catch((e) => {
-        this.viewModel.toggleFileUploadWarning(true);
-      });
+  private loadFromFile(
+    file: File,
+  ): Promise<{successes: string[]; fails: number}> {
+    const successes: string[] = [];
+    let fails = 0;
+    return file.text().then((contents) => {
+      try {
+        const blocksData = JSON.parse(contents);
+        if (!Array.isArray(blocksData) || blocksData.length === 0) {
+          // File did not contain a JSON array or was empty.
+          fails++;
+          return {successes, fails};
+        }
+        for (const block of blocksData) {
+          const fixedBlockData = convertBaseBlock(block);
+
+          // The name from the old factory might be used in this tool.
+          // Get a fresh name so we don't overwrite anything.
+          const name = storage.getNewUnusedName(fixedBlockData.fields.NAME);
+          fixedBlockData.fields.NAME = name;
+
+          // Convert the individual block to workspace data with one block
+          const data = {
+            blocks: {
+              languageVersion: 0,
+              blocks: [fixedBlockData],
+            },
+          };
+
+          // Save the new block
+          storage.updateBlock(name, JSON.stringify(data));
+          successes.push(name);
+        }
+      } catch (e) {
+        fails++;
+      }
+
+      return {successes, fails};
+    });
   }
 }

--- a/examples/developer-tools/src/index.css
+++ b/examples/developer-tools/src/index.css
@@ -102,6 +102,7 @@ md-menu {
 #file-upload-drop-zone > * {
   flex-grow: 0;
   margin: 12px 24px;
+  text-align: center;
 }
 #file-upload-drop-zone > span {
   font-size: 48px;
@@ -117,9 +118,11 @@ md-menu {
 }
 
 .warning-message {
-  visibility: hidden;
   color: #b00020;
-  text-align: center;
+}
+
+.hidden {
+  visibility: hidden;
 }
 
 /* Hides an element visually but not from screen readers */

--- a/examples/developer-tools/src/index.html
+++ b/examples/developer-tools/src/index.html
@@ -45,18 +45,26 @@
                 </label>
                 or drag it here
               </p>
-              <p id="file-upload-warning" class="warning-message">
+              <p id="file-upload-warning" class="warning-message hidden">
                 File could not be parsed. Make sure you're uploading the file
                 you downloaded from the legacy Block Factory.
               </p>
             </div>
           </div>
           <div slot="actions">
-            <md-text-button
-              id="file-upload-close"
-              form="form-id"
-              value="cancel">
+            <md-text-button id="file-upload-close" value="cancel">
               Cancel
+            </md-text-button>
+          </div>
+        </md-dialog>
+        <md-dialog id="upload-results-modal">
+          <div slot="headline">Import Results</div>
+          <div slot="content">
+            <p id="upload-results"></p>
+          </div>
+          <div slot="actions">
+            <md-text-button id="upload-results-close" value="ok">
+              OK
             </md-text-button>
           </div>
         </md-dialog>

--- a/examples/developer-tools/src/index.html
+++ b/examples/developer-tools/src/index.html
@@ -38,7 +38,8 @@
                 type="file"
                 id="file-upload"
                 class="visually-hidden"
-                accept=".txt" />
+                accept=".txt"
+                multiple="true" />
               <p>
                 <label for="file-upload" id="file-label" tabindex="1">
                   Choose a file

--- a/examples/developer-tools/src/serialization.ts
+++ b/examples/developer-tools/src/serialization.ts
@@ -60,30 +60,6 @@ export function loadBlock(workspace: Blockly.Workspace, blockName?: string) {
 }
 
 /**
- * Loads given block json into the given workspace.
- *
- * @param workspace Blockly workspace to load into.
- * @param blockJson Block json to load. This is state representing a single block,
- *    not the entire workspace.
- */
-export function loadBlockFromData(
-  workspace: Blockly.Workspace,
-  blockJson: Blockly.serialization.blocks.State,
-) {
-  // Disable events so we don't save while deleting blocks.
-  Blockly.Events.disable();
-  workspace.clear();
-  Blockly.Events.enable();
-
-  // There might be conflicts when loading a block from a file.
-  // If so, find a similar unused name so we don't overwrite.
-  const blockName = getNewUnusedName(blockJson.fields.NAME);
-  blockJson.fields.NAME = blockName;
-
-  Blockly.serialization.blocks.append(blockJson, workspace);
-}
-
-/**
  * Creates a new block from scratch.
  *
  * @param workspace Blockly workspace to load into.
@@ -94,25 +70,9 @@ export function createNewBlock(workspace: Blockly.Workspace) {
   workspace.clear();
   Blockly.Events.enable();
 
-  const blockName = getNewUnusedName();
+  const blockName = storage.getNewUnusedName();
   const startBlockJson = createStartBlock(blockName);
   Blockly.serialization.workspaces.load(startBlockJson, workspace);
-}
-
-/**
- * Finds a name for a block that isn't being used yet.
- *
- * @param startName Initial name to propose, or 'my_block' if not set.
- * @returns An unused name based on the proposed name.
- */
-function getNewUnusedName(startName = 'my_block'): string {
-  let name = startName;
-  let number = 0;
-  while (storage.getAllSavedBlockNames().has(name)) {
-    number += 1;
-    name = startName + number;
-  }
-  return name;
 }
 
 /**

--- a/examples/developer-tools/src/storage.ts
+++ b/examples/developer-tools/src/storage.ts
@@ -116,6 +116,22 @@ export function getProhibitedBlockNames(): Set<string> {
   return prohibitedBlockNames;
 }
 
+/**
+ * Finds a name for a block that isn't being used yet.
+ *
+ * @param startName Initial name to propose, or 'my_block' if not set.
+ * @returns An unused name based on the proposed name.
+ */
+export function getNewUnusedName(startName = 'my_block'): string {
+  let name = startName;
+  let number = 0;
+  while (getAllSavedBlockNames().has(name)) {
+    number += 1;
+    name = startName + number;
+  }
+  return name;
+}
+
 export interface BlockFactorySettings {
   blockDefinitionFormat: string;
   codeHeaderStyle: string;

--- a/examples/developer-tools/src/view_model.ts
+++ b/examples/developer-tools/src/view_model.ts
@@ -10,6 +10,7 @@ import '@material/web/dialog/dialog';
 import '@material/web/button/text-button';
 
 export class ViewModel {
+  // Main container divs for block factory
   mainWorkspaceDiv = document.getElementById('main-workspace');
   previewDiv = document.getElementById('block-preview');
   definitionDiv = document.getElementById('block-definition').firstChild;
@@ -17,17 +18,24 @@ export class ViewModel {
   codeHeadersDiv = document.getElementById('code-headers').firstChild;
   generatorStubDiv = document.getElementById('generator-stub').firstChild;
 
+  // Toolbar menu/buttons
   createButton = document.getElementById('create-btn');
   deleteButton = document.getElementById('delete-btn');
   loadButton = document.getElementById('load-btn');
   loadMenu = document.getElementById('load-menu');
 
+  // File upload dialog components
   fileModal = document.getElementById('file-upload-modal');
   fileModalCloseButton = document.getElementById('file-upload-close');
   fileDropZone = document.getElementById('file-upload-drop-zone');
   fileUploadInput = document.getElementById('file-upload');
   fileLabel = document.getElementById('file-label');
   fileUploadWarning = document.getElementById('file-upload-warning');
+
+  // File upload results dialog components
+  uploadResultsModal = document.getElementById('upload-results-modal');
+  uploadResultsText = document.getElementById('upload-results');
+  uploadResultsCloseButton = document.getElementById('upload-results-close');
 
   /**
    * Gets a string representing the format of the block
@@ -127,14 +135,44 @@ export class ViewModel {
 
   /**
    * Shows or hides the file upload error message.
+   * This is used when the entire file fails to parse.
    *
    * @param show true to show, false to hide.
    */
   toggleFileUploadWarning(show: boolean) {
     if (show) {
-      this.fileUploadWarning.style.visibility = 'visible';
+      this.fileUploadWarning.classList.remove('hidden');
     } else {
-      this.fileUploadWarning.style.visibility = 'hidden';
+      this.fileUploadWarning.classList.add('hidden');
+    }
+  }
+
+  /**
+   * Shows or hides the file upload results modal. This modal
+   * shows the results of uploading one or more block data files.
+   *
+   * @param show true to show, false to hide.
+   * @param message the html content to show in this modal, if show is true
+   */
+  toggleUploadResultsModal(show: true, message: HTMLElement): void;
+  toggleUploadResultsModal(show: false): void;
+  toggleUploadResultsModal(show: boolean, message?: HTMLElement): void {
+    if (show) {
+      this.uploadResultsModal.setAttribute('open', '');
+      // Set z-index of scrim so that it covers the Blockly toolbox
+      // https://github.com/material-components/material-web/issues/4948
+      if (this.uploadResultsModal.shadowRoot) {
+        const scrim =
+          this.uploadResultsModal.shadowRoot.querySelector<HTMLElement>(
+            '.scrim',
+          );
+        if (scrim) {
+          scrim.style.zIndex = '99';
+        }
+      }
+      this.uploadResultsText.replaceChildren(message);
+    } else {
+      this.uploadResultsModal.removeAttribute('open');
     }
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2291 

### Proposed Changes

- Adds the ability to upload one or more files downloaded from the old block factory tool (json format)
- Will show a message with the results of the upload, then load the first successful block if possible

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

Coming soon!

### Additional Information

The corresponding change in the old block factory to let you download the required data is coming soon

https://github.com/google/blockly-samples/assets/8573958/ef70d4bc-5669-48c2-aa0b-f1b7a6983a59


