### PR TITLE
fix: Don't call blur() when mouse leaves the colour picker.

### DIFF
--- a/plugins/field-colour/src/field_colour.ts
+++ b/plugins/field-colour/src/field_colour.ts
@@ -547,11 +547,10 @@ export class FieldColour extends Blockly.Field<string> {
   }
 
   /**
-   * Handle a mouse leave event.  Blur the picker and unhighlight
-   * the currently highlighted colour.
+   * Handle a mouse leave event by unnhighlighting the currently highlighted
+   * colour.
    */
   private onMouseLeave() {
-    this.picker?.blur();
     const highlighted = this.getHighlighted();
     if (highlighted) {
       Blockly.utils.dom.removeClass(highlighted, 'blocklyColourHighlighted');


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2498 

This PR updates the colour field to not call blur() when the mouse exits it. This improves keyboard accessibility by not unexpectedly moving focus.