### PR TITLE
Fix compilation issue with vite

### DIFF
--- a/plugins/continuous-toolbox/src/index.ts
+++ b/plugins/continuous-toolbox/src/index.ts
@@ -11,7 +11,7 @@
 import * as Blockly from 'blockly/core';
 
 import {ContinuousCategory} from './ContinuousCategory';
-import {ContinuousFlyout, LabelFlyoutItem} from './ContinuousFlyout';
+import {ContinuousFlyout, type LabelFlyoutItem} from './ContinuousFlyout';
 import {ContinuousMetrics} from './ContinuousMetrics';
 import {ContinuousToolbox} from './ContinuousToolbox';
 import {RecyclableBlockFlyoutInflater} from './RecyclableBlockFlyoutInflater';


### PR DESCRIPTION
Without explicit type export I see an error
```
node_modules/@blockly/continuous-toolbox/src/index.ts (14:26): "LabelFlyoutItem" is not exported by "node_modules/@blockly/continuous-toolbox/src/ContinuousFlyout.ts", imported by "node_modules/@blockly/continuous-toolbox/src/index.ts".
```

[Description](https://github.com/evanw/esbuild/issues/314#issuecomment-668401819)