### PR TITLE
fix: Fix bug that prevented keyboard navigation of color swatches.

### DIFF
--- a/plugins/field-colour/src/field_colour.ts
+++ b/plugins/field-colour/src/field_colour.ts
@@ -475,7 +475,7 @@ export class FieldColour extends Blockly.Field<string> {
    * @param dy Change of y.
    */
   private moveHighlightBy(dx: number, dy: number) {
-    if (!this.highlightedIndex) {
+    if (this.highlightedIndex === null) {
       return;
     }
 
@@ -564,7 +564,7 @@ export class FieldColour extends Blockly.Field<string> {
    * @returns Highlighted item (null if none).
    */
   private getHighlighted(): HTMLElement | null {
-    if (!this.highlightedIndex) {
+    if (this.highlightedIndex === null) {
       return null;
     }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2477

### Proposed Changes
This PR fixes a bug that prevented selecting color swatches via the keyboard after the top left swatch was selected, due to incorrect null checks that were triggered when the selected index was 0.