### PR TITLE
fix: explicitly set the padding on workspace search buttons

### DIFF
--- a/plugins/workspace-search/src/css.ts
+++ b/plugins/workspace-search/src/css.ts
@@ -70,6 +70,8 @@ const cssContent = `path.blocklyPath.blockly-ws-search-highlight {
   }
   .blockly-ws-search button {
     border: none;
+    padding-left: 6px;
+    padding-right: 6px;
   }
   .blockly-ws-search-actions {
     display: flex;


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-samples/issues/2458

### Proposed Changes

Fixes the buttons in the workspace search plugin widget in the Firefox browser by explicitly setting the button padding instead of relying on the user agent styles default.

Before:
![image](https://github.com/user-attachments/assets/bad423b1-69a2-4f29-b402-2a7975429f83)

After:
![image](https://github.com/user-attachments/assets/a7d5c75f-25f2-48a5-a88c-72f9d72755a3)


### Reason for Changes

The padding on the buttons in the workspace search plugin is currently just using the padding specified by the browser's user agent style for buttons. In Chrome, that padding is 6px on the left and right which results in a correctly sized button. Firefox on the other hand has slightly smaller buttons (4px of padding) which results in the error show in the linked issue.

### Test Coverage

N/A

### Documentation

N/A

### Additional Information

N/A