### PR TITLE
fix: Fix block-test under v13

### DIFF
--- a/plugins/block-test/src/drag.js
+++ b/plugins/block-test/src/drag.js
@@ -94,7 +94,10 @@ class DragToDupe extends Blockly.dragging.BlockDragStrategy {
    */
   revertDrag() {
     super.revertDrag();
-    if (this.draggingBlock.type === 'drag_to_dupe') {
+    if (
+      'isCloningAllowed' in this.draggingBlock &&
+      typeof this.draggingBlock.isCloningAllowed === 'function'
+    ) {
       this.draggingBlock.dispose();
     }
   }

--- a/plugins/block-test/src/drag.js
+++ b/plugins/block-test/src/drag.js
@@ -18,36 +18,99 @@ Blockly.Blocks['drag_to_dupe'] = {
     this.setOutput(true, null);
     this.appendDummyInput().appendField('drag to dupe');
     this.setDragStrategy(new DragToDupe(this));
+
+    this.cloningAllowed = true;
+    this.isCloningAllowed = () => {
+      return this.cloningAllowed && !this.isInFlyout && !this.isShadow();
+    };
+    this.setCloningAllowed = (/** @type {boolean} */ allowed) => {
+      this.cloningAllowed = allowed;
+    };
   },
 };
 
 /** Drag strategy that duplicates the block on drag. */
-class DragToDupe {
+class DragToDupe extends Blockly.dragging.BlockDragStrategy {
+  /**
+   * Creates a new `DragToDupe` drag strategy.
+   * @param {!Blockly.BlockSvg} block The block that will be dragged.
+   */
   constructor(block) {
-    this.block = block;
+    super(block);
+    this.draggingBlock = block;
   }
 
-  isMovable() {
-    return true;
+  /**
+   * Returns a block instance on which the drag should actually be performed,
+   * which may differ from that which we were instantiated with.
+   */
+  getTargetBlock() {
+    let targetBlock;
+
+    if (
+      'isCloningAllowed' in this.draggingBlock &&
+      typeof this.draggingBlock.isCloningAllowed === 'function' &&
+      this.draggingBlock.isCloningAllowed()
+    ) {
+      const json = Blockly.serialization.blocks.save(this.draggingBlock, {
+        addCoordinates: true,
+      });
+      if (json) {
+        targetBlock = /** @type {!Blockly.BlockSvg} */ (
+          Blockly.serialization.blocks.appendInternal(
+            json,
+            this.draggingBlock.workspace,
+            {
+              recordUndo: true,
+            },
+          )
+        );
+      }
+    }
+
+    targetBlock ??= super.getTargetBlock();
+    this.maybeSetCloningAllowed(targetBlock, false);
+    return targetBlock;
   }
 
-  startDrag(e) {
-    const data = this.block.toCopyData();
-    this.copy = Blockly.clipboard.paste(data, this.block.workspace);
-    this.baseStrat = new Blockly.dragging.BlockDragStrategy(this.copy);
-    this.baseStrat.startDrag(e);
+  /**
+   * Handles the end of a drag.
+   * @param {!PointerEvent|!KeyboardEvent} event The event that triggered the
+   *     end of the drag.
+   * @param {Blockly.DragDisposition} disposition How the drag is being ended.
+   */
+  endDrag(event, disposition) {
+    super.endDrag(event, disposition);
+    this.maybeSetCloningAllowed(this.draggingBlock, true);
+
+    if (disposition === Blockly.DragDisposition.REVERT) {
+      this.draggingBlock.dispose();
+    }
   }
 
-  drag(e) {
-    this.baseStrat.drag(e);
+  /**
+   * Handles a drag being reverted/cancelled.
+   */
+  revertDrag() {
+    super.revertDrag();
+    if (this.draggingBlock.type === 'drag_to_dupe') {
+      this.draggingBlock.dispose();
+    }
   }
 
-  endDrag(e) {
-    this.baseStrat.endDrag(e);
-  }
-
-  revertDrag(e) {
-    this.copy.dispose();
+  /**
+   * If supported, sets whether or not cloning the given block is allowed.
+   *
+   * @param {!Blockly.BlockSvg} block The block to toggle cloning on.
+   * @param {boolean} allowed Whether or not cloning should be allowed.
+   */
+  maybeSetCloningAllowed(block, allowed) {
+    if (
+      'setCloningAllowed' in block &&
+      typeof block.setCloningAllowed === 'function'
+    ) {
+      block.setCloningAllowed(allowed);
+    }
   }
 }
 

--- a/plugins/block-test/src/drag.js
+++ b/plugins/block-test/src/drag.js
@@ -43,6 +43,7 @@ class DragToDupe extends Blockly.dragging.BlockDragStrategy {
   /**
    * Returns a block instance on which the drag should actually be performed,
    * which may differ from that which we were instantiated with.
+   * @returns {!Blockly.BlockSvg} The block to drag.
    */
   getTargetBlock() {
     let targetBlock;
@@ -100,7 +101,6 @@ class DragToDupe extends Blockly.dragging.BlockDragStrategy {
 
   /**
    * If supported, sets whether or not cloning the given block is allowed.
-   *
    * @param {!Blockly.BlockSvg} block The block to toggle cloning on.
    * @param {boolean} allowed Whether or not cloning should be allowed.
    */

--- a/plugins/block-test/src/fields/validators.js
+++ b/plugins/block-test/src/fields/validators.js
@@ -555,11 +555,11 @@ export const category = {
  */
 export function onInit(workspace) {
   const addVariables = function (button) {
-    workspace.createVariable('1b', '', '1B');
-    workspace.createVariable('1c', '', '1C');
-    workspace.createVariable('2a', '', '2A');
-    workspace.createVariable('2b', '', '2B');
-    workspace.createVariable('2c', '', '2C');
+    workspace.getVariableMap().createVariable('1b', '', '1B');
+    workspace.getVariableMap().createVariable('1c', '', '1C');
+    workspace.getVariableMap().createVariable('2a', '', '2A');
+    workspace.getVariableMap().createVariable('2b', '', '2B');
+    workspace.getVariableMap().createVariable('2c', '', '2C');
   };
   const setInput = function (button) {
     Blockly.dialog.prompt('Input text to set.', 'ab', function (input) {

--- a/plugins/block-test/test/index.js
+++ b/plugins/block-test/test/index.js
@@ -19,6 +19,9 @@ import {
 document.addEventListener('DOMContentLoaded', function () {
   const workspace = Blockly.inject('root', {
     toolbox: toolbox,
+    maxInstances: {
+      test_basic_limit_instances: 3,
+    },
   });
   onInit(workspace);
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes

This PR fixes the behavior of some test blocks under Blockly v13. Specifically, it:

* Makes the duplicate-on-drag compatible with the updated APIs and more robust in general
* Uses non-deprecated variable-related methods
* Fixes an existing bug where the block that was supposed to be limited to 3 instances was not