### PR TITLE
fix: updated onDragEnter for backpack plugin to check for backpackabl…

### DIFF
--- a/plugins/workspace-backpack/src/backpack.ts
+++ b/plugins/workspace-backpack/src/backpack.ts
@@ -831,7 +831,7 @@ export class Backpack
    *   being dragged.
    */
   onDragEnter(dragElement: Blockly.IDraggable) {
-    if (dragElement instanceof Blockly.BlockSvg) {
+    if (isBackpackable(dragElement)) {
       this.updateHoverStying(true);
     }
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/2420

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
Changes the onDragEnter (hovering over backpack icon) to check for a backpackable object instead of a BlockSvg.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
This makes it cover more use-cases for the backpack plugin as well as make it possible for the multiselection in the multiselect plugin to also cause the hover UI change for the backpack.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
