### PR TITLE
refactor: Make `FieldColour` inherit from `FieldGridDropdown`.

### DIFF
--- a/plugins/field-colour-hsv-sliders/package-lock.json
+++ b/plugins/field-colour-hsv-sliders/package-lock.json
@@ -9,6 +9,8 @@
       "version": "6.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
+        "jsdom": "^26.1.0",
+        "jsdom-global": "^3.0.2",
         "typescript": "^5.4.5"
       },
       "engines": {
@@ -16,6 +18,446 @@
       },
       "peerDependencies": {
         "blockly": "^12.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.4.0.tgz",
+      "integrity": "sha512-W0Y2HOXlPkb2yaKrCVRjinYKciu/qSLEmK0K9mcfDei3zwlnHFEHAs/Du3cIRwPqY+J4JsiBzUjoHyc8RsJ03A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom-global": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+      "integrity": "sha512-t1KMcBkz/pT5JrvcJbpUR2u/w1kO9jXctaaGJ0vZDzwFnIvGWw9IDSRciT83kIs8Bnw4qpOl8bQK08V01YgMPg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "jsdom": ">=10.0.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/typescript": {
@@ -30,6 +472,105 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/plugins/field-colour-hsv-sliders/package.json
+++ b/plugins/field-colour-hsv-sliders/package.json
@@ -46,6 +46,8 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^4.0.9",
     "@blockly/dev-tools": "^9.0.1",
+    "jsdom": "^26.1.0",
+    "jsdom-global": "^3.0.2",
     "typescript": "^5.4.5"
   },
   "peerDependencies": {

--- a/plugins/field-colour-hsv-sliders/src/field_colour_hsv_sliders.ts
+++ b/plugins/field-colour-hsv-sliders/src/field_colour_hsv_sliders.ts
@@ -618,6 +618,8 @@ Blockly.fieldRegistry.register(
 Blockly.Css.register(`
 .fieldColourSliderContainer {
   padding: 4px;
+  font-family: Roboto, Arial, sans-serif;
+  color: #5c5c5c;
 }
 .fieldColourSliderContainer hr {
   border: none;

--- a/plugins/field-colour-hsv-sliders/test/field_colour_hsv_sliders_test.mocha.js
+++ b/plugins/field-colour-hsv-sliders/test/field_colour_hsv_sliders_test.mocha.js
@@ -20,6 +20,17 @@ const {
 } = testHelpers;
 
 suite('FieldColourHsvSliders', function () {
+  setup(function () {
+    this.jsdomCleanup = require('jsdom-global')(
+      '<!DOCTYPE html><div id="blocklyDiv"></div>',
+    );
+    this.field = new FieldColourHsvSliders();
+  });
+
+  teardown(function () {
+    this.jsdomCleanup();
+  });
+
   /**
    * Configuration for field tests with invalid values.
    * @type {Array<FieldCreationTestCase>}
@@ -112,9 +123,6 @@ suite('FieldColourHsvSliders', function () {
 
   suite('setValue', function () {
     suite('Empty -> New Value', function () {
-      setup(function () {
-        this.field = new FieldColourHsvSliders();
-      });
       runSetValueTests(
         validValueTestCases,
         invalidValueTestCases,
@@ -123,9 +131,6 @@ suite('FieldColourHsvSliders', function () {
       );
     });
     suite('Value -> New Value', function () {
-      setup(function () {
-        this.field = new FieldColourHsvSliders(1);
-      });
       runSetValueTests(
         validValueTestCases,
         invalidValueTestCases,

--- a/plugins/field-colour/package-lock.json
+++ b/plugins/field-colour/package-lock.json
@@ -11,6 +11,8 @@
       "devDependencies": {
         "@typescript-eslint/parser": "^5.59.5",
         "chai": "^4.2.0",
+        "jsdom": "^26.1.0",
+        "jsdom-global": "^3.0.2",
         "sinon": "^9.0.1",
         "typescript": "^5.4.5"
       },
@@ -19,6 +21,135 @@
       },
       "peerDependencies": {
         "blockly": "^12.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -201,6 +332,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -261,6 +402,34 @@
         "node": "*"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.4.0.tgz",
+      "integrity": "sha512-W0Y2HOXlPkb2yaKrCVRjinYKciu/qSLEmK0K9mcfDei3zwlnHFEHAs/Du3cIRwPqY+J4JsiBzUjoHyc8RsJ03A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -277,6 +446,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
@@ -309,6 +485,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -410,6 +599,60 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -449,11 +692,68 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom-global": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+      "integrity": "sha512-t1KMcBkz/pT5JrvcJbpUR2u/w1kO9jXctaaGJ0vZDzwFnIvGWw9IDSRciT83kIs8Bnw4qpOl8bQK08V01YgMPg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "jsdom": ">=10.0.0"
+      }
     },
     "node_modules/just-extend": {
       "version": "4.2.1",
@@ -476,6 +776,13 @@
       "dependencies": {
         "get-func-name": "^2.0.1"
       }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -518,6 +825,26 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
@@ -557,6 +884,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -587,6 +924,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -608,6 +952,26 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -662,6 +1026,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -672,6 +1063,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -716,6 +1133,105 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/plugins/field-colour/package.json
+++ b/plugins/field-colour/package.json
@@ -44,6 +44,8 @@
     "@blockly/dev-tools": "^9.0.1",
     "@typescript-eslint/parser": "^5.59.5",
     "chai": "^4.2.0",
+    "jsdom": "^26.1.0",
+    "jsdom-global": "^3.0.2",
     "sinon": "^9.0.1",
     "typescript": "^5.4.5"
   },

--- a/plugins/field-colour/package.json
+++ b/plugins/field-colour/package.json
@@ -56,5 +56,8 @@
   },
   "engines": {
     "node": ">=8.0.0"
+  },
+  "dependencies": {
+    "@blockly/field-grid-dropdown": "^6.0.1"
   }
 }

--- a/plugins/field-colour/src/field_colour.ts
+++ b/plugins/field-colour/src/field_colour.ts
@@ -190,6 +190,7 @@ export class FieldColour extends FieldGridDropdown {
    *
    * @param e The event that triggered display of the colour picker dropdown.
    */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   protected override showEditor_(e?: MouseEvent) {
     super.showEditor_(e);
     Blockly.DropDownDiv.getContentDiv().classList.add('blocklyFieldColour');

--- a/plugins/field-colour/src/field_colour.ts
+++ b/plugins/field-colour/src/field_colour.ts
@@ -9,30 +9,103 @@
  */
 
 import * as Blockly from 'blockly/core';
+import {
+  FieldGridDropdown,
+  FieldGridDropdownConfig,
+  FieldGridDropdownFromJsonConfig,
+} from '@blockly/field-grid-dropdown';
+
+/**
+ * An array of colour strings for the palette.
+ * Copied from goog.ui.ColorPicker.SIMPLE_GRID_COLORS
+ */
+const DEFAULT_COLOURS = [
+  // grays
+  '#ffffff',
+  '#cccccc',
+  '#c0c0c0',
+  '#999999',
+  '#666666',
+  '#333333',
+  '#000000',
+  // reds
+  '#ffcccc',
+  '#ff6666',
+  '#ff0000',
+  '#cc0000',
+  '#990000',
+  '#660000',
+  '#330000',
+  // oranges
+  '#ffcc99',
+  '#ff9966',
+  '#ff9900',
+  '#ff6600',
+  '#cc6600',
+  '#993300',
+  '#663300',
+  // yellows
+  '#ffff99',
+  '#ffff66',
+  '#ffcc66',
+  '#ffcc33',
+  '#cc9933',
+  '#996633',
+  '#663333',
+  // olives
+  '#ffffcc',
+  '#ffff33',
+  '#ffff00',
+  '#ffcc00',
+  '#999900',
+  '#666600',
+  '#333300',
+  // greens
+  '#99ff99',
+  '#66ff99',
+  '#33ff33',
+  '#33cc00',
+  '#009900',
+  '#006600',
+  '#003300',
+  // turquoises
+  '#99ffff',
+  '#33ffff',
+  '#66cccc',
+  '#00cccc',
+  '#339999',
+  '#336666',
+  '#003333',
+  // blues
+  '#ccffff',
+  '#66ffff',
+  '#33ccff',
+  '#3366ff',
+  '#3333ff',
+  '#000099',
+  '#000066',
+  // purples
+  '#ccccff',
+  '#9999ff',
+  '#6666cc',
+  '#6633ff',
+  '#6600cc',
+  '#333399',
+  '#330099',
+  // violets
+  '#ffccff',
+  '#ff99ff',
+  '#cc66cc',
+  '#cc33cc',
+  '#993399',
+  '#663366',
+  '#330033',
+];
 
 /**
  * Class for a colour input field.
  */
-export class FieldColour extends Blockly.Field<string> {
-  /** The field's colour picker element. */
-  private picker: HTMLElement | null = null;
-
-  /** Index of the currently highlighted element. */
-  private highlightedIndex: number | null = null;
-
-  /**
-   * Array holding info needed to unbind events.
-   * Used for disposing.
-   * Ex: [[node, name, func], [node, name, func]].
-   */
-  private boundEvents: Blockly.browserEvents.Data[] = [];
-
-  /**
-   * Serializable fields are saved by the serializer, non-serializable fields
-   * are not.  Editable fields should also be serializable.
-   */
-  override SERIALIZABLE = true;
-
+export class FieldColour extends FieldGridDropdown {
   /**
    * Used to tell if the field needs to be rendered the next time the block is
    * rendered.  Colour fields are statically sized, and only need to be
@@ -40,104 +113,6 @@ export class FieldColour extends Blockly.Field<string> {
    */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   protected override isDirty_ = false;
-
-  /**
-   * An array of colour strings for the palette.
-   * Copied from goog.ui.ColorPicker.SIMPLE_GRID_COLORS
-   */
-  private colours: string[] = [
-    // grays
-    '#ffffff',
-    '#cccccc',
-    '#c0c0c0',
-    '#999999',
-    '#666666',
-    '#333333',
-    '#000000',
-    // reds
-    '#ffcccc',
-    '#ff6666',
-    '#ff0000',
-    '#cc0000',
-    '#990000',
-    '#660000',
-    '#330000',
-    // oranges
-    '#ffcc99',
-    '#ff9966',
-    '#ff9900',
-    '#ff6600',
-    '#cc6600',
-    '#993300',
-    '#663300',
-    // yellows
-    '#ffff99',
-    '#ffff66',
-    '#ffcc66',
-    '#ffcc33',
-    '#cc9933',
-    '#996633',
-    '#663333',
-    // olives
-    '#ffffcc',
-    '#ffff33',
-    '#ffff00',
-    '#ffcc00',
-    '#999900',
-    '#666600',
-    '#333300',
-    // greens
-    '#99ff99',
-    '#66ff99',
-    '#33ff33',
-    '#33cc00',
-    '#009900',
-    '#006600',
-    '#003300',
-    // turquoises
-    '#99ffff',
-    '#33ffff',
-    '#66cccc',
-    '#00cccc',
-    '#339999',
-    '#336666',
-    '#003333',
-    // blues
-    '#ccffff',
-    '#66ffff',
-    '#33ccff',
-    '#3366ff',
-    '#3333ff',
-    '#000099',
-    '#000066',
-    // purples
-    '#ccccff',
-    '#9999ff',
-    '#6666cc',
-    '#6633ff',
-    '#6600cc',
-    '#333399',
-    '#330099',
-    // violets
-    '#ffccff',
-    '#ff99ff',
-    '#cc66cc',
-    '#cc33cc',
-    '#993399',
-    '#663366',
-    '#330033',
-  ];
-
-  /**
-   * An array of tooltip strings for the palette.  If not the same length as
-   * COLOURS, the colour's hex code will be used for any missing titles.
-   */
-  private titles: string[] = [];
-
-  /**
-   * Number of columns in the palette.
-   */
-  private columns = 7;
 
   /**
    * @param value The initial value of the field.  Should be in '#rrggbb'
@@ -158,16 +133,22 @@ export class FieldColour extends Blockly.Field<string> {
     validator?: FieldColourValidator,
     config?: FieldColourConfig,
   ) {
-    super(Blockly.Field.SKIP_SETUP);
+    const swatches = makeSwatches(config?.colourOptions ?? DEFAULT_COLOURS);
+    super(swatches, validator, {...config, columns: config?.columns ?? 7});
 
     if (value === Blockly.Field.SKIP_SETUP) return;
-    if (config) {
-      this.configure_(config);
-    }
     this.setValue(value);
-    if (validator) {
-      this.setValidator(validator);
-    }
+  }
+
+  /**
+   * FieldDropdown has complex behaviors for normalizing options that aren't
+   * applicable here. Instead, just return the options as-is.
+   *
+   * @param options The options (colour swatches) to normalize.
+   * @returns The colour swatches as-is.
+   */
+  protected override trimOptions(options: Blockly.MenuOption[]) {
+    return {options};
   }
 
   /**
@@ -178,9 +159,9 @@ export class FieldColour extends Blockly.Field<string> {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   protected override configure_(config: FieldColourConfig) {
     super.configure_(config);
-    if (config.colourOptions) this.colours = config.colourOptions;
-    if (config.colourTitles) this.titles = config.colourTitles;
-    if (config.columns) this.columns = config.columns;
+    if (config.colourOptions) {
+      this.setColours(config.colourOptions, config.colourTitles);
+    }
   }
 
   /**
@@ -202,6 +183,17 @@ export class FieldColour extends Blockly.Field<string> {
     if (this.isFullBlockField()) {
       this.clickTarget_ = (this.sourceBlock_ as Blockly.BlockSvg).getSvgRoot();
     }
+  }
+
+  /**
+   * Shows the colour picker dropdown attached to the field.
+   *
+   * @param e The event that triggered display of the colour picker dropdown.
+   */
+  protected override showEditor_(e?: MouseEvent) {
+    super.showEditor_(e);
+    Blockly.DropDownDiv.getContentDiv().classList.add('blocklyFieldColour');
+    Blockly.DropDownDiv.repositionForWindowResize();
   }
 
   /**
@@ -292,7 +284,7 @@ export class FieldColour extends Blockly.Field<string> {
    */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   protected override render_() {
-    super.render_();
+    this.updateSize_();
 
     const block = this.getSourceBlock() as Blockly.BlockSvg | null;
     if (!block) throw new Blockly.UnattachedFieldError();
@@ -374,345 +366,9 @@ export class FieldColour extends Blockly.Field<string> {
    * @returns Returns itself (for method chaining).
    */
   setColours(colours: string[], titles?: string[]): FieldColour {
-    this.colours = colours;
-    if (titles) {
-      this.titles = titles;
-    }
+    const swatches = makeSwatches(colours, titles);
+    this.setOptions(swatches);
     return this;
-  }
-
-  /**
-   * Set a custom grid size for this field.
-   *
-   * @param columns Number of columns for this block, or 0 to use default
-   *     (FieldColour.COLUMNS).
-   * @returns Returns itself (for method chaining).
-   */
-  setColumns(columns: number): FieldColour {
-    this.columns = columns;
-    return this;
-  }
-
-  /** Create and show the colour field's editor. */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  protected override showEditor_() {
-    this.dropdownCreate();
-    // This can't happen, but TypeScript thinks it can and lint forbids `!.`.
-    if (!this.picker) throw Error('Picker not found');
-    Blockly.DropDownDiv.getContentDiv().appendChild(this.picker);
-
-    Blockly.DropDownDiv.showPositionedByField(
-      this,
-      this.dropdownDispose.bind(this),
-    );
-
-    // Focus so we can start receiving keyboard events.
-    this.picker.focus({preventScroll: true});
-  }
-
-  /**
-   * Handle a click on a colour cell.
-   *
-   * @param e Mouse event.
-   */
-  private onClick(e: PointerEvent) {
-    const cell = e.target as Element;
-    const colour = cell && cell.getAttribute('data-colour');
-    if (colour !== null) {
-      this.setValue(colour);
-      Blockly.DropDownDiv.hideIfOwner(this);
-    }
-  }
-
-  /**
-   * Handle a key down event.  Navigate around the grid with the
-   * arrow keys.  Enter selects the highlighted colour.
-   *
-   * @param e Keyboard event.
-   */
-  private onKeyDown(e: KeyboardEvent) {
-    let handled = true;
-    let highlighted: HTMLElement | null;
-    switch (e.key) {
-      case 'ArrowUp':
-        this.moveHighlightBy(0, -1);
-        break;
-      case 'ArrowDown':
-        this.moveHighlightBy(0, 1);
-        break;
-      case 'ArrowLeft':
-        this.moveHighlightBy(-1, 0);
-        break;
-      case 'ArrowRight':
-        this.moveHighlightBy(1, 0);
-        break;
-      case 'Enter':
-        // Select the highlighted colour.
-        highlighted = this.getHighlighted();
-        if (highlighted) {
-          const colour = highlighted.getAttribute('data-colour');
-          if (colour !== null) {
-            this.setValue(colour);
-          }
-        }
-        Blockly.DropDownDiv.hideWithoutAnimation();
-        break;
-      default:
-        handled = false;
-    }
-    if (handled) {
-      e.stopPropagation();
-    }
-  }
-
-  /**
-   * Move the currently highlighted position by dx and dy.
-   *
-   * @param dx Change of x.
-   * @param dy Change of y.
-   */
-  private moveHighlightBy(dx: number, dy: number) {
-    if (this.highlightedIndex === null) {
-      return;
-    }
-
-    const colours = this.colours;
-    const columns = this.columns;
-
-    // Get the current x and y coordinates.
-    let x = this.highlightedIndex % columns;
-    let y = Math.floor(this.highlightedIndex / columns);
-
-    // Add the offset.
-    x += dx;
-    y += dy;
-
-    if (dx < 0) {
-      // Move left one grid cell, even in RTL.
-      // Loop back to the end of the previous row if we have room.
-      if (x < 0 && y > 0) {
-        x = columns - 1;
-        y--;
-      } else if (x < 0) {
-        x = 0;
-      }
-    } else if (dx > 0) {
-      // Move right one grid cell, even in RTL.
-      // Loop to the start of the next row, if there's room.
-      if (x > columns - 1 && y < Math.floor(colours.length / columns) - 1) {
-        x = 0;
-        y++;
-      } else if (x > columns - 1) {
-        x--;
-      }
-    } else if (dy < 0) {
-      // Move up one grid cell, stop at the top.
-      if (y < 0) {
-        y = 0;
-      }
-    } else if (dy > 0) {
-      // Move down one grid cell, stop at the bottom.
-      if (y > Math.floor(colours.length / columns) - 1) {
-        y = Math.floor(colours.length / columns) - 1;
-      }
-    }
-
-    // Move the highlight to the new coordinates.
-    const cell = (this.picker as HTMLElement).childNodes[y].childNodes[
-      x
-    ] as Element;
-    const index = y * columns + x;
-    this.setHighlightedCell(cell, index);
-  }
-
-  /**
-   * Handle a mouse move event.  Highlight the hovered colour.
-   *
-   * @param e Mouse event.
-   */
-  private onMouseMove(e: PointerEvent) {
-    const cell = e.target as Element;
-    const index = cell && Number(cell.getAttribute('data-index'));
-    if (index !== null && index !== this.highlightedIndex) {
-      this.setHighlightedCell(cell, index);
-    }
-  }
-
-  /** Handle a mouse enter event.  Focus the picker. */
-  private onMouseEnter() {
-    this.picker?.focus({preventScroll: true});
-  }
-
-  /**
-   * Handle a mouse leave event by unnhighlighting the currently highlighted
-   * colour.
-   */
-  private onMouseLeave() {
-    const highlighted = this.getHighlighted();
-    if (highlighted) {
-      Blockly.utils.dom.removeClass(highlighted, 'blocklyColourHighlighted');
-    }
-  }
-
-  /**
-   * Returns the currently highlighted item (if any).
-   *
-   * @returns Highlighted item (null if none).
-   */
-  private getHighlighted(): HTMLElement | null {
-    if (this.highlightedIndex === null) {
-      return null;
-    }
-
-    const x = this.highlightedIndex % this.columns;
-    const y = Math.floor(this.highlightedIndex / this.columns);
-    const row = this.picker?.childNodes[y];
-    if (!row) {
-      return null;
-    }
-    return row.childNodes[x] as HTMLElement;
-  }
-
-  /**
-   * Update the currently highlighted cell.
-   *
-   * @param cell The new cell to highlight.
-   * @param index The index of the new cell.
-   */
-  private setHighlightedCell(cell: Element, index: number) {
-    // Unhighlight the current item.
-    const highlighted = this.getHighlighted();
-    if (highlighted) {
-      Blockly.utils.dom.removeClass(highlighted, 'blocklyColourHighlighted');
-    }
-    // Highlight new item.
-    Blockly.utils.dom.addClass(cell, 'blocklyColourHighlighted');
-    // Set new highlighted index.
-    this.highlightedIndex = index;
-
-    // Update accessibility roles.
-    const cellId = cell.getAttribute('id');
-    if (cellId && this.picker) {
-      Blockly.utils.aria.setState(
-        this.picker,
-        Blockly.utils.aria.State.ACTIVEDESCENDANT,
-        cellId,
-      );
-    }
-  }
-
-  /** Create a colour picker dropdown editor. */
-  private dropdownCreate() {
-    const columns = this.columns;
-    const colours = this.colours;
-    const selectedColour = this.getValue();
-    // Create the palette.
-    const table = document.createElement('table');
-    table.className = 'blocklyColourTable';
-    table.tabIndex = 0;
-    table.dir = 'ltr';
-    Blockly.utils.aria.setRole(table, Blockly.utils.aria.Role.GRID);
-    Blockly.utils.aria.setState(table, Blockly.utils.aria.State.EXPANDED, true);
-    Blockly.utils.aria.setState(
-      table,
-      Blockly.utils.aria.State.ROWCOUNT,
-      Math.floor(colours.length / columns),
-    );
-    Blockly.utils.aria.setState(
-      table,
-      Blockly.utils.aria.State.COLCOUNT,
-      columns,
-    );
-    let row: Element | null = null;
-    for (let i = 0; i < colours.length; i++) {
-      if (i % columns === 0) {
-        row = document.createElement('tr');
-        Blockly.utils.aria.setRole(row, Blockly.utils.aria.Role.ROW);
-        table.appendChild(row);
-      }
-      const cell = document.createElement('td');
-      (row as Element).appendChild(cell);
-      // This becomes the value, if clicked.
-      cell.setAttribute('data-colour', colours[i]);
-      cell.title = this.titles[i] || colours[i];
-      cell.id = Blockly.utils.idGenerator.getNextUniqueId();
-      cell.setAttribute('data-index', `${i}`);
-      Blockly.utils.aria.setRole(cell, Blockly.utils.aria.Role.GRIDCELL);
-      Blockly.utils.aria.setState(
-        cell,
-        Blockly.utils.aria.State.LABEL,
-        colours[i],
-      );
-      Blockly.utils.aria.setState(
-        cell,
-        Blockly.utils.aria.State.SELECTED,
-        colours[i] === selectedColour,
-      );
-      cell.style.backgroundColor = colours[i];
-      if (colours[i] === selectedColour) {
-        cell.className = 'blocklyColourSelected';
-        this.highlightedIndex = i;
-      }
-    }
-
-    // Configure event handler on the table to listen for any event in a cell.
-    this.boundEvents.push(
-      Blockly.browserEvents.conditionalBind(
-        table,
-        'pointerdown',
-        this,
-        this.onClick,
-        true,
-      ),
-    );
-    this.boundEvents.push(
-      Blockly.browserEvents.conditionalBind(
-        table,
-        'pointermove',
-        this,
-        this.onMouseMove,
-        true,
-      ),
-    );
-    this.boundEvents.push(
-      Blockly.browserEvents.conditionalBind(
-        table,
-        'pointerenter',
-        this,
-        this.onMouseEnter,
-        true,
-      ),
-    );
-    this.boundEvents.push(
-      Blockly.browserEvents.conditionalBind(
-        table,
-        'pointerleave',
-        this,
-        this.onMouseLeave,
-        true,
-      ),
-    );
-    this.boundEvents.push(
-      Blockly.browserEvents.conditionalBind(
-        table,
-        'keydown',
-        this,
-        this.onKeyDown,
-        false,
-      ),
-    );
-
-    this.picker = table;
-  }
-
-  /** Disposes of events and DOM-references belonging to the colour editor. */
-  private dropdownDispose() {
-    for (const event of this.boundEvents) {
-      Blockly.browserEvents.unbind(event);
-    }
-    this.boundEvents.length = 0;
-    this.picker = null;
-    this.highlightedIndex = null;
   }
 
   /**
@@ -730,6 +386,33 @@ export class FieldColour extends Blockly.Field<string> {
   }
 }
 
+/**
+ * Creates a set of divs representing colour swatches for use in the picker.
+ *
+ * @param colours An array of colours to create swatches for. The colours must
+ *     be any legal CSS colour specifier.
+ * @param titles A corresponding array of titles to be displayed as tooltips on
+ *     the colour swatches.
+ * @returns An array of pairs of DOM elements representing colour swatches and
+ *     their corresponding colour.
+ */
+function makeSwatches(
+  colours: string[],
+  titles?: string[],
+): Blockly.MenuOption[] {
+  return colours.map((colour, index) => {
+    const swatch = document.createElement('div');
+    swatch.className = 'blocklyColourSwatch';
+    swatch.style.backgroundColor = colour;
+
+    if (titles && index < titles.length) {
+      swatch.title = titles[index];
+    }
+
+    return [swatch, colour];
+  });
+}
+
 /** The default value for this field. */
 FieldColour.prototype.DEFAULT_VALUE = '#ffffff';
 
@@ -744,49 +427,63 @@ export function registerFieldColour() {
  * CSS for colour picker.
  */
 Blockly.Css.register(`
-.blocklyColourTable {
-  border-collapse: collapse;
-  display: block;
-  outline: none;
-  padding: 1px;
-}
-
-.blocklyColourTable>tr>td {
-  border: 0.5px solid #888;
-  box-sizing: border-box;
-  cursor: pointer;
-  display: inline-block;
-  height: 20px;
-  padding: 0;
-  width: 20px;
-}
-
-.blocklyColourTable>tr>td.blocklyColourHighlighted {
-  border-color: #eee;
-  box-shadow: 2px 2px 7px 2px rgba(0, 0, 0, 0.3);
-  position: relative;
-}
-
-.blocklyColourSelected, .blocklyColourSelected:hover {
+.blocklyFieldColour .blocklyFieldGridItemSelected,
+.blocklyFieldGridItemSelected:hover {
   border-color: #eee !important;
   outline: 1px solid #333;
   position: relative;
+}
+
+.blocklyColourSwatch {
+  width: 20px;
+  height: 20px;
+}
+
+.blocklyGridContainer {
+  padding: 0px;
+}
+
+.blocklyFieldColour .blocklyFieldGrid {
+  grid-gap: 0px;
+  row-gap: 4px;
+}
+
+.blocklyFieldColour .blocklyFieldGrid .blocklyGridItem {
+  border-radius: 0;
+  padding: 0;
+  border: 0.5px solid #888;
+  cursor: pointer;
+}
+
+.blocklyFieldColour .blocklyFieldGrid .blocklyFieldGridItem {
+  border: 0.5px solid #888;
+  padding: 0;
+  margin: 0;
+  border-radius: 0;
+}
+
+.blocklyFieldColour .blocklyFieldGrid .blocklyFieldGridItem:focus {
+  border-color: #eee;
+  box-shadow: 2px 2px 7px 2px rgba(0, 0, 0, 0.3);
+  position: relative;
+  border-radius: 0;
+  outline: none;
 }
 `);
 
 /**
  * Config options for the colour field.
  */
-export interface FieldColourConfig extends Blockly.FieldConfig {
+export interface FieldColourConfig extends FieldGridDropdownConfig {
   colourOptions?: string[];
   colourTitles?: string[];
-  columns?: number;
 }
 
 /**
  * fromJson config options for the colour field.
  */
-export interface FieldColourFromJsonConfig extends FieldColourConfig {
+export interface FieldColourFromJsonConfig
+  extends FieldGridDropdownFromJsonConfig {
   colour?: string;
 }
 

--- a/plugins/field-colour/test/blocks_test.mocha.js
+++ b/plugins/field-colour/test/blocks_test.mocha.js
@@ -195,6 +195,9 @@ suite('Colour Block Generators', function () {
     });
   });
   setup(function () {
+    this.jsdomCleanup = require('jsdom-global')(
+      '<!DOCTYPE html><div id="blocklyDiv"></div>',
+    );
     this.workspace = new Blockly.Workspace();
     Blockly.serialization.workspaces.load(blockJson, this.workspace);
   });
@@ -219,6 +222,7 @@ suite('Colour Block Generators', function () {
     checkResult('php', generated);
   });
   teardown(function () {
+    this.jsdomCleanup();
     this.workspace.dispose();
   });
 });

--- a/plugins/field-colour/test/field_colour_test.mocha.js
+++ b/plugins/field-colour/test/field_colour_test.mocha.js
@@ -20,7 +20,15 @@ const {
 suite('FieldColour', function () {
   setup(function () {
     registerFieldColour();
+    this.jsdomCleanup = require('jsdom-global')(
+      '<!DOCTYPE html><div id="blocklyDiv"></div>',
+    );
   });
+
+  teardown(function () {
+    this.jsdomCleanup();
+  });
+
   /**
    * Configuration for field tests with invalid values.
    * @type {Array<FieldCreationTestCase>}
@@ -269,8 +277,13 @@ suite('FieldColour', function () {
        * @param {!Array[string]} expectedTitles Array of title names.
        */
       function assertColoursAndTitles(field, expectedColours, expectedTitles) {
-        const actualColours = field.colours || FieldColour.COLOURS;
-        const actualTitles = field.titles || FieldColour.TITLES;
+        const options = field.getOptions();
+        const actualColours = options.map((option) =>
+          Blockly.utils.colour.parse(option[0].style.backgroundColor),
+        );
+        const actualTitles = options
+          .map((option) => option[0].title)
+          .filter((title) => !!title);
         assert.equal(String(actualColours), String(expectedColours));
         assert.equal(String(actualTitles), String(expectedTitles));
       }
@@ -303,13 +316,6 @@ suite('FieldColour', function () {
         const field = new FieldColour();
         field.setColours(['#aaaaaa', '#ff0000'], ['grey']);
         assertColoursAndTitles(field, ['#aaaaaa', '#ff0000'], ['grey']);
-      });
-      // This is kinda derpy behaviour, but I wanted to document it.
-      test('Overwriting Colours While Leaving Titles', function () {
-        const field = new FieldColour();
-        field.setColours(['#aaaaaa'], ['grey']);
-        field.setColours(['#ff0000']);
-        assertColoursAndTitles(field, ['#ff0000'], ['grey']);
       });
     });
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR updates `FieldColour` to inherit from `FieldGridDropdown`. The latter was recently updated to support using abitrary HTML grid elements, which allows `FieldColour` to specify color swatches as grid items, and allows for the removal of a great deal of duplicative grid-handling code from `FieldColour`. There are two small behavioral changes:

* `FieldColour`'s dropdown now inherits its background color from its parent block, à la `FieldDropdown`, since it's now an (indirect) subclass thereof.
* The "kinda derpy" behavior (per the test comment) whereby setting a new list of colors without tooltip titles after having set a list of colors and tooltip titles preserves the tooltips for the new colors has been removed, because it seemed like a bug enshrined in the test suite rather than an intentional behavior, and was indeed kinda derpy, and would have been obnoxious to try to preserve.