### PR TITLE
fix: Fix keyboard navigation for the continuous toolbox

### DIFF
--- a/plugins/continuous-toolbox/src/ContinuousFlyout.ts
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.ts
@@ -193,6 +193,23 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
   }
 
   /**
+   * Returns the header item in the flyout corresponding to the given
+   * toolbox category, if any.
+   */
+  headerForCategory(
+    category: Blockly.ISelectableToolboxItem,
+  ): Blockly.IFocusableNode | undefined {
+    return this.getContents()
+      .find((item) => {
+        return (
+          this.toolboxItemIsLabel(item) &&
+          item.getElement().getButtonText() === category.getName()
+        );
+      })
+      ?.getElement();
+  }
+
+  /**
    * Step the scrolling animation by scrolling a fraction of the way to
    * a scroll target, and request the next frame if necessary.
    */

--- a/plugins/continuous-toolbox/src/ContinuousFlyout.ts
+++ b/plugins/continuous-toolbox/src/ContinuousFlyout.ts
@@ -195,6 +195,9 @@ export class ContinuousFlyout extends Blockly.VerticalFlyout {
   /**
    * Returns the header item in the flyout corresponding to the given
    * toolbox category, if any.
+   *
+   * @param category The toolbox category to retrieve header item for.
+   * @returns The given category's header item, or undefined if not found.
    */
   headerForCategory(
     category: Blockly.ISelectableToolboxItem,

--- a/plugins/continuous-toolbox/src/ContinuousToolbox.ts
+++ b/plugins/continuous-toolbox/src/ContinuousToolbox.ts
@@ -10,6 +10,7 @@
 
 import * as Blockly from 'blockly/core';
 import {ContinuousFlyout} from './ContinuousFlyout';
+import {ContinuousToolboxNavigator} from './ContinuousToolboxNavigator';
 
 /**
  * Class for continuous toolbox.
@@ -20,6 +21,12 @@ export class ContinuousToolbox extends Blockly.Toolbox {
    * changes.
    */
   private refreshDebouncer?: ReturnType<typeof setTimeout>;
+
+  /**
+   * Navigator object responsible for handling keyboard navigation within this
+   * toolbox.
+   */
+  private continuousToolboxNavigator = new ContinuousToolboxNavigator(this);
 
   /**
    * Initializes the continuous toolbox.
@@ -191,5 +198,13 @@ export class ContinuousToolbox extends Blockly.Toolbox {
       return flyout.getClientRect();
     }
     return super.getClientRect();
+  }
+
+  /**
+   * Returns the Navigator object responsible for handling keyboard navigation
+   * inside this toolbox.
+   */
+  override getNavigator(): Blockly.ToolboxNavigator {
+    return this.continuousToolboxNavigator;
   }
 }

--- a/plugins/continuous-toolbox/src/ContinuousToolboxNavigator.ts
+++ b/plugins/continuous-toolbox/src/ContinuousToolboxNavigator.ts
@@ -19,6 +19,9 @@ export class ContinuousToolboxNavigator extends Blockly.ToolboxNavigator {
   /**
    * Returns the next node when navigating "in", in this case the first flyout
    * item in the toolbox's currently selected category.
+   *
+   * @param node The node to navigate relative to.
+   * @returns The node "in" relative to the given node.
    */
   override getInNode(
     node = Blockly.getFocusManager().getFocusedNode(),

--- a/plugins/continuous-toolbox/src/ContinuousToolboxNavigator.ts
+++ b/plugins/continuous-toolbox/src/ContinuousToolboxNavigator.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2026 Raspberry Pi Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as Blockly from 'blockly/core';
+import {ContinuousToolbox} from './ContinuousToolbox';
+import {ContinuousCategory} from './ContinuousCategory';
+
+/**
+ * A Navigator that handles keyboard navigation within a continuous toolbox.
+ */
+export class ContinuousToolboxNavigator extends Blockly.ToolboxNavigator {
+  constructor(protected toolbox: ContinuousToolbox) {
+    super(toolbox);
+  }
+
+  /**
+   * Returns the next node when navigating "in", in this case the first flyout
+   * item in the toolbox's currently selected category.
+   */
+  override getInNode(
+    node = Blockly.getFocusManager().getFocusedNode(),
+  ): Blockly.IFocusableNode | null {
+    if (!(node instanceof ContinuousCategory)) return null;
+    return this.toolbox.getFlyout().headerForCategory(node) ?? null;
+  }
+}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR updates the continuous toolbox plugin for compatibility with Blockly v13's keyboard navigation system. Now, right arrow from the toolbox will focus the first item in the current toolbox category, vs before where it would always focus the first item in the entire flyout.
