### PR TITLE
fix: Mitigate shareable procedure flyout bug.

### DIFF
--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -1068,7 +1068,10 @@ const procedureCallerUpdateShapeMixin = {
   doProcedureUpdate: function () {
     if (!this.getProcedureModel()) return;
     const id = this.getProcedureModel().getId();
-    if (!this.getTargetWorkspace_().getProcedureMap().has(id)) {
+    if (
+      !this.getTargetWorkspace_().getProcedureMap().has(id) &&
+      !this.isInFlyout
+    ) {
       this.dispose(true);
       return;
     }


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes https://github.com/google/blockly-samples/issues/2484

### Proposed Changes

Prevents deletion of a procedure call block inside a flyout in response to deleting the associated definition.

### Reason for Changes

There's a bug where call blocks in flyouts get disposed twice, and the second time results in an error getting thrown that prevents opening the flyout.

Flyouts do not get immediately rerendered or updated in response to a block being deleted. However, when opening a flyout, they do dispose any blocks that they already own before re-rendering themselves. If one of these blocks was already disposed, it'll get disposed a second time (which fails). This PR prevents the block from getting disposed the first time, so that the flyout can successfully clear itself.

It might seem like a problem that a flyout that is open can continue to contain a call block for a procedure that doesn't exist anymore. However, if this call block is dragged to the workspace, the procedure definition will reappear.

This is the same workaround implemented by code.org in: https://github.com/code-dot-org/code-dot-org/pull/63662

Alternatively, we could investigate properly re-rendering the flyout in response to changes in its workspace, but that might involve changes to core blockly?

### Test Coverage

I tested manually.

### Documentation

N/A

### Additional Information

N/A