### PR TITLE
fix: TypeScript sample raises type error

### DIFF
--- a/examples/sample-app-ts/src/index.ts
+++ b/examples/sample-app-ts/src/index.ts
@@ -30,7 +30,7 @@ const ws = Blockly.inject(blocklyDiv, {toolbox});
 // generated code from the workspace, and evals the code.
 // In a real application, you probably shouldn't use `eval`.
 const runCode = () => {
-  const code = javascriptGenerator.workspaceToCode(ws);
+  const code = javascriptGenerator.workspaceToCode(ws as Blockly.Workspace);
   if (codeDiv) codeDiv.textContent = code;
 
   if (outputDiv) outputDiv.innerHTML = '';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ x ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Type conversion for argument of `workspaceToCode` at `index.ts`.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
TypeScript sample app is not executable because of a TS2345 error. The `ws` variable can possibly be null, which raises an error when calling `workspaceToCode`. After casting `ws` to `Blockly.Workspace`, the error is resolved.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
