### PR TITLE
feat: highlight text in workspace search on open and add backwards nav

### DIFF
--- a/plugins/workspace-search/src/workspace_search.ts
+++ b/plugins/workspace-search/src/workspace_search.ts
@@ -362,7 +362,11 @@ export class WorkspaceSearch implements Blockly.IPositionable {
       this.close();
     } else if (e.key === 'Enter') {
       if (this.searchOnInput) {
-        this.next();
+        if (e.shiftKey) {
+          this.previous();
+        } else {
+          this.next();
+        }
       } else {
         if (!this.inputElement) return;
         const inputValue = this.inputElement.value.trim();
@@ -440,6 +444,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
   open() {
     this.setVisible(true);
     this.inputElement?.focus();
+    this.inputElement?.select();
     if (this.searchText) {
       this.searchAndHighlight(this.searchText);
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/2438

### Proposed Changes

Tweaks the behavior of the workspace search plugin:
* Opening the search box now selects the current text
* Pressing shift+enter while navigating through search results now moves backwards in the list

### Reason for Changes

See attached issue

### Test Coverage

I tested both changes manually.

I attempted to add unit tests for the selection fix, but it seems like whatever headless DOM library the blockly test runner is using doesn't have great support for the `document.getSelection()` API.

### Documentation

None

### Additional Information

None
