### PR TITLE
chore: Export interface for label flyout items.

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousFlyout.ts
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.ts
@@ -13,7 +13,7 @@ import {ContinuousToolbox} from './ContinuousToolbox';
 import {ContinuousFlyoutMetrics} from './ContinuousFlyoutMetrics';
 import {RecyclableBlockFlyoutInflater} from './RecyclableBlockFlyoutInflater';
 
-interface LabelFlyoutItem extends Blockly.FlyoutItem {
+export interface LabelFlyoutItem extends Blockly.FlyoutItem {
   // Blockly.FlyoutButton represents both buttons and labels; a label is just
   // a borderless, non-clickable button.
   getElement(): Blockly.FlyoutButton;

--- a/plugins/continuous-toolbox/src/index.ts
+++ b/plugins/continuous-toolbox/src/index.ts
@@ -11,7 +11,7 @@
 import * as Blockly from 'blockly/core';
 
 import {ContinuousCategory} from './ContinuousCategory';
-import {ContinuousFlyout} from './ContinuousFlyout';
+import {ContinuousFlyout, LabelFlyoutItem} from './ContinuousFlyout';
 import {ContinuousMetrics} from './ContinuousMetrics';
 import {ContinuousToolbox} from './ContinuousToolbox';
 import {RecyclableBlockFlyoutInflater} from './RecyclableBlockFlyoutInflater';
@@ -21,6 +21,7 @@ export {
   ContinuousFlyout,
   ContinuousMetrics,
   ContinuousToolbox,
+  LabelFlyoutItem,
   RecyclableBlockFlyoutInflater,
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
This PR exports the `LabelFlyoutItem` interface, since subclasses need to reference it if they override the `toolboxItemIsLabel()` typeguard, as Scratch does.