### PR TITLE
fix: #2463 update event handling for field-bitmap to support touch 

### DIFF
--- a/plugins/field-bitmap/src/field-bitmap.ts
+++ b/plugins/field-bitmap/src/field-bitmap.ts
@@ -41,7 +41,7 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
   private valToPaintWith?: number;
   buttonOptions: Buttons;
   pixelSize: number;
-  pixelColours: { empty: string; filled: string };
+  pixelColours: {empty: string; filled: string};
   fieldHeight?: number;
 
   /**
@@ -60,8 +60,8 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
 
     this.SERIALIZABLE = true;
     this.CURSOR = 'default';
-    this.buttonOptions = { ...DEFAULT_BUTTONS, ...config?.buttons };
-    this.pixelColours = { ...DEFAULT_PIXEL_COLOURS, ...config?.colours };
+    this.buttonOptions = {...DEFAULT_BUTTONS, ...config?.buttons};
+    this.pixelColours = {...DEFAULT_PIXEL_COLOURS, ...config?.colours};
 
     // Configure value, height, and width
     const currentValue = this.getValue();
@@ -299,9 +299,8 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
     this.bindEvent(dropdownEditor, 'pointercancel', this.onPointerEnd);
     // Stop the browser from handling touch events and cancelling the event.
     this.bindEvent(dropdownEditor, 'touchmove', (e: Event) => {
-        e.preventDefault();
+      e.preventDefault();
     });
-
 
     this.editorPixels = [];
     for (let r = 0; r < this.imgHeight; r++) {
@@ -473,7 +472,7 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
   /**
    * Checks if a down event is on a pixel in this editor and if it is starts an
    * edit gesture.
-   * 
+   *
    * @param e The down event.
    */
   private onPointerStart(e: PointerEvent) {
@@ -490,7 +489,7 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
   /**
    * Updates the editor if we're in an edit gesture and the pointer is over a
    * pixel.
-   * 
+   *
    * @param e The move event.
    */
   private onPointerMove(e: PointerEvent) {

--- a/plugins/field-bitmap/src/field-bitmap.ts
+++ b/plugins/field-bitmap/src/field-bitmap.ts
@@ -471,8 +471,10 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
   }
 
   /**
+   * Checks if a down event is on a pixel in this editor and if it is starts an
+   * edit gesture.
    * 
-   * @param e 
+   * @param e The down event.
    */
   private onPointerStart(e: PointerEvent) {
     const currentElement = document.elementFromPoint(e.clientX, e.clientY);
@@ -486,8 +488,10 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
   }
 
   /**
+   * Updates the editor if we're in an edit gesture and the pointer is over a
+   * pixel.
    * 
-   * @param e 
+   * @param e The move event.
    */
   private onPointerMove(e: PointerEvent) {
     if (!this.pointerIsDown) {
@@ -536,7 +540,7 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
    * Resets pointer state (e.g. After either a pointerup event or if the
    * gesture is canceled).
    */
-  private onPointerEnd(e: PointerEvent) {
+  private onPointerEnd() {
     this.pointerIsDown = false;
     this.valToPaintWith = undefined;
   }


### PR DESCRIPTION

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes #2463 by changing how the editor handles mouse and touch events.

### Proposed Changes

Updates the Bitmap field to properly support touch events. This change is based on code-dot-org/code-dot-org#61709 .

- Switches from handling mouse events to pointer events and moves the event handling up to the editor. This prevents the touch events from getting trapped in an individual pixel.
- Uses bind instead of conditionalBind. conditionalBind does extra work to account for multi-touch gestures, which causes issues for the editor and isn't needed.
- Prevents default handling of touchmove (instead of drag) within the editor. The default handling cancels the original gesture when it converts it to a drag, which prevents future move events.
- Adds a cancel listener to also cleanup the edit state when canceled.

[Screen recording 2025-02-21 9.59.31 AM.webm](https://github.com/user-attachments/assets/9987ed04-451a-49ed-94cb-1e8addbb96ec)


### Reason for Changes

Touch events in the bitmap editor would get canceled by the browser, causing the gesture to end early and the state to not be cleaned up properly. This would cause Blockly to become partially unresponsive.

### Test Coverage

Tested manually on a Chromebook with a touch screen.

### Documentation


### Additional Information

<!-- Anything else we should know? -->
