### PR TITLE
feat: use a js legal name for the block in code output

### DIFF
--- a/examples/developer-tools/src/blocks/factory_base.ts
+++ b/examples/developer-tools/src/blocks/factory_base.ts
@@ -112,6 +112,9 @@ export const factoryBase = {
     this.moveInputBefore(name, 'COLOUR');
   },
   validateName: function (name: string): string | null {
+    // Name cannot be an empty string.
+    if (name === '') return null;
+
     // If the name is prohibited then it's never valid
     if (storage.getProhibitedBlockNames().has(name)) return null;
 

--- a/examples/developer-tools/src/output-generators/factory_base.ts
+++ b/examples/developer-tools/src/output-generators/factory_base.ts
@@ -26,13 +26,21 @@ import {
 } from './generator_stub_generator';
 
 /**
- * Gets a JavaScript-legal name for the block.
+ * Gets a name for the block that is likely to be JavaScript-legal.
+ * Replaces any character that isn't a digit, ascii letter, underscore,
+ * or dollar sign with an underscore. Prepends names that start with
+ * digits with an underscore.
+ *
+ * This does not check for reserved words in JavaScript, so the name isn't
+ * guaranteed to be a legal identifier.
+ * This also disallows what would be legal identifiers that use unicode
+ * letters.
  *
  * @param name user-entered name.
- * @returns legal name with underscores replacing spaces.
+ * @returns legal-ish name.
  */
 const getLegalBlockName = function (name: string): string {
-  return encodeURI(name.toLowerCase().replace(/ /g, '_').replace(/[^\w]/g, ''));
+  return name.replace(/[^\da-zA-Z_$]/g, '_').replace(/^(\d)/, '_$1');
 };
 
 /**

--- a/examples/developer-tools/src/output-generators/factory_base.ts
+++ b/examples/developer-tools/src/output-generators/factory_base.ts
@@ -26,6 +26,16 @@ import {
 } from './generator_stub_generator';
 
 /**
+ * Gets a JavaScript-legal name for the block.
+ *
+ * @param name user-entered name.
+ * @returns legal name with underscores replacing spaces.
+ */
+const getLegalBlockName = function (name: string): string {
+  return encodeURI(name.toLowerCase().replace(/ /g, '_').replace(/[^\w]/g, ''));
+};
+
+/**
  * Builds the 'message0' part of the JSON block definition.
  * The message should have label fields' text inlined into the message.
  * Doing so makes the message more translatable as fields can be moved around.
@@ -62,8 +72,7 @@ jsonDefinitionGenerator.forBlock['factory_base'] = function (
   block: Blockly.Block,
   generator: JsonDefinitionGenerator,
 ): string {
-  // TODO: Get a JSON-legal name for the block
-  const blockName = block.getFieldValue('NAME');
+  const blockName = getLegalBlockName(block.getFieldValue('NAME'));
   // Tooltip and Helpurl string blocks can't be removed, so we don't care what happens if the block doesn't exist
   const tooltip = JSON.parse(
     generator.valueToCode(block, 'TOOLTIP', JsonOrder.ATOMIC),
@@ -141,8 +150,7 @@ javascriptDefinitionGenerator.forBlock['factory_base'] = function (
   block: Blockly.Block,
   generator: JavascriptDefinitionGenerator,
 ) {
-  // TODO: Get a JavaScript-legal name for the block
-  const blockName = block.getFieldValue('NAME');
+  const blockName = getLegalBlockName(block.getFieldValue('NAME'));
   const inputsValue = generator.statementToCode(block, 'INPUTS');
   const inputs = inputsValue
     ? generator.prefixLines(inputsValue, generator.INDENT) + '\n'
@@ -242,7 +250,7 @@ generatorStubGenerator.forBlock['factory_base'] = function (
   generator: GeneratorStubGenerator,
 ): string {
   const lang = generator.getLanguage();
-  const blockName = block.getFieldValue('NAME');
+  const blockName = getLegalBlockName(block.getFieldValue('NAME'));
   const inputs = generator.statementToCode(block, 'INPUTS');
   const scriptPrefix = generator.getScriptMode() ? lang + '.' : '';
   const hasOutput = !!block.getInput('OUTPUTCHECK');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes 

### Proposed Changes

- Gets a JS-legal name for the block to use in output generators so that we generate valid json/js

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
