### PR TITLE
fix: Improve accessibility of `FieldAngle`

### DIFF
--- a/plugins/field-angle/README.md
+++ b/plugins/field-angle/README.md
@@ -63,6 +63,9 @@ This field accepts up to 9 parameters, in addition to the 4 accepted by the
   ticks end at you "max" rounded down to a multiple of your "majorTick".
   Defaults to 45.
 - "symbol" to specify the unit symbol to append to your number. Defaults to °.
+  If this is used to specify "radians" or similar,
+  `Blockly.Msg['ARIA_LABEL_FIELD_ANGLE']` should be overridden accordingly to
+  ensure that the screenreader description remains consistent.
 
 ### JavaScript
 

--- a/plugins/field-angle/src/field_angle.ts
+++ b/plugins/field-angle/src/field_angle.ts
@@ -169,6 +169,17 @@ export class FieldAngle extends Blockly.FieldNumber {
     }
   }
 
+  override getAriaTypeName() {
+    return Blockly.Msg['ARIA_TYPE_FIELD_ANGLE'];
+  }
+
+  override getAriaValue() {
+    return Blockly.Msg['ARIA_LABEL_FIELD_ANGLE'].replace(
+      '%1',
+      super.getAriaValue() ?? '',
+    );
+  }
+
   /**
    * Create the block UI for this field.
    *
@@ -181,7 +192,7 @@ export class FieldAngle extends Blockly.FieldNumber {
       // even in RTL (https://github.com/google/blockly/issues/2380).
       this.symbolElement = Blockly.utils.dom.createSvgElement(
         Blockly.utils.Svg.TSPAN,
-        {},
+        {class: 'blocklyAngleSymbol'},
       );
       this.symbolElement.appendChild(document.createTextNode(this.symbol));
       this.getTextElement().appendChild(this.symbolElement);
@@ -212,7 +223,6 @@ export class FieldAngle extends Blockly.FieldNumber {
       Blockly.utils.userAgent.MOBILE ||
       Blockly.utils.userAgent.ANDROID ||
       Blockly.utils.userAgent.IPAD;
-    super.showEditor_(e, noFocus, false);
 
     const editor = this.dropdownCreate();
     Blockly.DropDownDiv.getContentDiv().appendChild(editor);
@@ -229,6 +239,8 @@ export class FieldAngle extends Blockly.FieldNumber {
       this,
       this.dropdownDispose.bind(this),
     );
+
+    super.showEditor_(e, noFocus, false);
 
     this.updateGraph();
   }
@@ -388,6 +400,7 @@ export class FieldAngle extends Blockly.FieldNumber {
 
   /** Hide the editor. */
   private hide() {
+    this.recomputeAriaContext();
     Blockly.DropDownDiv.hideIfOwner(this);
     Blockly.WidgetDiv.hide();
   }
@@ -497,6 +510,7 @@ export class FieldAngle extends Blockly.FieldNumber {
             Blockly.Events.BLOCK_FIELD_INTERMEDIATE_CHANGE,
           ))(this.sourceBlock_, this.name || null, oldValue, this.value_),
         );
+        Blockly.utils.aria.announceDynamicAriaState(this.getAriaValue());
       }
     }
   }
@@ -666,6 +680,11 @@ export class FieldAngle extends Blockly.FieldNumber {
     // the static fromJson method.
     return new this(options.value, undefined, options);
   }
+
+  protected override widgetDispose_() {
+    super.widgetDispose_();
+    this.recomputeAriaContext();
+  }
 }
 
 /** Register the field and any dependencies. */
@@ -702,6 +721,10 @@ Blockly.Css.register(`
   stroke-width: 2;
   stroke-linecap: round;
   pointer-events: none;
+}
+
+.blocklyAngleSymbol {
+  dominant-baseline: central;
 }
 `);
 

--- a/plugins/field-angle/src/field_angle.ts
+++ b/plugins/field-angle/src/field_angle.ts
@@ -681,6 +681,10 @@ export class FieldAngle extends Blockly.FieldNumber {
     return new this(options.value, undefined, options);
   }
 
+  /**
+   * Hides the angle editor and updates the ARIA label.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   protected override widgetDispose_() {
     super.widgetDispose_();
     this.recomputeAriaContext();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR updates `FieldAngle` to improve its accessibility and compatibility with Blockly v13. Specifically, it:

* Adds "angle" as the ARIA type of the field
* Customizes the ARIA description to "X degrees"
* Adjusts focus management such that the field editor has focus rather than the visual angle picker, to ensure that values can be typed in by default
* Announces the new angle value when interacting with the angle picker using the mouse or using the up and down arrow keys to step the value
* Fixes the alignment of the º symbol relative to the rest of the text on v13