### PR TITLE
chore: Make eslint-config package private.

### DIFF
--- a/plugins/eslint-config/package.json
+++ b/plugins/eslint-config/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blockly/eslint-config",
   "version": "4.0.1",
+  "private": true,
   "description": "ESlint configuration used by Blockly plugins.",
   "files": [
     "index.js"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes part of #1975

### Proposed Changes
This PR makes the now-unused eslint-config package private. I have [already deprecated it](https://www.npmjs.com/package/@blockly/eslint-config?activeTab=readme) per #1975.