### PR TITLE
fix: Don't listen for shortcuts on the document.

### DIFF
--- a/plugins/dev-tools/src/playground/index.js
+++ b/plugins/dev-tools/src/playground/index.js
@@ -594,8 +594,8 @@ function registerEditorCommands(editor, playground) {
     try {
       Blockly.serialization.workspaces.load(JSON.parse(json), workspace);
     } catch (e) {
-      // If this fails that's fine.
-      return false;
+      // If this fails fall back to trying to load XML instead.
+      return loadXml();
     }
     return true;
   };
@@ -660,15 +660,5 @@ function registerEditorCommands(editor, playground) {
     contextMenuGroupId: 'playground',
     contextMenuOrder: 1,
     run: save,
-  });
-  document.addEventListener('keydown', (e) => {
-    const ctrlCmd = e.metaKey || e.ctrlKey;
-    if (ctrlCmd && e.key === 's') {
-      save();
-      e.preventDefault();
-    } else if (ctrlCmd && e.key === 'Enter') {
-      if (!loadJson()) loadXml();
-      e.preventDefault();
-    }
   });
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/google/blockly-keyboard-experimentation/issues/743

### Proposed Changes
This PR updates the advanced playground to not listen for command/control S/Enter on the document, and instead only on the editor, where these were also registered. This avoids a conflict with Command Enter and keyboard navigation.