### PR TITLE
fix: Wait for an animation frame before showing the date picker

### DIFF
--- a/plugins/field-date/src/field_date.ts
+++ b/plugins/field-date/src/field_date.ts
@@ -142,14 +142,17 @@ export class FieldDate extends Blockly.FieldTextInput {
     if (!this.htmlInput_) return;
     Blockly.utils.dom.addClass(this.htmlInput_, 'blocklyDateInput');
 
-    // NOTE: HTMLInputElement.showPicker() is not available in earlier
-    // TypeScript versions (like 4.7.4), so casting to `any` to be compatible
-    // with dev scripts. Additionally, it's not available for date inputs for
-    // Safari. For browser compatibility of showPicker, see:
-    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    (this.htmlInput_ as any).showPicker();
-    /* eslint-enable @typescript-eslint/no-explicit-any */
+    // Delay showing the picker until the editor has a chance to position
+    window.requestAnimationFrame(() => {
+      // NOTE: HTMLInputElement.showPicker() is not available in earlier
+      // TypeScript versions (like 4.7.4), so casting to `any` to be compatible
+      // with dev scripts. Additionally, it's not available for date inputs for
+      // Safari. For browser compatibility of showPicker, see:
+      // https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker
+      /* eslint-disable @typescript-eslint/no-explicit-any */
+      (this.htmlInput_ as any).showPicker();
+      /* eslint-enable @typescript-eslint/no-explicit-any */
+    });
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2513 

### Proposed Changes

Wrap the call to showPicker() in requestAnimationFrame so that it happens after the editor is positioned.

### Reason for Changes

https://github.com/google/blockly/pull/8646 wrapped field_input.resizeEditor_ in a promise which delayed the positioning of the editor until after the current call stack. This caused it to not be positioned when showPicker() was called.

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
