### PR TITLE
chore: Remove unnecessary code, clarify comments for suggested-blocks plugin

### DIFF
--- a/plugins/suggested-blocks/src/index.js
+++ b/plugins/suggested-blocks/src/index.js
@@ -31,7 +31,7 @@ export class BlockSuggestor {
      */
     this.defaultJsonForBlockLookup = {};
     /**
-     * List of reently used block types
+     * List of recently used block types in order, starting from the most recent
      */
     this.recentlyUsedBlocks = [];
     /**
@@ -51,7 +51,7 @@ export class BlockSuggestor {
   }
 
   /**
-   * Generates a list of the 10 most frequently used blocks, in order.
+   * Generates a list of the most frequently used blocks, in order.
    * Includes a secondary sort by most recent blocks.
    * @returns {!Array<!Blockly.utils.toolbox.BlockInfo>}A list of block JSON
    */
@@ -83,23 +83,20 @@ export class BlockSuggestor {
   };
 
   /**
-   * Generates a list of the 10 most recently used blocks.
+   * Generates a list of the most recently used blocks, in order, starting from
+   * the most recent.
    * @returns {Array <object>} A list of block JSON objects
    */
   getRecentlyUsed = function () {
+    // recentlyUsedBlocks sorted from most recent and spec requires sets
+    // preserve insertion order
     const uniqueRecentBlocks = [...new Set(this.recentlyUsedBlocks)];
-    const recencyMap = new Map();
-    for (const [index, key] of this.recentlyUsedBlocks.entries()) {
-      if (!recencyMap.has(key)) {
-        recencyMap.set(key, index + 1);
-      }
-    }
-    uniqueRecentBlocks.sort((a, b) => recencyMap[a] - recencyMap[b]);
     return this.generateBlockData(uniqueRecentBlocks);
   };
 
   /**
-   * Converts a list of block types to a full-fledge list of block data.
+   * Converts a list of block types to a full-fledge list of block data, limited
+   * to the specified size of the category
    * @param {Array<string>} blockTypeList the list of block types
    * @returns {Array<JSON>} the block data list
    */


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [ x ] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
The code for `getRecentlyUsed` had a logical error where it attempted to access values from a `Map` using bracket notation (`recencyMap[a]` - `recencyMap[b]`) instead of the intended `get` method.  This caused the callback to the `sort` function callback to consistently receive `undefined` values and `NaN` outputs. So, every pair of items from the Array would be considered equal. Due to the [stability](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#sort_stability) of the `sort` method in modern browsers, this did not cause a functional bug, as the original order of the `recentlyUsedBlocks` Array was preserved.

Since the spec guarantees sets preserve insertion order for iteration, the sorting code was actually redundant, and so I removed it.

### Proposed Changes

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->
No functional changes. Removed the unnecessary code in `getRecentlyUsed` and included a comment as to why this code was unnecessary. Also, added comments specifying that `recentlyUsedBlocks` needed to be sorted in reverse insertion order, corrected a minor typo, and clarifying comments about sizes of Arrays returned from some functions. Specifically, `getMostUsed` and `getRecentlyUsed` had comments that they returned Arrays of `10` blocks, but this was dependent upon a default value given to the `init` function which need not be the actual value and was independent of the `SuggestedBlocks` class. So, I removed the mention of `10`, particularly because these functions weren't directly responsible for truncating the list. And I added a comment mentioning the limit on the helper function `generateBlockData`, which directly sliced the Array.

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->
Clarity of interface, simplification of code, and reduction of the chances of introduction of unexpected bugs with future changes.

### Test Coverage

<!-- TODO: Please create unit tests, and explain here how they cover
           your changes, or tell us how you tested it manually. If
           your changes include browser-specific behaviour, include
           information about the browser and device that you used for
           testing. -->

Tests for recently used blocks already in place. 

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->
Changes to documentation for this plugin should be automatically generated.

### Additional Information

<!-- Anything else we should know? -->
If merged, these changes should also be incorporated in the AI suggested blocks plugin that builds on top of it (https://groups.google.com/g/blockly/c/U25u2macb00/m/QLmXtELRAQAJ) 

CC: @BenHenning 
