### PR TITLE
fix: Fix the instructions for configuring the debug renderer.

### DIFF
--- a/plugins/dev-tools/README.md
+++ b/plugins/dev-tools/README.md
@@ -183,7 +183,7 @@ To see the different information the debug renderer surfaces, you can modify
 the config from the browser console.
 
 ```js
-DebugRenderer.config = {
+DebugDrawer.config = {
   rows: true,
   rowSpacers: true,
   elems: true,


### PR DESCRIPTION
This PR updates the devtools README to reflect the correct namespace for the debug renderer's configuration object.