### PR TITLE
fix: use type-only export for LabelFlyoutItem to fix build error

### DIFF
--- a/plugins/continuous-toolbox/src/index.ts
+++ b/plugins/continuous-toolbox/src/index.ts
@@ -11,8 +11,8 @@
 import * as Blockly from 'blockly/core';
 
 import {ContinuousCategory} from './ContinuousCategory';
-import { ContinuousFlyout } from './ContinuousFlyout';
-import type { LabelFlyoutItem } from './ContinuousFlyout';
+import {ContinuousFlyout} from './ContinuousFlyout';
+import type {LabelFlyoutItem} from './ContinuousFlyout';
 import {ContinuousMetrics} from './ContinuousMetrics';
 import {ContinuousToolbox} from './ContinuousToolbox';
 import {RecyclableBlockFlyoutInflater} from './RecyclableBlockFlyoutInflater';

--- a/plugins/continuous-toolbox/src/index.ts
+++ b/plugins/continuous-toolbox/src/index.ts
@@ -11,7 +11,8 @@
 import * as Blockly from 'blockly/core';
 
 import {ContinuousCategory} from './ContinuousCategory';
-import {ContinuousFlyout, LabelFlyoutItem} from './ContinuousFlyout';
+import { ContinuousFlyout } from './ContinuousFlyout';
+import type { LabelFlyoutItem } from './ContinuousFlyout';
 import {ContinuousMetrics} from './ContinuousMetrics';
 import {ContinuousToolbox} from './ContinuousToolbox';
 import {RecyclableBlockFlyoutInflater} from './RecyclableBlockFlyoutInflater';


### PR DESCRIPTION
LabelFlyoutItem is a TypeScript interface and should be exported as a type-only export. 
Exporting it as a value causes build tools (Rollup, Vite, etc.) to fail because the value does not exist at runtime.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

- [x] I validated my changes by running a Vite build and verifying no errors occurred

## The details
### Resolves

Fixes build error when importing LabelFlyoutItem as a value from ContinuousFlyout.ts
(`"LabelFlyoutItem" is not exported by ContinuousFlyout.ts`)

Fixes #2608

### Proposed Changes

- Changed `index.ts` to export LabelFlyoutItem as a type-only export:
```ts
import { ContinuousFlyout } from './ContinuousFlyout';
import type { LabelFlyoutItem } from './ContinuousFlyout';

export { ContinuousFlyout } from './ContinuousFlyout';
export type { LabelFlyoutItem } from './ContinuousFlyout';
