### PR TITLE
fix: Update content highlight when workspace comment is moved.

### DIFF
--- a/plugins/content-highlight/src/index.ts
+++ b/plugins/content-highlight/src/index.ts
@@ -17,6 +17,9 @@ const contentChangeEvents = [
   Blockly.Events.VIEWPORT_CHANGE,
   Blockly.Events.BLOCK_MOVE,
   Blockly.Events.BLOCK_DELETE,
+  Blockly.Events.COMMENT_MOVE,
+  Blockly.Events.COMMENT_CREATE,
+  Blockly.Events.COMMENT_DELETE,
 ];
 
 /**


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Partially addresses https://github.com/google/blockly-samples/issues/2330

### Proposed Changes

This adds `COMMENT_MOVE`, `COMMENT_CREATE`, and `COMMENT_DELETE` to the list of events that can trigger the content highlight boundaries to update.

### Reason for Changes

Otherwise the content highlight bounds won't update when workspace comments are moved, and it is possible for a comment to be outside of the bounds.

### Test Coverage

N/A

### Documentation

N/A

### Additional Information

This only partially addresses the situation. I know of two possible improvements, both of which would require updating blockly core to fire additional events related to workspace comments:

1. Starting to drag a normal block hides the content highlight until you finish the drag, but workspace comments do not fire any event when a drag is started so there's no possibility to handle this case. Instead, the content highlight will remain in place while dragging a workspace comment and will only be updated when the drag is finished.
2. Resizing a workspace comment does not fire any event and thus cannot update the content highlight. (Also the resize handle can get visually detached from the comment in my testing, but that's a separate bug.)
