### PR TITLE
fix: improve bitmap field editor styles for large images and/or no buttons

### DIFF
--- a/plugins/field-bitmap/src/field-bitmap.ts
+++ b/plugins/field-bitmap/src/field-bitmap.ts
@@ -262,6 +262,9 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
       'div',
       'dropdownEditor',
     );
+    if (this.buttonOptions.randomize || this.buttonOptions.clear) {
+      dropdownEditor.classList.add('has-buttons');
+    }
     const pixelContainer = this.createElementWithClassname(
       'div',
       'pixelContainer',
@@ -613,6 +616,8 @@ Blockly.Css.register(`
   flex-direction: column;
   display: flex;
   justify-content: center;
+}
+.dropdownEditor.has-buttons {
   margin-bottom: 20px;
 }
 .pixelContainer {
@@ -635,5 +640,8 @@ Blockly.Css.register(`
 }
 .controlButton {
   margin: 5px 0;
+}
+.blocklyDropDownContent{
+  max-height: unset;
 }
 `);

--- a/plugins/field-bitmap/src/field-bitmap.ts
+++ b/plugins/field-bitmap/src/field-bitmap.ts
@@ -271,6 +271,9 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
     );
     dropdownEditor.appendChild(pixelContainer);
 
+    // This prevents the normal max-height from adding a scroll bar for large images.
+    Blockly.DropDownDiv.getContentDiv().classList.add('contains-bitmap-editor');
+
     this.bindEvent(dropdownEditor, 'mouseup', this.onMouseUp);
     this.bindEvent(dropdownEditor, 'mouseleave', this.onMouseUp);
     this.bindEvent(dropdownEditor, 'dragstart', (e: Event) => {
@@ -429,6 +432,10 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
     this.editorPixels = null;
     // Set this.initialValue back to null.
     this.initialValue = null;
+
+    Blockly.DropDownDiv.getContentDiv().classList.remove(
+      'contains-bitmap-editor',
+    );
   }
 
   /**
@@ -641,7 +648,7 @@ Blockly.Css.register(`
 .controlButton {
   margin: 5px 0;
 }
-.blocklyDropDownContent{
-  max-height: unset;
+.blocklyDropDownContent.contains-bitmap-editor {
+  max-height: none;
 }
 `);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/pull/2351#pullrequestreview-2060573975

### Proposed Changes

1. Override maximum-height rule for the bitmap field dropdown's editor, which will allow large images to be displayed without scrolling.
2. Conditionally add another class if the editor has buttons, and only then use an extra 20px bottom margin. 


### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

While testing a recent update to the bitmap field plugin (https://github.com/google/blockly-samples/pull/2351), it was noticed that dropdown content is cut off for large images.
- https://github.com/google/blockly-samples/pull/2351#pullrequestreview-2060573975

> In local testing with the supplied test blocks, however, I have noted what appears to be a bug with sizing the pop-up for the "Static field height, custom colors, no buttons" test block:

<img width="387" alt="331197691-3a1423e4-43fc-4ac8-aa72-db393d4746c6" src="https://github.com/google/blockly-samples/assets/43474485/4c253eed-3cc0-430b-b476-808909137983">


This bug is unrelated to the recent update, and is due instead to a max height set in Core for all Blockly dropdowns: https://github.com/google/blockly/blob/049993405e23cf4bf05943eb0d5070116715db2c/core/css.ts#L127

While doing this, I also noticed an existing 20px bottom margin, which seemed undesirable if there were no buttons: 
<img width="294" alt="image" src="https://github.com/google/blockly-samples/assets/43474485/1884d096-c70c-4c4e-b2c3-2c6d4c5315c1"><img width="306" alt="image" src="https://github.com/google/blockly-samples/assets/43474485/91639c57-9bf3-4662-ab71-91cc12e2499f">

Because buttons were always present before the most recent update, this bug is directly related to that work.

The results of the changes here are that the editor no longer has a maximum height, and there is equal padding on all sides when no buttons are shown:
<img width="411" alt="image" src="https://github.com/google/blockly-samples/assets/43474485/e39128cc-2007-4648-b470-ce0a6c6d5b3a">

The obvious drawback to proposed solution is that block designers will need to be especially careful not to provide blocks with images that are overly large for their users' devices and screen resolution. Alternative solutions could be to dynamically resize the editor content or to keep a (potentially adjusted) maximum height and live with the scroll bar. I didn't pursue either of those options at this time.

### Test Coverage

No changes to test coverage are included.

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

No changes to documentation are needed.

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

N/A
<!-- Anything else we should know? -->
