### PR TITLE
Fix conflict when using field-grid-dropdown with field-colour

### DIFF
--- a/plugins/field-colour/src/index.ts
+++ b/plugins/field-colour/src/index.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {registerFieldGridDropdown} from '@blockly/field-grid-dropdown';
+registerFieldGridDropdown();
 export * from './field_colour';
 
 import * as colourPicker from './blocks/colourPicker';

--- a/plugins/field-grid-dropdown/README.md
+++ b/plugins/field-grid-dropdown/README.md
@@ -36,7 +36,11 @@ in Blockly core. The config object bag passed into this field accepts additional
 
 ```js
 import * as Blockly from 'blockly';
-import {FieldGridDropdown} from '@blockly/field-grid-dropdown';
+import {
+  FieldGridDropdown,
+  registerFieldGridDropdown,
+} from '@blockly/field-grid-dropdown';
+registerFieldGridDropdown();
 Blockly.Blocks['test_field_grid_dropdown'] = {
   init: function () {
     this.appendDummyInput()
@@ -62,7 +66,8 @@ Blockly.Blocks['test_field_grid_dropdown'] = {
 
 ```js
 import * as Blockly from 'blockly';
-import '@blockly/field-grid-dropdown';
+import {registerFieldGridDropdown} from '@blockly/field-grid-dropdown';
+registerFieldGridDropdown();
 Blockly.defineBlocksWithJsonArray([
   {
     type: 'test_field_grid_dropdown',

--- a/plugins/field-grid-dropdown/src/index.ts
+++ b/plugins/field-grid-dropdown/src/index.ts
@@ -208,7 +208,10 @@ export class FieldGridDropdown extends Blockly.FieldDropdown {
   }
 }
 
-Blockly.fieldRegistry.register('field_grid_dropdown', FieldGridDropdown);
+/** Register the field and any dependencies. */
+export function registerFieldGridDropdown() {
+  Blockly.fieldRegistry.register('field_grid_dropdown', FieldGridDropdown);
+}
 
 /**
  * CSS for grid field.


### PR DESCRIPTION
## 🐛 Fix: Register Conflict Between `@blockly/field-grid-dropdown` and `@blockly/field-colour`

This PR addresses an issue where using `@blockly/field-grid-dropdown` and `@blockly/field-colour` together would cause a `Name "field_grid_dropdown" already registered` error due to double registration.

### 🔧 Changes Made

- Introduced a new utility function `registerFieldGridDropdown()` in `@blockly/field-grid-dropdown`.
- Modified `@blockly/field-colour` to import and call `registerFieldGridDropdown()` explicitly.
- Ensured that the dropdown field is only registered once and safely when needed.

### ✅ Benefits

- Avoids duplicate field registration errors.
- Improves modular use of Blockly plugins.
- Safer integration of multiple plugins across different projects.


<img width="850" height="157" alt="Ekran Resmi 2025-09-07 01 47 13" src="https://github.com/user-attachments/assets/43967bfb-13a3-4137-b81a-e7ae2a220971" />
