### PR TITLE
fix: update content highlight when undoing the deletion of blocks.

### DIFF
--- a/plugins/content-highlight/src/index.ts
+++ b/plugins/content-highlight/src/index.ts
@@ -15,6 +15,7 @@ import * as Blockly from 'blockly/core';
  */
 const contentChangeEvents = [
   Blockly.Events.VIEWPORT_CHANGE,
+  Blockly.Events.BLOCK_CREATE,
   Blockly.Events.BLOCK_MOVE,
   Blockly.Events.BLOCK_DELETE,
   Blockly.Events.COMMENT_MOVE,


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

I couldn't replicate the bug reported at the top of https://github.com/google/blockly-samples/issues/2175 (where reloading the page does not highlight the content) when testing locally (admittedly I was building against Blockly v11.2.0, and I can replicate it at the currently published version of https://google.github.io/blockly-samples/plugins/content-highlight/test/index.html )

However, I could replicate the bug reported in the comment https://github.com/google/blockly-samples/issues/2175#issuecomment-2189677600 and this PR fixes that.

Fixes 

### Proposed Changes

Adds BLOCK_CREATE to the list of events that can trigger updating the content highlight.

### Reason for Changes

BLOCK_DELETE was already in the list, which successfully updates the content-highlight when deleting a block. However, undoing the deletion results in a BLOCK_CREATE event being fired. (I presume other methods of adding blocks to the workspace also result in other events that are already being listened to, like BLOCK_MOVE.)

### Test Coverage

I tested manually.

### Documentation

N/A

### Additional Information

N/A
