### PR TITLE
Fix(#2382) Remove references to Blockly.FieldColour from keyboard-navigation

### DIFF
--- a/plugins/keyboard-navigation/src/navigation_controller.js
+++ b/plugins/keyboard-navigation/src/navigation_controller.js
@@ -58,10 +58,6 @@ export class NavigationController {
    * @protected
    */
   addShortcutHandlers() {
-    if (Blockly.FieldColour) {
-      Blockly.FieldColour.prototype.onShortcut = this.fieldColourHandler;
-    }
-
     if (Blockly.FieldDropdown) {
       Blockly.FieldDropdown.prototype.onShortcut = this.fieldDropdownHandler;
     }
@@ -77,10 +73,6 @@ export class NavigationController {
    * @protected
    */
   removeShortcutHandlers() {
-    if (Blockly.FieldColour) {
-      Blockly.FieldColour.prototype.onShortcut = null;
-    }
-
     if (Blockly.FieldDropdown) {
       Blockly.FieldDropdown.prototype.onShortcut = null;
     }
@@ -88,40 +80,6 @@ export class NavigationController {
     if (Blockly.Toolbox) {
       Blockly.Toolbox.prototype.onShortcut = null;
     }
-  }
-
-  /**
-   * Handles the given keyboard shortcut.
-   * This is only triggered when keyboard accessibility mode is enabled.
-   * @param {!Blockly.ShortcutRegistry.KeyboardShortcut} shortcut The shortcut
-   *     to be handled.
-   * @returns {boolean} True if the field handled the shortcut,
-   *     false otherwise.
-   * @this {Blockly.FieldColour}
-   * @protected
-   */
-  fieldColourHandler(shortcut) {
-    if (this.picker_) {
-      switch (shortcut.name) {
-        case Constants.SHORTCUT_NAMES.PREVIOUS:
-          this.moveHighlightBy_(0, -1);
-          return true;
-        case Constants.SHORTCUT_NAMES.NEXT:
-          this.moveHighlightBy_(0, 1);
-          return true;
-        case Constants.SHORTCUT_NAMES.OUT:
-          this.moveHighlightBy_(-1, 0);
-          return true;
-        case Constants.SHORTCUT_NAMES.IN:
-          this.moveHighlightBy_(1, 0);
-          return true;
-        default:
-          return false;
-      }
-    }
-    // If we haven't already handled the shortcut, let the default Field
-    // handler try.
-    return Blockly.Field.prototype.onShortcut.call(this, shortcut);
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves 

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2382 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
The PR attempts to remove all lines that were referencing Blockly.FieldColour , as that field no longer exists .

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
As Blockly.FieldColour  no longer exists, so even referencing it causes webpack warnings.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->
NA

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
NA

### Additional Information

<!-- Anything else we should know? -->
