### PR TITLE
fix: Fix minimap plugin under v13

### DIFF
--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -164,13 +164,6 @@ export class Minimap {
     if (!blockEvents.has(event.type)) {
       return; // Filter out events.
     }
-    if (
-      event.type === Blockly.Events.BLOCK_CREATE &&
-      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-      (event as any).xml.tagName === 'shadow'
-    ) {
-      return; // Filter out shadow blocks.
-    }
     // Run the event in the minimap.
     const json = event.toJson();
     if (this.minimapWorkspace) {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR fixes compatibility of the minimap plugin with Blockly v13. We removed the `xml` attribute of block creation events, so its attempt at filtering shadow blocks failed. I wound up just removing the code because I couldn't determine its purpose; it was introduced in https://github.com/RaspberryPiFoundation/blockly-samples/pull/1867, but on the existing live demo shadow blocks are in fact displayed in the minimap, and it would seem odd to omit them. I tried covering/uncovering a shadow block with this change, and the minimap reflected the state of the workspace without issue. Likewise, blocks that have shadow children are displayed properly.