### PR TITLE
chore: add all examples to lerna and bump private pkg versions again

### DIFF
--- a/examples/lerna.json
+++ b/examples/lerna.json
@@ -1,5 +1,5 @@
 {
-  "packages": ["blockly-**", "**-demo"],
+  "packages": ["blockly-**", "**-demo", "**-codelab", "sample-**"],
   "version": "independent",
   "npmClient": "npm",
   "useNx": false

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,7 +123,7 @@ function publish(force) {
     // creates the release on GitHub.
     console.log(`Publishing ${force ? 'all' : 'changed'} plugins.`);
     execSync(
-      `lerna publish --no-private --conventional-commits --create-release github` +
+      `lerna publish --conventional-commits --create-release github` +
         `${force ? ' --force-publish=*' : ''}`,
       {cwd: releaseDir, stdio: 'inherit'},
     );
@@ -168,7 +168,7 @@ function publishFromPackage(done) {
 
   // Run lerna publish. Will not update versions.
   console.log(`Publishing plugins from package.json versions.`);
-  execSync(`lerna publish from-package --no-private`, {
+  execSync(`lerna publish from-package`, {
     cwd: releaseDir,
     stdio: 'inherit',
   });
@@ -195,7 +195,7 @@ function checkVersions(done) {
     'even if you answer yes to the prompt.',
   );
   execSync(
-    `lerna version --no-private --conventional-commits --no-git-tag-version --no-push`,
+    `lerna version --conventional-commits --no-git-tag-version --no-push`,
     {cwd: releaseDir, stdio: 'inherit'},
   );
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes problems with lerna bumping private packages (i.e. plugins we aren't ready to publish yet for whatever reason).

The way I would like lerna to handle private packages: during publish, don't bump the private package's version number (leave it at 0.0.0) but DO bump the versions of its dependencies, just like it does for non-private packages (e.g. bump dev-tools from 1.2.3 to 1.2.4 when dev-tools is published. this happens automatically for non-private packages)

Lerna can actually deal with private packages in one of two ways:
- Option 1: Totally ignore private packages. Don't bump their version, but also don't bump the versions of their dependencies either
- Option 2: Always bump all versions: Bump the private package's version (e.g. to 0.1.0), and also bump the versions of their dependencies

We were doing option 2 for a long while. This has the drawback of when we finally do publish a plugin, it's some weird version number. Then we switched to doing option 1 in https://github.com/google/blockly-samples/pull/1718 . However, these flags were not necessary to prevent actually publishing the plugin, just to prevent it from being bumped an extra major version while it wasn't being published. We never removed them after. 
Option 1 has the drawback of creating peer dependency headaches when we update the minimum blockly version or update to a new major version of dev-tools. This prevented github pages from being updated this morning, because after the plugins got published with their new versions, the `theme-hackermode` plugin was using v11 of blockly but wasn't bumped to use v8 of dev-tools. Since the versions were out of sync, it did not use the local version of dev-tools and therefore caused `npm ci` to fail because v7 of dev-tools isn't compatible with v11 of blockly.

Lerna/npm will never actually publish private packages regardless of this flag being present. The flag just controls if lerna bumps their versions, not whether they get published.


Also, some of the examples were not included in the lerna config for examples, so their dependencies were not being installed by `lerna bootstrap` in examples.

### Proposed Changes

- Removes the `--no-private` flag so that private plugins get their versions bumped when other plugins are published
- Adds codelabs and sample-apps to the lerna config so they are managed as part of the monorepo too.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
