### PR TITLE
fix: toolbox-search cannot focus in Blockly v12

### DIFF
--- a/plugins/toolbox-search/src/toolbox_search.ts
+++ b/plugins/toolbox-search/src/toolbox_search.ts
@@ -137,33 +137,23 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
     this.blockSearcher.indexBlocks([...availableBlocks]);
   }
 
-  /**
-   * Handles a click on this toolbox category.
-   *
-   * @param e The click event.
-   */
-  override onClick(e: Event) {
-    super.onClick(e);
-    e.preventDefault();
-    e.stopPropagation();
-    this.setSelected(this.parentToolbox_.getSelectedItem() === this);
+  /** See IFocusableNode.getFocusableElement. */
+  getFocusableElement(): HTMLElement | SVGElement {
+    if (!this.searchField) {
+      throw Error('This field currently has no representative DOM element.');
+    }
+    return this.searchField;
   }
 
-  /**
-   * Handles changes in the selection state of this category.
-   *
-   * @param isSelected Whether or not the category is now selected.
-   */
-  override setSelected(isSelected: boolean) {
-    super.setSelected(isSelected);
+  /** See IFocusableNode.onNodeFocus. */
+  onNodeFocus(): void {
+    this.matchBlocks();
+  }
+
+  /** See IFocusableNode.onNodeBlur. */
+  onNodeBlur(): void {
     if (!this.searchField) return;
-    if (isSelected) {
-      this.searchField.focus();
-      this.matchBlocks();
-    } else {
-      this.searchField.value = '';
-      this.searchField.blur();
-    }
+    this.searchField.value = '';
   }
 
   /**

--- a/plugins/toolbox-search/src/toolbox_search.ts
+++ b/plugins/toolbox-search/src/toolbox_search.ts
@@ -138,7 +138,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
   }
 
   /** See IFocusableNode.getFocusableElement. */
-  getFocusableElement(): HTMLElement | SVGElement {
+  override getFocusableElement(): HTMLElement | SVGElement {
     if (!this.searchField) {
       throw Error('This field currently has no representative DOM element.');
     }
@@ -146,12 +146,12 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
   }
 
   /** See IFocusableNode.onNodeFocus. */
-  onNodeFocus(): void {
+  override onNodeFocus(): void {
     this.matchBlocks();
   }
 
   /** See IFocusableNode.onNodeBlur. */
-  onNodeBlur(): void {
+  override onNodeBlur(): void {
     if (!this.searchField) return;
     this.searchField.value = '';
   }

--- a/plugins/toolbox-search/src/toolbox_search.ts
+++ b/plugins/toolbox-search/src/toolbox_search.ts
@@ -97,7 +97,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
       callback: () => {
         const position = this.getPosition();
         if (position < 0) return false;
-        this.parentToolbox_.selectItemByPosition(position);
+        Blockly.getFocusManager().focusNode(this);
         return true;
       },
       keyCodes: [shortcut],


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2577 
The input in toolbox-search cannot focus because of the new FocusManager mechanism in Blockly v12.

### Proposed Changes
Rewrite the focus logic using the interface provided by FocusManager.
<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
