### PR TITLE
fix: Fix typed-variable-modal build and tests

### DIFF
--- a/plugins/typed-variable-modal/src/TypedVariableModal.js
+++ b/plugins/typed-variable-modal/src/TypedVariableModal.js
@@ -191,7 +191,7 @@ export class TypedVariableModal extends Modal {
         Blockly.dialog.alert(msg);
       } else {
         // No conflict
-        this.workspace_.createVariable(text, type);
+        this.workspace_.getVariableMap().createVariable(text, type);
         this.hide();
       }
     } else {

--- a/plugins/typed-variable-modal/test/typed_variable_modal_test.mocha.js
+++ b/plugins/typed-variable-modal/test/typed_variable_modal_test.mocha.js
@@ -144,9 +144,9 @@ suite('TypedVariableModal', function () {
     });
     test('Valid name', function () {
       this.typedVarModal.getValidInput_ = sinon.fake.returns('varName');
-      this.workspace.createVariable = sinon.fake();
+      this.workspace.getVariableMap().createVariable = sinon.fake();
       this.typedVarModal.onConfirm_();
-      assert(this.workspace.createVariable.calledOnce);
+      assert(this.workspace.getVariableMap().createVariable.calledOnce);
     });
     test('Variable with different type already exists', function () {
       Blockly.Variables.nameUsedWithAnyType = sinon.fake.returns({
@@ -191,7 +191,8 @@ suite('TypedVariableModal', function () {
       this.typedVarModal.init();
     });
     test('Using rename variable name', function () {
-      this.typedVarModal.variableNameInput_.value = 'Rename variable...';
+      this.typedVarModal.variableNameInput_.value =
+        Blockly.Msg['RENAME_VARIABLE'];
       assert.equal(this.typedVarModal.getValidInput_(), null);
     });
     test('Using new variable name', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR fixes the typed-variable-modal's build by removing a deprecated method call. It also removes deprecated calls from the tests, and updates them to reflect a changed string in core.