### PR TITLE
fix: Fix JSDom whinging about its default stylesheet

### DIFF
--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -165,7 +165,8 @@ module.exports = (env) => {
             commonjs2: 'blockly/lua',
             amd: 'blockly/lua',
           },
+          'jsdom': 'commonjs jsdom',
         }
-      : {},
+      : {jsdom: 'commonjs jsdom'},
   };
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves
### Proposed Changes
This PR fixes an issue where tests would fail with an error along the lines of "ENOENT: no such file or directory, open '/browser/default-stylesheet.css'", due to recent versions of JSDom trying to load a stylesheet for some reason. This fix was recommended by Gemini and does appear to resolve the issue.