### PR TITLE
chore: add test block that duplicates on drag

### DIFF
--- a/plugins/block-test/src/drag.js
+++ b/plugins/block-test/src/drag.js
@@ -10,6 +10,47 @@
  * @author samelh@google.com (Sam El-Husseini)
  */
 
+import * as Blockly from 'blockly/core';
+
+/** Block that duplicates itself on drag. */
+Blockly.Blocks['drag_to_dupe'] = {
+  init: function () {
+    this.setOutput(true, null);
+    this.appendDummyInput().appendField('drag to dupe');
+    this.setDragStrategy(new DragToDupe(this));
+  },
+};
+
+/** Drag strategy that duplicates the block on drag. */
+class DragToDupe {
+  constructor(block) {
+    this.block = block;
+  }
+
+  isMovable() {
+    return true;
+  }
+
+  startDrag(e) {
+    const data = this.block.toCopyData();
+    this.copy = Blockly.clipboard.paste(data, this.block.workspace);
+    this.baseStrat = new Blockly.dragging.BlockDragStrategy(this.copy);
+    this.baseStrat.startDrag(e);
+  }
+
+  drag(e) {
+    this.baseStrat.drag(e);
+  }
+
+  endDrag(e) {
+    this.baseStrat.endDrag(e);
+  }
+
+  revertDrag(e) {
+    this.copy.dispose();
+  }
+}
+
 /**
  * The Drag category.
  */
@@ -126,6 +167,21 @@ export const category = {
     </block>
   </statement>
 </block>`,
+    },
+    {
+      kind: 'BLOCK',
+      type: 'drag_to_dupe',
+    },
+    {
+      kind: 'BLOCK',
+      type: 'text_print',
+      inputs: {
+        TEXT: {
+          shadow: {
+            type: 'drag_to_dupe',
+          },
+        },
+      },
     },
   ],
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes N/A

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Adds a test blocks that duplicates on drag so we can ensure we don't regress in support for that functionality.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
Tested that with my local version of Blockly the block duplicates both when it is a real block and when it is a shadow.

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
N/A

### Additional Information

<!-- Anything else we should know? -->
N/A
