### PR TITLE
fix: Add `getClass()` to `FieldColour`.

### DIFF
--- a/plugins/field-colour/src/field_colour.ts
+++ b/plugins/field-colour/src/field_colour.ts
@@ -731,6 +731,15 @@ export class FieldColour extends Blockly.Field<string> {
     // the static fromJson method.
     return new this(options.colour, undefined, options);
   }
+
+  /**
+   * Returns the class of this field.
+   *
+   * @returns FieldColour.
+   */
+  getClass() {
+    return FieldColour;
+  }
 }
 
 /** The default value for this field. */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves
This PR makes FieldColour properly conform to the newly-introduced `INavigable`, which should fix errors in the keyboard experimentation repo. This fixes https://github.com/google/blockly-keyboard-experimentation/issues/498