### PR TITLE
chore: remove dev-tools dependency from custom tooltip demo

### DIFF
--- a/examples/custom-tooltips-demo/index.html
+++ b/examples/custom-tooltips-demo/index.html
@@ -6,7 +6,6 @@
     <script src="./node_modules/blockly/blockly_compressed.js"></script>
     <script src="./node_modules/blockly/blocks_compressed.js"></script>
     <script src="./node_modules/blockly/msg/en.js"></script>
-    <script src="./node_modules/@blockly/dev-tools/dist/index.js"></script>
     <script src="./index.js"></script>
     <style>
       html,
@@ -17,6 +16,6 @@
   </head>
 
   <body>
-    <div id="root"></div>
+    <div id="root" style="height: 600px; width: 600px"></div>
   </body>
 </html>

--- a/examples/custom-tooltips-demo/index.js
+++ b/examples/custom-tooltips-demo/index.js
@@ -43,20 +43,6 @@ function initTooltips() {
   Blockly.Tooltip.setCustomTooltip(customTooltip);
 }
 
-/**
- * Create a workspace.
- * @param {HTMLElement} blocklyDiv The blockly container div.
- * @param {!Blockly.BlocklyOptions} options The Blockly options.
- * @returns {!Blockly.WorkspaceSvg} The created workspace.
- */
-function createWorkspace(blocklyDiv, options) {
-  const workspace = Blockly.inject(blocklyDiv, options);
-
-  initTooltips();
-
-  return workspace;
-}
-
 document.addEventListener('DOMContentLoaded', function () {
   Blockly.Blocks['custom_tooltip_1'] = {
     init: function () {
@@ -76,7 +62,7 @@ document.addEventListener('DOMContentLoaded', function () {
       this.setHelpUrl('');
     },
   };
-  const defaultOptions = {
+  const options = {
     toolbox: {
       kind: 'flyoutToolbox',
       contents: [
@@ -86,11 +72,6 @@ document.addEventListener('DOMContentLoaded', function () {
     },
   };
 
-  // createPlayground is from @blockly/dev-tools.
-  // eslint-disable-next-line no-undef
-  createPlayground(
-    document.getElementById('root'),
-    createWorkspace,
-    defaultOptions,
-  );
+  Blockly.inject(document.getElementById('root'), options);
+  initTooltips();
 });

--- a/examples/custom-tooltips-demo/package-lock.json
+++ b/examples/custom-tooltips-demo/package-lock.json
@@ -8,119 +8,8 @@
       "name": "blockly-custom-tooltips-demo",
       "version": "0.0.0",
       "dependencies": {
-        "@blockly/dev-tools": "^8.0.0",
         "blockly": "^11.0.0"
       }
-    },
-    "node_modules/@blockly/block-test": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@blockly/block-test/-/block-test-6.0.0.tgz",
-      "integrity": "sha512-zvKJ4XdFiemmoceMEL6B8AsZRpbJob+XpzmHXXU47mxsVOJdzOBClPdnE6vniDDLk6JDGjREP8A5Av1CR3xKCA==",
-      "engines": {
-        "node": ">=8.17.0"
-      },
-      "peerDependencies": {
-        "blockly": "^11.0.0"
-      }
-    },
-    "node_modules/@blockly/dev-tools": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@blockly/dev-tools/-/dev-tools-8.0.0.tgz",
-      "integrity": "sha512-HpVat0USAQBCDka8qwKNCH92MSIFCkVojEn1fdUlJw3B1Jpt996CmlBVUcJZOwDpRzJUnrxUgI7jm+bcdVzTzg==",
-      "dependencies": {
-        "@blockly/block-test": "^6.0.0",
-        "@blockly/theme-dark": "^7.0.0",
-        "@blockly/theme-deuteranopia": "^6.0.0",
-        "@blockly/theme-highcontrast": "^6.0.0",
-        "@blockly/theme-tritanopia": "^6.0.0",
-        "chai": "^4.2.0",
-        "dat.gui": "^0.7.7",
-        "lodash.assign": "^4.2.0",
-        "lodash.merge": "^4.6.2",
-        "monaco-editor": "^0.20.0",
-        "sinon": "^9.0.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "blockly": "^11.0.0"
-      }
-    },
-    "node_modules/@blockly/theme-dark": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-dark/-/theme-dark-7.0.0.tgz",
-      "integrity": "sha512-e8Jls55ad68DWeRHAABz8kg0FWH79jGOoaU34vaFykfYXHt+lrD7P1k3eKzj1B/NPHeFg7JN2Dep9WBD5l59HQ==",
-      "engines": {
-        "node": ">=8.17.0"
-      },
-      "peerDependencies": {
-        "blockly": "^11.0.0"
-      }
-    },
-    "node_modules/@blockly/theme-deuteranopia": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-deuteranopia/-/theme-deuteranopia-6.0.0.tgz",
-      "integrity": "sha512-cHyV2i7Y6gsjP8vtwdPhwHDOL5LxtxDJd6zi0SCoTo1JM1Z/Se/v5BSkk4V6vz2XB9ZkTEFEesWmNkZ7Zn3V7Q==",
-      "engines": {
-        "node": ">=8.17.0"
-      },
-      "peerDependencies": {
-        "blockly": "^11.0.0"
-      }
-    },
-    "node_modules/@blockly/theme-highcontrast": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-highcontrast/-/theme-highcontrast-6.0.0.tgz",
-      "integrity": "sha512-9nDhLpy/35VSOiBtHezhx+i2s8zJlEX6ZD1KH1A5eQ89nBqzzE6/wPabNs8PZPH62bZoVAowDvY5R6WlfUXqsQ==",
-      "engines": {
-        "node": ">=8.17.0"
-      },
-      "peerDependencies": {
-        "blockly": "^11.0.0"
-      }
-    },
-    "node_modules/@blockly/theme-tritanopia": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@blockly/theme-tritanopia/-/theme-tritanopia-6.0.0.tgz",
-      "integrity": "sha512-0FiF+hKotNL3AqWtlF3epdGDpBJInEf5as2GPM2rNMGhgYIXEG397bEQsPUw/3W/mDE7GlRZPqUTe+C7UxkRVA==",
-      "engines": {
-        "node": ">=8.17.0"
-      },
-      "peerDependencies": {
-        "blockly": "^11.0.0"
-      }
-    },
-    "node_modules/@sinonjs/commons": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
-      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
-      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
-      "dependencies": {
-        "@sinonjs/commons": "^1.6.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
     },
     "node_modules/agent-base": {
       "version": "7.1.1",
@@ -131,14 +20,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/asynckit": {
@@ -155,34 +36,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chai": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/combined-stream": {
@@ -206,11 +59,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/dat.gui": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.9.tgz",
-      "integrity": "sha512-sCNc1OHobc+Erc1HqiswYgHdVNpSJUlk/Hz8vzOCsER7rl+oF/4+v8GXFUyCgtXpoCX6+bnmg07DedLvBLwYKQ=="
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -245,31 +93,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
-    "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/entities": {
@@ -294,22 +123,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -363,11 +176,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-    },
     "node_modules/jsdom": {
       "version": "23.0.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.0.0.tgz",
@@ -407,34 +215,6 @@
         }
       }
     },
-    "node_modules/just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
-    },
-    "node_modules/lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-    },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -454,27 +234,10 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/monaco-editor": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.20.0.tgz",
-      "integrity": "sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ=="
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/nise": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
-      "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/fake-timers": "^6.0.0",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      }
     },
     "node_modules/nwsapi": {
       "version": "2.2.10",
@@ -490,22 +253,6 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/psl": {
@@ -552,35 +299,6 @@
         "node": ">=v12.22.7"
       }
     },
-    "node_modules/sinon": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
-      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
-      "deprecated": "16.1.1",
-      "dependencies": {
-        "@sinonjs/commons": "^1.8.1",
-        "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/samsam": "^5.3.1",
-        "diff": "^4.0.2",
-        "nise": "^4.0.4",
-        "supports-color": "^7.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -609,14 +327,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/universalify": {

--- a/examples/custom-tooltips-demo/package.json
+++ b/examples/custom-tooltips-demo/package.json
@@ -3,12 +3,11 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@blockly/dev-tools": "^8.0.0",
     "blockly": "^11.0.0"
   },
   "blocklyDemoConfig": {
     "title": "Custom Tooltips",
-    "description": "Example of using a custom tooltip renderer. Make sure you select the 'default' toolbox.",
+    "description": "Example of using a custom tooltip renderer.",
     "files": [
       "index.html",
       "index.js",
@@ -16,8 +15,7 @@
       "./node_modules/blockly/blockly_compressed.js",
       "./node_modules/blockly/blockly_compressed.js.map",
       "./node_modules/blockly/blocks_compressed.js",
-      "./node_modules/blockly/msg/en.js",
-      "./node_modules/@blockly/dev-tools/dist/index.js"
+      "./node_modules/blockly/msg/en.js"
     ]
   }
 }


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly-samples/issues/2370

### Proposed Changes

Remove dependency on dev-tools and use a simple workspace instead of the advanced playground.

### Reason for Changes

Reduce unnecessary interdependencies in demos and examples. This was not making use of the advanced playground features.

### Test Coverage
Tested by opening the page locally.

### Documentation
Instructions in `package.json` have been updated.

### Additional Information

<!-- Anything else we should know? -->
