### PR TITLE
feat: Toolbox-Search add support for preset blocks

### DIFF
--- a/plugins/toolbox-search/src/block_searcher.ts
+++ b/plugins/toolbox-search/src/block_searcher.ts
@@ -10,7 +10,10 @@ import * as Blockly from 'blockly/core';
  * A class that provides methods for indexing and searching blocks.
  */
 export class BlockSearcher {
-  private trigramsToBlocks = new Map<string, Set<Blockly.utils.toolbox.BlockInfo>>();
+  private trigramsToBlocks = new Map<
+    string,
+    Set<Blockly.utils.toolbox.BlockInfo>
+  >();
 
   /**
    * Populates the cached map of trigrams to the blocks they correspond to.
@@ -44,7 +47,10 @@ export class BlockSearcher {
    * @param field We need to check the type of field
    * @param block The block to associate the trigrams with.
    */
-  private indexDropdownOption(field: Blockly.Field, block: Blockly.utils.toolbox.BlockInfo) {
+  private indexDropdownOption(
+    field: Blockly.Field,
+    block: Blockly.utils.toolbox.BlockInfo,
+  ) {
     if (field instanceof Blockly.FieldDropdown) {
       field.getOptions(true).forEach((option) => {
         if (typeof option[0] === 'string') {
@@ -66,7 +72,10 @@ export class BlockSearcher {
     return [
       ...this.generateTrigrams(query)
         .map((trigram) => {
-          return this.trigramsToBlocks.get(trigram) ?? new Set<Blockly.utils.toolbox.BlockInfo>();
+          return (
+            this.trigramsToBlocks.get(trigram) ??
+            new Set<Blockly.utils.toolbox.BlockInfo>()
+          );
         })
         .reduce((matches, current) => {
           return this.getIntersection(matches, current);
@@ -84,7 +93,9 @@ export class BlockSearcher {
    */
   private indexBlockText(text: string, block: Blockly.utils.toolbox.BlockInfo) {
     this.generateTrigrams(text).forEach((trigram) => {
-      const blockSet = this.trigramsToBlocks.get(trigram) ?? new Set<Blockly.utils.toolbox.BlockInfo>();
+      const blockSet =
+        this.trigramsToBlocks.get(trigram) ??
+        new Set<Blockly.utils.toolbox.BlockInfo>();
       blockSet.add(block);
       this.trigramsToBlocks.set(trigram, blockSet);
     });
@@ -116,7 +127,10 @@ export class BlockSearcher {
    * @param b The second set.
    * @returns The intersection of the two sets.
    */
-  private getIntersection(a: Set<Blockly.utils.toolbox.BlockInfo>, b: Set<Blockly.utils.toolbox.BlockInfo>): Set<Blockly.utils.toolbox.BlockInfo> {
+  private getIntersection(
+    a: Set<Blockly.utils.toolbox.BlockInfo>,
+    b: Set<Blockly.utils.toolbox.BlockInfo>,
+  ): Set<Blockly.utils.toolbox.BlockInfo> {
     return new Set([...a].filter((value) => b.has(value)));
   }
 }

--- a/plugins/toolbox-search/src/toolbox_search.ts
+++ b/plugins/toolbox-search/src/toolbox_search.ts
@@ -113,7 +113,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
    */
   private getAvailableBlocks(
     schema: Blockly.utils.toolbox.ToolboxItemInfo,
-    allBlocks: Set<string>,
+    allBlocks: Set<Blockly.utils.toolbox.BlockInfo>,
   ) {
     if ('contents' in schema) {
       schema.contents.forEach((contents) => {
@@ -121,7 +121,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
       });
     } else if (schema.kind.toLowerCase() === 'block') {
       if ('type' in schema && schema.type) {
-        allBlocks.add(schema.type);
+        allBlocks.add(schema);
       }
     }
   }
@@ -130,7 +130,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
    * Builds the BlockSearcher index based on the available blocks.
    */
   private initBlockSearcher() {
-    const availableBlocks = new Set<string>();
+    const availableBlocks = new Set<Blockly.utils.toolbox.BlockInfo>();
     this.workspace_.options.languageTree?.contents?.forEach((item) =>
       this.getAvailableBlocks(item, availableBlocks),
     );
@@ -173,12 +173,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
     const query = this.searchField?.value || '';
 
     this.flyoutItems_ = query
-      ? this.blockSearcher.blockTypesMatching(query).map((blockType) => {
-          return {
-            kind: 'block',
-            type: blockType,
-          };
-        })
+      ? this.blockSearcher.blockTypesMatching(query)
       : [];
 
     if (!this.flyoutItems_.length) {

--- a/plugins/toolbox-search/test/tests.mocha.js
+++ b/plugins/toolbox-search/test/tests.mocha.js
@@ -17,34 +17,80 @@ suite('Toolbox search', () => {
 suite('BlockSearcher', () => {
   test('indexes the default value of dropdown fields', () => {
     const searcher = new BlockSearcher();
+    const blocks = [
+      {
+        kind: 'block',
+        type: 'lists_sort',
+      },
+      {
+        kind: 'block',
+        type: 'lists_split',
+      },
+    ];
     // Text on these:
     // lists_sort: sort <numeric> <ascending>
     // lists_split: make <list from text> with delimiter ,
-    searcher.indexBlocks(['lists_sort', 'lists_split']);
+    searcher.indexBlocks(blocks);
 
     const numericMatches = searcher.blockTypesMatching('numeric');
-    assert.sameMembers(['lists_sort'], numericMatches);
+    assert.sameMembers(numericMatches, [blocks[0]]);
 
     const listFromTextMatches = searcher.blockTypesMatching('list from text');
-    assert.sameMembers(['lists_split'], listFromTextMatches);
+    assert.sameMembers(listFromTextMatches, [blocks[1]]);
   });
 
   test('is not case-sensitive', () => {
     const searcher = new BlockSearcher();
-    searcher.indexBlocks(['lists_create_with']);
+    const listCreateWithBlock = {
+      kind: 'block',
+      type: 'lists_create_with',
+    };
+    searcher.indexBlocks([listCreateWithBlock]);
 
     const lowercaseMatches = searcher.blockTypesMatching('create list');
-    assert.sameMembers(['lists_create_with'], lowercaseMatches);
+    assert.sameMembers(lowercaseMatches, [listCreateWithBlock]);
 
     const uppercaseMatches = searcher.blockTypesMatching('CREATE LIST');
-    assert.sameMembers(['lists_create_with'], uppercaseMatches);
+    assert.sameMembers(uppercaseMatches, [listCreateWithBlock]);
 
     const ransomNoteMatches = searcher.blockTypesMatching('cReATe LiST');
-    assert.sameMembers(['lists_create_with'], ransomNoteMatches);
+    assert.sameMembers(ransomNoteMatches, [listCreateWithBlock]);
   });
 
   test('returns an empty list when no matches are found', () => {
     const searcher = new BlockSearcher();
     assert.isEmpty(searcher.blockTypesMatching('abc123'));
+  });
+
+  test('returns preset blocks', () => {
+    const searcher = new BlockSearcher();
+    const blocks = [
+      {
+        kind: 'block',
+        type: 'text_replace',
+        inputs: {
+          FROM: {
+            shadow: {
+              type: 'text',
+            },
+          },
+          TO: {
+            shadow: {
+              type: 'text',
+            },
+          },
+          TEXT: {
+            shadow: {
+              type: 'text',
+            },
+          },
+        },
+      },
+    ];
+
+    searcher.indexBlocks(blocks);
+
+    const matches = searcher.blockTypesMatching('replace');
+    assert.sameMembers(matches, [blocks[0]]);
   });
 });


### PR DESCRIPTION
## The basics

- [X] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Fixes #2593 

### Proposed Changes

Extend the toolbox-search plugin so that searches also include preset blocks defined in the toolbox.

<img width="1005" height="1387" alt="image" src="https://github.com/user-attachments/assets/c4fcd581-188f-472b-8a76-afdc2de7a1c5" />

### Reason for Changes

Ensures consistent behavior: block configurations available in the toolbox should also appear in search results. 

### Test Coverage

The unit tests have been refactored to work with the changed `indexBlocks` parameters. I also added a test case that validates the preset block behaviour.

### Documentation

### Additional Information

I had to use the fix provided in #2578 for testing with the newest Blockly version.
