### PR TITLE
fix: make toolbox search focusable

### DIFF
--- a/plugins/toolbox-search/src/toolbox_search.ts
+++ b/plugins/toolbox-search/src/toolbox_search.ts
@@ -20,6 +20,7 @@ import {BlockSearcher} from './block_searcher';
 export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
   private static readonly START_SEARCH_SHORTCUT = 'startSearch';
   static readonly SEARCH_CATEGORY_KIND = 'search';
+  private readonly SEARCH_INPUT_ID = 'toolbox-search-input';
   private searchField?: HTMLInputElement;
   private blockSearcher = new BlockSearcher();
 
@@ -50,6 +51,7 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
   protected override createDom_(): HTMLDivElement {
     const dom = super.createDom_();
     this.searchField = document.createElement('input');
+    this.searchField.id = this.SEARCH_INPUT_ID;
     this.searchField.type = 'search';
     this.searchField.placeholder = 'Search';
     this.workspace_.RTL
@@ -58,13 +60,18 @@ export class ToolboxSearchCategory extends Blockly.ToolboxCategory {
     this.searchField.addEventListener('keyup', (event) => {
       if (event.key === 'Escape') {
         this.parentToolbox_.clearSelection();
-        return true;
+        return;
       }
 
       this.matchBlocks();
     });
     this.rowContents_?.replaceChildren(this.searchField);
     return dom;
+  }
+
+  /** The ID of the toolbox item must match the ID of the focusable node. */
+  override getId(): string {
+    return this.SEARCH_INPUT_ID;
   }
 
   /**


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2598 

### Proposed Changes

- Sets an ID for the focusable node, which is required

### Reason for Changes

<!--TODO: Explain why these changes should be made.  Include screenshots if applicable. -->

### Test Coverage

Manually tested that interacting with search with mouse is working as expected with both blockly 12.1.0 and 12.3.0

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

Note that this plugin needs additional work to be compatible with keyboard navigation. I will file a separate bug with more information.
