### PR TITLE
fix: update pixel with new values

### DIFF
--- a/plugins/field-bitmap/src/field-bitmap.ts
+++ b/plugins/field-bitmap/src/field-bitmap.ts
@@ -42,6 +42,7 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
   buttonOptions: Buttons;
   pixelSize: number;
   pixelColours: {empty: string; filled: string};
+  fieldHeight?: number;
 
   /**
    * Constructor for the bitmap field.
@@ -73,8 +74,9 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
       // Set a default empty value
       this.setValue(this.getEmptyArray());
     }
-    if (config?.fieldHeight) {
-      this.pixelSize = config.fieldHeight / this.imgHeight;
+    this.fieldHeight = config?.fieldHeight;
+    if (this.fieldHeight) {
+      this.pixelSize = this.fieldHeight / this.imgHeight;
     } else {
       this.pixelSize = DEFAULT_PIXEL_SIZE;
     }
@@ -178,6 +180,12 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
     if (newValue) {
       this.imgHeight = newValue.length;
       this.imgWidth = newValue[0] ? newValue[0].length : 0;
+      // If the field height is static, adjust the pixel size to fit.
+      if (this.fieldHeight) {
+        this.pixelSize = this.fieldHeight / this.imgHeight;
+      } else {
+        this.pixelSize = DEFAULT_PIXEL_SIZE;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/2372

### Proposed Changes

This pull request allows the bitmap field to recalculate its pixel size when a static field height is provided and the field's value is updated.

### Reason for Changes

If the field value is updated to an array of a different length, an unchanging pixel size would mean that the rendered height of the field would change unexpectedly.

With this change, the field height is always respected, even when the image height (in pixels) changes.

![image](https://github.com/google/blockly-samples/assets/43474485/54ddfddc-e3e7-4fde-b253-b73618b8a213)

### Test Coverage
### Documentation


There are no proposed changes in test coverage or documentation at this time.

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

I've implemented a similar fix for Code.org already so this is not immediately blocking to us.
<!-- Anything else we should know? -->
