### PR TITLE
chore: Bump Blockly dependency to v13 beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@eslint/js": "^8.49.0",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
-        "blockly": "^12.0.0",
+        "blockly": "^13.0.0-beta.4",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "eslint": "^8.49.0",
         "eslint-config-google": "^0.14.0",
@@ -47,6 +47,18 @@
       "dependencies": {
         "@blockly/workspace-backpack": "^7.0.0",
         "blockly": "^12.0.0"
+      }
+    },
+    "examples/backpack-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/blockly-angular": {
@@ -147,6 +159,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "examples/blockly-rtc/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/blockly-rtc/node_modules/brace-expansion": {
@@ -388,6 +412,18 @@
         "blockly": "^12.0.0"
       }
     },
+    "examples/custom-dialogs-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "examples/custom-generator-codelab": {
       "name": "generator-sample-app",
       "version": "1.0.0",
@@ -403,6 +439,18 @@
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
+      }
+    },
+    "examples/custom-generator-codelab/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/custom-renderer-codelab": {
@@ -422,11 +470,35 @@
         "webpack-dev-server": "^5.0.4"
       }
     },
+    "examples/custom-renderer-codelab/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "examples/custom-tooltips-demo": {
       "name": "blockly-custom-tooltips-demo",
       "version": "0.0.0",
       "dependencies": {
         "blockly": "^12.0.0"
+      }
+    },
+    "examples/custom-tooltips-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/developer-tools": {
@@ -451,11 +523,35 @@
         "webpack-dev-server": "^5.0.4"
       }
     },
+    "examples/developer-tools/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "examples/devsite-demo": {
       "name": "blockly-devsite-demo",
       "version": "0.0.0",
       "dependencies": {
         "blockly": "^12.0.0"
+      }
+    },
+    "examples/devsite-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/devsite-landing-demo": {
@@ -465,11 +561,35 @@
         "blockly": "^12.0.0"
       }
     },
+    "examples/devsite-landing-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "examples/fixed-demo": {
       "name": "blockly-fixed-demo",
       "version": "0.0.0",
       "dependencies": {
         "blockly": "^12.0.0"
+      }
+    },
+    "examples/fixed-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/generator-demo": {
@@ -479,11 +599,35 @@
         "blockly": "^12.0.0"
       }
     },
+    "examples/generator-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "examples/graph-demo": {
       "name": "blockly-graph-demo",
       "version": "0.0.0",
       "dependencies": {
         "blockly": "^12.0.0"
+      }
+    },
+    "examples/graph-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/headless-demo": {
@@ -493,11 +637,35 @@
         "blockly": "^12.0.0"
       }
     },
+    "examples/headless-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "examples/interpreter-demo": {
       "name": "blockly-interpreter-demo",
       "version": "0.0.0",
       "dependencies": {
         "blockly": "^12.0.0"
+      }
+    },
+    "examples/interpreter-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/max-blocks-demo": {
@@ -507,11 +675,35 @@
         "blockly": "^12.0.0"
       }
     },
+    "examples/max-blocks-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "examples/mirror-demo": {
       "name": "blockly-mirror-demo",
       "version": "0.0.0",
       "dependencies": {
         "blockly": "^12.0.0"
+      }
+    },
+    "examples/mirror-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/pitch-field-demo": {
@@ -521,6 +713,18 @@
         "blockly": "^12.0.0"
       }
     },
+    "examples/pitch-field-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "examples/resizable-demo": {
       "name": "blockly-resizable-demo",
       "version": "0.0.0",
@@ -528,11 +732,35 @@
         "blockly": "^12.0.0"
       }
     },
+    "examples/resizable-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "examples/rtl-demo": {
       "name": "blockly-rtl-demo",
       "version": "0.0.0",
       "dependencies": {
         "blockly": "^12.0.0"
+      }
+    },
+    "examples/rtl-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/sample-app": {
@@ -570,10 +798,46 @@
         "webpack-dev-server": "^5.0.4"
       }
     },
+    "examples/sample-app-ts/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "examples/sample-app/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "examples/single-direction-scroll-demo": {
       "version": "0.0.0",
       "dependencies": {
         "blockly": "^12.0.0"
+      }
+    },
+    "examples/single-direction-scroll-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "examples/toolbox-demo": {
@@ -583,11 +847,35 @@
         "blockly": "^12.0.0"
       }
     },
+    "examples/toolbox-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "examples/turtle-field-demo": {
       "name": "blockly-turtle-field-demo",
       "version": "0.0.0",
       "dependencies": {
         "blockly": "^12.0.0"
+      }
+    },
+    "examples/turtle-field-demo/node_modules/blockly": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+      "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsdom": "26.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -619,11 +907,12 @@
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -659,22 +948,10 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      },
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1809,9 +2086,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.29",
@@ -5134,6 +5412,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -5597,14 +5876,16 @@
       "license": "MIT"
     },
     "node_modules/blockly": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.1.0.tgz",
-      "integrity": "sha512-J9OMcMVR1HaqqRf3WJJpLBUHh4hy3Ma7JQoMZruRH7evS3kxrihHodVFOuqQzRvHtBtTtcQjzVLZog+0vpB58g==",
-      "dependencies": {
-        "jsdom": "26.1.0"
-      },
+      "version": "13.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-13.0.0-beta.4.tgz",
+      "integrity": "sha512-eTnhrnaZBh9V0uR8VR2iRe8a6kAqXLIkBb4pRmoEfNcRzI4jCMXPQS9bmbBXIXRsONajLtYSTjbdPX+swcZUEw==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "jsdom": "^27.4.0"
       }
     },
     "node_modules/blockly-backpack-demo": {
@@ -6160,9 +6441,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001734",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz",
-      "integrity": "sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "funding": [
         {
           "type": "opencollective",
@@ -6176,7 +6457,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "4.5.0",
@@ -6199,6 +6481,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -6461,6 +6744,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -6468,7 +6752,8 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -8547,9 +8832,10 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.200",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz",
-      "integrity": "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w=="
+      "version": "1.5.356",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.356.tgz",
+      "integrity": "sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==",
+      "license": "ISC"
     },
     "node_modules/email-addresses": {
       "version": "5.0.0",
@@ -8824,8 +9110,52 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -11210,6 +11540,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -12515,6 +12846,44 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/js-green-licenses": {
@@ -15296,9 +15665,10 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "license": "MIT"
     },
     "node_modules/nopt": {
       "version": "8.1.0",
@@ -19512,6 +19882,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -19704,41 +20075,6 @@
         "uglify-js": {
           "optional": true
         }
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/terser/node_modules/commander": {
@@ -20352,9 +20688,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -20369,6 +20705,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -24471,36 +24808,6 @@
         "node": ">=10"
       }
     },
-    "plugins/block-shareable-procedures/node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "plugins/block-shareable-procedures/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "plugins/block-shareable-procedures/node_modules/form-data": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
@@ -24679,16 +24986,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
-      }
-    },
-    "plugins/block-shareable-procedures/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "plugins/block-shareable-procedures/node_modules/supports-color": {
@@ -25011,14 +25308,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "plugins/dev-scripts/node_modules/@babel/code-frame": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
       }
     },
     "plugins/dev-scripts/node_modules/ajv": {
@@ -26618,36 +26907,6 @@
         "node": ">=12"
       }
     },
-    "plugins/modal/node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "plugins/modal/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "plugins/modal/node_modules/http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -26724,16 +26983,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "plugins/modal/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "plugins/modal/node_modules/tough-cookie": {
@@ -27287,36 +27536,6 @@
         "node": ">=12"
       }
     },
-    "plugins/typed-variable-modal/node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "plugins/typed-variable-modal/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "plugins/typed-variable-modal/node_modules/http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -27393,16 +27612,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "plugins/typed-variable-modal/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "plugins/typed-variable-modal/node_modules/tough-cookie": {
@@ -27635,36 +27844,6 @@
         "node": ">=12"
       }
     },
-    "plugins/workspace-search/node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "plugins/workspace-search/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "plugins/workspace-search/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -27782,16 +27961,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
-      }
-    },
-    "plugins/workspace-search/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "plugins/workspace-search/node_modules/supports-color": {
@@ -27929,11 +28098,11 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       }
@@ -27958,19 +28127,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="
-    },
-    "@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      }
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
     },
     "@babel/runtime": {
       "version": "7.28.4",
@@ -28144,24 +28303,6 @@
             "whatwg-url": "^8.0.0"
           }
         },
-        "escodegen": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-          "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-          "dev": true,
-          "requires": {
-            "esprima": "^4.0.1",
-            "estraverse": "^5.2.0",
-            "esutils": "^2.0.2",
-            "source-map": "~0.6.1"
-          }
-        },
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        },
         "form-data": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
@@ -28309,13 +28450,6 @@
             "nise": "^5.1.4",
             "supports-color": "^7.2.0"
           }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -28507,14 +28641,6 @@
         "webpack-dev-server": "^5.0.4"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-          "requires": {
-            "@babel/highlight": "^7.10.4"
-          }
-        },
         "ajv": {
           "version": "6.12.6",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -29681,24 +29807,6 @@
             "webidl-conversions": "^7.0.0"
           }
         },
-        "escodegen": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-          "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-          "dev": true,
-          "requires": {
-            "esprima": "^4.0.1",
-            "estraverse": "^5.2.0",
-            "esutils": "^2.0.2",
-            "source-map": "~0.6.1"
-          }
-        },
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        },
         "http-proxy-agent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -29759,13 +29867,6 @@
           "requires": {
             "xmlchars": "^2.2.0"
           }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
         },
         "tough-cookie": {
           "version": "4.1.4",
@@ -29916,24 +30017,6 @@
             "webidl-conversions": "^7.0.0"
           }
         },
-        "escodegen": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-          "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-          "dev": true,
-          "requires": {
-            "esprima": "^4.0.1",
-            "estraverse": "^5.2.0",
-            "esutils": "^2.0.2",
-            "source-map": "~0.6.1"
-          }
-        },
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        },
         "http-proxy-agent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -29994,13 +30077,6 @@
           "requires": {
             "xmlchars": "^2.2.0"
           }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
         },
         "tough-cookie": {
           "version": "4.1.4",
@@ -30160,24 +30236,6 @@
             "webidl-conversions": "^7.0.0"
           }
         },
-        "escodegen": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-          "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-          "dev": true,
-          "requires": {
-            "esprima": "^4.0.1",
-            "estraverse": "^5.2.0",
-            "esutils": "^2.0.2",
-            "source-map": "~0.6.1"
-          }
-        },
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -30271,13 +30329,6 @@
             "nise": "^4.0.4",
             "supports-color": "^7.1.0"
           }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -31207,9 +31258,9 @@
       }
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.29",
@@ -33564,6 +33615,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -33902,90 +33954,218 @@
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "blockly": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.1.0.tgz",
-      "integrity": "sha512-J9OMcMVR1HaqqRf3WJJpLBUHh4hy3Ma7JQoMZruRH7evS3kxrihHodVFOuqQzRvHtBtTtcQjzVLZog+0vpB58g==",
-      "requires": {
-        "jsdom": "26.1.0"
-      }
+      "version": "13.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-13.0.0-beta.4.tgz",
+      "integrity": "sha512-eTnhrnaZBh9V0uR8VR2iRe8a6kAqXLIkBb4pRmoEfNcRzI4jCMXPQS9bmbBXIXRsONajLtYSTjbdPX+swcZUEw==",
+      "dev": true
     },
     "blockly-backpack-demo": {
       "version": "file:examples/backpack-demo",
       "requires": {
         "@blockly/workspace-backpack": "^7.0.0",
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-custom-dialog-demo": {
       "version": "file:examples/custom-dialogs-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-custom-tooltips-demo": {
       "version": "file:examples/custom-tooltips-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-devsite-demo": {
       "version": "file:examples/devsite-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-devsite-landing-demo": {
       "version": "file:examples/devsite-landing-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-fixed-demo": {
       "version": "file:examples/fixed-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-generator-demo": {
       "version": "file:examples/generator-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-graph-demo": {
       "version": "file:examples/graph-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-headless-demo": {
       "version": "file:examples/headless-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-interpreter-demo": {
       "version": "file:examples/interpreter-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-max-blocks-demo": {
       "version": "file:examples/max-blocks-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-mirror-demo": {
       "version": "file:examples/mirror-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-pitch-field-demo": {
       "version": "file:examples/pitch-field-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-realtime-demo": {
@@ -34022,6 +34202,14 @@
           "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
           "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
           "dev": true
+        },
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
         },
         "brace-expansion": {
           "version": "2.0.2",
@@ -34172,24 +34360,64 @@
       "version": "file:examples/resizable-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-rtl-demo": {
       "version": "file:examples/rtl-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-toolbox-demo": {
       "version": "file:examples/toolbox-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "blockly-turtle-field-demo": {
       "version": "file:examples/turtle-field-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "bluebird": {
@@ -34535,9 +34763,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001734",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz",
-      "integrity": "sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A=="
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw=="
     },
     "chai": {
       "version": "4.5.0",
@@ -34557,6 +34785,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -34740,6 +34969,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -34747,7 +34977,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "color-support": {
       "version": "1.1.3",
@@ -36073,6 +36304,16 @@
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "dezalgo": {
@@ -36265,9 +36506,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.5.200",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz",
-      "integrity": "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w=="
+      "version": "1.5.356",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.356.tgz",
+      "integrity": "sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw=="
     },
     "email-addresses": {
       "version": "5.0.0",
@@ -36473,7 +36714,35 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "eslint": {
       "version": "8.52.0",
@@ -37546,6 +37815,16 @@
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "get-caller-file": {
@@ -38223,7 +38502,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.1.0",
@@ -39106,6 +39386,31 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -41113,9 +41418,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ=="
     },
     "nopt": {
       "version": "8.1.0",
@@ -43102,6 +43407,16 @@
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "renderkid": {
@@ -43330,6 +43645,16 @@
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "sample-app-typescript": {
@@ -43345,6 +43670,16 @@
         "webpack": "^5.93.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.0.4"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "saxes": {
@@ -43684,6 +44019,16 @@
       "version": "file:examples/single-direction-scroll-demo",
       "requires": {
         "blockly": "^12.0.0"
+      },
+      "dependencies": {
+        "blockly": {
+          "version": "12.5.1",
+          "resolved": "https://registry.npmjs.org/blockly/-/blockly-12.5.1.tgz",
+          "integrity": "sha512-etXLpUtEkcRibHGwIJ4BsvnIzMJJs0C0yPIjE/W0NCtj8ACha/a7Q9n7Ib6+j7N4EzQ0p28YPZMnypi5pNIj1g==",
+          "requires": {
+            "jsdom": "26.1.0"
+          }
+        }
       }
     },
     "sinon": {
@@ -44217,6 +44562,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -44351,31 +44697,6 @@
         "schema-utils": "^4.3.0",
         "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "jest-worker": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-          "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-          "requires": {
-            "@types/node": "*",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^8.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "text-decoder": {
@@ -44796,9 +45117,9 @@
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "requires": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@eslint/js": "^8.49.0",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
-    "blockly": "^12.0.0",
+    "blockly": "^13.0.0-beta.4",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "eslint": "^8.49.0",
     "eslint-config-google": "^0.14.0",

--- a/plugins/scroll-options/src/ScrollBlockDragger.ts
+++ b/plugins/scroll-options/src/ScrollBlockDragger.ts
@@ -190,7 +190,7 @@ export class ScrollBlockDragger extends Blockly.dragging.Dragger {
     if (!isAutoScrollable(this.draggable)) return;
 
     const mouse = Blockly.utils.svgMath.screenToWsCoordinates(
-      this.workspace,
+      this.draggable.workspace,
       new Blockly.utils.Coordinate(e.clientX, e.clientY),
     );
 
@@ -206,7 +206,9 @@ export class ScrollBlockDragger extends Blockly.dragging.Dragger {
     };
 
     // Get ViewMetrics in workspace coordinates.
-    const viewMetrics = this.workspace.getMetricsManager().getViewMetrics(true);
+    const viewMetrics = this.draggable.workspace
+      .getMetricsManager()
+      .getViewMetrics(true);
 
     // Get possible scroll velocities based on the location of both the block
     // and the mouse.
@@ -229,7 +231,7 @@ export class ScrollBlockDragger extends Blockly.dragging.Dragger {
 
     // Update the autoscroll or start a new one.
     this.activeAutoScroll_ =
-      this.activeAutoScroll_ || new AutoScroll(this.workspace, this);
+      this.activeAutoScroll_ || new AutoScroll(this.draggable.workspace, this);
     this.activeAutoScroll_.updateProperties(overallScrollVector);
   }
 

--- a/plugins/theme-highcontrast/src/index.ts
+++ b/plugins/theme-highcontrast/src/index.ts
@@ -90,7 +90,6 @@ export default Blockly.Theme.defineTheme('highcontrast', {
   componentStyles: {
     selectedGlowColour: '#000000',
     // selectedGlowSize: 1,
-    replacementGlowColour: '#000000',
   },
   fontStyle: {
     family: undefined, // Use default font-family.

--- a/plugins/workspace-backpack/src/backpack_helpers.ts
+++ b/plugins/workspace-backpack/src/backpack_helpers.ts
@@ -46,6 +46,7 @@ function registerEmptyBackpack(workspace: Blockly.WorkspaceSvg) {
         workspace,
       },
       weight: 0,
+      id: 'empty_backpack',
     };
     menuOptions.push(backpackOptions);
   };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
This PR updates the new v13 branch to use the current beta of v13 of Blockly to allow development of v13-compatible plugins. It also makes initial fixes to ensure that all plugins build.