### PR TITLE
chore(deps): Update `blockly` dev dependency to `blockly@12.0.0-beta.4`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@eslint/js": "^8.49.0",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
-        "blockly": "^12.0.0-beta.1",
+        "blockly": "^12.0.0-beta.4",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "eslint": "^8.49.0",
         "eslint-config-google": "^0.14.0",
@@ -911,9 +911,9 @@
       }
     },
     "node_modules/blockly": {
-      "version": "12.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.1.tgz",
-      "integrity": "sha512-lECwZ4K+YuLXMM0yxWTz1lwkmDl424sst7h/dhtSefuCki8afjI/F87byYK/ZIZsMKBEz2+8wEJ1Wlx5cYWIAg==",
+      "version": "12.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.4.tgz",
+      "integrity": "sha512-KY26RP8GfJRTqX/EUWSwu7ilVwhdGU0qQTrgdUGl+frsgqlBqCtIWZJVCxMafCAUWyAlU9+5aQ7UBItcR2MVQQ==",
       "dev": true,
       "dependencies": {
         "jsdom": "25.0.1"
@@ -6367,9 +6367,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "12.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.1.tgz",
-      "integrity": "sha512-lECwZ4K+YuLXMM0yxWTz1lwkmDl424sst7h/dhtSefuCki8afjI/F87byYK/ZIZsMKBEz2+8wEJ1Wlx5cYWIAg==",
+      "version": "12.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.4.tgz",
+      "integrity": "sha512-KY26RP8GfJRTqX/EUWSwu7ilVwhdGU0qQTrgdUGl+frsgqlBqCtIWZJVCxMafCAUWyAlU9+5aQ7UBItcR2MVQQ==",
       "dev": true,
       "requires": {
         "jsdom": "25.0.1"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@eslint/js": "^8.49.0",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
-    "blockly": "^12.0.0-beta.1",
+    "blockly": "^12.0.0-beta.4",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "eslint": "^8.49.0",
     "eslint-config-google": "^0.14.0",

--- a/plugins/field-colour/package.json
+++ b/plugins/field-colour/package.json
@@ -48,7 +48,7 @@
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "blockly": "^11.0.0"
+    "blockly": "^12.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/field-colour/src/field_colour.ts
+++ b/plugins/field-colour/src/field_colour.ts
@@ -209,7 +209,7 @@ export class FieldColour extends Blockly.Field<string> {
    *
    * @returns True if this field should take up the full block. False otherwise.
    */
-  protected isFullBlockField(): boolean {
+  override isFullBlockField(): boolean {
     const block = this.getSourceBlock();
     if (!block) throw new Blockly.UnattachedFieldError();
 

--- a/plugins/field-grid-dropdown/src/grid.ts
+++ b/plugins/field-grid-dropdown/src/grid.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {utils, browserEvents, MenuOption} from 'blockly/core';
+import {utils, browserEvents, MenuOption, FieldDropdown} from 'blockly/core';
 import {GridItem} from './grid_item';
 
 /**
@@ -88,6 +88,9 @@ export class Grid {
   private populateItems(options: MenuOption[]) {
     let row = document.createElement('div');
     for (const [index, item] of options.entries()) {
+      // TODO(#2507): Don't just ignore separators.
+      if (item === FieldDropdown.SEPARATOR) continue;
+
       if (index % this.columns === 0) {
         row = document.createElement('div');
         row.className = 'blocklyFieldGridRow';

--- a/plugins/field-multilineinput/src/field_multilineinput.ts
+++ b/plugins/field-multilineinput/src/field_multilineinput.ts
@@ -163,9 +163,11 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
       );
     }
     let textLines = this.getText();
+    // TODO(google/blockly#8738): Use minimum-width setting mechanism
+    // to be introduced in PR #9011.
     if (!textLines) {
       // Prevent the field from disappearing if empty.
-      return Blockly.Field.NBSP;
+      return '\u00A0'; // Non-breaking space.
     }
     const lines = textLines.split('\n');
     textLines = '';
@@ -182,7 +184,8 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
       }
       // Replace whitespace with non-breaking spaces so the text doesn't
       // collapse.
-      text = text.replace(/\s/g, Blockly.Field.NBSP);
+      // TODO(google/blockly#8738): Use Blockly.Field.NBSP.
+      text = text.replace(/\s/g, '\u00A0'); // Non-breaking space.
 
       textLines += text;
       if (i !== displayLinesNumber - 1) {

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -7,7 +7,7 @@
     "boot": "lerna bootstrap",
     "build": "lerna run build",
     "clean": "lerna run clean",
-    "clean:node": "lerna run clean --yes",
+    "clean:node": "lerna clean --yes",
     "postinstall": "npm run boot",
     "predeploy": "lerna run predeploy",
     "test": "lerna run test"


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes

* Fix `clean:node` npm script that was inadvertently broken by a mistranscription in PR #2453.
* Bump `blockly` dev dependency to v12.0.0-beta.4.
* Fix type of `FieldColour.prototype.isFullBlockField`, as superclass method  becomes public in v12.0.0.
* Fix `FieldMultilineInput` to not depend on `Field.NBSP`, which was temporarily removed.
  * Include a `TODO` to reinstate use of `.NBSP` where appropriate.
* Fix `FieldGridDropdown` to not fail type checking due to the introduction of spacers.

### Reason for Changes

Keep samples working with v12.

### Test Coverage

Passes `npm test` (at least, I think it does—`FieldDate` tests always fail when tested outside the US!)

Have _not_ done manual testing of individual plugins.

