### PR TITLE
fix: set button type to 'button' and format workspace_search.ts

### DIFF
--- a/examples/blockly-react/src/index.css
+++ b/examples/blockly-react/src/index.css
@@ -1,8 +1,8 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -17,6 +17,6 @@ body {
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family:
+    source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/examples/blockly-svelte/public/global.css
+++ b/examples/blockly-svelte/public/global.css
@@ -10,8 +10,9 @@ body {
   margin: 0;
   padding: 8px;
   box-sizing: border-box;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu,
+    Cantarell, 'Helvetica Neue', sans-serif;
 }
 
 a {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "gulp-header": "^2.0.9",
         "http-server": "^14.1.1",
         "js-green-licenses": "^4.0.0",
-        "prettier": "^3.0.3",
+        "prettier": "^3.5.3",
         "rimraf": "^3.0.2",
         "showdown": "^2.1.0",
         "typescript": "^5.5.4"
@@ -4509,9 +4509,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -9098,9 +9098,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gulp-header": "^2.0.9",
     "http-server": "^14.1.1",
     "js-green-licenses": "^4.0.0",
-    "prettier": "^3.0.3",
+    "prettier": "^3.5.3",
     "rimraf": "^3.0.2",
     "showdown": "^2.1.0",
     "typescript": "^5.5.4"

--- a/plugins/cross-tab-copy-paste/README.md
+++ b/plugins/cross-tab-copy-paste/README.md
@@ -43,9 +43,8 @@ Blockly.ContextMenuRegistry.registry.unregister('blockDuplicate');
 
 // optional: You can change the position of the menu added to the context menu.
 Blockly.ContextMenuRegistry.registry.getItem('blockCopyToStorage').weight = 2;
-Blockly.ContextMenuRegistry.registry.getItem(
-  'blockPasteFromStorage',
-).weight = 3;
+Blockly.ContextMenuRegistry.registry.getItem('blockPasteFromStorage').weight =
+  3;
 ```
 
 ## Options

--- a/plugins/workspace-search/src/workspace_search.ts
+++ b/plugins/workspace-search/src/workspace_search.ts
@@ -273,6 +273,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
     // Create the button
     const btn = document.createElement('button');
     Blockly.utils.dom.addClass(btn, className);
+    btn.type = 'button';
     btn.setAttribute('aria-label', text);
     return btn;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I validated my changes

## The details
### Resolves

Fixes #2510

### Proposed Changes

Updated the `createBtn` helper method in the workspace-search plugin to explicitly set the button’s `type` attribute to `"button"`.

```ts
private createBtn(className: string, text: string): HTMLButtonElement {
  const btn = document.createElement('button');
  Blockly.utils.dom.addClass(btn, className);
  btn.type = "button";
  btn.setAttribute('aria-label', text);
  return btn;
}
