### PR TITLE
revert: revert last publish with incorrect versions

### DIFF
--- a/plugins/block-dynamic-connection/CHANGELOG.md
+++ b/plugins/block-dynamic-connection/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.7.15](https://github.com/google/blockly-samples/compare/@blockly/block-dynamic-connection@0.7.14...@blockly/block-dynamic-connection@0.7.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/block-dynamic-connection
-
-
-
-
-
 ## [0.7.14](https://github.com/google/blockly-samples/compare/@blockly/block-dynamic-connection@0.7.13...@blockly/block-dynamic-connection@0.7.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/block-dynamic-connection

--- a/plugins/block-dynamic-connection/package-lock.json
+++ b/plugins/block-dynamic-connection/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/block-dynamic-connection",
-  "version": "0.7.15",
+  "version": "0.7.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/block-dynamic-connection",
-      "version": "0.7.15",
+      "version": "0.7.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.2.0",

--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/block-dynamic-connection",
-  "version": "0.7.15",
+  "version": "0.7.14",
   "description": "A group of blocks that add connections dynamically.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.2.0",
     "mocha": "^10.2.0",
     "typescript": "^5.4.5"

--- a/plugins/block-plus-minus/CHANGELOG.md
+++ b/plugins/block-plus-minus/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [8.0.15](https://github.com/google/blockly-samples/compare/@blockly/block-plus-minus@8.0.14...@blockly/block-plus-minus@8.0.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/block-plus-minus
-
-
-
-
-
 ## [8.0.14](https://github.com/google/blockly-samples/compare/@blockly/block-plus-minus@8.0.13...@blockly/block-plus-minus@8.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/block-plus-minus

--- a/plugins/block-plus-minus/package-lock.json
+++ b/plugins/block-plus-minus/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/block-plus-minus",
-  "version": "8.0.15",
+  "version": "8.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/block-plus-minus",
-      "version": "8.0.15",
+      "version": "8.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.2.0",

--- a/plugins/block-plus-minus/package.json
+++ b/plugins/block-plus-minus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/block-plus-minus",
-  "version": "8.0.15",
+  "version": "8.0.14",
   "description": "A group of blocks that replace the built-in mutator UI with a +/- based UI.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.2.0",
     "mocha": "^10.2.0",
     "sinon": "^9.0.1"

--- a/plugins/block-shareable-procedures/CHANGELOG.md
+++ b/plugins/block-shareable-procedures/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.16](https://github.com/google/blockly-samples/compare/@blockly/block-shareable-procedures@5.0.15...@blockly/block-shareable-procedures@5.0.16) (2025-05-15)
-
-
-### Bug Fixes
-
-* Remove use of deleted `Block.setEnabled()`. ([bf44961](https://github.com/google/blockly-samples/commit/bf449611e35e063a5ccd59e25d6a5e3eca3c7f56))
-
-
-
-
-
 ## [5.0.15](https://github.com/google/blockly-samples/compare/@blockly/block-shareable-procedures@5.0.14...@blockly/block-shareable-procedures@5.0.15) (2025-02-27)
 
 

--- a/plugins/block-shareable-procedures/package-lock.json
+++ b/plugins/block-shareable-procedures/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/block-shareable-procedures",
-  "version": "5.0.16",
+  "version": "5.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/block-shareable-procedures",
-      "version": "5.0.16",
+      "version": "5.0.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.3.7",

--- a/plugins/block-shareable-procedures/package.json
+++ b/plugins/block-shareable-procedures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/block-shareable-procedures",
-  "version": "5.0.16",
+  "version": "5.0.15",
   "description": "A plugin that adds procedure blocks which are backed by explicit data models.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,8 +41,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.3.7",
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",

--- a/plugins/block-test/CHANGELOG.md
+++ b/plugins/block-test/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.12](https://github.com/google/blockly-samples/compare/@blockly/block-test@6.0.11...@blockly/block-test@6.0.12) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/block-test
-
-
-
-
-
 ## [6.0.11](https://github.com/google/blockly-samples/compare/@blockly/block-test@6.0.10...@blockly/block-test@6.0.11) (2024-12-03)
 
 **Note:** Version bump only for package @blockly/block-test

--- a/plugins/block-test/package-lock.json
+++ b/plugins/block-test/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@blockly/block-test",
-  "version": "6.0.12",
+  "version": "6.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/block-test",
-      "version": "6.0.12",
+      "version": "6.0.11",
       "license": "Apache 2.0",
       "devDependencies": {
-        "@blockly/dev-scripts": "^4.0.8"
+        "@blockly/dev-scripts": "^4.0.7"
       },
       "engines": {
         "node": ">=8.17.0"

--- a/plugins/block-test/package.json
+++ b/plugins/block-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/block-test",
-  "version": "6.0.12",
+  "version": "6.0.11",
   "description": "A group of Blockly test blocks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,7 +39,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8"
+    "@blockly/dev-scripts": "^4.0.7"
   },
   "peerDependencies": {
     "blockly": "^12.0.0"

--- a/plugins/content-highlight/CHANGELOG.md
+++ b/plugins/content-highlight/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.16](https://github.com/google/blockly-samples/compare/@blockly/workspace-content-highlight@5.0.15...@blockly/workspace-content-highlight@5.0.16) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/workspace-content-highlight
-
-
-
-
-
 ## [5.0.15](https://github.com/google/blockly-samples/compare/@blockly/workspace-content-highlight@5.0.14...@blockly/workspace-content-highlight@5.0.15) (2025-02-20)
 
 

--- a/plugins/content-highlight/package-lock.json
+++ b/plugins/content-highlight/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/workspace-content-highlight",
-  "version": "5.0.16",
+  "version": "5.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/workspace-content-highlight",
-      "version": "5.0.16",
+      "version": "5.0.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.4.5"

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/workspace-content-highlight",
-  "version": "5.0.16",
+  "version": "5.0.15",
   "description": "A Blockly workspace plugin that adds a highlight around the content area.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -43,8 +43,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "typescript": "^5.4.5"
   },
   "peerDependencies": {

--- a/plugins/continuous-toolbox/CHANGELOG.md
+++ b/plugins/continuous-toolbox/CHANGELOG.md
@@ -3,18 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.15](https://github.com/google/blockly-samples/compare/@blockly/continuous-toolbox@6.0.14...@blockly/continuous-toolbox@6.0.15) (2025-05-15)
-
-
-### Bug Fixes
-
-* Don't pin continuous-toolbox to Blockly v12.0.0-beta.0. ([#2532](https://github.com/google/blockly-samples/issues/2532)) ([9f49e28](https://github.com/google/blockly-samples/commit/9f49e2811a8c078a6377c4b38025c2cf5d04e744))
-* Fix scrolling and API issues with the continuous toolbox plugin. ([#2485](https://github.com/google/blockly-samples/issues/2485)) ([7476290](https://github.com/google/blockly-samples/commit/7476290ff118105c2b6fa39c747b0871cf5ea411))
-
-
-
-
-
 ## [6.0.14](https://github.com/google/blockly-samples/compare/@blockly/continuous-toolbox@6.0.13...@blockly/continuous-toolbox@6.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/continuous-toolbox

--- a/plugins/continuous-toolbox/package-lock.json
+++ b/plugins/continuous-toolbox/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@blockly/continuous-toolbox",
-  "version": "6.0.15",
+  "version": "6.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/continuous-toolbox",
-      "version": "6.0.15",
+      "version": "6.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blockly/dev-scripts": "^4.0.8",
-        "@blockly/dev-tools": "^8.1.1"
+        "@blockly/dev-scripts": "^4.0.7",
+        "@blockly/dev-tools": "^8.1.0"
       },
       "engines": {
         "node": ">=8.17.0"

--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/continuous-toolbox",
-  "version": "6.0.15",
+  "version": "6.0.14",
   "description": "A Blockly plugin that adds a continous-scrolling style toolbox and flyout",
   "scripts": {
     "build": "blockly-scripts build",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1"
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0"
   },
   "peerDependencies": {
     "blockly": "^12.0.0"

--- a/plugins/cross-tab-copy-paste/CHANGELOG.md
+++ b/plugins/cross-tab-copy-paste/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.15](https://github.com/google/blockly-samples/compare/@blockly/plugin-cross-tab-copy-paste@6.0.14...@blockly/plugin-cross-tab-copy-paste@6.0.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/plugin-cross-tab-copy-paste
-
-
-
-
-
 ## [6.0.14](https://github.com/google/blockly-samples/compare/@blockly/plugin-cross-tab-copy-paste@6.0.13...@blockly/plugin-cross-tab-copy-paste@6.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/plugin-cross-tab-copy-paste

--- a/plugins/cross-tab-copy-paste/package-lock.json
+++ b/plugins/cross-tab-copy-paste/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@blockly/plugin-cross-tab-copy-paste",
-  "version": "6.0.15",
+  "version": "6.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/plugin-cross-tab-copy-paste",
-      "version": "6.0.15",
+      "version": "6.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blockly/dev-scripts": "^4.0.8",
-        "@blockly/dev-tools": "^8.1.1"
+        "@blockly/dev-scripts": "^4.0.7",
+        "@blockly/dev-tools": "^8.1.0"
       },
       "engines": {
         "node": ">=8.17.0"

--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-cross-tab-copy-paste",
-  "version": "6.0.15",
+  "version": "6.0.14",
   "description": "Allows you to copy blocks with cross-tab.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1"
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0"
   },
   "peerDependencies": {
     "blockly": "^12.0.0"

--- a/plugins/dev-scripts/CHANGELOG.md
+++ b/plugins/dev-scripts/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [4.0.8](https://github.com/google/blockly-samples/compare/@blockly/dev-scripts@4.0.7...@blockly/dev-scripts@4.0.8) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/dev-scripts
-
-
-
-
-
 ## [4.0.7](https://github.com/google/blockly-samples/compare/@blockly/dev-scripts@4.0.6...@blockly/dev-scripts@4.0.7) (2024-12-03)
 
 **Note:** Version bump only for package @blockly/dev-scripts

--- a/plugins/dev-scripts/package-lock.json
+++ b/plugins/dev-scripts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/dev-scripts",
-  "version": "4.0.8",
+  "version": "4.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/dev-scripts",
-      "version": "4.0.8",
+      "version": "4.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.8.3",

--- a/plugins/dev-scripts/package.json
+++ b/plugins/dev-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/dev-scripts",
-  "version": "4.0.8",
+  "version": "4.0.7",
   "description": "Configuration and scripts for Blockly plugins.",
   "scripts": {
     "lint": "eslint ."

--- a/plugins/dev-tools/CHANGELOG.md
+++ b/plugins/dev-tools/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [8.1.1](https://github.com/google/blockly-samples/compare/@blockly/dev-tools@8.1.0...@blockly/dev-tools@8.1.1) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/dev-tools
-
-
-
-
-
 # [8.1.0](https://github.com/google/blockly-samples/compare/@blockly/dev-tools@8.0.13...@blockly/dev-tools@8.1.0) (2025-02-13)
 
 

--- a/plugins/dev-tools/package-lock.json
+++ b/plugins/dev-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/dev-tools",
-  "version": "8.1.1",
+  "version": "8.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/dev-tools",
-      "version": "8.1.1",
+      "version": "8.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chai": "^4.2.0",

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/dev-tools",
-  "version": "8.1.1",
+  "version": "8.1.0",
   "description": "A library of common utilities for Blockly extension development.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -38,11 +38,11 @@
     "src"
   ],
   "dependencies": {
-    "@blockly/block-test": "^6.0.12",
-    "@blockly/theme-dark": "^7.0.11",
-    "@blockly/theme-deuteranopia": "^6.0.11",
-    "@blockly/theme-highcontrast": "^6.0.11",
-    "@blockly/theme-tritanopia": "^6.0.11",
+    "@blockly/block-test": "^6.0.11",
+    "@blockly/theme-dark": "^7.0.10",
+    "@blockly/theme-deuteranopia": "^6.0.10",
+    "@blockly/theme-highcontrast": "^6.0.10",
+    "@blockly/theme-tritanopia": "^6.0.10",
     "chai": "^4.2.0",
     "dat.gui": "^0.7.7",
     "lodash.assign": "^4.2.0",
@@ -51,7 +51,7 @@
     "sinon": "^9.0.2"
   },
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
+    "@blockly/dev-scripts": "^4.0.7",
     "@types/dat.gui": "^0.7.5"
   },
   "peerDependencies": {

--- a/plugins/disable-top-blocks/CHANGELOG.md
+++ b/plugins/disable-top-blocks/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.5.15](https://github.com/google/blockly-samples/compare/@blockly/disable-top-blocks@0.5.14...@blockly/disable-top-blocks@0.5.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/disable-top-blocks
-
-
-
-
-
 ## [0.5.14](https://github.com/google/blockly-samples/compare/@blockly/disable-top-blocks@0.5.13...@blockly/disable-top-blocks@0.5.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/disable-top-blocks

--- a/plugins/disable-top-blocks/package-lock.json
+++ b/plugins/disable-top-blocks/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@blockly/disable-top-blocks",
-  "version": "0.5.15",
+  "version": "0.5.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/disable-top-blocks",
-      "version": "0.5.15",
+      "version": "0.5.14",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blockly/dev-scripts": "^4.0.8",
-        "@blockly/dev-tools": "^8.1.1"
+        "@blockly/dev-scripts": "^4.0.7",
+        "@blockly/dev-tools": "^8.1.0"
       },
       "engines": {
         "node": ">=8.17.0"

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/disable-top-blocks",
-  "version": "0.5.15",
+  "version": "0.5.14",
   "description": "A Blockly plugin that shows the 'disable' context menu option only on non-orphan blocks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -38,8 +38,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1"
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0"
   },
   "peerDependencies": {
     "blockly": "^12.0.0"

--- a/plugins/field-angle/CHANGELOG.md
+++ b/plugins/field-angle/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.15](https://github.com/google/blockly-samples/compare/@blockly/field-angle@5.0.14...@blockly/field-angle@5.0.15) (2025-05-15)
-
-
-### Bug Fixes
-
-* Fix ephemeral focus being taken twice ([#2521](https://github.com/google/blockly-samples/issues/2521)) ([29b5a0d](https://github.com/google/blockly-samples/commit/29b5a0d896e7e6f7eb83867bd5b2577bf808e839)), closes [#2514](https://github.com/google/blockly-samples/issues/2514) [#2515](https://github.com/google/blockly-samples/issues/2515) [#2514](https://github.com/google/blockly-samples/issues/2514) [#2515](https://github.com/google/blockly-samples/issues/2515) [#2527](https://github.com/google/blockly-samples/issues/2527)
-
-
-
-
-
 ## [5.0.14](https://github.com/google/blockly-samples/compare/@blockly/field-angle@5.0.13...@blockly/field-angle@5.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/field-angle

--- a/plugins/field-angle/package-lock.json
+++ b/plugins/field-angle/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/field-angle",
-  "version": "5.0.15",
+  "version": "5.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/field-angle",
-      "version": "5.0.15",
+      "version": "5.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.2.0",

--- a/plugins/field-angle/package.json
+++ b/plugins/field-angle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-angle",
-  "version": "5.0.15",
+  "version": "5.0.14",
   "description": "A Blockly angle field.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",
     "typescript": "^5.4.5"

--- a/plugins/field-bitmap/CHANGELOG.md
+++ b/plugins/field-bitmap/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.16](https://github.com/google/blockly-samples/compare/@blockly/field-bitmap@5.0.15...@blockly/field-bitmap@5.0.16) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/field-bitmap
-
-
-
-
-
 ## [5.0.15](https://github.com/google/blockly-samples/compare/@blockly/field-bitmap@5.0.14...@blockly/field-bitmap@5.0.15) (2025-02-27)
 
 

--- a/plugins/field-bitmap/package-lock.json
+++ b/plugins/field-bitmap/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/field-bitmap",
-  "version": "5.0.16",
+  "version": "5.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/field-bitmap",
-      "version": "5.0.16",
+      "version": "5.0.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.3.6",

--- a/plugins/field-bitmap/package.json
+++ b/plugins/field-bitmap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-bitmap",
-  "version": "5.0.16",
+  "version": "5.0.15",
   "description": "A field that lets users input a pixel grid with their mouse.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.3.6",
     "mocha": "^10.7.0",
     "typescript": "^5.4.5"

--- a/plugins/field-colour-hsv-sliders/CHANGELOG.md
+++ b/plugins/field-colour-hsv-sliders/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.18](https://github.com/google/blockly-samples/compare/@blockly/field-colour-hsv-sliders@5.0.17...@blockly/field-colour-hsv-sliders@5.0.18) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/field-colour-hsv-sliders
-
-
-
-
-
 ## [5.0.17](https://github.com/google/blockly-samples/compare/@blockly/field-colour-hsv-sliders@5.0.16...@blockly/field-colour-hsv-sliders@5.0.17) (2025-05-08)
 
 **Note:** Version bump only for package @blockly/field-colour-hsv-sliders

--- a/plugins/field-colour-hsv-sliders/package-lock.json
+++ b/plugins/field-colour-hsv-sliders/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/field-colour-hsv-sliders",
-  "version": "5.0.18",
+  "version": "5.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/field-colour-hsv-sliders",
-      "version": "5.0.18",
+      "version": "5.0.17",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.4.5"

--- a/plugins/field-colour-hsv-sliders/package.json
+++ b/plugins/field-colour-hsv-sliders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-colour-hsv-sliders",
-  "version": "5.0.18",
+  "version": "5.0.17",
   "description": "A Blockly colour field using HSV sliders.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,11 +41,11 @@
     "src"
   ],
   "dependencies": {
-    "@blockly/field-colour": "^5.0.18"
+    "@blockly/field-colour": "^5.0.17"
   },
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "typescript": "^5.4.5"
   },
   "peerDependencies": {

--- a/plugins/field-colour/CHANGELOG.md
+++ b/plugins/field-colour/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.18](https://github.com/google/blockly-samples/compare/@blockly/field-colour@5.0.17...@blockly/field-colour@5.0.18) (2025-05-15)
-
-
-### Reverts
-
-* Revert "fix: Add `getClass()` to `FieldColour`. (#2506)" ([144b6d0](https://github.com/google/blockly-samples/commit/144b6d0c4b939e1f329986220e30ebdfcf93453c)), closes [#2506](https://github.com/google/blockly-samples/issues/2506)
-
-
-
-
-
 ## [5.0.17](https://github.com/google/blockly-samples/compare/@blockly/field-colour@5.0.16...@blockly/field-colour@5.0.17) (2025-05-08)
 
 

--- a/plugins/field-colour/package-lock.json
+++ b/plugins/field-colour/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/field-colour",
-  "version": "5.0.18",
+  "version": "5.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/field-colour",
-      "version": "5.0.18",
+      "version": "5.0.17",
       "license": "Apache-2.0",
       "devDependencies": {
         "@typescript-eslint/parser": "^5.59.5",

--- a/plugins/field-colour/package.json
+++ b/plugins/field-colour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-colour",
-  "version": "5.0.18",
+  "version": "5.0.17",
   "description": "A Blockly colour field.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "@typescript-eslint/parser": "^5.59.5",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",

--- a/plugins/field-date/CHANGELOG.md
+++ b/plugins/field-date/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [9.0.15](https://github.com/google/blockly-samples/compare/@blockly/field-date@9.0.14...@blockly/field-date@9.0.15) (2025-05-15)
-
-
-### Bug Fixes
-
-* Wait for an animation frame before showing the date picker ([e3b1054](https://github.com/google/blockly-samples/commit/e3b1054eb0b511aa4ab270725c989369270ee8d6))
-
-
-
-
-
 ## [9.0.14](https://github.com/google/blockly-samples/compare/@blockly/field-date@9.0.13...@blockly/field-date@9.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/field-date

--- a/plugins/field-date/package-lock.json
+++ b/plugins/field-date/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/field-date",
-  "version": "9.0.15",
+  "version": "9.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/field-date",
-      "version": "9.0.15",
+      "version": "9.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.2.0",

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-date",
-  "version": "9.0.15",
+  "version": "9.0.14",
   "description": "A Blockly date picker field that uses the browser's date picker.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -42,8 +42,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",
     "typescript": "^5.4.5"

--- a/plugins/field-dependent-dropdown/CHANGELOG.md
+++ b/plugins/field-dependent-dropdown/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [4.0.15](https://github.com/google/blockly-samples/compare/@blockly/field-dependent-dropdown@4.0.14...@blockly/field-dependent-dropdown@4.0.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/field-dependent-dropdown
-
-
-
-
-
 ## [4.0.14](https://github.com/google/blockly-samples/compare/@blockly/field-dependent-dropdown@4.0.13...@blockly/field-dependent-dropdown@4.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/field-dependent-dropdown

--- a/plugins/field-dependent-dropdown/package-lock.json
+++ b/plugins/field-dependent-dropdown/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/field-dependent-dropdown",
-  "version": "4.0.15",
+  "version": "4.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/field-dependent-dropdown",
-      "version": "4.0.15",
+      "version": "4.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.2.0",

--- a/plugins/field-dependent-dropdown/package.json
+++ b/plugins/field-dependent-dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-dependent-dropdown",
-  "version": "4.0.15",
+  "version": "4.0.14",
   "description": "A Blockly dropdown field that automatically updates its available options depending on the value of another field.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -41,8 +41,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",
     "typescript": "^5.4.5"

--- a/plugins/field-grid-dropdown/CHANGELOG.md
+++ b/plugins/field-grid-dropdown/CHANGELOG.md
@@ -3,18 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.15](https://github.com/google/blockly-samples/compare/@blockly/field-grid-dropdown@5.0.14...@blockly/field-grid-dropdown@5.0.15) (2025-05-15)
-
-
-### Bug Fixes
-
-* **FieldGridDropdown:** Handle presence of HTMLElement in MenuOptions ([43bdfab](https://github.com/google/blockly-samples/commit/43bdfabeb658331d3991430ec92589ba415dac75))
-* Fix the field-grid-dropdown tests. ([452051e](https://github.com/google/blockly-samples/commit/452051e02520803e7cf85e63e0bfb8191a838a98))
-
-
-
-
-
 ## [5.0.14](https://github.com/google/blockly-samples/compare/@blockly/field-grid-dropdown@5.0.13...@blockly/field-grid-dropdown@5.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/field-grid-dropdown

--- a/plugins/field-grid-dropdown/package-lock.json
+++ b/plugins/field-grid-dropdown/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/field-grid-dropdown",
-  "version": "5.0.15",
+  "version": "5.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/field-grid-dropdown",
-      "version": "5.0.15",
+      "version": "5.0.14",
       "license": "Apache 2.0",
       "devDependencies": {
         "typescript": "^5.4.5"

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-grid-dropdown",
-  "version": "5.0.15",
+  "version": "5.0.14",
   "description": "A Blockly dropdown field with grid layout.",
   "scripts": {
     "build": "blockly-scripts build",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "typescript": "^5.4.5"
   },
   "peerDependencies": {

--- a/plugins/field-multilineinput/CHANGELOG.md
+++ b/plugins/field-multilineinput/CHANGELOG.md
@@ -3,22 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.16](https://github.com/google/blockly-samples/compare/@blockly/field-multilineinput@5.0.15...@blockly/field-multilineinput@5.0.16) (2025-05-15)
-
-
-### Bug Fixes
-
-* Fix multi-line text color by using the correct class ([91a8473](https://github.com/google/blockly-samples/commit/91a8473736b5c0cc3e04c809f4a888469bc96f77))
-
-
-### Reverts
-
-* "fix(FieldMultilineInput): Use string literal instead of Field.NBSP" ([539ae4f](https://github.com/google/blockly-samples/commit/539ae4fe4499fca3d781c29f462836ac64d45ce6))
-
-
-
-
-
 ## [5.0.15](https://github.com/google/blockly-samples/compare/@blockly/field-multilineinput@5.0.14...@blockly/field-multilineinput@5.0.15) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/field-multilineinput

--- a/plugins/field-multilineinput/package-lock.json
+++ b/plugins/field-multilineinput/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/field-multilineinput",
-  "version": "5.0.16",
+  "version": "5.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/field-multilineinput",
-      "version": "5.0.16",
+      "version": "5.0.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.2.0",

--- a/plugins/field-multilineinput/package.json
+++ b/plugins/field-multilineinput/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-multilineinput",
-  "version": "5.0.16",
+  "version": "5.0.15",
   "description": "A Blockly multilineinput field.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",
     "typescript": "^5.4.5"

--- a/plugins/field-slider/CHANGELOG.md
+++ b/plugins/field-slider/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.0.15](https://github.com/google/blockly-samples/compare/@blockly/field-slider@7.0.14...@blockly/field-slider@7.0.15) (2025-05-15)
-
-
-### Bug Fixes
-
-* Fix ephemeral focus being taken twice ([#2521](https://github.com/google/blockly-samples/issues/2521)) ([29b5a0d](https://github.com/google/blockly-samples/commit/29b5a0d896e7e6f7eb83867bd5b2577bf808e839)), closes [#2514](https://github.com/google/blockly-samples/issues/2514) [#2515](https://github.com/google/blockly-samples/issues/2515) [#2514](https://github.com/google/blockly-samples/issues/2514) [#2515](https://github.com/google/blockly-samples/issues/2515) [#2527](https://github.com/google/blockly-samples/issues/2527)
-
-
-
-
-
 ## [7.0.14](https://github.com/google/blockly-samples/compare/@blockly/field-slider@7.0.13...@blockly/field-slider@7.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/field-slider

--- a/plugins/field-slider/package-lock.json
+++ b/plugins/field-slider/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/field-slider",
-  "version": "7.0.15",
+  "version": "7.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/field-slider",
-      "version": "7.0.15",
+      "version": "7.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.2.0",

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/field-slider",
-  "version": "7.0.15",
+  "version": "7.0.14",
   "description": "A Blockly slider field.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.2.0",
     "sinon": "^9.0.1",
     "typescript": "^5.4.5"

--- a/plugins/fixed-edges/CHANGELOG.md
+++ b/plugins/fixed-edges/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.15](https://github.com/google/blockly-samples/compare/@blockly/fixed-edges@5.0.14...@blockly/fixed-edges@5.0.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/fixed-edges
-
-
-
-
-
 ## [5.0.14](https://github.com/google/blockly-samples/compare/@blockly/fixed-edges@5.0.13...@blockly/fixed-edges@5.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/fixed-edges

--- a/plugins/fixed-edges/package-lock.json
+++ b/plugins/fixed-edges/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@blockly/fixed-edges",
-  "version": "5.0.15",
+  "version": "5.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/fixed-edges",
-      "version": "5.0.15",
+      "version": "5.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blockly/dev-scripts": "^4.0.8",
-        "@blockly/dev-tools": "^8.1.1"
+        "@blockly/dev-scripts": "^4.0.7",
+        "@blockly/dev-tools": "^8.1.0"
       },
       "engines": {
         "node": ">=8.17.0"

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/fixed-edges",
-  "version": "5.0.15",
+  "version": "5.0.14",
   "description": "A plugin that provides a MetricsManager that can be used to prevent the workspace from expanding to the top/left/right/bottom when blocks are dragged to that edge.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -38,8 +38,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1"
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0"
   },
   "peerDependencies": {
     "blockly": "^12.0.0"

--- a/plugins/migration/CHANGELOG.md
+++ b/plugins/migration/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.0.4](https://github.com/google/blockly-samples/compare/@blockly/migrate@3.0.3...@blockly/migrate@3.0.4) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/migrate
-
-
-
-
-
 ## [3.0.3](https://github.com/google/blockly-samples/compare/@blockly/migrate@3.0.2...@blockly/migrate@3.0.3) (2025-03-13)
 
 **Note:** Version bump only for package @blockly/migrate

--- a/plugins/migration/package-lock.json
+++ b/plugins/migration/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/migrate",
-  "version": "3.0.4",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/migrate",
-      "version": "3.0.4",
+      "version": "3.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.0.1",

--- a/plugins/migration/package.json
+++ b/plugins/migration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/migrate",
-  "version": "3.0.4",
+  "version": "3.0.3",
   "description": "A collection of tools that help with migrating apps using Blockly to new versions of BLockly.",
   "bin": "./bin/migrate.js",
   "author": "Blockly Team",

--- a/plugins/modal/CHANGELOG.md
+++ b/plugins/modal/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.0.15](https://github.com/google/blockly-samples/compare/@blockly/plugin-modal@7.0.14...@blockly/plugin-modal@7.0.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/plugin-modal
-
-
-
-
-
 ## [7.0.14](https://github.com/google/blockly-samples/compare/@blockly/plugin-modal@7.0.13...@blockly/plugin-modal@7.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/plugin-modal

--- a/plugins/modal/package-lock.json
+++ b/plugins/modal/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/plugin-modal",
-  "version": "7.0.15",
+  "version": "7.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/plugin-modal",
-      "version": "7.0.15",
+      "version": "7.0.14",
       "license": "Apache 2.0",
       "devDependencies": {
         "jsdom": "^19.0.0",

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-modal",
-  "version": "7.0.15",
+  "version": "7.0.14",
   "description": "A Blockly plugin that creates a modal.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",
     "mocha": "^10.1.0",

--- a/plugins/scroll-options/CHANGELOG.md
+++ b/plugins/scroll-options/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.15](https://github.com/google/blockly-samples/compare/@blockly/plugin-scroll-options@6.0.14...@blockly/plugin-scroll-options@6.0.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/plugin-scroll-options
-
-
-
-
-
 ## [6.0.14](https://github.com/google/blockly-samples/compare/@blockly/plugin-scroll-options@6.0.13...@blockly/plugin-scroll-options@6.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/plugin-scroll-options

--- a/plugins/scroll-options/package-lock.json
+++ b/plugins/scroll-options/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/plugin-scroll-options",
-  "version": "6.0.15",
+  "version": "6.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/plugin-scroll-options",
-      "version": "6.0.15",
+      "version": "6.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.4.5"

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-scroll-options",
-  "version": "6.0.15",
+  "version": "6.0.14",
   "description": "A Blockly plugin that adds advanced scroll options such as scroll-on-drag and scroll while holding a block.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "typescript": "^5.4.5"
   },
   "peerDependencies": {

--- a/plugins/shadow-block-converter/CHANGELOG.md
+++ b/plugins/shadow-block-converter/CHANGELOG.md
@@ -3,18 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.16](https://github.com/google/blockly-samples/compare/@blockly/shadow-block-converter@6.0.15...@blockly/shadow-block-converter@6.0.16) (2025-05-15)
-
-
-### Bug Fixes
-
-* Fix shadow-block-converter tests. ([6bd3916](https://github.com/google/blockly-samples/commit/6bd39168b25b989056b642861a2983938db93187))
-* Re-enable shadow block converter test ([#2529](https://github.com/google/blockly-samples/issues/2529)) ([1f5d169](https://github.com/google/blockly-samples/commit/1f5d16944bb1b6a40e28af7297625ba11fa7aaad)), closes [#2525](https://github.com/google/blockly-samples/issues/2525) [#2524](https://github.com/google/blockly-samples/issues/2524) [#2528](https://github.com/google/blockly-samples/issues/2528) [#2528](https://github.com/google/blockly-samples/issues/2528)
-
-
-
-
-
 ## [6.0.15](https://github.com/google/blockly-samples/compare/@blockly/shadow-block-converter@6.0.14...@blockly/shadow-block-converter@6.0.15) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/shadow-block-converter

--- a/plugins/shadow-block-converter/package-lock.json
+++ b/plugins/shadow-block-converter/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/shadow-block-converter",
-  "version": "6.0.16",
+  "version": "6.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/shadow-block-converter",
-      "version": "6.0.16",
+      "version": "6.0.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.2.0",

--- a/plugins/shadow-block-converter/package.json
+++ b/plugins/shadow-block-converter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/shadow-block-converter",
-  "version": "6.0.16",
+  "version": "6.0.15",
   "description": "A workspace change listener that converts shadow blocks to real blocks when the user edits them.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.2.0",
     "jsdom": "^26.1.0",
     "jsdom-global": "^3.0.2",

--- a/plugins/strict-connection-checker/CHANGELOG.md
+++ b/plugins/strict-connection-checker/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.15](https://github.com/google/blockly-samples/compare/@blockly/plugin-strict-connection-checker@5.0.14...@blockly/plugin-strict-connection-checker@5.0.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/plugin-strict-connection-checker
-
-
-
-
-
 ## [5.0.14](https://github.com/google/blockly-samples/compare/@blockly/plugin-strict-connection-checker@5.0.13...@blockly/plugin-strict-connection-checker@5.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/plugin-strict-connection-checker

--- a/plugins/strict-connection-checker/package-lock.json
+++ b/plugins/strict-connection-checker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/plugin-strict-connection-checker",
-  "version": "5.0.15",
+  "version": "5.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/plugin-strict-connection-checker",
-      "version": "5.0.15",
+      "version": "5.0.14",
       "license": "Apache 2.0",
       "devDependencies": {
         "chai": "^4.2.0"

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-strict-connection-checker",
-  "version": "5.0.15",
+  "version": "5.0.14",
   "description": "A connection checker that prevents blocks that don't provide type information from being connected to blocks that do.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.2.0"
   },
   "peerDependencies": {

--- a/plugins/suggested-blocks/CHANGELOG.md
+++ b/plugins/suggested-blocks/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [5.0.15](https://github.com/google/blockly-samples/compare/@blockly/suggested-blocks@5.0.14...@blockly/suggested-blocks@5.0.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/suggested-blocks
-
-
-
-
-
 ## [5.0.14](https://github.com/google/blockly-samples/compare/@blockly/suggested-blocks@5.0.13...@blockly/suggested-blocks@5.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/suggested-blocks

--- a/plugins/suggested-blocks/package-lock.json
+++ b/plugins/suggested-blocks/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/suggested-blocks",
-  "version": "5.0.15",
+  "version": "5.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/suggested-blocks",
-      "version": "5.0.15",
+      "version": "5.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.3.6",

--- a/plugins/suggested-blocks/package.json
+++ b/plugins/suggested-blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/suggested-blocks",
-  "version": "5.0.15",
+  "version": "5.0.14",
   "description": "A plugin that adds toolbox panes with suggested blocks based on the user's past usage of blocks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.3.6",
     "sinon": "^14.0.0"
   },

--- a/plugins/theme-dark/CHANGELOG.md
+++ b/plugins/theme-dark/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.0.11](https://github.com/google/blockly-samples/compare/@blockly/theme-dark@7.0.10...@blockly/theme-dark@7.0.11) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/theme-dark
-
-
-
-
-
 ## [7.0.10](https://github.com/google/blockly-samples/compare/@blockly/theme-dark@7.0.9...@blockly/theme-dark@7.0.10) (2024-12-03)
 
 **Note:** Version bump only for package @blockly/theme-dark

--- a/plugins/theme-dark/package-lock.json
+++ b/plugins/theme-dark/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@blockly/theme-dark",
-  "version": "7.0.11",
+  "version": "7.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/theme-dark",
-      "version": "7.0.11",
+      "version": "7.0.10",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blockly/dev-scripts": "^4.0.8"
+        "@blockly/dev-scripts": "^4.0.7"
       },
       "engines": {
         "node": ">=8.17.0"

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-dark",
-  "version": "7.0.11",
+  "version": "7.0.10",
   "description": "A Blockly dark theme.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8"
+    "@blockly/dev-scripts": "^4.0.7"
   },
   "peerDependencies": {
     "blockly": "^12.0.0"

--- a/plugins/theme-deuteranopia/CHANGELOG.md
+++ b/plugins/theme-deuteranopia/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.11](https://github.com/google/blockly-samples/compare/@blockly/theme-deuteranopia@6.0.10...@blockly/theme-deuteranopia@6.0.11) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/theme-deuteranopia
-
-
-
-
-
 ## [6.0.10](https://github.com/google/blockly-samples/compare/@blockly/theme-deuteranopia@6.0.9...@blockly/theme-deuteranopia@6.0.10) (2024-12-03)
 
 **Note:** Version bump only for package @blockly/theme-deuteranopia

--- a/plugins/theme-deuteranopia/package-lock.json
+++ b/plugins/theme-deuteranopia/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@blockly/theme-deuteranopia",
-  "version": "6.0.11",
+  "version": "6.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/theme-deuteranopia",
-      "version": "6.0.11",
+      "version": "6.0.10",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blockly/dev-scripts": "^4.0.8"
+        "@blockly/dev-scripts": "^4.0.7"
       },
       "engines": {
         "node": ">=8.17.0"

--- a/plugins/theme-deuteranopia/package.json
+++ b/plugins/theme-deuteranopia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-deuteranopia",
-  "version": "6.0.11",
+  "version": "6.0.10",
   "description": "A Blockly theme for people that have deuteranopia.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8"
+    "@blockly/dev-scripts": "^4.0.7"
   },
   "peerDependencies": {
     "blockly": "^12.0.0"

--- a/plugins/theme-highcontrast/CHANGELOG.md
+++ b/plugins/theme-highcontrast/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.11](https://github.com/google/blockly-samples/compare/@blockly/theme-highcontrast@6.0.10...@blockly/theme-highcontrast@6.0.11) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/theme-highcontrast
-
-
-
-
-
 ## [6.0.10](https://github.com/google/blockly-samples/compare/@blockly/theme-highcontrast@6.0.9...@blockly/theme-highcontrast@6.0.10) (2024-12-03)
 
 **Note:** Version bump only for package @blockly/theme-highcontrast

--- a/plugins/theme-highcontrast/package-lock.json
+++ b/plugins/theme-highcontrast/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@blockly/theme-highcontrast",
-  "version": "6.0.11",
+  "version": "6.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/theme-highcontrast",
-      "version": "6.0.11",
+      "version": "6.0.10",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blockly/dev-scripts": "^4.0.8"
+        "@blockly/dev-scripts": "^4.0.7"
       },
       "engines": {
         "node": ">=8.17.0"

--- a/plugins/theme-highcontrast/package.json
+++ b/plugins/theme-highcontrast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-highcontrast",
-  "version": "6.0.11",
+  "version": "6.0.10",
   "description": "A Blockly high contrast theme.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8"
+    "@blockly/dev-scripts": "^4.0.7"
   },
   "peerDependencies": {
     "blockly": "^12.0.0"

--- a/plugins/theme-modern/CHANGELOG.md
+++ b/plugins/theme-modern/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.11](https://github.com/google/blockly-samples/compare/@blockly/theme-modern@6.0.10...@blockly/theme-modern@6.0.11) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/theme-modern
-
-
-
-
-
 ## [6.0.10](https://github.com/google/blockly-samples/compare/@blockly/theme-modern@6.0.9...@blockly/theme-modern@6.0.10) (2024-12-03)
 
 **Note:** Version bump only for package @blockly/theme-modern

--- a/plugins/theme-modern/package-lock.json
+++ b/plugins/theme-modern/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@blockly/theme-modern",
-  "version": "6.0.11",
+  "version": "6.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/theme-modern",
-      "version": "6.0.11",
+      "version": "6.0.10",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blockly/dev-scripts": "^4.0.8"
+        "@blockly/dev-scripts": "^4.0.7"
       },
       "engines": {
         "node": ">=8.17.0"

--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-modern",
-  "version": "6.0.11",
+  "version": "6.0.10",
   "description": "A Blockly modern theme with darker block borders.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8"
+    "@blockly/dev-scripts": "^4.0.7"
   },
   "peerDependencies": {
     "blockly": "^12.0.0"

--- a/plugins/theme-tritanopia/CHANGELOG.md
+++ b/plugins/theme-tritanopia/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.11](https://github.com/google/blockly-samples/compare/@blockly/theme-tritanopia@6.0.10...@blockly/theme-tritanopia@6.0.11) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/theme-tritanopia
-
-
-
-
-
 ## [6.0.10](https://github.com/google/blockly-samples/compare/@blockly/theme-tritanopia@6.0.9...@blockly/theme-tritanopia@6.0.10) (2024-12-03)
 
 **Note:** Version bump only for package @blockly/theme-tritanopia

--- a/plugins/theme-tritanopia/package-lock.json
+++ b/plugins/theme-tritanopia/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@blockly/theme-tritanopia",
-  "version": "6.0.11",
+  "version": "6.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/theme-tritanopia",
-      "version": "6.0.11",
+      "version": "6.0.10",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blockly/dev-scripts": "^4.0.8"
+        "@blockly/dev-scripts": "^4.0.7"
       },
       "engines": {
         "node": ">=8.17.0"

--- a/plugins/theme-tritanopia/package.json
+++ b/plugins/theme-tritanopia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/theme-tritanopia",
-  "version": "6.0.11",
+  "version": "6.0.10",
   "description": "A Blockly theme for people that have tritanopia.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,7 +40,7 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8"
+    "@blockly/dev-scripts": "^4.0.7"
   },
   "peerDependencies": {
     "blockly": "^12.0.0"

--- a/plugins/toolbox-search/CHANGELOG.md
+++ b/plugins/toolbox-search/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.0.15](https://github.com/google/blockly-samples/compare/@blockly/toolbox-search@2.0.14...@blockly/toolbox-search@2.0.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/toolbox-search
-
-
-
-
-
 ## [2.0.14](https://github.com/google/blockly-samples/compare/@blockly/toolbox-search@2.0.13...@blockly/toolbox-search@2.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/toolbox-search

--- a/plugins/toolbox-search/package-lock.json
+++ b/plugins/toolbox-search/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/toolbox-search",
-  "version": "2.0.15",
+  "version": "2.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/toolbox-search",
-      "version": "2.0.15",
+      "version": "2.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.3.7",

--- a/plugins/toolbox-search/package.json
+++ b/plugins/toolbox-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/toolbox-search",
-  "version": "2.0.15",
+  "version": "2.0.14",
   "description": "A Blockly plugin that adds a toolbox category that allows searching for blocks.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.3.7",
     "typescript": "^5.4.5"
   },

--- a/plugins/typed-variable-modal/CHANGELOG.md
+++ b/plugins/typed-variable-modal/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [8.0.15](https://github.com/google/blockly-samples/compare/@blockly/plugin-typed-variable-modal@8.0.14...@blockly/plugin-typed-variable-modal@8.0.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/plugin-typed-variable-modal
-
-
-
-
-
 ## [8.0.14](https://github.com/google/blockly-samples/compare/@blockly/plugin-typed-variable-modal@8.0.13...@blockly/plugin-typed-variable-modal@8.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/plugin-typed-variable-modal

--- a/plugins/typed-variable-modal/package-lock.json
+++ b/plugins/typed-variable-modal/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/plugin-typed-variable-modal",
-  "version": "8.0.15",
+  "version": "8.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/plugin-typed-variable-modal",
-      "version": "8.0.15",
+      "version": "8.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "jsdom": "^19.0.0",

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-typed-variable-modal",
-  "version": "8.0.15",
+  "version": "8.0.14",
   "description": "A Blockly plugin to create a modal for creating typed variables.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",
     "mocha": "^10.1.0",
@@ -50,7 +50,7 @@
     "blockly": "^12.0.0"
   },
   "dependencies": {
-    "@blockly/plugin-modal": "^7.0.15"
+    "@blockly/plugin-modal": "^7.0.14"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/workspace-backpack/CHANGELOG.md
+++ b/plugins/workspace-backpack/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.15](https://github.com/google/blockly-samples/compare/@blockly/workspace-backpack@6.0.14...@blockly/workspace-backpack@6.0.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/workspace-backpack
-
-
-
-
-
 ## [6.0.14](https://github.com/google/blockly-samples/compare/@blockly/workspace-backpack@6.0.13...@blockly/workspace-backpack@6.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/workspace-backpack

--- a/plugins/workspace-backpack/package-lock.json
+++ b/plugins/workspace-backpack/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/workspace-backpack",
-  "version": "6.0.15",
+  "version": "6.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/workspace-backpack",
-      "version": "6.0.15",
+      "version": "6.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.4.5"

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/workspace-backpack",
-  "version": "6.0.15",
+  "version": "6.0.14",
   "description": "A Blockly plugin that adds Backpack support.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -40,8 +40,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "typescript": "^5.4.5"
   },
   "peerDependencies": {

--- a/plugins/workspace-minimap/CHANGELOG.md
+++ b/plugins/workspace-minimap/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.2.15](https://github.com/google/blockly-samples/compare/@blockly/workspace-minimap@0.2.14...@blockly/workspace-minimap@0.2.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/workspace-minimap
-
-
-
-
-
 ## [0.2.14](https://github.com/google/blockly-samples/compare/@blockly/workspace-minimap@0.2.13...@blockly/workspace-minimap@0.2.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/workspace-minimap

--- a/plugins/workspace-minimap/package-lock.json
+++ b/plugins/workspace-minimap/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/workspace-minimap",
-  "version": "0.2.15",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/workspace-minimap",
-      "version": "0.2.15",
+      "version": "0.2.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.2.0",

--- a/plugins/workspace-minimap/package.json
+++ b/plugins/workspace-minimap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/workspace-minimap",
-  "version": "0.2.15",
+  "version": "0.2.14",
   "description": "A Blockly plugin.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "chai": "^4.2.0",
     "typescript": "^5.4.5"
   },

--- a/plugins/workspace-search/CHANGELOG.md
+++ b/plugins/workspace-search/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [9.1.9](https://github.com/google/blockly-samples/compare/@blockly/plugin-workspace-search@9.1.8...@blockly/plugin-workspace-search@9.1.9) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/plugin-workspace-search
-
-
-
-
-
 ## [9.1.8](https://github.com/google/blockly-samples/compare/@blockly/plugin-workspace-search@9.1.7...@blockly/plugin-workspace-search@9.1.8) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/plugin-workspace-search

--- a/plugins/workspace-search/package-lock.json
+++ b/plugins/workspace-search/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/plugin-workspace-search",
-  "version": "9.1.9",
+  "version": "9.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/plugin-workspace-search",
-      "version": "9.1.9",
+      "version": "9.1.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "jsdom": "^19.0.0",

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/plugin-workspace-search",
-  "version": "9.1.9",
+  "version": "9.1.8",
   "description": "A Blockly plugin that adds workspace search support.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -39,8 +39,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",
     "sinon": "^9.0.1",

--- a/plugins/zoom-to-fit/CHANGELOG.md
+++ b/plugins/zoom-to-fit/CHANGELOG.md
@@ -3,14 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [6.0.15](https://github.com/google/blockly-samples/compare/@blockly/zoom-to-fit@6.0.14...@blockly/zoom-to-fit@6.0.15) (2025-05-15)
-
-**Note:** Version bump only for package @blockly/zoom-to-fit
-
-
-
-
-
 ## [6.0.14](https://github.com/google/blockly-samples/compare/@blockly/zoom-to-fit@6.0.13...@blockly/zoom-to-fit@6.0.14) (2025-02-13)
 
 **Note:** Version bump only for package @blockly/zoom-to-fit

--- a/plugins/zoom-to-fit/package-lock.json
+++ b/plugins/zoom-to-fit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockly/zoom-to-fit",
-  "version": "6.0.15",
+  "version": "6.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockly/zoom-to-fit",
-      "version": "6.0.15",
+      "version": "6.0.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.4.5"

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockly/zoom-to-fit",
-  "version": "6.0.15",
+  "version": "6.0.14",
   "description": "A Blockly plugin that adds a zoom-to-fit control to the workspace.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",
@@ -38,8 +38,8 @@
     "src"
   ],
   "devDependencies": {
-    "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/dev-tools": "^8.1.1",
+    "@blockly/dev-scripts": "^4.0.7",
+    "@blockly/dev-tools": "^8.1.0",
     "typescript": "^5.4.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
Reverts https://github.com/google/blockly-samples/commit/332ddbcc50c81f77072e1043ad8557e3c1b4b556 due to incorrect version numbers.