### PR TITLE
fix: Fix a bug that could cause a crash when deleting a shared procedure definition.

### DIFF
--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -1066,7 +1066,7 @@ const procedureCallerUpdateShapeMixin = {
    * Updates the shape of this block to reflect the state of the data model.
    */
   doProcedureUpdate: function () {
-    if (!this.getProcedureModel()) return;
+    if (!this.getProcedureModel() || this.isDeadOrDying()) return;
     const id = this.getProcedureModel().getId();
     if (
       !this.getTargetWorkspace_().getProcedureMap().has(id) &&

--- a/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
+++ b/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
@@ -1302,6 +1302,93 @@ suite('Procedures', function () {
     );
 
     test(
+      'when a procedure definition block is deleted, deleting its callers ' +
+        'with arguments that call another procedure does not cause a crash',
+      function () {
+        // This test exercises the scenario reported in
+        // https://github.com/google/blockly-samples/issues/2557
+        Blockly.serialization.workspaces.load(
+          {
+            blocks: {
+              languageVersion: 0,
+              blocks: [
+                {
+                  type: 'procedures_defnoreturn',
+                  id: 'dosomething',
+                  extraState: {
+                    procedureId: 'dosomething_procmodel',
+                  },
+                  fields: {
+                    NAME: 'do something',
+                  },
+                },
+                {
+                  type: 'procedures_defreturn',
+                  id: 'dosomething2',
+                  extraState: {
+                    procedureId: 'dosomething2_procmodel',
+                  },
+                  fields: {
+                    NAME: 'do something2',
+                  },
+                },
+                {
+                  type: 'procedures_callnoreturn',
+                  id: 'call_dosomething',
+                  extraState: {
+                    name: 'do something',
+                    params: ['x'],
+                  },
+                  inputs: {
+                    ARG0: {
+                      block: {
+                        type: 'procedures_callreturn',
+                        id: 'call_dosomething2',
+                        extraState: {
+                          name: 'do something2',
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            variables: [
+              {
+                name: 'x',
+                id: 'x_var',
+              },
+            ],
+            procedures: [
+              {
+                id: 'dosomething_procmodel',
+                name: 'do something',
+                returnTypes: null,
+                parameters: [
+                  {
+                    id: 'x_param',
+                    name: 'x',
+                  },
+                ],
+              },
+              {
+                id: 'dosomething2_procmodel',
+                name: 'do something2',
+                returnTypes: [],
+              },
+            ],
+          },
+          this.workspace,
+        );
+
+        const defBlock = this.workspace.getBlockById('dosomething');
+        // Should not cause an exception to be thrown.
+        defBlock.dispose();
+        globalThis.clock.runAll();
+      },
+    );
+
+    test(
       'when a procedure definition block is deleted, a delete event for ' +
         'its data model is fired',
       function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2557 

### Proposed Changes
This PR checks whether a procedure block is actively being deleted when it is told to update itself. This can happen in the case of nested procedure call blocks. I also added a test recreating the scenario in question, which failed before this change and passes after it. A big thank you also to @bbrudastyy who initially reported this problem!