### PR TITLE
fix(codelabs): incorrectly-formatted hyperlink

### DIFF
--- a/codelabs/custom_renderer/custom_renderer.md
+++ b/codelabs/custom_renderer/custom_renderer.md
@@ -41,7 +41,7 @@ This codelab will add code to the Blockly sample app to create and use a new cus
 
 ### The application
 
-Use the (`npx @blockly/create-package app`)[https://www.npmjs.com/package/@blockly/create-package) command to create a standalone application that contains a sample setup of Blockly, including custom blocks and a display of the generated code and output.
+Use the Use the [`npx @blockly/create-package`](https://www.npmjs.com/package/@blockly/create-package) command to create a standalone application that contains a sample setup of Blockly, including custom blocks and a display of the generated code and output.
   1. Run `npx @blockly/create-package app custom-renderer-codelab`.  This will create a blockly application in the folder `custom-renderer-codelab`.
   1. `cd` into the new directory: `cd custom-renderer-codelab`.
   1. Run `npm start` to start the server and run the sample application.


### PR DESCRIPTION
Hi @cpcallen,

Thank you for your feedback on my previous pull request. I appreciate the guidance and the opportunity to contribute to Blockly.

I have addressed the issue you highlighted regarding the incorrectly-formatted hyperlink in the first bullet point in the "### The application" section. This PR is focused solely on correcting that specific hyperlink format to align with the rest of the content.

I have followed the guide on contributing to Blockly, especially the section about conventional commits, to ensure this PR adheres to your standards.