### PR TITLE
fix: Improve accessibility of `FieldDate`

### DIFF
--- a/plugins/field-date/src/field_date.ts
+++ b/plugins/field-date/src/field_date.ts
@@ -94,6 +94,32 @@ export class FieldDate extends Blockly.FieldTextInput {
   }
 
   /**
+   * Returns a description of the type of this field for screenreaders.
+   */
+  override getAriaTypeName() {
+    return Blockly.Msg['ARIA_TYPE_FIELD_DATE'];
+  }
+
+  /**
+   * Returns a description of the current date for use by screenreaders.
+   */
+  override getAriaValue() {
+    const stringValue = this.getValue();
+    if (!stringValue) return super.getAriaValue();
+
+    const date = new Date(stringValue);
+    // Use a localized long-form description of the date, e.g. January XX, 20XX,
+    // rather than a short-form/ISO version of the date which may be read out
+    // with slashes or the like.
+    return date.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      timeZone: 'UTC',
+    });
+  }
+
+  /**
    * Renders the field. If the picker is shown make sure it has the current
    * date selected.
    */


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR improves the accessibility of `FieldDate`. Specifically, it:

* Indicates the field's type as "date"
* Customizes the ARIA label to use a localized, long-form description of the date, like "January 23, 2024" rather than "1/23/2024" (or local equivalent) which may be read out as "one slash twenty three slash two thousand twenty four", to improve understandability.

[9986](https://github.com/RaspberryPiFoundation/blockly/pull/9986) is also needed to make this field accessible; without it, the value cannot be committed via the keyboard.