### PR TITLE
fix: Fix multi-line text color by using the correct class

### DIFF
--- a/plugins/field-bitmap/src/field-bitmap.ts
+++ b/plugins/field-bitmap/src/field-bitmap.ts
@@ -245,8 +245,8 @@ export class FieldBitmap extends Blockly.Field<number[][]> {
     // lines.
     const svgRoot = this.getSvgRoot();
     if (svgRoot) {
-      Blockly.utils.dom.removeClass(svgRoot, 'blocklyNonEditableText');
-      Blockly.utils.dom.removeClass(svgRoot, 'blocklyEditableText');
+      Blockly.utils.dom.removeClass(svgRoot, 'blocklyNonEditableField');
+      Blockly.utils.dom.removeClass(svgRoot, 'blocklyEditableField');
     }
     return editable;
   }

--- a/plugins/field-multilineinput/src/field_multilineinput.ts
+++ b/plugins/field-multilineinput/src/field_multilineinput.ts
@@ -141,7 +141,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
     this.textGroup = Blockly.utils.dom.createSvgElement(
       Blockly.utils.Svg.G,
       {
-        class: 'blocklyEditableText',
+        class: 'blocklyEditableField',
       },
       this.fieldGroup_,
     );


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2517
Fixes #2516 

### Proposed Changes

Updates EditableText to EditableField per https://github.com/google/blockly/pull/8475/files.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

These classes were renamed in core.
<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
