### PR TITLE
fix: Re-enable shadow block converter test

### DIFF
--- a/plugins/shadow-block-converter/test/shadow_block_converter_test.mocha.js
+++ b/plugins/shadow-block-converter/test/shadow_block_converter_test.mocha.js
@@ -11,7 +11,7 @@ const {shadowBlockConversionChangeListener} = require('../src/index');
 
 const assert = chai.assert;
 
-suite.skip('shadowBlockConversionChangeListener', function () {
+suite('shadowBlockConversionChangeListener', function () {
   /**
    * Create a parent block with an unconnected value connection.
    * @param {Blockly.Workspace} workspace The workspace to use.
@@ -38,6 +38,8 @@ suite.skip('shadowBlockConversionChangeListener', function () {
       '<!DOCTYPE html><div id="blocklyDiv"></div>',
       {pretendToBeVisual: true},
     );
+    // See https://github.com/google/blockly-samples/issues/2528 for context.
+    global.SVGElement = window.SVGElement;
 
     this.workspace = Blockly.inject('blocklyDiv');
     this.workspace.addChangeListener(shadowBlockConversionChangeListener);


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes #2525

### Proposed Changes

This re-enables the shadow block converter test disabled in #2524.

### Reason for Changes

It's preferable to not keep tests disabled as it's easy to forget about them (and having them disabled increases the risk of discovering regressions being delayed or never noticed).

This particular fix is discussed in #2528. It's a bit complicated exactly how the global namespace is managed via `jsdom-global`, but essentially `SVGElement` (made available to Node.js via `jsdom`) is not being automatically bound to the global namespace and this works around the issue.

### Test Coverage

N/A -- This is a test-only change.

### Documentation

No documentation changes are needed.

### Additional Information

This is a slightly ugly workaround, but it seems viable for the medium-term while #2528 is considered.