### PR TITLE
fix(developer-tools):  Copy buttons not working in Blockly Developer Tools

### DIFF
--- a/examples/developer-tools/src/index.html
+++ b/examples/developer-tools/src/index.html
@@ -149,7 +149,7 @@
               <h2>
                 Code Headers
                 <md-icon-button
-                  class="action-button"
+                  class="action-button copy-button"
                   data-owner-id="code-headers"
                   aria-label="Copy code">
                   <md-icon>content_copy</md-icon>
@@ -161,7 +161,7 @@
               <h2>
                 Block Definition
                 <md-icon-button
-                  class="action-button"
+                  class="action-button copy-button"
                   data-owner-id="block-definition"
                   aria-label="Copy code">
                   <md-icon>content_copy</md-icon>
@@ -175,7 +175,7 @@
               <h2>
                 Generator Stub
                 <md-icon-button
-                  class="action-button"
+                  class="action-button copy-button"
                   data-owner-id="generator-stub"
                   aria-label="Copy code">
                   <md-icon>content_copy</md-icon>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2433 

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
This pull request addresses the issue where clicking on the copy buttons for generated code blocks in Blockly Developer Tools does not work. The problem occurs on both the latest versions of Firefox and Chrome. The changes include updates to class names of the copy buttons and fixes clipboard interactions.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
The copy buttons were not functioning correctly, which hindered users from copying generated code blocks. The changes ensure that the copy functionality works as expected, improving the user experience in Blockly Developer Tools.

### Test Coverage

_NA_

### Documentation

_NA_

### Additional Information

_NA_