### PR TITLE
feat: Added button to Advanced Playground to import state.

### DIFF
--- a/plugins/dev-tools/src/playground/ui.js
+++ b/plugins/dev-tools/src/playground/ui.js
@@ -109,7 +109,6 @@ export function renderPlayground(container) {
   const tabButtons = document.createElement('div');
   tabButtons.style.position = 'absolute';
   tabButtons.style.height = '30px';
-  tabButtons.style.width = '50px';
   tabButtons.style.top = '0';
   tabButtons.style.right = '0';
   tabButtons.style.display = 'flex';
@@ -165,4 +164,16 @@ export function renderCheckbox(id, label) {
   checkboxLabel.textContent = label;
   checkboxLabel.setAttribute('for', id);
   return [checkbox, checkboxLabel];
+}
+
+/**
+ * Render a button.
+ * @param {string} label The text content of the button.
+ * @returns {HTMLButtonElement} The button element.
+ */
+export function renderButton(label) {
+  const button = document.createElement('button');
+  button.setAttribute('type', 'button');
+  button.textContent = label;
+  return button;
 }


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes: https://github.com/google/blockly-samples/issues/2206

It also fixes an unreported bug where importing XML duplicated all blocks.

### Proposed Changes

Adds a button between the editor tabs and the "Auto" checkbox to import the tab editor contents to the workspace, reusing the existing logic that is accessible via the right-click context menu or the ctrl-enter keyboard shortcut.

Also there was a bug in the existing logic for importing from XML, where the imported blocks would be added on top of any existing blocks in the workspace without first clearing the workspace. The logic has been updated to clear the workspace first.

The new button is hidden when a tab other than the XML or JSON tab is selected.

The new button looks like this:
<img width="665" alt="image" src="https://github.com/user-attachments/assets/ca6791b9-05a8-4d6a-b745-711957d5872b" />

### Reason for Changes

It's hard for users to discover the option to import via the right click menu.

### Test Coverage

N/A

### Documentation

None, although having a visible button is an improvement over the context menu.