### PR TITLE
fix: Update screenshot plugin for compatibility with CSS vars.

### DIFF
--- a/plugins/dev-tools/src/screenshot.js
+++ b/plugins/dev-tools/src/screenshot.js
@@ -84,7 +84,11 @@ function workspaceToSvg_(workspace, callback, customCss) {
   );
   svg.setAttribute('width', width);
   svg.setAttribute('height', height);
-  svg.setAttribute('style', 'background-color: transparent');
+  svg.setAttribute(
+    'style',
+    'background-color: transparent; ' +
+      workspace.getInjectionDiv().style.cssText, // has CSS vars for SVG filters
+  );
 
   const css = [].slice
     .call(document.head.querySelectorAll('style'))


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes the screenshot plugin to be compatible with the changes in https://github.com/google/blockly/pull/8671 which fixes https://github.com/google/blockly/issues/8272

### Proposed Changes

It copies the inline style of the injection div to the screenshot svg.

### Reason for Changes

The injection div's inline style uses CSS variables to link to the SVG filters that might be used by the blocks in the screenshot.

### Test Coverage

No new tests but I manually tested taking screenshots while linking to blockly rc/v12.0.0.

### Documentation

N/A

### Additional Information

This change isn't necessary until Blockly v12.0.0 is released, but it's compatible with existing Blockly so we might as well fix it now.
