### PR TITLE
fix: add documentation about locales for colour blocks

### DIFF
--- a/plugins/field-colour/README.md
+++ b/plugins/field-colour/README.md
@@ -280,6 +280,25 @@ colourBlend.installBlock({
 });
 ```
 
+#### Message files and locales
+
+The blocks in this package contain text that can be 
+[localized](https://developers.google.com/blockly/guides/create-custom-blocks/localize-blocks)
+into multiple languages. As of August 2024, the relevant messages are
+included in the core Blockly language files.
+
+If your blocks show `%{BKY_COLOUR_BLEND_TITLE}` or similar text instead
+of the expected text, make sure that you either:
+
+- Import the [default Blockly modules](https://developers.google.com/blockly/guides/configure/web/translations#import_blockly_default_modules),
+which includes the English langfiles, or
+- Explicitly [import a language](https://developers.google.com/blockly/guides/configure/web/translations#import_blockly_languages)
+and call `setLocale` before using these blocks.
+
+For more information on Blockly's approach to localization, see the 
+[Localize Blocks](https://developers.google.com/blockly/guides/create-custom-blocks/localize-blocks)
+developer guide.
+
 ### API Reference
 
 - `setColours`: Sets the colour options, and optionally the titles for the

--- a/plugins/field-colour/README.md
+++ b/plugins/field-colour/README.md
@@ -282,7 +282,7 @@ colourBlend.installBlock({
 
 #### Message files and locales
 
-The blocks in this package contain text that can be 
+The blocks in this package contain text that can be
 [localized](https://developers.google.com/blockly/guides/create-custom-blocks/localize-blocks)
 into multiple languages. As of August 2024, the relevant messages are
 included in the core Blockly language files.
@@ -291,11 +291,11 @@ If your blocks show `%{BKY_COLOUR_BLEND_TITLE}` or similar text instead
 of the expected text, make sure that you either:
 
 - Import the [default Blockly modules](https://developers.google.com/blockly/guides/configure/web/translations#import_blockly_default_modules),
-which includes the English langfiles, or
+  which includes the English langfiles, or
 - Explicitly [import a language](https://developers.google.com/blockly/guides/configure/web/translations#import_blockly_languages)
-and call `setLocale` before using these blocks.
+  and call `setLocale` before using these blocks.
 
-For more information on Blockly's approach to localization, see the 
+For more information on Blockly's approach to localization, see the
 [Localize Blocks](https://developers.google.com/blockly/guides/create-custom-blocks/localize-blocks)
 developer guide.
 


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves
Fixes https://github.com/google/blockly-samples/issues/2238

### Proposed Changes

Add documentation about message files for the colour field blocks, including links to Blockly's localization guide.

### Reason for Changes

Follow-up from earlier work.

