### PR TITLE
chore: update to v12 beta.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@eslint/js": "^8.49.0",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
-        "blockly": "^12.0.0-beta.6",
+        "blockly": "^12.0.0-beta.7",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "eslint": "^8.49.0",
         "eslint-config-google": "^0.14.0",
@@ -1041,11 +1041,10 @@
       }
     },
     "node_modules/blockly": {
-      "version": "12.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.6.tgz",
-      "integrity": "sha512-LlecuVKaMVNCpQgjGmUfLeC1aJZP09Z7s1ENZnR2q2rUvJKlRUklnbsqrTR7nhSylZD3TlaPpODMW/92dj+GXA==",
+      "version": "12.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.7.tgz",
+      "integrity": "sha512-yKwPekH7cu2mELAoznExl11dfrCT4Phmynmm7fLJYmOsuVjUmPOUWRPGQd4e8ccCemkt5NLm7KmRWRZ1+4pXEA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "jsdom": "26.1.0"
       },
@@ -6513,9 +6512,9 @@
       "dev": true
     },
     "blockly": {
-      "version": "12.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.6.tgz",
-      "integrity": "sha512-LlecuVKaMVNCpQgjGmUfLeC1aJZP09Z7s1ENZnR2q2rUvJKlRUklnbsqrTR7nhSylZD3TlaPpODMW/92dj+GXA==",
+      "version": "12.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.0.0-beta.7.tgz",
+      "integrity": "sha512-yKwPekH7cu2mELAoznExl11dfrCT4Phmynmm7fLJYmOsuVjUmPOUWRPGQd4e8ccCemkt5NLm7KmRWRZ1+4pXEA==",
       "dev": true,
       "requires": {
         "jsdom": "26.1.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@eslint/js": "^8.49.0",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
-    "blockly": "^12.0.0-beta.6",
+    "blockly": "^12.0.0-beta.7",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "eslint": "^8.49.0",
     "eslint-config-google": "^0.14.0",


### PR DESCRIPTION
Updates to blockly@12.0.0-beta.7