### PR TITLE
feat!: Improve accessibility of the grid field.

### DIFF
--- a/plugins/field-grid-dropdown/src/grid.ts
+++ b/plugins/field-grid-dropdown/src/grid.ts
@@ -11,7 +11,7 @@ import {GridItem} from './grid_item';
  * Class for managing a group of items displayed in a grid.
  */
 export class Grid {
-  /** Mapping from grid item ID to grid item. */
+  /** Mapping from grid item ID to index in the items list. */
   private itemIndices = new Map<string, number>();
 
   /** List of items displayed in this grid. */
@@ -257,7 +257,8 @@ export class Grid {
    * Returns the GridItem object at the given index in the grid.
    *
    * @param index The index to retrieve the grid item at.
-   * @returns The GridItem at the given index.
+   * @returns The GridItem at the given index, or undefined if the index is
+   *     invalid.
    */
   private itemAtIndex(index: number): GridItem | undefined {
     return this.items[index];

--- a/plugins/field-grid-dropdown/src/grid.ts
+++ b/plugins/field-grid-dropdown/src/grid.ts
@@ -55,6 +55,37 @@ export class Grid {
     utils.aria.setRole(this.root, utils.aria.Role.GRID);
     container.appendChild(this.root);
 
+    this.populateItems(options);
+
+    this.keyDownHandler = browserEvents.conditionalBind(
+      this.root,
+      'keydown',
+      this,
+      this.onKeyDown,
+    );
+
+    this.pointerMoveHandler = browserEvents.conditionalBind(
+      this.root,
+      'pointermove',
+      this,
+      this.onPointerMove,
+      true,
+    );
+
+    if (columns >= 1) {
+      this.columns = columns;
+      this.root.style.setProperty('--grid-columns', `${this.columns}`);
+    } else {
+      throw new Error(`Number of columns must be >= 1; got ${columns}`);
+    }
+  }
+
+  /**
+   * Creates grid items in the DOM given a list of model objects.
+   *
+   * @param options A list of grid item model objects.
+   */
+  private populateItems(options: MenuOption[]) {
     let row = document.createElement('div');
     for (const [index, item] of options.entries()) {
       if (index % this.columns === 0) {
@@ -87,28 +118,6 @@ export class Grid {
       );
       this.itemIndices.set(gridItem.getId(), this.itemIndices.size);
       this.items.push(gridItem);
-    }
-
-    this.keyDownHandler = browserEvents.conditionalBind(
-      this.root,
-      'keydown',
-      this,
-      this.onKeyDown,
-    );
-
-    this.pointerMoveHandler = browserEvents.conditionalBind(
-      this.root,
-      'pointermove',
-      this,
-      this.onPointerMove,
-      true,
-    );
-
-    if (columns >= 1) {
-      this.columns = columns;
-      this.root.style.setProperty('--grid-columns', `${this.columns}`);
-    } else {
-      throw new Error(`Number of columns must be >= 1; got ${columns}`);
     }
   }
 

--- a/plugins/field-grid-dropdown/src/grid.ts
+++ b/plugins/field-grid-dropdown/src/grid.ts
@@ -246,6 +246,7 @@ export class Grid {
   /**
    * Returns the index of the given item within the grid.
    *
+   * @param item The item to return the index of.
    * @returns The index of the given item within the grid.
    */
   private indexOfItem(item: GridItem): number {
@@ -255,6 +256,7 @@ export class Grid {
   /**
    * Returns the GridItem object at the given index in the grid.
    *
+   * @param index The index to retrieve the grid item at.
    * @returns The GridItem at the given index.
    */
   private itemAtIndex(index: number): GridItem | undefined {

--- a/plugins/field-grid-dropdown/src/grid.ts
+++ b/plugins/field-grid-dropdown/src/grid.ts
@@ -1,0 +1,280 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {GridItem} from './grid_item';
+
+/**
+ * Class for managing a group of items displayed in a grid.
+ */
+export class Grid {
+  /** Mapping from grid item ID to grid item. */
+  private itemIndices = new Map<string, number>();
+
+  /** List of items displayed in this grid. */
+  private items = new Array<GridItem>();
+
+  /** Root DOM element of this grid. */
+  private root: HTMLDivElement;
+
+  /** Identifier for keydown handler to be unregistered in dispose(). */
+  private keyDownHandler: Blockly.browserEvents.Data | null = null;
+
+  /** Identifier for pointermove handler to be unregistered in dispose(). */
+  private pointerMoveHandler: Blockly.browserEvents.Data | null = null;
+
+  /** Function to be called when an item in this grid is selected. */
+  private selectionCallback?: (selectedItem: GridItem) => void;
+
+  /**
+   * Creates a new Grid instance.
+   *
+   * @param container The parent element of this grid in the DOM.
+   * @param options A list of MenuOption objects representing the items to be
+   *     shown in this grid.
+   * @param columns The number of columns to display items in.
+   * @param rtl True if this grid is being shown in a right-to-left environment.
+   * @param selectionCallback Function to be called when an item in the grid is
+   *     selected.
+   */
+  constructor(
+    container: HTMLElement,
+    options: Blockly.MenuOption[],
+    private readonly columns: number,
+    private readonly rtl: boolean,
+    selectionCallback: (selectedItem: GridItem) => void,
+  ) {
+    this.selectionCallback = selectionCallback;
+
+    this.root = document.createElement('div');
+    this.root.className = 'blocklyGrid';
+    this.root.tabIndex = 0;
+    Blockly.utils.aria.setRole(this.root, Blockly.utils.aria.Role.GRID);
+    container.appendChild(this.root);
+
+    let row = document.createElement('div');
+    for (const [index, item] of options.entries()) {
+      if (index % this.columns === 0) {
+        row = document.createElement('div');
+        row.className = 'blocklyGridRow';
+        Blockly.utils.aria.setRole(row, Blockly.utils.aria.Role.ROW);
+        this.root.appendChild(row);
+      }
+
+      const [label, value] = item;
+      const content = (() => {
+        if (typeof label === 'object') {
+          // Convert ImageProperties to an HTMLImageElement.
+          const image = new Image(label['width'], label['height']);
+          image.src = label['src'];
+          image.alt = label['alt'] || '';
+          return image;
+        }
+        return label;
+      })();
+
+      const gridItem = new GridItem(
+        row,
+        content,
+        value,
+        (selectedItem: GridItem) => {
+          this.setSelectedValue(selectedItem.getValue());
+          this.selectionCallback?.(selectedItem);
+        },
+      );
+      this.itemIndices.set(gridItem.getId(), this.itemIndices.size);
+      this.items.push(gridItem);
+    }
+
+    this.keyDownHandler = Blockly.browserEvents.conditionalBind(
+      this.root,
+      'keydown',
+      this,
+      this.onKeyDown,
+    );
+
+    this.pointerMoveHandler = Blockly.browserEvents.conditionalBind(
+      this.root,
+      'pointermove',
+      this,
+      this.onPointerMove,
+      true,
+    );
+
+    if (columns >= 1) {
+      this.columns = columns;
+      this.root.style.setProperty('--grid-columns', `${this.columns}`);
+    } else {
+      throw new Error(`Number of columns must be >= 1; got ${columns}`);
+    }
+  }
+
+  /**
+   * Disposes of this grid.
+   */
+  dispose() {
+    this.selectionCallback = undefined;
+    for (const item of this.items) {
+      item.dispose();
+    }
+    this.itemIndices.clear();
+    this.items.length = 0;
+    if (this.keyDownHandler) {
+      Blockly.browserEvents.unbind(this.keyDownHandler);
+      this.keyDownHandler = null;
+    }
+
+    if (this.pointerMoveHandler) {
+      Blockly.browserEvents.unbind(this.pointerMoveHandler);
+      this.pointerMoveHandler = null;
+    }
+    this.root.remove();
+  }
+
+  /**
+   * Handles a keydown event in the grid, generally by moving focus.
+   *
+   * @param e The keydown event to handle.
+   */
+  private onKeyDown(e: KeyboardEvent) {
+    if (
+      !this.items.length ||
+      e.shiftKey ||
+      e.ctrlKey ||
+      e.metaKey ||
+      e.altKey
+    ) {
+      return;
+    }
+
+    switch (e.key) {
+      case 'ArrowUp':
+        this.moveFocus(-1 * this.columns, true);
+        break;
+      case 'ArrowDown':
+        this.moveFocus(this.columns, true);
+        break;
+      case 'ArrowLeft':
+        this.moveFocus(-1 * (this.rtl ? -1 : 1), true);
+        break;
+      case 'ArrowRight':
+        this.moveFocus(1 * (this.rtl ? -1 : 1), true);
+        break;
+      case 'PageUp':
+      case 'Home':
+        this.moveFocus(0, false);
+        break;
+      case 'PageDown':
+      case 'End':
+        this.moveFocus(this.items.length - 1, false);
+        break;
+      default:
+        // Not a key the grid is interested in.
+        return;
+    }
+    // The grid used this key, don't let it have secondary effects.
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  /**
+   * Handles a pointermove event in the grid by focusing the hovered item.
+   *
+   * @param e The pointermove event to handle.
+   */
+  private onPointerMove(e: PointerEvent) {
+    // Don't highlight grid items on "pointermove" if the pointer didn't
+    // actually move (but the content under it did due to e.g. scrolling into
+    // view), or if the target isn't an Element, which should never happen, but
+    // TS needs to be reassured of that.
+    if (!(e.movementX || e.movementY) || !(e.target instanceof Element)) return;
+
+    const gridItem = e.target.closest('.blocklyGridItem');
+    if (!gridItem) return;
+
+    const targetId = gridItem.id;
+    const targetIndex = this.itemIndices.get(targetId);
+    if (targetIndex === undefined) return;
+    this.moveFocus(targetIndex, false);
+  }
+
+  /**
+   * Selects the item with the given value in the grid.
+   *
+   * @param value The value of the grid item to select.
+   */
+  setSelectedValue(value: string) {
+    for (const [index, item] of this.items.entries()) {
+      const selected = item.getValue() === value;
+      item.setSelected(selected);
+      if (selected) {
+        this.moveFocus(index, false);
+      }
+    }
+  }
+
+  /**
+   * Moves browser focus to the grid item at the given index.
+   *
+   * @param index The index of the item to focus.
+   * @param relative True to interpret the index as relative to the currently
+   *     focused item, false to move focus to it as an absolute value.
+   */
+  private moveFocus(index: number, relative: boolean) {
+    let targetIndex = index;
+
+    if (relative) {
+      const focusedItem = this.getFocusedItem();
+      if (!focusedItem) return;
+      targetIndex += this.indexOfItem(focusedItem);
+    }
+
+    const targetItem = this.itemAtIndex(targetIndex);
+    if (!targetItem) return;
+
+    targetItem.focus();
+    Blockly.utils.aria.setState(
+      this.root,
+      Blockly.utils.aria.State.ACTIVEDESCENDANT,
+      targetItem.getId(),
+    );
+  }
+
+  /**
+   * Returns the index of the given item within the grid.
+   *
+   * @returns The index of the given item within the grid.
+   */
+  private indexOfItem(item: GridItem): number {
+    return this.itemIndices.get(item.getId()) ?? -1;
+  }
+
+  /**
+   * Returns the GridItem object at the given index in the grid.
+   *
+   * @returns The GridItem at the given index.
+   */
+  private itemAtIndex(index: number): GridItem | undefined {
+    return this.items[index];
+  }
+
+  /**
+   * Returns the currently focused grid item, if any.
+   *
+   * @returns The focused grid item, or undefined if no item is focused.
+   */
+  private getFocusedItem(): GridItem | undefined {
+    const element =
+      this.root.querySelector('.blocklyGridItem:focus') ??
+      this.root.querySelector('.blocklyGridItem');
+    if (!element || !element.id) return undefined;
+
+    const index = this.itemIndices.get(element.id);
+    if (index === undefined) return undefined;
+
+    return this.itemAtIndex(index);
+  }
+}

--- a/plugins/field-grid-dropdown/src/grid.ts
+++ b/plugins/field-grid-dropdown/src/grid.ts
@@ -50,7 +50,7 @@ export class Grid {
     this.selectionCallback = selectionCallback;
 
     this.root = document.createElement('div');
-    this.root.className = 'blocklyGrid';
+    this.root.className = 'blocklyFieldGrid';
     this.root.tabIndex = 0;
     utils.aria.setRole(this.root, utils.aria.Role.GRID);
     container.appendChild(this.root);
@@ -59,7 +59,7 @@ export class Grid {
     for (const [index, item] of options.entries()) {
       if (index % this.columns === 0) {
         row = document.createElement('div');
-        row.className = 'blocklyGridRow';
+        row.className = 'blocklyFieldGridRow';
         utils.aria.setRole(row, utils.aria.Role.ROW);
         this.root.appendChild(row);
       }
@@ -192,7 +192,7 @@ export class Grid {
     // TS needs to be reassured of that.
     if (!(e.movementX || e.movementY) || !(e.target instanceof Element)) return;
 
-    const gridItem = e.target.closest('.blocklyGridItem');
+    const gridItem = e.target.closest('.blocklyFieldGridItem');
     if (!gridItem) return;
 
     const targetId = gridItem.id;
@@ -271,8 +271,8 @@ export class Grid {
    */
   private getFocusedItem(): GridItem | undefined {
     const element =
-      this.root.querySelector('.blocklyGridItem:focus') ??
-      this.root.querySelector('.blocklyGridItem');
+      this.root.querySelector('.blocklyFieldGridItem:focus') ??
+      this.root.querySelector('.blocklyFieldGridItem');
     if (!element || !element.id) return undefined;
 
     const index = this.itemIndices.get(element.id);

--- a/plugins/field-grid-dropdown/src/grid.ts
+++ b/plugins/field-grid-dropdown/src/grid.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
+import {utils, browserEvents, MenuOption} from 'blockly/core';
 import {GridItem} from './grid_item';
 
 /**
@@ -21,10 +21,10 @@ export class Grid {
   private root: HTMLDivElement;
 
   /** Identifier for keydown handler to be unregistered in dispose(). */
-  private keyDownHandler: Blockly.browserEvents.Data | null = null;
+  private keyDownHandler: browserEvents.Data | null = null;
 
   /** Identifier for pointermove handler to be unregistered in dispose(). */
-  private pointerMoveHandler: Blockly.browserEvents.Data | null = null;
+  private pointerMoveHandler: browserEvents.Data | null = null;
 
   /** Function to be called when an item in this grid is selected. */
   private selectionCallback?: (selectedItem: GridItem) => void;
@@ -42,7 +42,7 @@ export class Grid {
    */
   constructor(
     container: HTMLElement,
-    options: Blockly.MenuOption[],
+    options: MenuOption[],
     private readonly columns: number,
     private readonly rtl: boolean,
     selectionCallback: (selectedItem: GridItem) => void,
@@ -52,7 +52,7 @@ export class Grid {
     this.root = document.createElement('div');
     this.root.className = 'blocklyGrid';
     this.root.tabIndex = 0;
-    Blockly.utils.aria.setRole(this.root, Blockly.utils.aria.Role.GRID);
+    utils.aria.setRole(this.root, utils.aria.Role.GRID);
     container.appendChild(this.root);
 
     let row = document.createElement('div');
@@ -60,7 +60,7 @@ export class Grid {
       if (index % this.columns === 0) {
         row = document.createElement('div');
         row.className = 'blocklyGridRow';
-        Blockly.utils.aria.setRole(row, Blockly.utils.aria.Role.ROW);
+        utils.aria.setRole(row, utils.aria.Role.ROW);
         this.root.appendChild(row);
       }
 
@@ -89,14 +89,14 @@ export class Grid {
       this.items.push(gridItem);
     }
 
-    this.keyDownHandler = Blockly.browserEvents.conditionalBind(
+    this.keyDownHandler = browserEvents.conditionalBind(
       this.root,
       'keydown',
       this,
       this.onKeyDown,
     );
 
-    this.pointerMoveHandler = Blockly.browserEvents.conditionalBind(
+    this.pointerMoveHandler = browserEvents.conditionalBind(
       this.root,
       'pointermove',
       this,
@@ -123,12 +123,12 @@ export class Grid {
     this.itemIndices.clear();
     this.items.length = 0;
     if (this.keyDownHandler) {
-      Blockly.browserEvents.unbind(this.keyDownHandler);
+      browserEvents.unbind(this.keyDownHandler);
       this.keyDownHandler = null;
     }
 
     if (this.pointerMoveHandler) {
-      Blockly.browserEvents.unbind(this.pointerMoveHandler);
+      browserEvents.unbind(this.pointerMoveHandler);
       this.pointerMoveHandler = null;
     }
     this.root.remove();
@@ -236,9 +236,9 @@ export class Grid {
     if (!targetItem) return;
 
     targetItem.focus();
-    Blockly.utils.aria.setState(
+    utils.aria.setState(
       this.root,
-      Blockly.utils.aria.State.ACTIVEDESCENDANT,
+      utils.aria.State.ACTIVEDESCENDANT,
       targetItem.getId(),
     );
   }

--- a/plugins/field-grid-dropdown/src/grid_item.ts
+++ b/plugins/field-grid-dropdown/src/grid_item.ts
@@ -40,7 +40,7 @@ export class GridItem {
 
     this.element = document.createElement('button');
     this.element.id = utils.idGenerator.getNextUniqueId();
-    this.element.className = 'blocklyGridItem';
+    this.element.className = 'blocklyFieldGridItem';
     this.clickHandler = browserEvents.conditionalBind(
       this.element,
       'click',
@@ -108,7 +108,7 @@ export class GridItem {
       utils.aria.State.SELECTED,
       this.selected,
     );
-    this.element.classList.toggle('blocklyGridItemSelected', this.selected);
+    this.element.classList.toggle('blocklyFieldGridItemSelected', this.selected);
     if (this.isSelected()) {
       this.focus();
     }
@@ -169,11 +169,11 @@ export class GridItem {
    * @returns The vertical distance between items in this grid.
    */
   private getInterItemSpacing() {
-    const grid = this.element.closest('.blocklyGrid');
+    const grid = this.element.closest('.blocklyFieldGrid');
     if (!grid) return 0;
 
     const items = [
-      ...grid.querySelectorAll('.blocklyGridItem'),
+      ...grid.querySelectorAll('.blocklyFieldGridItem'),
     ] as HTMLElement[];
     if (!items.length) return 0;
 

--- a/plugins/field-grid-dropdown/src/grid_item.ts
+++ b/plugins/field-grid-dropdown/src/grid_item.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as Blockly from 'blockly/core';
+import {browserEvents, utils} from 'blockly/core';
 
 /**
  * Class representing an item in a grid.
@@ -14,7 +14,7 @@ export class GridItem {
   private element: HTMLButtonElement;
 
   /** Identifier for a click handler to unregister during dispose(). */
-  private clickHandler: Blockly.browserEvents.Data | null;
+  private clickHandler: browserEvents.Data | null;
 
   /** Callback to invoke when this item is selected. */
   private selectionCallback?: (selectedItem: GridItem) => void;
@@ -39,9 +39,9 @@ export class GridItem {
     this.selectionCallback = selectionCallback;
 
     this.element = document.createElement('button');
-    this.element.id = Blockly.utils.idGenerator.getNextUniqueId();
+    this.element.id = utils.idGenerator.getNextUniqueId();
     this.element.className = 'blocklyGridItem';
-    this.clickHandler = Blockly.browserEvents.conditionalBind(
+    this.clickHandler = browserEvents.conditionalBind(
       this.element,
       'click',
       this,
@@ -54,7 +54,7 @@ export class GridItem {
       typeof content === 'string' ? document.createTextNode(content) : content;
     this.element.appendChild(contentDom);
 
-    Blockly.utils.aria.setRole(this.element, Blockly.utils.aria.Role.GRIDCELL);
+    utils.aria.setRole(this.element, utils.aria.Role.GRIDCELL);
   }
 
   /**
@@ -64,7 +64,7 @@ export class GridItem {
     this.selectionCallback = undefined;
     this.element.remove();
     if (this.clickHandler) {
-      Blockly.browserEvents.unbind(this.clickHandler);
+      browserEvents.unbind(this.clickHandler);
       this.clickHandler = null;
     }
   }
@@ -103,9 +103,9 @@ export class GridItem {
    */
   setSelected(selected: boolean) {
     this.selected = selected;
-    Blockly.utils.aria.setState(
+    utils.aria.setState(
       this.element,
-      Blockly.utils.aria.State.SELECTED,
+      utils.aria.State.SELECTED,
       this.selected,
     );
     this.element.classList.toggle('blocklyGridItemSelected', this.selected);

--- a/plugins/field-grid-dropdown/src/grid_item.ts
+++ b/plugins/field-grid-dropdown/src/grid_item.ts
@@ -1,0 +1,191 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import type {Grid} from './grid';
+
+/**
+ * Class representing an item in a grid.
+ */
+export class GridItem {
+  /** The DOM element for the grid item. */
+  private element: HTMLButtonElement;
+
+  /** Identifier for a click handler to unregister during dispose(). */
+  private clickHandler: Blockly.browserEvents.Data | null;
+
+  /** Callback to invoke when this item is selected. */
+  private selectionCallback?: (selectedItem: GridItem) => void;
+
+  /** Whether or not this item is currently selected. */
+  private selected = false;
+
+  /**
+   * Creates a new GridItem.
+   *
+   * @param container The parent element of this grid item in the DOM.
+   * @param content: The content to display in this grid item.
+   * @param value: The programmatic value of this grid item.
+   * @param selectionCallback: Function to call when this item is selected.
+   */
+  constructor(
+    container: HTMLElement,
+    content: string | HTMLElement,
+    private readonly value: string,
+    selectionCallback: (selectedItem: GridItem) => void,
+  ) {
+    this.selectionCallback = selectionCallback;
+
+    this.element = document.createElement('button');
+    this.element.id = Blockly.utils.idGenerator.getNextUniqueId();
+    this.element.className = 'blocklyGridItem';
+    this.clickHandler = Blockly.browserEvents.conditionalBind(
+      this.element,
+      'click',
+      this,
+      this.onClick,
+      true,
+    );
+    container.appendChild(this.element);
+
+    const contentDom =
+      typeof content === 'string' ? document.createTextNode(content) : content;
+    this.element.appendChild(contentDom);
+
+    Blockly.utils.aria.setRole(this.element, Blockly.utils.aria.Role.GRIDCELL);
+  }
+
+  /**
+   * Disposes of this grid item.
+   */
+  dispose() {
+    this.selectionCallback = undefined;
+    this.element.remove();
+    if (this.clickHandler) {
+      Blockly.browserEvents.unbind(this.clickHandler);
+      this.clickHandler = null;
+    }
+  }
+
+  /**
+   * Gets the unique ID for this grid item.
+   *
+   * @returns This item's unique ID.
+   */
+  getId(): string {
+    return this.element.id;
+  }
+
+  /**
+   * Gets the value associated with this grid item.
+   *
+   * @returns Value associated with this grid item.
+   */
+  getValue(): string {
+    return this.value;
+  }
+
+  /**
+   * Returns whether or not this grid item is selected.
+   *
+   * @returns True if this grid item is selected, otherwise false.
+   */
+  isSelected() {
+    return this.selected;
+  }
+
+  /**
+   * Sets whether or not this grid item is selected.
+   *
+   * @param selected True if this grid item should be selected, otherwise false.
+   */
+  setSelected(selected: boolean) {
+    this.selected = selected;
+    Blockly.utils.aria.setState(
+      this.element,
+      Blockly.utils.aria.State.SELECTED,
+      this.selected,
+    );
+    this.element.classList.toggle('blocklyGridItemSelected', this.selected);
+    if (this.isSelected()) {
+      this.focus();
+    }
+  }
+
+  /**
+   * Handles clicks on this grid item by marking it as selected.
+   */
+  private onClick() {
+    this.setSelected(true);
+    this.selectionCallback?.(this);
+  }
+
+  /**
+   * Makes this grid item the browser focus target, and scrolls it into view
+   * if needed.
+   */
+  focus() {
+    // Focus the element, but don't scroll the document since that's too
+    // aggressive.
+    this.element.focus({preventScroll: true});
+
+    const scrollingParent = this.element.offsetParent;
+    if (!scrollingParent) return;
+    const offsetTop = this.element.offsetTop;
+    const scrollTop = scrollingParent.scrollTop;
+    const spacing = this.getInterItemSpacing();
+
+    // Scroll the element into view if it's offscreen above the grid's viewport.
+    if (offsetTop < scrollTop) {
+      scrollingParent.scrollTo(0, offsetTop - spacing);
+    } else if (
+      offsetTop + this.element.offsetHeight >
+      scrollTop + scrollingParent.clientHeight
+    ) {
+      // Scroll into view if this item is below the grid's viewport.
+      scrollingParent.scrollBy(
+        0,
+        offsetTop +
+          this.element.clientHeight -
+          (scrollTop + scrollingParent.clientHeight) +
+          spacing,
+      );
+    }
+  }
+
+  /**
+   * Returns the vertical spacing between grid items in pixels.
+   *
+   * This value can be specified by the user in CSS, so we can't just use a
+   * hardcoded value. Moreover, while we could check our computed style, the
+   * grid gap can be specified in several units. Instead, this somewhat hackily
+   * finds all the sibling items in this grid and loops through them until it
+   * encounters one with a different vertical location from its predecessor,
+   * then computes the effective gap based on their relative position and
+   * height.
+   *
+   * @returns The vertical distance between items in this grid.
+   */
+  private getInterItemSpacing() {
+    const grid = this.element.closest('.blocklyGrid');
+    if (!grid) return 0;
+
+    const items = [
+      ...grid.querySelectorAll('.blocklyGridItem'),
+    ] as HTMLElement[];
+    if (!items.length) return 0;
+
+    let previousTop = items[0].offsetTop;
+    let previousHeight = items[0].offsetHeight;
+    for (const item of items) {
+      if (item.offsetTop !== previousTop) {
+        return item.offsetTop - previousHeight - previousTop;
+      }
+    }
+
+    return 0;
+  }
+}

--- a/plugins/field-grid-dropdown/src/grid_item.ts
+++ b/plugins/field-grid-dropdown/src/grid_item.ts
@@ -70,7 +70,7 @@ export class GridItem {
   }
 
   /**
-   * Gets the unique ID for this grid item.
+   * Gets the unique (within the grid) ID for this grid item.
    *
    * @returns This item's unique ID.
    */

--- a/plugins/field-grid-dropdown/src/grid_item.ts
+++ b/plugins/field-grid-dropdown/src/grid_item.ts
@@ -17,7 +17,7 @@ export class GridItem {
   private clickHandler: browserEvents.Data | null;
 
   /** Callback to invoke when this item is selected. */
-  private selectionCallback?: (selectedItem: GridItem) => void;
+  private selectionCallback: ((selectedItem: GridItem) => void) | null;
 
   /** Whether or not this item is currently selected. */
   private selected = false;
@@ -61,7 +61,7 @@ export class GridItem {
    * Disposes of this grid item.
    */
   dispose() {
-    this.selectionCallback = undefined;
+    this.selectionCallback = null;
     this.element.remove();
     if (this.clickHandler) {
       browserEvents.unbind(this.clickHandler);
@@ -103,12 +103,11 @@ export class GridItem {
    */
   setSelected(selected: boolean) {
     this.selected = selected;
-    utils.aria.setState(
-      this.element,
-      utils.aria.State.SELECTED,
+    utils.aria.setState(this.element, utils.aria.State.SELECTED, this.selected);
+    this.element.classList.toggle(
+      'blocklyFieldGridItemSelected',
       this.selected,
     );
-    this.element.classList.toggle('blocklyFieldGridItemSelected', this.selected);
     if (this.isSelected()) {
       this.focus();
     }

--- a/plugins/field-grid-dropdown/src/grid_item.ts
+++ b/plugins/field-grid-dropdown/src/grid_item.ts
@@ -5,7 +5,6 @@
  */
 
 import * as Blockly from 'blockly/core';
-import type {Grid} from './grid';
 
 /**
  * Class representing an item in a grid.
@@ -27,9 +26,9 @@ export class GridItem {
    * Creates a new GridItem.
    *
    * @param container The parent element of this grid item in the DOM.
-   * @param content: The content to display in this grid item.
-   * @param value: The programmatic value of this grid item.
-   * @param selectionCallback: Function to call when this item is selected.
+   * @param content The content to display in this grid item.
+   * @param value The programmatic value of this grid item.
+   * @param selectionCallback Function to call when this item is selected.
    */
   constructor(
     container: HTMLElement,
@@ -178,11 +177,11 @@ export class GridItem {
     ] as HTMLElement[];
     if (!items.length) return 0;
 
-    let previousTop = items[0].offsetTop;
-    let previousHeight = items[0].offsetHeight;
+    const initialTop = items[0].offsetTop;
+    const initialHeight = items[0].offsetHeight;
     for (const item of items) {
-      if (item.offsetTop !== previousTop) {
-        return item.offsetTop - previousHeight - previousTop;
+      if (item.offsetTop !== initialTop) {
+        return item.offsetTop - initialHeight - initialTop;
       }
     }
 

--- a/plugins/field-grid-dropdown/src/index.ts
+++ b/plugins/field-grid-dropdown/src/index.ts
@@ -142,7 +142,7 @@ export class FieldGridDropdown extends Blockly.FieldDropdown {
       Blockly.DropDownDiv.getContentDiv(),
       this.getOptions(false),
       this.columns,
-      !!this.getSourceBlock()?.workspace.RTL,
+      rtl,
       (selectedItem: GridItem) => {
         Blockly.DropDownDiv.hideIfOwner(this);
         this.setValue(selectedItem.getValue());

--- a/plugins/field-grid-dropdown/src/index.ts
+++ b/plugins/field-grid-dropdown/src/index.ts
@@ -149,7 +149,9 @@ export class FieldGridDropdown extends Blockly.FieldDropdown {
       },
     );
 
-    Blockly.DropDownDiv.getContentDiv().classList.add('blocklyGridContainer');
+    Blockly.DropDownDiv.getContentDiv().classList.add(
+      'blocklyFieldGridContainer',
+    );
 
     const colours = this.getColours();
     if (colours && colours.border) {
@@ -212,17 +214,17 @@ Blockly.fieldRegistry.register('field_grid_dropdown', FieldGridDropdown);
  * CSS for grid field.
  */
 Blockly.Css.register(`
-   .blocklyGridContainer {
+   .blocklyFieldGridContainer {
      padding: 7px;
    }
    
-  .blocklyGrid {
+  .blocklyFieldGrid {
     display: grid;
     grid-gap: 7px;
     grid-template-columns: repeat(var(--grid-columns), min-content);
   }
 
- .blocklyGrid .blocklyGridItem {
+ .blocklyFieldGrid .blocklyFieldGridItem {
    border: 1px solid rgba(1, 1, 1, 0.5);
    border-radius: 4px;
    color: white;
@@ -233,15 +235,15 @@ Blockly.Css.register(`
    padding: 6px 15px;
  }
  
- .blocklyGrid .blocklyGridRow {
+ .blocklyFieldGrid .blocklyFieldGridRow {
    display: contents;
  }
  
- .blocklyGrid .blocklyGridItem.blocklyGridItemSelected {
+ .blocklyFieldGrid .blocklyFieldGridItem.blocklyFieldGridItemSelected {
    background-color: rgba(1, 1, 1, 0.25);
  }
 
- .blocklyGrid .blocklyGridItem:focus {
+ .blocklyFieldGrid .blocklyFieldGridItem:focus {
    box-shadow: 0 0 0 4px hsla(0, 0%, 100%, .2);
    outline: none;
  }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2481

### Proposed Changes
This PR updates the grid field to improve its accessibility. Specifically:

* The focused item in the grid can now be navigated using the left and right arrow keys, in addition to up and down.
* The grid is no longer a menu, but instead is an element with aria-role `grid`, made up of rows and cells with the appropriate roles.
* Items are scrolled into view when navigation exceeds the bounds of the dropdown div

### Breaking Changes
Since this field no longer uses menus as its backing representation, the CSS class structure has changed dramatically. Broadly speaking, `.blocklyFieldGrid` targets the grid itself, and `.blocklyFieldGridItem` targets each individual item. For details, refer to the CSS registered at the end of index.ts.