### PR TITLE
fix: unpkg import in Getting Started codelab for blockly v11

### DIFF
--- a/codelabs/getting_started/getting_started.md
+++ b/codelabs/getting_started/getting_started.md
@@ -101,7 +101,7 @@ Open `starter-code/index.html` in a text editor and scroll to the end. You can s
 Add Blockly just before these two scripts. The order is important, because you will use Blockly objects later in `main.js`.  Your imports should now look like this:
 
 ```html
-<script src="https://unpkg.com/blockly"></script>
+<script src="https://unpkg.com/blockly/blockly.min.js"></script>
 <script src="scripts/music_maker.js"></script>
 <script src="scripts/main.js"></script>
 ```

--- a/codelabs/getting_started/getting_started.md
+++ b/codelabs/getting_started/getting_started.md
@@ -101,7 +101,10 @@ Open `starter-code/index.html` in a text editor and scroll to the end. You can s
 Add Blockly just before these two scripts. The order is important, because you will use Blockly objects later in `main.js`.  Your imports should now look like this:
 
 ```html
-<script src="https://unpkg.com/blockly/blockly.min.js"></script>
+<script src="https://unpkg.com/blockly/blockly_compressed.js"></script>
+<script src="https://unpkg.com/blockly/blocks_compressed.js"></script>
+<script src="https://unpkg.com/blockly/javascript_compressed.js"></script>
+<script src="https://unpkg.com/blockly/msg/en.js"></script>
 <script src="scripts/music_maker.js"></script>
 <script src="scripts/main.js"></script>
 ```

--- a/examples/getting-started-codelab/complete-code/index.html
+++ b/examples/getting-started-codelab/complete-code/index.html
@@ -52,7 +52,7 @@
       </div>
     </main>
 
-    <script src="https://unpkg.com/blockly"></script>
+    <script src="https://unpkg.com/blockly/blockly.min.js"></script>
     <script src="scripts/sound_blocks.js"></script>
     <script src="scripts/music_maker.js"></script>
     <script src="scripts/main.js"></script>

--- a/examples/getting-started-codelab/complete-code/index.html
+++ b/examples/getting-started-codelab/complete-code/index.html
@@ -52,7 +52,10 @@
       </div>
     </main>
 
-    <script src="https://unpkg.com/blockly/blockly.min.js"></script>
+    <script src="https://unpkg.com/blockly/blockly_compressed.js"></script>
+    <script src="https://unpkg.com/blockly/blocks_compressed.js"></script>
+    <script src="https://unpkg.com/blockly/javascript_compressed.js"></script>
+    <script src="https://unpkg.com/blockly/msg/en.js"></script>
     <script src="scripts/sound_blocks.js"></script>
     <script src="scripts/music_maker.js"></script>
     <script src="scripts/main.js"></script>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->

Fixes #2378

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

Change the unpkg import to be valid.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

See #2378 for more info.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

This PR updates the codelab documentation.

### Additional Information

<!-- Anything else we should know? -->
