### PR TITLE
fix: remove some uses of generateFieldTextBlocks

### DIFF
--- a/plugins/field-angle/test/index.ts
+++ b/plugins/field-angle/test/index.ts
@@ -9,61 +9,299 @@
  */
 
 import * as Blockly from 'blockly';
-import {generateFieldTestBlocks, createPlayground} from '@blockly/dev-tools';
+import {createPlayground} from '@blockly/dev-tools';
 import {registerFieldAngle} from '../src/index';
 
-const toolbox = generateFieldTestBlocks('field_angle', [
+/**
+ * An array of blocks that are defined only for the purposes of
+ * manually and visually testing the angle field.
+ */
+const testBlockDefinitions = [
   {
-    label: 'Compass',
-    args: {
-      mode: 'compass',
-      value: 90,
-    },
+    type: 'test_standard_field_values',
+    message0: '%1',
+    args0: [
+      {
+        type: 'field_angle',
+        name: 'FIELDNAME',
+        alt: {
+          type: 'field_label',
+          text: `No field_angle`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
   {
-    label: 'Protractor',
-    args: {
-      mode: 'protractor',
-      value: 90,
-    },
+    type: 'test_custom_field_values',
+    message0: '%1',
+    args0: [
+      {
+        type: 'field_angle',
+        name: 'FIELDNAME',
+        value: 50,
+        alt: {
+          type: 'field_label',
+          text: `No field_angle`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },  {
+    type: 'test_custom_field_values_compass',
+    message0: 'compass %1',
+    args0: [
+      {
+        type: 'field_angle',
+        name: 'FIELDNAME',
+        mode: 'compass',
+        value: 90,
+        alt: {
+          type: 'field_label',
+          text: `No field_angle`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },  {
+    type: 'test_custom_field_values_protractor',
+    message0: 'protractor %1',
+    args0: [
+      {
+        type: 'field_angle',
+        name: 'FIELDNAME',
+        mode: 'protractor',
+        value: 90,
+        alt: {
+          type: 'field_label',
+          text: `No field_angle`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
   {
-    label: 'Round',
-    args: {
-      precision: 0.1,
-      value: 123,
-    },
+    type: 'test_custom_field_values_round',
+    message0: 'round %1',
+    args0: [
+      {
+        type: 'field_angle',
+        name: 'FIELDNAME',
+        precision: 0.1,
+        value: 123,
+        alt: {
+          type: 'field_label',
+          text: `No field_angle`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
   {
-    label: 'Radians',
-    args: {
-      precision: 0.1,
-      clockwise: true,
-      value: 0,
-      min: 0,
-      max: Math.PI,
-      displayMin: -Math.PI,
-      displayMax: Math.PI,
-      minorTick: Math.PI / 8,
-      majorTick: Math.PI,
-      symbol: ' rad',
-    },
+    type: 'test_custom_field_values_radians',
+    message0: 'radians %1',
+    args0: [
+      {
+        type: 'field_angle',
+        name: 'FIELDNAME',
+        precision: 0.1,
+        clockwise: true,
+        value: 0,
+        min: 0,
+        max: Math.PI,
+        displayMin: -Math.PI,
+        displayMax: Math.PI,
+        minorTick: Math.PI / 8,
+        majorTick: Math.PI,
+        symbol: ' rad',
+        alt: {
+          type: 'field_label',
+          text: `No field_angle`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
   {
-    label: 'Quadrant',
-    args: {
-      precision: 1,
-      value: 0,
-      min: 0,
-      max: 2,
-      displayMin: 0,
-      displayMax: 8,
-      minorTick: 0,
-      majorTick: 1,
-      symbol: '',
-    },
+    type: 'test_custom_field_values_quadrant',
+    message0: 'quadrant %1',
+    args0: [
+      {
+        type: 'field_angle',
+        name: 'FIELDNAME',
+        precision: 1,
+        value: 0,
+        min: 0,
+        max: 2,
+        displayMin: 0,
+        displayMax: 8,
+        minorTick: 0,
+        majorTick: 1,
+        symbol: '',
+        alt: {
+          type: 'field_label',
+          text: `No field_angle`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
-]);
+  {
+    type: 'test_standard_field_values_and_label',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_angle',
+        name: 'FIELDNAME',
+        alt: {
+          type: 'field_label',
+          text: `No field_angle`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+  {
+    type: 'test_custom_field_values_and_label',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_angle',
+        name: 'FIELDNAME',
+        value: 50,
+        alt: {
+          type: 'field_label',
+          text: `No field_angle`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+  {
+    type: 'test_parent_block',
+    message0: 'parent %1',
+    args0: [
+      {
+        type: 'input_value',
+        name: 'INPUT',
+      },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    style: 'loop_blocks',
+  },
+];
+
+Blockly.defineBlocksWithJsonArray(testBlockDefinitions);
+
+/**
+ * A test toolbox containing the exported blocks and a variety of
+ * test blocks to exercise the angle field in different contexts
+ * (on a shadow block, as the only field on a block, etc).
+ * These are in a simple toolbox, rather than a category toolbox, so that
+ * they are all instantiated every time the test page is opened.
+ */
+const jsonToolbox = {
+  contents: [
+    {
+      kind: 'label',
+      text: 'Test blocks: default field values',
+    },
+    {
+      kind: 'block',
+      type: 'test_standard_field_values',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_standard_field_values',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_standard_field_values_and_label',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_standard_field_values_and_label',
+          },
+        },
+      },
+    },
+    {
+      kind: 'label',
+      text: 'Test blocks: custom field values',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_compass',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_protractor',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_round',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_radians',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_quadrant',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_custom_field_values',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_and_label',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_custom_field_values_and_label',
+          },
+        },
+      },
+    },
+  ],
+};
 
 /**
  * Create a workspace.
@@ -83,7 +321,7 @@ function createWorkspace(
 document.addEventListener('DOMContentLoaded', function () {
   registerFieldAngle();
   const defaultOptions: Blockly.BlocklyOptions = {
-    toolbox,
+    toolbox: jsonToolbox,
   };
   const rootElement = document.getElementById('root');
   if (rootElement) {

--- a/plugins/field-angle/test/index.ts
+++ b/plugins/field-angle/test/index.ts
@@ -49,7 +49,8 @@ const testBlockDefinitions = [
     ],
     output: null,
     style: 'math_blocks',
-  },  {
+  },
+  {
     type: 'test_custom_field_values_compass',
     message0: 'compass %1',
     args0: [
@@ -66,7 +67,8 @@ const testBlockDefinitions = [
     ],
     output: null,
     style: 'math_blocks',
-  },  {
+  },
+  {
     type: 'test_custom_field_values_protractor',
     message0: 'protractor %1',
     args0: [

--- a/plugins/field-bitmap/test/index.js
+++ b/plugins/field-bitmap/test/index.js
@@ -10,33 +10,188 @@
 
 import '../src/field-bitmap';
 
-import {createPlayground, generateFieldTestBlocks} from '@blockly/dev-tools';
+import {createPlayground} from '@blockly/dev-tools';
 import * as Blockly from 'blockly';
 
-const toolbox = generateFieldTestBlocks('field_bitmap', [
+/**
+ * An array of blocks that are defined only for the purposes of
+ * manually and visually testing the bitmap field.
+ */
+const testBlockDefinitions = [
   {
-    label: 'With Default',
-    args: {
-      value: [
-        [0, 0, 0, 0, 0, 0, 0],
-        [0, 1, 1, 0, 1, 1, 0],
-        [0, 0, 0, 0, 0, 0, 0],
-        [0, 1, 1, 1, 1, 1, 0],
-        [0, 1, 0, 0, 0, 1, 0],
-        [0, 0, 1, 1, 1, 0, 0],
-        [0, 0, 0, 0, 0, 0, 0],
-      ],
-    },
+    type: 'test_standard_field_values',
+    message0: '%1',
+    args0: [
+      {
+        type: 'field_bitmap',
+        name: 'FIELDNAME',
+        alt: {
+          type: 'field_label',
+          text: `No field_bitmap`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
   {
-    label: 'Empty',
-    args: {
-      width: 3,
-      height: 3,
-      value: undefined,
-    },
+    type: 'test_custom_field_values',
+    message0: '%1',
+    args0: [
+      {
+        type: 'field_bitmap',
+        name: 'FIELDNAME',
+        value: [
+          [1, 0, 1],
+          [0, 1, 0],
+          [0, 0, 0],
+        ],
+        width: 3,
+        height: 3,
+        alt: {
+          type: 'field_label',
+          text: `No field_bitmap`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
-]);
+  {
+    type: 'test_standard_field_values_and_label',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_bitmap',
+        name: 'FIELDNAME',
+        alt: {
+          type: 'field_label',
+          text: `No field_bitmap`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+  {
+    type: 'test_custom_field_values_and_label',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_bitmap',
+        name: 'FIELDNAME',
+        value: [
+          [1, 0, 1],
+          [0, 1, 0],
+          [0, 0, 0],
+        ],
+        width: 3,
+        height: 3,
+        alt: {
+          type: 'field_label',
+          text: `No field_bitmap`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+  {
+    type: 'test_parent_block',
+    message0: 'parent %1',
+    args0: [
+      {
+        type: 'input_value',
+        name: 'INPUT',
+      },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    style: 'loop_blocks',
+  },
+];
+
+Blockly.defineBlocksWithJsonArray(testBlockDefinitions);
+
+/**
+ * A test toolbox containing the exported blocks and a variety of
+ * test blocks to exercise the bitmap field in different contexts
+ * (on a shadow block, as the only field on a block, etc).
+ * These are in a simple toolbox, rather than a category toolbox, so that
+ * they are all instantiated every time the test page is opened.
+ */
+const jsonToolbox = {
+  contents: [
+    {
+      kind: 'label',
+      text: 'Test blocks: default field values',
+    },
+    {
+      kind: 'block',
+      type: 'test_standard_field_values',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_standard_field_values',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_standard_field_values_and_label',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_standard_field_values_and_label',
+          },
+        },
+      },
+    },
+    {
+      kind: 'label',
+      text: 'Test blocks: custom field values',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_custom_field_values',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_and_label',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_custom_field_values_and_label',
+          },
+        },
+      },
+    },
+  ],
+};
 
 /**
  * Create a workspace.
@@ -51,7 +206,7 @@ function createWorkspace(blocklyDiv, options) {
 
 document.addEventListener('DOMContentLoaded', function () {
   const defaultOptions = {
-    toolbox,
+    toolbox: jsonToolbox,
   };
   createPlayground(
     document.getElementById('root'),

--- a/plugins/field-colour-hsv-sliders/test/index.ts
+++ b/plugins/field-colour-hsv-sliders/test/index.ts
@@ -9,17 +9,176 @@
  */
 
 import * as Blockly from 'blockly';
-import {generateFieldTestBlocks, createPlayground} from '@blockly/dev-tools';
+import {createPlayground} from '@blockly/dev-tools';
 import '../src/index';
 
-const toolbox = generateFieldTestBlocks('field_colour_hsv_sliders', [
+/**
+ * An array of blocks that are defined only for the purposes of
+ * manually and visually testing the HSV slider field.
+ */
+const testBlockDefinitions = [
   {
-    label: 'HSV Colour Test Blocks',
-    args: {
-      colour: '#ff0000',
-    },
+    type: 'test_standard_field_values',
+    message0: '%1',
+    args0: [
+      {
+        type: 'field_colour_hsv_sliders',
+        name: 'FIELDNAME',
+        alt: {
+          type: 'field_label',
+          text: `No field_colour_hsv_sliders`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
-]);
+  {
+    type: 'test_custom_field_values',
+    message0: '%1',
+    args0: [
+      {
+        type: 'field_colour_hsv_sliders',
+        name: 'FIELDNAME',
+        colour: '#ff0000',
+        alt: {
+          type: 'field_label',
+          text: `No field_colour_hsv_sliders`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+  {
+    type: 'test_standard_field_values_and_label',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_colour_hsv_sliders',
+        name: 'FIELDNAME',
+        alt: {
+          type: 'field_label',
+          text: `No field_colour_hsv_sliders`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+  {
+    type: 'test_custom_field_values_and_label',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_colour_hsv_sliders',
+        name: 'FIELDNAME',
+        colour: '#ff0000',
+        alt: {
+          type: 'field_label',
+          text: `No field_colour_hsv_sliders`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+  {
+    type: 'test_parent_block',
+    message0: 'parent %1',
+    args0: [
+      {
+        type: 'input_value',
+        name: 'INPUT',
+      },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    style: 'loop_blocks',
+  },
+];
+
+Blockly.defineBlocksWithJsonArray(testBlockDefinitions);
+
+/**
+ * A test toolbox containing the exported blocks and a variety of
+ * test blocks to exercise the colour field in different contexts
+ * (on a shadow block, as the only field on a block, etc).
+ * These are in a simple toolbox, rather than a category toolbox, so that
+ * they are all instantiated every time the test page is opened.
+ */
+const jsonToolbox = {
+  contents: [
+    {
+      kind: 'label',
+      text: 'Test blocks: default field values',
+    },
+    {
+      kind: 'block',
+      type: 'test_standard_field_values',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_standard_field_values',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_standard_field_values_and_label',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_standard_field_values_and_label',
+          },
+        },
+      },
+    },
+    {
+      kind: 'label',
+      text: 'Test blocks: custom field values',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_custom_field_values',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_and_label',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_custom_field_values_and_label',
+          },
+        },
+      },
+    },
+  ],
+};
 
 /**
  * Create a workspace.
@@ -38,7 +197,7 @@ function createWorkspace(
 
 document.addEventListener('DOMContentLoaded', function () {
   const defaultOptions: Blockly.BlocklyOptions = {
-    toolbox,
+    toolbox: jsonToolbox,
   };
   const rootElement = document.getElementById('root');
   if (rootElement) {

--- a/plugins/field-date/test/index.ts
+++ b/plugins/field-date/test/index.ts
@@ -9,40 +9,198 @@
  */
 
 import * as Blockly from 'blockly';
-import {generateFieldTestBlocks, createPlayground} from '@blockly/dev-tools';
-import {FieldDateFromJsonConfig} from '../src/index';
+import {createPlayground} from '@blockly/dev-tools';
 import '../src/index';
 
-// NOTE: The args type should be updated to allow the JsonConfig types.
-interface Args {
-  [key: string]: unknown;
-}
+/**
+ * An array of blocks that are defined only for the purposes of
+ * manually and visually testing the date field.
+ */
+const testBlockDefinitions = [
+  {
+    type: 'test_standard_field_values',
+    message0: '%1',
+    args0: [
+      {
+        type: 'field_date',
+        name: 'FIELDNAME',
+        alt: {
+          type: 'field_label',
+          text: `No field_date`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+  {
+    type: 'test_custom_field_values',
+    message0: '%1',
+    args0: [
+      {
+        type: 'field_date',
+        name: 'FIELDNAME',
+        date: '2020-02-20',
+        alt: {
+          type: 'field_label',
+          text: `No field_date`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+  {
+    type: 'test_standard_field_values_and_label',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_date',
+        name: 'FIELDNAME',
+        alt: {
+          type: 'field_label',
+          text: `No field_date`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+  {
+    type: 'test_custom_field_values_and_label',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_date',
+        name: 'FIELDNAME',
+        date: '2020-02-20',
+        alt: {
+          type: 'field_label',
+          text: `No field_date`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+  {
+    type: 'test_parent_block',
+    message0: 'parent %1',
+    args0: [
+      {
+        type: 'input_value',
+        name: 'INPUT',
+      },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    style: 'loop_blocks',
+  },
+  {
+    type: 'test_custom_field_values_and_tooltip',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_date',
+        name: 'FIELDNAME',
+        date: '2021-03-13',
+        tooltip: 'This date block has a tooltip!',
+        alt: {
+          type: 'field_label',
+          text: `No field_date`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+];
 
-const basicConfig: FieldDateFromJsonConfig = {
-  date: '2020-02-20',
+Blockly.defineBlocksWithJsonArray(testBlockDefinitions);
+
+/**
+ * A test toolbox containing the exported blocks and a variety of
+ * test blocks to exercise the date field in different contexts
+ * (on a shadow block, as the only field on a block, etc).
+ * These are in a simple toolbox, rather than a category toolbox, so that
+ * they are all instantiated every time the test page is opened.
+ */
+const jsonToolbox = {
+  contents: [
+    {
+      kind: 'label',
+      text: 'Test blocks: default field values',
+    },
+    {
+      kind: 'block',
+      type: 'test_standard_field_values',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_standard_field_values',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_standard_field_values_and_label',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_standard_field_values_and_label',
+          },
+        },
+      },
+    },
+    {
+      kind: 'label',
+      text: 'Test blocks: custom field values',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_custom_field_values',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_and_label',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_custom_field_values_and_label',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_and_tooltip',
+    },
+  ],
 };
-
-const tooltipConfig: FieldDateFromJsonConfig = {
-  date: '2021-03-13',
-  tooltip: 'This date block has a tooltip!',
-};
-
-const emptyConfig: FieldDateFromJsonConfig = {};
-
-const toolbox = generateFieldTestBlocks('field_date', [
-  {
-    label: 'Basic Date Input',
-    args: basicConfig as Args,
-  },
-  {
-    label: 'Tooltip Date Input',
-    args: tooltipConfig as Args,
-  },
-  {
-    label: 'Default Date Input',
-    args: emptyConfig as Args,
-  },
-]);
 
 /**
  * Create a workspace.
@@ -61,7 +219,7 @@ function createWorkspace(
 
 document.addEventListener('DOMContentLoaded', function () {
   const defaultOptions: Blockly.BlocklyOptions = {
-    toolbox,
+    toolbox: jsonToolbox,
   };
   const rootElement = document.getElementById('root');
   if (rootElement) {

--- a/plugins/field-grid-dropdown/test/index.ts
+++ b/plugins/field-grid-dropdown/test/index.ts
@@ -24,9 +24,7 @@ const testBlockDefinitions = [
       {
         type: 'field_grid_dropdown',
         name: 'FIELDNAME',
-        options: [
-          ['A', 'A'],
-        ],
+        options: [['A', 'A']],
         alt: {
           type: 'field_label',
           text: `No field_grid_dropdown`,
@@ -63,7 +61,8 @@ const testBlockDefinitions = [
     ],
     output: null,
     style: 'math_blocks',
-  },  {
+  },
+  {
     type: 'test_custom_field_values_long_text_list',
     message0: 'Long text list %1',
     args0: [
@@ -106,7 +105,8 @@ const testBlockDefinitions = [
     ],
     output: null,
     style: 'math_blocks',
-  },  {
+  },
+  {
     type: 'test_custom_field_values_images',
     message0: 'Images %1',
     args0: [
@@ -303,9 +303,7 @@ const testBlockDefinitions = [
       {
         type: 'field_grid_dropdown',
         name: 'FIELDNAME',
-        options: [
-          ['A', 'A'],
-        ],
+        options: [['A', 'A']],
         alt: {
           type: 'field_label',
           text: `No field_grid_dropdown`,
@@ -322,9 +320,7 @@ const testBlockDefinitions = [
       {
         type: 'field_grid_dropdown',
         name: 'FIELDNAME',
-        options: [
-          ['A', 'A'],
-        ],
+        options: [['A', 'A']],
         alt: {
           type: 'field_label',
           text: `No field_grid_dropdown`,

--- a/plugins/field-grid-dropdown/test/index.ts
+++ b/plugins/field-grid-dropdown/test/index.ts
@@ -9,219 +9,443 @@
  */
 
 import * as Blockly from 'blockly';
-import {generateFieldTestBlocks, createPlayground} from '@blockly/dev-tools';
+import {createPlayground} from '@blockly/dev-tools';
 import '../src/index';
 
-const toolbox = generateFieldTestBlocks('field_grid_dropdown', [
+/**
+ * An array of blocks that are defined only for the purposes of
+ * manually and visually testing the dropdown grid field.
+ */
+const testBlockDefinitions = [
   {
-    label: 'Different text length',
-    args: {
-      options: [
-        ['A', 'A'],
-        ['long text ', 'long text'],
-        ['B', 'B'],
-        ['C', 'C'],
-        [
-          'really really really loooooong text',
-          'really really really loooooong text',
+    type: 'test_standard_field_values',
+    message0: '%1',
+    args0: [
+      {
+        type: 'field_grid_dropdown',
+        name: 'FIELDNAME',
+        options: [
+          ['A', 'A'],
         ],
-        ['D', 'D'],
-        ['E', 'E'],
-      ],
-    },
+        alt: {
+          type: 'field_label',
+          text: `No field_grid_dropdown`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
   {
-    label: 'Long text list',
-    args: {
-      options: [
-        ['A', 'A'],
-        ['B', 'B'],
-        ['C', 'C'],
-        ['D', 'D'],
-        ['E', 'E'],
-        ['D', 'F'],
-        ['G', 'G'],
-        ['H', 'H'],
-        ['I', 'I'],
-        ['J', 'J'],
-        ['K', 'K'],
-        ['L', 'L'],
-        ['M', 'M'],
-        ['N', 'N'],
-        ['O', 'O'],
-        ['P', 'P'],
-        ['Q', 'Q'],
-        ['R', 'R'],
-        ['S', 'S'],
-        ['T', 'T'],
-        ['U', 'U'],
-        ['V', 'V'],
-        ['W', 'W'],
-        ['X', 'X'],
-        ['Y', 'Y'],
-        ['Z', 'Z'],
-      ],
-    },
+    type: 'test_custom_field_values',
+    message0: 'Different text length %1',
+    args0: [
+      {
+        type: 'field_grid_dropdown',
+        name: 'FIELDNAME',
+        options: [
+          ['A', 'A'],
+          ['long text ', 'long text'],
+          ['B', 'B'],
+          ['C', 'C'],
+          [
+            'really really really loooooong text',
+            'really really really loooooong text',
+          ],
+          ['D', 'D'],
+          ['E', 'E'],
+        ],
+        alt: {
+          type: 'field_label',
+          text: `No field_grid_dropdown`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },  {
+    type: 'test_custom_field_values_long_text_list',
+    message0: 'Long text list %1',
+    args0: [
+      {
+        type: 'field_grid_dropdown',
+        name: 'FIELDNAME',
+        options: [
+          ['A', 'A'],
+          ['B', 'B'],
+          ['C', 'C'],
+          ['D', 'D'],
+          ['E', 'E'],
+          ['D', 'F'],
+          ['G', 'G'],
+          ['H', 'H'],
+          ['I', 'I'],
+          ['J', 'J'],
+          ['K', 'K'],
+          ['L', 'L'],
+          ['M', 'M'],
+          ['N', 'N'],
+          ['O', 'O'],
+          ['P', 'P'],
+          ['Q', 'Q'],
+          ['R', 'R'],
+          ['S', 'S'],
+          ['T', 'T'],
+          ['U', 'U'],
+          ['V', 'V'],
+          ['W', 'W'],
+          ['X', 'X'],
+          ['Y', 'Y'],
+          ['Z', 'Z'],
+        ],
+        alt: {
+          type: 'field_label',
+          text: `No field_grid_dropdown`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },  {
+    type: 'test_custom_field_values_images',
+    message0: 'Images %1',
+    args0: [
+      {
+        type: 'field_grid_dropdown',
+        name: 'FIELDNAME',
+        options: [
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/a.png',
+              width: 32,
+              height: 32,
+              alt: 'A',
+            },
+            'A',
+          ],
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/b.png',
+              width: 32,
+              height: 32,
+              alt: 'B',
+            },
+            'B',
+          ],
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/c.png',
+              width: 32,
+              height: 32,
+              alt: 'C',
+            },
+            'C',
+          ],
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/d.png',
+              width: 32,
+              height: 32,
+              alt: 'D',
+            },
+            'D',
+          ],
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/e.png',
+              width: 32,
+              height: 32,
+              alt: 'E',
+            },
+            'E',
+          ],
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/f.png',
+              width: 32,
+              height: 32,
+              alt: 'F',
+            },
+            'F',
+          ],
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/g.png',
+              width: 32,
+              height: 32,
+              alt: 'G',
+            },
+            'G',
+          ],
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/h.png',
+              width: 32,
+              height: 32,
+              alt: 'H',
+            },
+            'H',
+          ],
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/i.png',
+              width: 32,
+              height: 32,
+              alt: 'I',
+            },
+            'I',
+          ],
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/j.png',
+              width: 32,
+              height: 32,
+              alt: 'J',
+            },
+            'J',
+          ],
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/k.png',
+              width: 32,
+              height: 32,
+              alt: 'K',
+            },
+            'K',
+          ],
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/l.png',
+              width: 32,
+              height: 32,
+              alt: 'L',
+            },
+            'L',
+          ],
+          [
+            {
+              src: 'https://blockly-demo.appspot.com/static/tests/media/m.png',
+              width: 32,
+              height: 32,
+              alt: 'M',
+            },
+            'M',
+          ],
+        ],
+        alt: {
+          type: 'field_label',
+          text: `No field_grid_dropdown`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
   {
-    label: 'Images',
-    args: {
-      options: [
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/a.png',
-            width: 32,
-            height: 32,
-            alt: 'A',
-          },
-          'A',
+    type: 'test_custom_field_values_4_columns',
+    message0: '4 columns %1',
+    args0: [
+      {
+        type: 'field_grid_dropdown',
+        name: 'FIELDNAME',
+        columns: '4',
+        options: [
+          ['A', 'A'],
+          ['B', 'B'],
+          ['C', 'C'],
+          ['D', 'D'],
+          ['E', 'E'],
+          ['F', 'F'],
+          ['G', 'G'],
+          ['H', 'H'],
         ],
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/b.png',
-            width: 32,
-            height: 32,
-            alt: 'B',
-          },
-          'B',
-        ],
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/c.png',
-            width: 32,
-            height: 32,
-            alt: 'C',
-          },
-          'C',
-        ],
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/d.png',
-            width: 32,
-            height: 32,
-            alt: 'D',
-          },
-          'D',
-        ],
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/e.png',
-            width: 32,
-            height: 32,
-            alt: 'E',
-          },
-          'E',
-        ],
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/f.png',
-            width: 32,
-            height: 32,
-            alt: 'F',
-          },
-          'F',
-        ],
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/g.png',
-            width: 32,
-            height: 32,
-            alt: 'G',
-          },
-          'G',
-        ],
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/h.png',
-            width: 32,
-            height: 32,
-            alt: 'H',
-          },
-          'H',
-        ],
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/i.png',
-            width: 32,
-            height: 32,
-            alt: 'I',
-          },
-          'I',
-        ],
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/j.png',
-            width: 32,
-            height: 32,
-            alt: 'J',
-          },
-          'J',
-        ],
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/k.png',
-            width: 32,
-            height: 32,
-            alt: 'K',
-          },
-          'K',
-        ],
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/l.png',
-            width: 32,
-            height: 32,
-            alt: 'L',
-          },
-          'L',
-        ],
-        [
-          {
-            src: 'https://blockly-demo.appspot.com/static/tests/media/m.png',
-            width: 32,
-            height: 32,
-            alt: 'M',
-          },
-          'M',
-        ],
-      ],
-    },
+        alt: {
+          type: 'field_label',
+          text: `No field_grid_dropdown`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
   {
-    label: '4 columns',
-    args: {
-      columns: '4',
-      options: [
-        ['A', 'A'],
-        ['B', 'B'],
-        ['C', 'C'],
-        ['D', 'D'],
-        ['E', 'E'],
-        ['F', 'F'],
-        ['G', 'G'],
-        ['H', 'H'],
-      ],
-    },
+    type: 'test_custom_field_values_custom_colours',
+    message0: 'Custom colours %1',
+    args0: [
+      {
+        type: 'field_grid_dropdown',
+        name: 'FIELDNAME',
+        primaryColour: '#783105',
+        borderColour: '#d6a587',
+        options: [
+          ['A', 'A'],
+          ['B', 'B'],
+          ['C', 'C'],
+          ['D', 'D'],
+          ['E', 'E'],
+          ['F', 'F'],
+          ['G', 'G'],
+          ['H', 'H'],
+        ],
+        alt: {
+          type: 'field_label',
+          text: `No field_grid_dropdown`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
   {
-    label: 'custom colours',
-    args: {
-      primaryColour: '#783105',
-      borderColour: '#d6a587',
-      options: [
-        ['A', 'A'],
-        ['B', 'B'],
-        ['C', 'C'],
-        ['D', 'D'],
-        ['E', 'E'],
-        ['F', 'F'],
-        ['G', 'G'],
-        ['H', 'H'],
-      ],
-    },
+    type: 'test_standard_field_values_and_label',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_grid_dropdown',
+        name: 'FIELDNAME',
+        options: [
+          ['A', 'A'],
+        ],
+        alt: {
+          type: 'field_label',
+          text: `No field_grid_dropdown`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
-]);
+  {
+    type: 'test_custom_field_values_and_label',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_grid_dropdown',
+        name: 'FIELDNAME',
+        options: [
+          ['A', 'A'],
+        ],
+        alt: {
+          type: 'field_label',
+          text: `No field_grid_dropdown`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },
+  {
+    type: 'test_parent_block',
+    message0: 'parent %1',
+    args0: [
+      {
+        type: 'input_value',
+        name: 'INPUT',
+      },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    style: 'loop_blocks',
+  },
+];
 
+Blockly.defineBlocksWithJsonArray(testBlockDefinitions);
+
+/**
+ * A test toolbox containing the exported blocks and a variety of
+ * test blocks to exercise the dropdown grid field in different contexts
+ * (on a shadow block, as the only field on a block, etc).
+ * These are in a simple toolbox, rather than a category toolbox, so that
+ * they are all instantiated every time the test page is opened.
+ */
+const jsonToolbox = {
+  contents: [
+    {
+      kind: 'label',
+      text: 'Test blocks: default field values',
+    },
+    {
+      kind: 'block',
+      type: 'test_standard_field_values',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_standard_field_values',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_standard_field_values_and_label',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_standard_field_values_and_label',
+          },
+        },
+      },
+    },
+    {
+      kind: 'label',
+      text: 'Test blocks: custom field values',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_long_text_list',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_images',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_4_columns',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_custom_colours',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_custom_field_values',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_and_label',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_custom_field_values_and_label',
+          },
+        },
+      },
+    },
+  ],
+};
 /**
  * Create a workspace.
  *
@@ -239,7 +463,7 @@ function createWorkspace(
 
 document.addEventListener('DOMContentLoaded', function () {
   const defaultOptions: Blockly.BlocklyOptions = {
-    toolbox,
+    toolbox: jsonToolbox,
   };
   const rootElement = document.getElementById('root');
   if (rootElement) {

--- a/plugins/field-slider/test/index.ts
+++ b/plugins/field-slider/test/index.ts
@@ -10,39 +10,240 @@
  */
 
 import * as Blockly from 'blockly';
-import {generateFieldTestBlocks, createPlayground} from '@blockly/dev-tools';
+import {createPlayground} from '@blockly/dev-tools';
 import '../src/index';
 
-const toolbox = generateFieldTestBlocks('field_slider', [
+/**
+ * An array of blocks that are defined only for the purposes of
+ * manually and visually testing the slider field.
+ */
+const testBlockDefinitions = [
   {
-    label: 'Basic',
-    args: {
-      value: 50,
-    },
+    type: 'test_standard_field_values',
+    message0: '%1',
+    args0: [
+      {
+        type: 'field_slider',
+        name: 'FIELDNAME',
+        alt: {
+          type: 'field_label',
+          text: `No field_slider`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
   {
-    label: 'Min',
-    args: {
-      value: 20,
-      min: 10,
-    },
+    type: 'test_custom_field_values',
+    message0: '%1',
+    args0: [
+      {
+        type: 'field_slider',
+        name: 'FIELDNAME',
+        value: 50,
+        alt: {
+          type: 'field_label',
+          text: `No field_slider`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },  {
+    type: 'test_custom_field_values_max',
+    message0: 'max %1',
+    args0: [
+      {
+        type: 'field_slider',
+        name: 'FIELDNAME',
+        value: 70,
+        max: 80,
+        alt: {
+          type: 'field_label',
+          text: `No field_slider`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },  {
+    type: 'test_custom_field_values_min',
+    message0: 'min %1',
+    args0: [
+      {
+        type: 'field_slider',
+        name: 'FIELDNAME',
+        value: 20,
+        min: 10,
+        alt: {
+          type: 'field_label',
+          text: `No field_slider`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
+  },  {
+    type: 'test_custom_field_values_max_and_min',
+    message0: 'max and min %1',
+    args0: [
+      {
+        type: 'field_slider',
+        name: 'FIELDNAME',
+        value: 60,
+        min: 10,
+        max: 80,
+        alt: {
+          type: 'field_label',
+          text: `No field_slider`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
   {
-    label: 'Max',
-    args: {
-      value: 70,
-      max: 80,
-    },
+    type: 'test_standard_field_values_and_label',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_slider',
+        name: 'FIELDNAME',
+        alt: {
+          type: 'field_label',
+          text: `No field_slider`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
   {
-    label: 'Min and Max',
-    args: {
-      value: 60,
-      min: 10,
-      max: 80,
-    },
+    type: 'test_custom_field_values_and_label',
+    message0: 'block %1',
+    args0: [
+      {
+        type: 'field_slider',
+        name: 'FIELDNAME',
+        value: 50,
+        alt: {
+          type: 'field_label',
+          text: `No field_slider`,
+        },
+      },
+    ],
+    output: null,
+    style: 'math_blocks',
   },
-]);
+  {
+    type: 'test_parent_block',
+    message0: 'parent %1',
+    args0: [
+      {
+        type: 'input_value',
+        name: 'INPUT',
+      },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    style: 'loop_blocks',
+  },
+];
+
+Blockly.defineBlocksWithJsonArray(testBlockDefinitions);
+
+/**
+ * A test toolbox containing the exported blocks and a variety of
+ * test blocks to exercise the slider field in different contexts
+ * (on a shadow block, as the only field on a block, etc).
+ * These are in a simple toolbox, rather than a category toolbox, so that
+ * they are all instantiated every time the test page is opened.
+ */
+const jsonToolbox = {
+  contents: [
+    {
+      kind: 'label',
+      text: 'Test blocks: default field values',
+    },
+    {
+      kind: 'block',
+      type: 'test_standard_field_values',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_standard_field_values',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_standard_field_values_and_label',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_standard_field_values_and_label',
+          },
+        },
+      },
+    },
+    {
+      kind: 'label',
+      text: 'Test blocks: custom field values',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_max',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_min',
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_max_and_min',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_custom_field_values',
+          },
+        },
+      },
+    },
+    {
+      kind: 'block',
+      type: 'test_custom_field_values_and_label',
+    },
+    {
+      kind: 'block',
+      type: 'test_parent_block',
+      inputs: {
+        INPUT: {
+          shadow: {
+            type: 'test_custom_field_values_and_label',
+          },
+        },
+      },
+    },
+  ],
+};
 
 /**
  * Create a workspace.
@@ -61,7 +262,7 @@ function createWorkspace(
 
 document.addEventListener('DOMContentLoaded', function () {
   const defaultOptions: Blockly.BlocklyOptions = {
-    toolbox,
+    toolbox: jsonToolbox,
   };
   const rootElement = document.getElementById('root');
   if (rootElement) {

--- a/plugins/field-slider/test/index.ts
+++ b/plugins/field-slider/test/index.ts
@@ -50,7 +50,8 @@ const testBlockDefinitions = [
     ],
     output: null,
     style: 'math_blocks',
-  },  {
+  },
+  {
     type: 'test_custom_field_values_max',
     message0: 'max %1',
     args0: [
@@ -67,7 +68,8 @@ const testBlockDefinitions = [
     ],
     output: null,
     style: 'math_blocks',
-  },  {
+  },
+  {
     type: 'test_custom_field_values_min',
     message0: 'min %1',
     args0: [
@@ -84,7 +86,8 @@ const testBlockDefinitions = [
     ],
     output: null,
     style: 'math_blocks',
-  },  {
+  },
+  {
     type: 'test_custom_field_values_max_and_min',
     message0: 'max and min %1',
     args0: [


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly-samples/issues/2356

### Proposed Changes

Removes uses of `generateFieldTextBlocks` for fields where it was breaking the test pages.

### Reason for Changes
Swap indirection for code duplication, to make it easier to read the test code and see what's being tested.

### Test Coverage
These are tests.

### Documentation
None
