### PR TITLE
fix: Add labels to empty statement blocks for drag tests

### DIFF
--- a/plugins/block-test/src/connections/statement.js
+++ b/plugins/block-test/src/connections/statement.js
@@ -15,7 +15,7 @@ import * as Blockly from 'blockly/core';
 Blockly.defineBlocksWithJsonArray([
   {
     type: 'test_connections_statement_blue',
-    message0: 'B %1',
+    message0: 'Blue %1',
     args0: [
       {
         type: 'input_statement',
@@ -35,7 +35,7 @@ Blockly.defineBlocksWithJsonArray([
   },
   {
     type: 'test_connections_statement_yellow',
-    message0: 'Y %1',
+    message0: 'Yellow %1',
     args0: [
       {
         type: 'input_statement',
@@ -59,7 +59,7 @@ Blockly.defineBlocksWithJsonArray([
   },
   {
     type: 'test_connections_statement_red',
-    message0: 'R %1',
+    message0: 'Red %1',
     args0: [
       {
         type: 'input_statement',
@@ -79,7 +79,7 @@ Blockly.defineBlocksWithJsonArray([
   },
   {
     type: 'test_connections_statement_nonext',
-    message0: 'N %1',
+    message0: 'None %1',
     args0: [
       {
         type: 'input_statement',

--- a/plugins/block-test/src/connections/statement.js
+++ b/plugins/block-test/src/connections/statement.js
@@ -15,7 +15,7 @@ import * as Blockly from 'blockly/core';
 Blockly.defineBlocksWithJsonArray([
   {
     type: 'test_connections_statement_blue',
-    message0: '%1',
+    message0: 'B %1',
     args0: [
       {
         type: 'input_statement',
@@ -35,7 +35,7 @@ Blockly.defineBlocksWithJsonArray([
   },
   {
     type: 'test_connections_statement_yellow',
-    message0: '%1',
+    message0: 'Y %1',
     args0: [
       {
         type: 'input_statement',
@@ -59,7 +59,7 @@ Blockly.defineBlocksWithJsonArray([
   },
   {
     type: 'test_connections_statement_red',
-    message0: '%1',
+    message0: 'R %1',
     args0: [
       {
         type: 'input_statement',
@@ -79,7 +79,7 @@ Blockly.defineBlocksWithJsonArray([
   },
   {
     type: 'test_connections_statement_nonext',
-    message0: '%1',
+    message0: 'N %1',
     args0: [
       {
         type: 'input_statement',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Necessary but not sufficient for https://github.com/google/blockly/issues/9217 

### Proposed Changes

Adds a single character text label to each of the empty statement input test blocks.

### Reason for Changes

The webdriver tests in main can't drag blocks that have a hole in the middle and no text label. In order to drag these four blocks out they need to have a label that can be used as the drag target element.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
