### PR TITLE
fix: Fix scrolling and API issues with the continuous toolbox plugin.

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousFlyout.ts
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.ts
@@ -118,7 +118,8 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
    * Returns the scroll position for the given category name.
    *
    * @param name Category name.
-   * @returns Scroll position for given category, or null if not found.
+   * @returns Scroll position for given category in workspace units, or null if
+   *     not found.
    */
   getCategoryScrollPosition(name: string): number | null {
     const position = this.scrollPositions.get(name);

--- a/plugins/continuous-toolbox/src/ContinuousFlyout.ts
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.ts
@@ -116,6 +116,7 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
 
   /**
    * Returns the scroll position for the given category name.
+   *
    * @param name Category name.
    * @returns Scroll position for given category, or null if not found.
    */

--- a/plugins/continuous-toolbox/src/ContinuousFlyout.ts
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.ts
@@ -89,7 +89,7 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
       .forEach((label) => {
         this.scrollPositions.set(
           label.getButtonText(),
-          label.getPosition().y - label.height,
+          Math.max(0, label.getPosition().y - this.GAP_Y / 2),
         );
       });
   }
@@ -161,7 +161,7 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
    */
   scrollToCategory(category: Blockly.ISelectableToolboxItem) {
     const position = this.scrollPositions.get(category.getName());
-    if (!position) {
+    if (position === undefined) {
       console.warn(`Scroll position not recorded for category ${name}`);
       return;
     }
@@ -173,8 +173,7 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
    * a scroll target, and request the next frame if necessary.
    */
   private stepScrollAnimation() {
-    if (!this.scrollTarget) return;
-
+    if (this.scrollTarget === undefined) return;
     const currentScrollPos = -this.getWorkspace().scrollY;
     const diff = this.scrollTarget - currentScrollPos;
     if (Math.abs(diff) < 1) {

--- a/plugins/continuous-toolbox/src/ContinuousFlyout.ts
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.ts
@@ -115,6 +115,19 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
   }
 
   /**
+   * Returns the scroll position for the given category name.
+   * @param name Category name.
+   * @returns Scroll position for given category, or null if not found.
+   */
+  getCategoryScrollPosition(name: string): number | null {
+    const position = this.scrollPositions.get(name);
+    if (position === undefined) {
+      console.warn(`Scroll position not recorded for category ${name}`);
+    }
+    return position ?? null;
+  }
+
+  /**
    * Selects an item in the toolbox based on the scroll position of the flyout.
    *
    * @param position Current scroll position of the workspace.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves
This PR fixes bugs that (1) prevented scrolling the flyout if the first category was clicked, (2) caused jank when scrolling the flyout via the scrollbar and (3) reintroduces the `getCategoryScrollPosition()` method, which is used by Scratch.