### PR TITLE
fix: remove keyboard nav option from dev-tools

### DIFF
--- a/plugins/dev-tools/src/playground/options.js
+++ b/plugins/dev-tools/src/playground/options.js
@@ -1080,29 +1080,4 @@ function addActions(gui, workspace) {
     false,
     'Toggle console logging of flyout events.',
   );
-
-  // Accessibility actions.
-  gui.addCheckboxAction(
-    'Keyboard Nav',
-    (_workspace, value) => {
-      if (value) {
-        Blockly.navigation.enableKeyboardAccessibility();
-      } else {
-        Blockly.navigation.disableKeyboardAccessibility();
-      }
-    },
-    'Accessibility',
-    workspace.keyboardAccessibilityMode,
-    'Toggle keyboard accessibility mode',
-  );
-  gui.addCheckboxAction(
-    'Navigate All',
-    (_workspace, value) => {
-      Blockly.ASTNode.NAVIGATE_ALL_FIELDS = value;
-    },
-    'Accessibility',
-    Blockly.ASTNode.NAVIGATE_ALL_FIELDS,
-    'Toggle navigating to all fields. False to only navigate to clickable' +
-      ' fields.',
-  );
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

work on #2345 

### Proposed Changes

- removes keyboard nav options from dev-tools gui

### Reason for Changes

keyboard nav was removed from core a while ago so these buttons haven't done anything.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
