### PR TITLE
fix: prevent Enter/Space from propagating from Grid

### DIFF
--- a/plugins/field-grid-dropdown/src/grid.ts
+++ b/plugins/field-grid-dropdown/src/grid.ts
@@ -189,6 +189,12 @@ export class Grid {
       case 'End':
         this.moveFocus(this.items.length - 1, false);
         break;
+      case 'Enter':
+      case 'Space':
+        // Handled via GridItem click handler, so we want its default but it
+        // must not propagate.
+        e.stopPropagation();
+        return;
       default:
         // Not a key the grid is interested in.
         return;


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
See https://github.com/google/blockly-keyboard-experimentation/issues/618
This is a narrower fix than the one on https://github.com/google/blockly-keyboard-experimentation/pull/619

### Proposed Changes

Prevent Enter/Space from propagating from Grid so it is not inappropriately handled by other listeners, e.g. the keyboard navigation plugin.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage


### Documentation


### Additional Information

