### PR TITLE
fix: Remove deprecated calls from block-shareable-procedures

### DIFF
--- a/plugins/block-shareable-procedures/src/blocks.ts
+++ b/plugins/block-shareable-procedures/src/blocks.ts
@@ -257,13 +257,13 @@ const procedureDefVarMixin = function () {
      * @this {Blockly.Block}
      */
     renameVarById: function (oldId, newId) {
-      const oldVar = this.workspace.getVariableById(oldId);
+      const oldVar = this.workspace.getVariableMap().getVariableById(oldId);
       const model = this.getProcedureModel();
       const index = model
         .getParameters()
         .findIndex((p) => p.getVariableModel() === oldVar);
       if (index === -1) return; // Not found.
-      const newVar = this.workspace.getVariableById(newId);
+      const newVar = this.workspace.getVariableMap().getVariableById(newId);
       const oldParam = model.getParameter(index);
       oldParam.setName(newVar.name);
     },

--- a/plugins/block-shareable-procedures/src/observable_parameter_model.ts
+++ b/plugins/block-shareable-procedures/src/observable_parameter_model.ts
@@ -47,8 +47,8 @@ export class ObservableParameterModel
     if (name === this.variable.getName()) return this;
     const oldName = this.variable.getName();
     this.variable =
-      this.workspace.getVariable(name) ??
-      this.workspace.createVariable(name, '', id);
+      this.workspace.getVariableMap().getVariable(name) ??
+      this.workspace.getVariableMap().createVariable(name, '', id);
     triggerProceduresUpdate(this.workspace);
     if (this.shouldFireEvents) {
       Blockly.Events.fire(

--- a/plugins/block-shareable-procedures/test/data_models.mocha.js
+++ b/plugins/block-shareable-procedures/test/data_models.mocha.js
@@ -491,7 +491,7 @@ suite('Procedure data models', function () {
 
   suite('backing variable to parameters', function () {
     test('construction references an existing variable if available', function () {
-      const variable = this.workspace.createVariable('test1');
+      const variable = this.workspace.getVariableMap().createVariable('test1');
       const param = new ObservableParameterModel(this.workspace, 'test1');
 
       chai.assert.equal(
@@ -505,14 +505,14 @@ suite('Procedure data models', function () {
       const param = new ObservableParameterModel(this.workspace, 'test1');
 
       chai.assert.equal(
-        this.workspace.getVariable('test1'),
+        this.workspace.getVariableMap().getVariable('test1'),
         param.getVariableModel(),
         'Expected the parameter model to create a variable',
       );
     });
 
     test('setName references an existing variable if available', function () {
-      const variable = this.workspace.createVariable('test2');
+      const variable = this.workspace.getVariableMap().createVariable('test2');
       const param = new ObservableParameterModel(this.workspace, 'test1');
 
       param.setName('test2');
@@ -530,7 +530,7 @@ suite('Procedure data models', function () {
       param.setName('test2');
 
       chai.assert.equal(
-        this.workspace.getVariable('test2'),
+        this.workspace.getVariableMap().getVariable('test2'),
         param.getVariableModel(),
         'Expected the parameter model to create a variable',
       );

--- a/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
+++ b/plugins/block-shareable-procedures/test/procedure_blocks.mocha.js
@@ -47,12 +47,12 @@ suite('Procedures', function () {
     this.eventSpy = this.sandbox.spy();
     this.workspace.addChangeListener(this.eventSpy);
 
-    this.workspace.createVariable('preCreatedVar', '', 'preCreatedVarId');
-    this.workspace.createVariable(
-      'preCreatedTypedVar',
-      'type',
-      'preCreatedTypedVarId',
-    );
+    this.workspace
+      .getVariableMap()
+      .createVariable('preCreatedVar', '', 'preCreatedVarId');
+    this.workspace
+      .getVariableMap()
+      .createVariable('preCreatedTypedVar', 'type', 'preCreatedTypedVarId');
 
     Blockly.defineBlocksWithJsonArray([
       {
@@ -869,7 +869,7 @@ suite('Procedures', function () {
       defBlock.compose(containerBlock);
 
       assert.isNotNull(
-        this.workspace.getVariable('param1', ''),
+        this.workspace.getVariableMap().getVariable('param1', ''),
         'Expected the old variable to continue to exist',
       );
     });
@@ -890,8 +890,10 @@ suite('Procedures', function () {
           .connection.connect(paramBlock.previousConnection);
         defBlock.compose(containerBlock);
 
-        const variable = this.workspace.getVariable('param1', '');
-        this.workspace.renameVariableById(variable.getId(), 'new name');
+        const variable = this.workspace
+          .getVariableMap()
+          .getVariable('param1', '');
+        this.workspace.getVariableMap().renameVariable(variable, 'new name');
 
         assert.isNotNull(
           defBlock.getField('PARAMS'),
@@ -922,8 +924,10 @@ suite('Procedures', function () {
           .connection.connect(paramBlock.previousConnection);
         defBlock.compose(containerBlock);
 
-        const variable = this.workspace.getVariable('param1', '');
-        this.workspace.renameVariableById(variable.getId(), 'new name');
+        const variable = this.workspace
+          .getVariableMap()
+          .getVariable('param1', '');
+        this.workspace.getVariableMap().renameVariable(variable, 'new name');
 
         assert.equal(
           paramBlock.getFieldValue('NAME'),
@@ -950,8 +954,10 @@ suite('Procedures', function () {
           .connection.connect(paramBlock.previousConnection);
         defBlock.compose(containerBlock);
 
-        const variable = this.workspace.getVariable('param1', '');
-        this.workspace.renameVariableById(variable.getId(), 'new name');
+        const variable = this.workspace
+          .getVariableMap()
+          .getVariable('param1', '');
+        this.workspace.getVariableMap().renameVariable(variable, 'new name');
 
         assert.isNotNull(
           callBlock.getInput('ARG0'),
@@ -981,8 +987,12 @@ suite('Procedures', function () {
           .connection.connect(paramBlock.previousConnection);
         defBlock.compose(containerBlock);
 
-        const variable = this.workspace.getVariable('param1', '');
-        this.workspace.renameVariableById(variable.getId(), 'preCreatedVar');
+        const variable = this.workspace
+          .getVariableMap()
+          .getVariable('param1', '');
+        this.workspace
+          .getVariableMap()
+          .renameVariable(variable, 'preCreatedVar');
 
         assert.isNotNull(
           defBlock.getField('PARAMS'),
@@ -1013,8 +1023,12 @@ suite('Procedures', function () {
           .connection.connect(paramBlock.previousConnection);
         defBlock.compose(containerBlock);
 
-        const variable = this.workspace.getVariable('param1', '');
-        this.workspace.renameVariableById(variable.getId(), 'preCreatedVar');
+        const variable = this.workspace
+          .getVariableMap()
+          .getVariable('param1', '');
+        this.workspace
+          .getVariableMap()
+          .renameVariable(variable, 'preCreatedVar');
 
         assert.equal(
           paramBlock.getFieldValue('NAME'),
@@ -1041,8 +1055,12 @@ suite('Procedures', function () {
           .connection.connect(paramBlock.previousConnection);
         defBlock.compose(containerBlock);
 
-        const variable = this.workspace.getVariable('param1', '');
-        this.workspace.renameVariableById(variable.getId(), 'preCreatedVar');
+        const variable = this.workspace
+          .getVariableMap()
+          .getVariable('param1', '');
+        this.workspace
+          .getVariableMap()
+          .renameVariable(variable, 'preCreatedVar');
 
         assert.isNotNull(
           callBlock.getInput('ARG0'),

--- a/plugins/block-shareable-procedures/test/procedure_test_helpers.js
+++ b/plugins/block-shareable-procedures/test/procedure_test_helpers.js
@@ -42,7 +42,9 @@ export function createGenUidStubWithReturns(returnIds) {
 export function assertBlockVarModels(block, varIds) {
   const expectedVarModels = [];
   for (let i = 0; i < varIds.length; i++) {
-    expectedVarModels.push(block.workspace.getVariableById(varIds[i]));
+    expectedVarModels.push(
+      block.workspace.getVariableMap().getVariableById(varIds[i]),
+    );
   }
   assert.sameDeepOrderedMembers(block.getVarModels(), expectedVarModels);
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes

This PR updates a variety of variable-related method calls that now need to be called on `VariableMap` as of v13. This fixes the build of block-shareable-procedures.