### PR TITLE
chore: Add node.js v24 to CI build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/core#making_and_verifying_a_change)

## The details
### Proposed Changes

Add node.js v24 to CI build matrix

### Reason for Changes

Node.js v24 has now been released, so add it to our build matrix.

Node v18 is no longer in LTS but we want to continue to test on it until it is removed from package.json engines.

### Test Coverage

Slightly improved