### PR TITLE
fix: add custom blocks back to sample-apps

### DIFF
--- a/examples/sample-app-ts/src/blocks/text.ts
+++ b/examples/sample-app-ts/src/blocks/text.ts
@@ -12,17 +12,12 @@ import * as Blockly from 'blockly/core';
 // own custom blocks.
 const addText = {
   type: 'add_text',
-  message0: 'Add text %1 with color %2',
+  message0: 'Add text %1',
   args0: [
     {
       type: 'input_value',
       name: 'TEXT',
       check: 'String',
-    },
-    {
-      type: 'input_value',
-      name: 'COLOR',
-      check: 'Colour',
     },
   ],
   previousStatement: null,

--- a/examples/sample-app-ts/src/generators/javascript.ts
+++ b/examples/sample-app-ts/src/generators/javascript.ts
@@ -17,22 +17,18 @@ forBlock['add_text'] = function (
   generator: Blockly.CodeGenerator,
 ) {
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
-  const color =
-    generator.valueToCode(block, 'COLOR', Order.ATOMIC) || "'#ffffff'";
-
   const addText = generator.provideFunction_(
     'addText',
-    `function ${generator.FUNCTION_NAME_PLACEHOLDER_}(text, color) {
+    `function ${generator.FUNCTION_NAME_PLACEHOLDER_}(text) {
 
   // Add text to the output area.
   const outputDiv = document.getElementById('output');
   const textEl = document.createElement('p');
   textEl.innerText = text;
-  textEl.style.color = color;
   outputDiv.appendChild(textEl);
 }`,
   );
   // Generate the function call for this block.
-  const code = `${addText}(${text}, ${color});\n`;
+  const code = `${addText}(${text});\n`;
   return code;
 };

--- a/examples/sample-app-ts/src/index.ts
+++ b/examples/sample-app-ts/src/index.ts
@@ -20,7 +20,11 @@ Object.assign(javascriptGenerator.forBlock, forBlock);
 const codeDiv = document.getElementById('generatedCode')?.firstChild;
 const outputDiv = document.getElementById('output');
 const blocklyDiv = document.getElementById('blocklyDiv');
-const ws = blocklyDiv && Blockly.inject(blocklyDiv, {toolbox});
+
+if (!blocklyDiv) {
+  throw new Error(`div with id 'blocklyDiv' not found`);
+}
+const ws = Blockly.inject(blocklyDiv, {toolbox});
 
 // This function resets the code and output divs, shows the
 // generated code from the workspace, and evals the code.

--- a/examples/sample-app-ts/src/toolbox.ts
+++ b/examples/sample-app-ts/src/toolbox.ts
@@ -491,6 +491,20 @@ export const toolbox = {
             },
           },
         },
+        {
+          kind: 'block',
+          type: 'add_text',
+          inputs: {
+            TEXT: {
+              shadow: {
+                type: 'text',
+                fields: {
+                  TEXT: 'abc',
+                },
+              },
+            },
+          },
+        },
       ],
     },
     {

--- a/examples/sample-app/src/blocks/text.js
+++ b/examples/sample-app/src/blocks/text.js
@@ -12,17 +12,12 @@ import * as Blockly from 'blockly/core';
 // own custom blocks.
 const addText = {
   type: 'add_text',
-  message0: 'Add text %1 with color %2',
+  message0: 'Add text %1',
   args0: [
     {
       type: 'input_value',
       name: 'TEXT',
       check: 'String',
-    },
-    {
-      type: 'input_value',
-      name: 'COLOR',
-      check: 'Colour',
     },
   ],
   previousStatement: null,

--- a/examples/sample-app/src/generators/javascript.js
+++ b/examples/sample-app/src/generators/javascript.js
@@ -13,22 +13,18 @@ export const forBlock = Object.create(null);
 
 forBlock['add_text'] = function (block, generator) {
   const text = generator.valueToCode(block, 'TEXT', Order.NONE) || "''";
-  const color =
-    generator.valueToCode(block, 'COLOR', Order.ATOMIC) || "'#ffffff'";
-
   const addText = generator.provideFunction_(
     'addText',
-    `function ${generator.FUNCTION_NAME_PLACEHOLDER_}(text, color) {
+    `function ${generator.FUNCTION_NAME_PLACEHOLDER_}(text) {
 
   // Add text to the output area.
   const outputDiv = document.getElementById('output');
   const textEl = document.createElement('p');
   textEl.innerText = text;
-  textEl.style.color = color;
   outputDiv.appendChild(textEl);
 }`,
   );
   // Generate the function call for this block.
-  const code = `${addText}(${text}, ${color});\n`;
+  const code = `${addText}(${text});\n`;
   return code;
 };

--- a/examples/sample-app/src/toolbox.js
+++ b/examples/sample-app/src/toolbox.js
@@ -491,6 +491,20 @@ export const toolbox = {
             },
           },
         },
+        {
+          kind: 'block',
+          type: 'add_text',
+          inputs: {
+            TEXT: {
+              shadow: {
+                type: 'text',
+                fields: {
+                  TEXT: 'abc',
+                },
+              },
+            },
+          },
+        },
       ],
     },
     {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2366 

### Proposed Changes

- Adds custom blocks back to sample-app toolbox, this time without the colour input
- Fixes minor type bug in the sample-app-ts 

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
