### PR TITLE
chore: fix lerna release config

### DIFF
--- a/plugins/lerna.json
+++ b/plugins/lerna.json
@@ -2,5 +2,9 @@
   "packages": ["*"],
   "version": "independent",
   "npmClient": "npm",
+  "changelogPreset": {
+    "name": "conventionalcommits"
+  },
+  "ignoreChanges": ["**/package-lock.json"],
   "useNx": false
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes issue with lerna version not handling breaking changes correctly.

### Proposed Changes

Adds some missing config to the lerna config.

### Reason for Changes

These options were removed in the migration that happened in https://github.com/google/blockly-samples/pull/2446

However, they are important for publishing. The default changelog spec only considers something breaking if it has `BREAKING CHANGE: ` in the footer of the commit. We want it to consider it breaking if it has the `!` in the prefix. This setting enforces that. See prior art at https://github.com/google/blockly-samples/pull/1316

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
