### PR TITLE
fix: Fix the workspace-search plugin tests

### DIFF
--- a/plugins/workspace-search/test/workspace_search_test.mocha.js
+++ b/plugins/workspace-search/test/workspace_search_test.mocha.js
@@ -67,6 +67,7 @@ suite('WorkspaceSearch', function () {
     this.jsdomCleanup = require('jsdom-global')(
       '<!DOCTYPE html><div id="blocklyDiv"></div>',
     );
+    this.clock = sinon.useFakeTimers();
     this.workspace = Blockly.inject('blocklyDiv');
     this.workspaceSearch = new WorkspaceSearch(this.workspace);
     // See https://github.com/RaspberryPiFoundation/blockly-samples/issues/2528 for context.
@@ -74,6 +75,10 @@ suite('WorkspaceSearch', function () {
   });
 
   teardown(function () {
+    this.workspaceSearch.dispose();
+    this.workspace.dispose();
+    this.clock.runAll();
+    this.clock.restore();
     this.jsdomCleanup();
   });
 
@@ -459,7 +464,7 @@ suite('WorkspaceSearch', function () {
       this.workspaceSearch.init();
       // Check starting position
       this.focusManager = Blockly.FocusManager.getFocusManager();
-      this.focusManager.focusTree(this.workspace);
+      this.focusManager.focusNode(this.alphaBlock);
       const originalBlock = /** @type {Blockly.BlockSvg} */ (
         this.focusManager.getFocusedNode()
       );
@@ -483,11 +488,11 @@ suite('WorkspaceSearch', function () {
       assertFocusedNodeType('beta_block');
     });
 
-    test('close with no match restores focus', function () {
+    test('close with no match restores focus to workspace', function () {
       this.workspaceSearch.searchAndHighlight('nothingMatchesThis', false);
       this.workspaceSearch.close();
 
-      assertFocusedNodeType('alpha_block');
+      assert.equal(Blockly.getFocusManager().getFocusedNode(), this.workspace);
     });
 
     test('close with match followed by non-match still focuses last found block', function () {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes

This PR fixes the tests for the workspace-search plugin. There were two issues:

* At some point, we changed the behavior to allow the workspace to be directly focusable rather than focusing the first block. The tests were expecting the latter behavior; I updated them to expect and verify the former.
* Things weren't being cleaned up and timers were firing after test teardown, causing a failure to be reported even though all testcases were passing.