### PR TITLE
fix: only select the first category when the flyout is shown when there is no selection

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousFlyout.js
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.js
@@ -224,7 +224,9 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
     super.show(flyoutDef);
     this.recordScrollPositions();
     this.workspace_.resizeContents();
-    this.selectCategoryByScrollPosition_(0);
+    if (!this.getParentToolbox_().getSelectedItem()) {
+      this.selectCategoryByScrollPosition_(0);
+    }
   }
 
   /**


### PR DESCRIPTION
This changes the continuous flyout to only select the first category in the toolbox when it is shown if there is not already a selection. `show()` is sometimes used to refresh/update the flyout contents, in which case changing the toolbox's selection is undesirable.