### PR TITLE
fix(workspace-search): set button type to "button" to prevent unintended form submissions

### DIFF
--- a/plugins/workspace-search/src/workspace_search.ts
+++ b/plugins/workspace-search/src/workspace_search.ts
@@ -273,6 +273,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
     // Create the button
     const btn = document.createElement('button');
     Blockly.utils.dom.addClass(btn, className);
+    btn.type = "button";
     btn.setAttribute('aria-label', text);
     return btn;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes [#2510](https://github.com/google/blockly-samples/issues/2510)

### Proposed Changes

Updated the `createBtn` helper method in the `workspace-search` plugin to explicitly set the button’s `type` attribute to `"button"`.

```ts
private createBtn(className: string, text: string): HTMLButtonElement {
  const btn = document.createElement('button');
  Blockly.utils.dom.addClass(btn, className);
  btn.type = "button";
  btn.setAttribute('aria-label', text);
  return btn;
}
