### PR TITLE
fix: Implement alternative highlighting scheme for search

### DIFF
--- a/plugins/workspace-search/src/css.ts
+++ b/plugins/workspace-search/src/css.ts
@@ -41,11 +41,14 @@ const arrowUpSvgDataUri =
 /**
  * CSS for workspace search.
  */
-const cssContent = `path.blocklyPath.blockly-ws-search-highlight {
-    fill: #000;
+const cssContent = `.blockly-ws-search-active g.blocklyDraggable>path {
+    filter: saturate(0);
   }
-  path.blocklyPath.blockly-ws-search-highlight.blockly-ws-search-current {
-    fill: grey;
+  .blockly-ws-search-active g.blockly-ws-search-highlight>path {
+    filter: saturate(50%);
+  }
+  .blockly-ws-search-active g.blockly-ws-search-current>path {
+    filter: saturate(150%);
   }
   .blockly-ws-search-close-btn {
     background: url(${closeSvgDataUri}) no-repeat top left;

--- a/plugins/workspace-search/src/workspace_search.ts
+++ b/plugins/workspace-search/src/workspace_search.ts
@@ -487,6 +487,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
       this.searchText,
       this.caseSensitive,
     );
+    this.workspace.getSvgGroup().classList.add('blockly-ws-search-active');
     this.highlightSearchGroup(this.blocks);
     let currentIdx = 0;
     if (preserveCurrent) {
@@ -581,6 +582,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
     }
     this.currentBlockIndex = -1;
     this.blocks = [];
+    this.workspace.getSvgGroup().classList.remove('blockly-ws-search-active');
   }
 
   /**
@@ -590,7 +592,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
    * @param currentBlock The block to highlight.
    */
   protected highlightCurrentSelection(currentBlock: Blockly.BlockSvg) {
-    const path = currentBlock.pathObject.svgPath;
+    const path = currentBlock.getSvgRoot();
     Blockly.utils.dom.addClass(path, 'blockly-ws-search-current');
   }
 
@@ -600,7 +602,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
    * @param currentBlock The block to unhighlight.
    */
   protected unhighlightCurrentSelection(currentBlock: Blockly.BlockSvg) {
-    const path = currentBlock.pathObject.svgPath;
+    const path = currentBlock.getSvgRoot();
     Blockly.utils.dom.removeClass(path, 'blockly-ws-search-current');
   }
 
@@ -611,7 +613,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
    */
   protected highlightSearchGroup(blocks: Blockly.BlockSvg[]) {
     blocks.forEach((block) => {
-      const blockPath = block.pathObject.svgPath;
+      const blockPath = block.getSvgRoot();
       Blockly.utils.dom.addClass(blockPath, 'blockly-ws-search-highlight');
     });
   }
@@ -623,7 +625,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
    */
   protected unhighlightSearchGroup(blocks: Blockly.BlockSvg[]) {
     blocks.forEach((block) => {
-      const blockPath = block.pathObject.svgPath;
+      const blockPath = block.getSvgRoot();
       Blockly.utils.dom.removeClass(blockPath, 'blockly-ws-search-highlight');
     });
   }

--- a/plugins/workspace-search/test/workspace_search_test.mocha.js
+++ b/plugins/workspace-search/test/workspace_search_test.mocha.js
@@ -22,7 +22,7 @@ suite('WorkspaceSearch', function () {
    * @returns {boolean} True if the block is currently highlighted.
    */
   function isBlockHighlighted(block) {
-    const path = block.pathObject.svgPath;
+    const path = block.getSvgRoot();
     const classes = path.getAttribute('class');
     return (
       (' ' + classes + ' ').indexOf(' blockly-ws-search-highlight ') !== -1
@@ -34,7 +34,7 @@ suite('WorkspaceSearch', function () {
    * @returns {boolean} True if the block is currently styled.
    */
   function isBlockCurrentStyled(block) {
-    const path = block.pathObject.svgPath;
+    const path = block.getSvgRoot();
     const classes = path.getAttribute('class');
     return (' ' + classes + ' ').indexOf(' blockly-ws-search-current ') !== -1;
   }


### PR DESCRIPTION
Change-Id: Ifcee0a5a30374b0d1e72a24c6c6d538dba16e58f

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

As discussed at the Blockly Summit, the highlighting behavior of the workspace-search plugin could be improved. This is one attempt at that. It might be worth further tweaking of the CSS attributes.

### Proposed Changes

This PR updates the workspace search plugin to desaturate non-matching blocks while supersaturating the selected block to draw more focus to the selection rather than turning the actively highlighted block black. The currently focused block gets saturation +50%, other matching blocks get saturation -50%, and non-matching blocks are completely desaturated.

<img width="343" alt="image" src="https://github.com/user-attachments/assets/77a4a026-0d9c-4a3f-b19d-eafbcc784f45" />

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Because changing the coloring logic needed to move the CSS classes around, I updated the test logic for detecting whether a block is actively in the search set.

### Documentation

For developers looking to change the behavior, we may want to document how they override the CSS rules defined in plugins/workspace-search/src/css.ts. Anyone overriding the existing CSS rules will need to update their definitions.

### Additional Information

<!-- Anything else we should know? -->
