### PR TITLE
fix(block-test): Fix incorrect references to Blockly.prompt

### DIFF
--- a/plugins/block-test/src/fields/dropdowns.js
+++ b/plugins/block-test/src/fields/dropdowns.js
@@ -352,7 +352,7 @@ const dynamicDropdownOptions_ = [];
  * @package
  */
 const addDynamicDropdownOption = function () {
-  Blockly.prompt(
+  Blockly.dialog.prompt(
     'Add an option?',
     'option ' + dynamicDropdownOptions_.length,
     function (text) {
@@ -380,7 +380,7 @@ const removeDynamicDropdownOption = function () {
   const defaultText = dynamicDropdownOptions_[0]
     ? dynamicDropdownOptions_[0][0]
     : '';
-  Blockly.prompt('Remove an option?', defaultText, function (text) {
+  Blockly.dialog.prompt('Remove an option?', defaultText, function (text) {
     for (let i = 0, option; (option = dynamicDropdownOptions_[i]); i++) {
       // The option is an array containing human-readable text and a
       // language-neutral id, we'll compare against the human-readable text.

--- a/plugins/block-test/src/fields/validators.js
+++ b/plugins/block-test/src/fields/validators.js
@@ -660,7 +660,7 @@ export function onInit(workspace) {
     workspace.createVariable('2c', '', '2C');
   };
   const setInput = function (button) {
-    Blockly.prompt('Input text to set.', 'ab', function (input) {
+    Blockly.dialog.prompt('Input text to set.', 'ab', function (input) {
       const blocks = button.getTargetWorkspace().getAllBlocks(false);
       for (let i = 0, block; (block = blocks[i]); i++) {
         if (block.getField('INPUT')) {


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes

Use `Blockly.dialog.prompt` instead of `Blockly.prompt`.

### Reason for Changes

This function was moved in v7.20211209.0.  Apparently these files were never updated.  This change unbreaks the relevant functionality and reduces the number of webpack build warnings for this and several other plugins.
