### PR TITLE
fix: hackermode theme deps

### DIFF
--- a/plugins/theme-hackermode/package.json
+++ b/plugins/theme-hackermode/package.json
@@ -41,8 +41,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^3.1.1",
-    "@blockly/dev-tools": "^7.1.11",
+    "@blockly/dev-scripts": "^4.0.0",
+    "@blockly/dev-tools": "^8.0.0",
     "blockly": "^11.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Updates the hackermode deps to depend on plugins that depend on v11. Other plugins get automatically updated, but this one doesn't because it's private. This is blocking updating the ghpages for samples.