### PR TITLE
fix(docs): Update README for multiline field

### DIFF
--- a/plugins/field-multilineinput/README.md
+++ b/plugins/field-multilineinput/README.md
@@ -63,11 +63,11 @@ import {registerFieldMultilineInput} from '@blockly/field-multilineinput';
 registerFieldMultilineInput();
 Blockly.defineBlocksWithJsonArray([
     {
-        "type": "test_field_multilineinput",
+        "type": "test_field_multilinetext",
         "message0": "multilineinput: %1",
         "args0": [
             {
-                "type": "field_multilineinput",
+                "type": "field_multilinetext",
                 "name": "FIELDNAME",
                 "text": "some text \n with newlines"
             }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2393 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

Historical note: Even before we removed these fields from core, this inconsistency between the js class name and the json registered name existed, so it's probably been here since the introduction of the json registry, and we opt not to change it for consistency which would break any users of this field.
