### PR TITLE
fix: add boolean to dispose function call 

### DIFF
--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -1065,7 +1065,7 @@ const procedureCallerUpdateShapeMixin = {
     if (!this.getProcedureModel()) return;
     const id = this.getProcedureModel().getId();
     if (!this.getTargetWorkspace_().getProcedureMap().has(id)) {
-      this.dispose();
+      this.dispose(true);
       return;
     }
     this.updateName_();

--- a/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
+++ b/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
@@ -1330,8 +1330,8 @@ suite('Procedures', function () {
         const ifBlock1 = this.workspace.newBlock('controls_if');
         const ifBlock2 = this.workspace.newBlock('controls_if');
 
-        ifBlock1.nextConnection.outputConnection = callBlock1;
-        callBlock1.nextConnection.outputConnection = ifBlock2;
+        ifBlock1.nextConnection.connect(callBlock1.previousConnection);
+        callBlock1.nextConnection.connect(ifBlock2.previousConnection);
 
         defBlock.dispose(true);
         globalThis.clock.runAll();

--- a/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
+++ b/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
@@ -1320,6 +1320,36 @@ suite('Procedures', function () {
         );
       },
     );
+
+    test(
+      'when the procedure definition block is deleted, all of its ' +
+        'associated callers are deleted, but the other blocks remain',
+      function () {
+        const defBlock = createProcDefBlock(this.workspace);
+        const callBlock1 = createProcCallBlock(this.workspace);
+        const ifBlock1 = this.workspace.newBlock('controls_if');
+        const ifBlock2 = this.workspace.newBlock('controls_if');
+
+        ifBlock1.nextConnection.outputConnection = callBlock1;
+        callBlock1.nextConnection.outputConnection = ifBlock2;
+
+        defBlock.dispose(true);
+        globalThis.clock.runAll();
+
+        assert.isTrue(
+          callBlock1.disposed,
+          'Expected the first caller to be disposed',
+        );
+        assert.isFalse(
+          ifBlock1.disposed,
+          'Expected the first if block 1 to be not be disposed',
+        );
+        assert.isFalse(
+          ifBlock2.disposed,
+          'Expected the second if block 2 to be not be disposed',
+        );
+      },
+    );
   });
 
   suite('caller blocks creating new def blocks', function () {


### PR DESCRIPTION
## The basics
- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves
Fixes #2217

### Proposed Changes

- adds true to the dispose()
- ![Screenshot 2024-05-06 at 3 14 45 PM](https://github.com/google/blockly-samples/assets/52472550/d17cd604-2ab7-4fc4-9d66-f3848b1438d4)


### Reason for Changes
- adding `dispose(true)` makes sure the blocks that are not associated with the procedures block remain **undeleted**

- ### Test Coverage
- Test, I tried to recreate, the blocks being connected to each other, and mimicking the deletion process of procedures child, which should still keep the other blocks intact and undeleted
![Screenshot 2024-05-06 at 3 17 33 PM](https://github.com/google/blockly-samples/assets/52472550/a02ea0a0-d70e-4bcb-b90a-9db46d40e7a6)

My testing logic was: 
- create the def procedure block`"type": "procedures_defnoreturn"`
![Screenshot 2024-05-06 at 3 26 01 PM](https://github.com/google/blockly-samples/assets/52472550/b1587197-508f-4dbb-a82b-dbb5afdbe4e6)

- create the child block `"type": "procedures_callnoreturn"`
![Screenshot 2024-05-06 at 3 26 51 PM](https://github.com/google/blockly-samples/assets/52472550/b541f790-38fa-4a4a-8158-0a339aa483d6)

- then basically create two if blocks `"type": "controls_if"`
![Screenshot 2024-05-06 at 3 27 28 PM](https://github.com/google/blockly-samples/assets/52472550/3c45f89e-a168-4553-9622-5827d0196a54)

- then tried to connect those blocks
![Screenshot 2024-05-06 at 3 29 02 PM](https://github.com/google/blockly-samples/assets/52472550/4c21514f-45ab-4db6-8a95-0f96d23a870e)
![Screenshot 2024-05-06 at 3 29 29 PM](https://github.com/google/blockly-samples/assets/52472550/f031c726-9e9e-4071-9930-d811de1f3e30)

- I tried to pass in `dispose(true)`, so when the procedure block is deleted, the blocks not associated with procedure block remains intact.


