### PR TITLE
fix: Modify Webpack sourcemap parameters to account for Windows path separators

### DIFF
--- a/examples/custom-generator-codelab/webpack.config.js
+++ b/examples/custom-generator-codelab/webpack.config.js
@@ -46,14 +46,14 @@ module.exports = (env, argv) => {
 
     // Include the source maps for Blockly for easier debugging Blockly code.
     config.module.rules.push({
-      test: /(blockly\/.*\.js)$/,
+      test: /(blockly[/\\].*\.js)$/,
       use: [require.resolve('source-map-loader')],
       enforce: 'pre',
     });
 
     // Ignore spurious warnings from source-map-loader
     // It can't find source maps for some Closure modules and that is expected
-    config.ignoreWarnings = [/Failed to parse source map/];
+    config.ignoreWarnings = [/Failed to parse source map.*blockly/];
   }
   return config;
 };

--- a/examples/custom-renderer-codelab/webpack.config.js
+++ b/examples/custom-renderer-codelab/webpack.config.js
@@ -46,14 +46,14 @@ module.exports = (env, argv) => {
 
     // Include the source maps for Blockly for easier debugging Blockly code.
     config.module.rules.push({
-      test: /(blockly\/.*\.js)$/,
+      test: /(blockly[/\\].*\.js)$/,
       use: [require.resolve('source-map-loader')],
       enforce: 'pre',
     });
 
     // Ignore spurious warnings from source-map-loader
     // It can't find source maps for some Closure modules and that is expected
-    config.ignoreWarnings = [/Failed to parse source map/];
+    config.ignoreWarnings = [/Failed to parse source map.*blockly/];
   }
   return config;
 };

--- a/examples/keyboard-navigation-codelab/webpack.config.js
+++ b/examples/keyboard-navigation-codelab/webpack.config.js
@@ -46,14 +46,14 @@ module.exports = (env, argv) => {
 
     // Include the source maps for Blockly for easier debugging Blockly code.
     config.module.rules.push({
-      test: /(blockly\/.*\.js)$/,
+      test: /(blockly[/\\].*\.js)$/,
       use: [require.resolve('source-map-loader')],
       enforce: 'pre',
     });
 
     // Ignore spurious warnings from source-map-loader
     // It can't find source maps for some Closure modules and that is expected
-    config.ignoreWarnings = [/Failed to parse source map/];
+    config.ignoreWarnings = [/Failed to parse source map.*blockly/];
   }
   return config;
 };

--- a/examples/sample-app-ts/webpack.config.js
+++ b/examples/sample-app-ts/webpack.config.js
@@ -54,14 +54,14 @@ module.exports = (env, argv) => {
 
     // Include the source maps for Blockly for easier debugging Blockly code.
     config.module.rules.push({
-      test: /(blockly\/.*\.js)$/,
+      test: /(blockly[/\\].*\.js)$/,
       use: [require.resolve('source-map-loader')],
       enforce: 'pre',
     });
 
     // Ignore spurious warnings from source-map-loader
     // It can't find source maps for some Closure modules and that is expected
-    config.ignoreWarnings = [/Failed to parse source map/];
+    config.ignoreWarnings = [/Failed to parse source map.*blockly/];
   }
   return config;
 };

--- a/examples/sample-app/webpack.config.js
+++ b/examples/sample-app/webpack.config.js
@@ -46,14 +46,14 @@ module.exports = (env, argv) => {
 
     // Include the source maps for Blockly for easier debugging Blockly code.
     config.module.rules.push({
-      test: /(blockly\/.*\.js)$/,
+      test: /(blockly[/\\].*\.js)$/,
       use: [require.resolve('source-map-loader')],
       enforce: 'pre',
     });
 
     // Ignore spurious warnings from source-map-loader
     // It can't find source maps for some Closure modules and that is expected
-    config.ignoreWarnings = [/Failed to parse source map/];
+    config.ignoreWarnings = [/Failed to parse source map.*blockly/];
   }
   return config;
 };

--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -107,7 +107,7 @@ module.exports = (env) => {
       rules: [
         // Load Blockly source maps.
         {
-          test: /(blockly\/.*\.js)$/,
+          test: /(blockly[/\\].*\.js)$/,
           use: [require.resolve('source-map-loader')],
           enforce: 'pre',
         },
@@ -119,7 +119,7 @@ module.exports = (env) => {
     },
     // Ignore spurious warnings from source-map-loader
     // It can't find source maps for some Closure modules and that is expected
-    ignoreWarnings: [/Failed to parse source map/],
+    ignoreWarnings: [/Failed to parse source map.*blockly/],
     plugins,
     externals: isProduction
       ? {


### PR DESCRIPTION
## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details

### Proposed Changes

This PR modifies the Webpack configurations throughout the repository such that:
  - The regular expression used to determine which sourcemaps to load/look for works on Windows systems.
  - The regular expression used to determine which sourcemap parsing errors to ignore only covers paths containing the term "blockly"

### Reason for Changes

Prior to this change, Blockly source maps wouldn't load on Windows systems, as Windows uses a backslash as a path separator, not a forward slash. The parsing error regex was modified as it occurred to me that it was overly broad, and might hide meaningful errors over the course of regular development.
