### PR TITLE
fix: Fix incorrect Blockly imports

### DIFF
--- a/plugins/block-plus-minus/src/if.js
+++ b/plugins/block-plus-minus/src/if.js
@@ -8,7 +8,7 @@
  * @fileoverview Changes the if block to use a +/- mutator UI.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 import {createMinusField} from './field_minus';
 import {createPlusField} from './field_plus';
 

--- a/plugins/block-plus-minus/src/list_create.js
+++ b/plugins/block-plus-minus/src/list_create.js
@@ -8,7 +8,7 @@
  * @fileoverview Changes the list_create block to use a +/- mutator UI.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 import {createPlusField} from './field_plus';
 import {createMinusField} from './field_minus';
 

--- a/plugins/block-plus-minus/src/procedures.js
+++ b/plugins/block-plus-minus/src/procedures.js
@@ -8,7 +8,7 @@
  * @fileoverview Changes the procedure blocks to use a +/- mutator UI.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 import {createMinusField} from './field_minus';
 import {createPlusField} from './field_plus';
 

--- a/plugins/block-plus-minus/src/text_join.js
+++ b/plugins/block-plus-minus/src/text_join.js
@@ -8,7 +8,7 @@
  * @fileoverview Changes the text_join block to use a +/- mutator UI.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 import {createPlusField} from './field_plus';
 import {createMinusField} from './field_minus';
 

--- a/plugins/block-test/src/serialization/blocks.js
+++ b/plugins/block-test/src/serialization/blocks.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 import './fields';
 
 Blockly.defineBlocksWithJsonArray([

--- a/plugins/block-test/src/serialization/category.js
+++ b/plugins/block-test/src/serialization/category.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 import './blocks';
 
 /**

--- a/plugins/block-test/src/serialization/fields.js
+++ b/plugins/block-test/src/serialization/fields.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 /**
  * Field that does not override any serialization hooks.

--- a/plugins/dev-create/templates/block/template/src/index.js
+++ b/plugins/dev-create/templates/block/template/src/index.js
@@ -9,7 +9,7 @@
  * @fileoverview Block overview.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 // TODO: Update block definition.
 Blockly.defineBlocksWithJsonArray([

--- a/plugins/dev-create/templates/field/template/src/index.js
+++ b/plugins/dev-create/templates/field/template/src/index.js
@@ -9,7 +9,7 @@
  * @fileoverview Field overview.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 // TODO: Rename field and update description.
 /**

--- a/plugins/dev-create/templates/theme/template/src/index.js
+++ b/plugins/dev-create/templates/theme/template/src/index.js
@@ -9,7 +9,7 @@
  * @fileoverview Theme overview.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 // TODO: Edit theme name.
 export default Blockly.Theme.defineTheme('THEME_NAME', {

--- a/plugins/dev-create/templates/typescript-block/template/src/index.ts
+++ b/plugins/dev-create/templates/typescript-block/template/src/index.ts
@@ -9,7 +9,7 @@
  * @fileoverview Block overview.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 // TODO: Update block definition.
 Blockly.defineBlocksWithJsonArray([

--- a/plugins/dev-tools/src/debugDrawer.js
+++ b/plugins/dev-tools/src/debugDrawer.js
@@ -8,7 +8,7 @@
  * @fileoverview Visualizer for debugging custom renderers in Blockly.
  * @author fenichel@google.com (Rachel Fenichel)
  */
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 /**
  * A basic visualizer for debugging custom renderers.

--- a/plugins/dev-tools/src/populateRandom.js
+++ b/plugins/dev-tools/src/populateRandom.js
@@ -8,7 +8,7 @@
  * @fileoverview Helper for randomly populating a workspace.
  * @author fenichel@google.com (Rachel Fenichel)
  */
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 /**
  * Populate the workspace with a random set of blocks, for testing.

--- a/plugins/dev-tools/src/screenshot.js
+++ b/plugins/dev-tools/src/screenshot.js
@@ -8,7 +8,7 @@
  * @fileoverview Download screenshot.
  * @author samelh@google.com (Sam El-Husseini)
  */
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 /**
  * Convert an SVG datauri into a PNG datauri.

--- a/plugins/dev-tools/src/spaghetti.js
+++ b/plugins/dev-tools/src/spaghetti.js
@@ -9,7 +9,7 @@
  * blocks, for testing.
  * @author samelh@google.com (Sam El-Husseini)
  */
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 const spaghettiXml = [
   '  <block type="controls_if">',

--- a/plugins/field-bitmap/src/field-bitmap.ts
+++ b/plugins/field-bitmap/src/field-bitmap.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 export const DEFAULT_HEIGHT = 5;
 export const DEFAULT_WIDTH = 5;

--- a/plugins/fixed-edges/src/index.js
+++ b/plugins/fixed-edges/src/index.js
@@ -9,7 +9,7 @@
  * configurable.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 /**
  * @typedef {{

--- a/plugins/migration/test/rename.mocha.js
+++ b/plugins/migration/test/rename.mocha.js
@@ -53,7 +53,7 @@ suite('Rename', function () {
       ],
     };
     const oldString = `
-import Blockly from 'blockly';
+import * as Blockly from 'blockly';
 
 class SubClass extends Blockly.moduleC {
   constructor() {
@@ -81,7 +81,7 @@ class SubClass extends Blockly.moduleC {
     const newString = new Renamer(database, '0.0.0', '1.0.0').rename(oldString);
 
     const expectedString = `
-import Blockly from 'blockly';
+import * as Blockly from 'blockly';
 
 class SubClass extends Blockly.moduleC.ClassC {
   constructor() {

--- a/plugins/scroll-options/src/index.js
+++ b/plugins/scroll-options/src/index.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 import {EdgeScrollOptions, ScrollBlockDragger} from './ScrollBlockDragger';
 import {getTranslation} from './utils';
 

--- a/plugins/theme-dark/src/index.js
+++ b/plugins/theme-dark/src/index.js
@@ -8,7 +8,7 @@
  * @fileoverview Dark theme.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 /**
  * Dark theme.

--- a/plugins/theme-deuteranopia/src/index.js
+++ b/plugins/theme-deuteranopia/src/index.js
@@ -8,7 +8,7 @@
  * @fileoverview Deuteranopia theme.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 const defaultBlockStyles = {
   colour_blocks: {

--- a/plugins/theme-highcontrast/src/index.js
+++ b/plugins/theme-highcontrast/src/index.js
@@ -10,7 +10,7 @@
  * Darker colours to contrast the white font.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 const defaultBlockStyles = {
   colour_blocks: {

--- a/plugins/theme-modern/src/index.js
+++ b/plugins/theme-modern/src/index.js
@@ -8,7 +8,7 @@
  * @fileoverview Modern theme.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 export default Blockly.Theme.defineTheme('modern', {
   base: Blockly.Themes.Classic,

--- a/plugins/theme-tritanopia/src/index.js
+++ b/plugins/theme-tritanopia/src/index.js
@@ -8,7 +8,7 @@
  * @fileoverview Tritanopia theme.
  */
 
-import Blockly from 'blockly/core';
+import * as Blockly from 'blockly/core';
 
 const defaultBlockStyles = {
   colour_blocks: {


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details

### Proposed Changes

We have for some time promulgated

    import * as Blockly from 'blockly/core';

as the correct way to import Blockly in our documentation. **Update our own plugins and templates to match.**

### Reason for Changes

Because we have been packaging Blockly until now only as CJS modules, and CJS modules always provide an (unnamed) default export consisting of the module.exports object, importing Blockly with

    import Blockly from 'blockly/core';

(note no `*`) has worked fine (and similarly for all the other entrypoints).

As the sources for the entrypoints (`core/blockly.ts`, `blocks/blocks.ts`, etc.) do not explicitly declare a `default` export, however, this should not be relied upon: when we start shipping Blockly as pure-ESM there will be no default export and so `import Blockly from …` will stop working.
