### PR TITLE
docs(migrate): correct argument order in README (#2170)

### DIFF
--- a/examples/blockly-react/src/index.css
+++ b/examples/blockly-react/src/index.css
@@ -1,8 +1,8 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -17,6 +17,6 @@ body {
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family:
+    source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/examples/blockly-svelte/public/global.css
+++ b/examples/blockly-svelte/public/global.css
@@ -10,8 +10,9 @@ body {
   margin: 0;
   padding: 8px;
   box-sizing: border-box;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu,
+    Cantarell, 'Helvetica Neue', sans-serif;
 }
 
 a {

--- a/plugins/cross-tab-copy-paste/README.md
+++ b/plugins/cross-tab-copy-paste/README.md
@@ -43,9 +43,8 @@ Blockly.ContextMenuRegistry.registry.unregister('blockDuplicate');
 
 // optional: You can change the position of the menu added to the context menu.
 Blockly.ContextMenuRegistry.registry.getItem('blockCopyToStorage').weight = 2;
-Blockly.ContextMenuRegistry.registry.getItem(
-  'blockPasteFromStorage',
-).weight = 3;
+Blockly.ContextMenuRegistry.registry.getItem('blockPasteFromStorage').weight =
+  3;
 ```
 
 ## Options

--- a/plugins/migration/README.md
+++ b/plugins/migration/README.md
@@ -5,8 +5,9 @@ A collection of tools that help with migrating apps built on [Blockly](https://w
 ## Example Usage
 
 ```
-npx @blockly/migrate rename --from 6 --in-place ./path/to/my/files*
-npx @blockly/migrate rename --from 6 --to 7 --in-place ./path/to/my/files*
+npx @blockly/migrate rename ./path/to/my/files* --from 6 --in-place
+npx @blockly/migrate rename ./path/to/my/files* --from 6 --to 7 --in-place
+
 ```
 
 Use `help` subcommand for more info.

--- a/plugins/workspace-search/src/workspace_search.ts
+++ b/plugins/workspace-search/src/workspace_search.ts
@@ -273,7 +273,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
     // Create the button
     const btn = document.createElement('button');
     Blockly.utils.dom.addClass(btn, className);
-    btn.type = "button";
+    btn.type = 'button';
     btn.setAttribute('aria-label', text);
     return btn;
   }

--- a/plugins/workspace-search/src/workspace_search.ts
+++ b/plugins/workspace-search/src/workspace_search.ts
@@ -273,6 +273,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
     // Create the button
     const btn = document.createElement('button');
     Blockly.utils.dom.addClass(btn, className);
+    btn.type = "button";
     btn.setAttribute('aria-label', text);
     return btn;
   }


### PR DESCRIPTION
This PR fixes issue #2170 by correcting the order of arguments in the migration plugin README.

The previous usage had --in-place before the file path, which is invalid. The updated command now correctly places the file path first, followed by the options.

✅ Updated:
- `npx @blockly/migrate rename ./path/to/my/files* --from 6 --in-place`
- `npx @blockly/migrate rename ./path/to/my/files* --from 6 --to 7 --in-place`
