### PR TITLE
fix: dev-tools only set monaco model and text when changing

### DIFF
--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -175,6 +175,12 @@ export function createPlayground(
               wordWrap: true,
             });
           }
+          if (
+            generateModel.getValue() === text &&
+            editor.getModel() === generateModel
+          ) {
+            return;
+          }
           generateModel.pushEditOperations(
             [],
             [{range: generateModel.getFullModelRange(), text}],


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes:
- https://github.com/mit-cml/workspace-multiselect/pull/62#issuecomment-2196819235
- https://github.com/mit-cml/workspace-multiselect/pull/62#issuecomment-2212561339
- https://github.com/mit-cml/workspace-multiselect/pull/62#issuecomment-2214203536

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

This commit introduces a workaround, so that we only update the page when we have model or text updates in monaco.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

In multi-select plugin, a significant amount of workspace change events (for each block) can be triggered at the same time, which causes the garbage collection mechanism to fail, so that we eventually have JS heap overflow and the page crashed in Chromium.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
