### PR TITLE
fix(field-grid-dropdown): add overflow:auto to enable scroll in grid …

### DIFF
--- a/plugins/field-grid-dropdown/src/index.ts
+++ b/plugins/field-grid-dropdown/src/index.ts
@@ -216,6 +216,7 @@ Blockly.fieldRegistry.register('field_grid_dropdown', FieldGridDropdown);
 Blockly.Css.register(`
    .blocklyFieldGridContainer {
      padding: 7px;
+     overflow: auto;
    }
    
   .blocklyFieldGrid {


### PR DESCRIPTION
<!--
- Thanks for submitting code to Blockly! Please fill out the following as part of your pull request so we can review your code more easily.
-->

## The basics

- [x] I validated my changes  
  [Guide followed](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details

### Resolves

Fixes #2542

### Proposed Changes

Added `overflow: auto` to the `.blocklyFieldGridContainer` class in `plugins/field-grid-dropdown/src/index.ts`.  
This change restores scroll behavior for dropdown grids that exceed their container height.

### Reason for Changes

In previous versions (v11), the dropdown grid was scrollable. That behavior was removed in newer versions, causing usability issues when the list exceeds the visible space.  
This change brings back that scroll behavior without affecting the dropdown’s functionality.

### Test Coverage

Tested manually in:
- Chrome (latest)
- Firefox (latest)

Verified that the dropdown shows a scrollbar when the content exceeds the height and works as expected.

### Documentation

No documentation changes are required.
