### PR TITLE
Remove backpack count from copy to message

### DIFF
--- a/plugins/workspace-backpack/src/backpack_helpers.ts
+++ b/plugins/workspace-backpack/src/backpack_helpers.ts
@@ -108,11 +108,7 @@ function registerCopyToBackpack(disablePreconditionContainsCheck: boolean) {
       if (!scope.block) {
         return '';
       }
-      const backpack = scope.block.workspace
-        .getComponentManager()
-        .getComponent('backpack') as Backpack;
-      const backpackCount = backpack.getCount();
-      return `${Blockly.Msg['COPY_TO_BACKPACK']} (${backpackCount})`;
+      return Blockly.Msg['COPY_TO_BACKPACK'];
     },
     preconditionFn: function (scope: Blockly.ContextMenuRegistry.Scope) {
       if (!scope.block) return 'hidden';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves
Resolves #2599.
### Proposed Changes

Removes backpack count from copy to backpack message.

### Reason for Changes

https://github.com/mit-cml/workspace-multiselect/pull/43