### PR TITLE
feat(workspace-search): focus found block on close or restore focus

### DIFF
--- a/plugins/workspace-search/src/workspace_search.ts
+++ b/plugins/workspace-search/src/workspace_search.ts
@@ -43,6 +43,15 @@ export class WorkspaceSearch implements Blockly.IPositionable {
   protected blocks: Blockly.BlockSvg[] = [];
 
   /**
+   * The last highlighted block, which we focus on close.
+   *
+   * This block is focused on close even if the most recent search found nothing
+   * because we've centered on it and it's helpful for focus to be in sync with
+   * the scroll position.
+   */
+  private lastHighlighted: Blockly.BlockSvg | null = null;
+
+  /**
    * Index of the currently "selected" block in the blocks array.
    */
   protected currentBlockIndex = -1;
@@ -436,6 +445,7 @@ export class WorkspaceSearch implements Blockly.IPositionable {
 
     this.highlightCurrentSelection(currentBlock);
     this.workspace.centerOnBlock(currentBlock.id, false);
+    this.lastHighlighted = currentBlock;
   }
 
   /**
@@ -455,8 +465,14 @@ export class WorkspaceSearch implements Blockly.IPositionable {
    */
   close() {
     this.setVisible(false);
-    this.workspace.markFocused();
+    const focusManager = Blockly.FocusManager.getFocusManager();
+    if (this.lastHighlighted && !this.lastHighlighted.isDisposed()) {
+      focusManager.focusNode(this.lastHighlighted);
+    } else {
+      focusManager.focusTree(this.workspace);
+    }
     this.clearBlocks();
+    this.lastHighlighted = null;
   }
 
   /**


### PR DESCRIPTION
## The basics

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes  https://github.com/google/blockly-samples/issues/2575

### Proposed Changes

Focus the found block on close or restore focus. This matches browser in find in page behaviour where Escape closes find and moves focus to the highlighted item.

When there's no search performed or nothing ever matched we restore focus to the previous node.

Where there was a match but then the search changes so it no longer matched we still focus that last match, because we've scrolled it into view which may have moved the previous focus position out of view. In this scenario browsers seem to focus the element but not mark it as focus:visible but we don't have a similar distinction.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Added jsdom tests.

### Additional Information

Unsure if this behaviour is OK to just change without requiring option. More impact for keyboard user if we just do it but not sure if anyone will be affected by the focus change.
