### PR TITLE
chore: Remove `engines` field from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24179,9 +24179,6 @@
         "mocha": "^11.7.6",
         "typescript": "^6.0.3"
       },
-      "engines": {
-        "node": ">=8.17.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24196,9 +24193,6 @@
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
         "sinon": "^22.0.0"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -24217,9 +24211,6 @@
         "sinon": "^22.0.0",
         "typescript": "^6.0.3"
       },
-      "engines": {
-        "node": ">=8.17.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24230,9 +24221,6 @@
       "license": "Apache 2.0",
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.12"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -24247,9 +24235,6 @@
         "@blockly/dev-tools": "^9.0.9",
         "typescript": "^6.0.3"
       },
-      "engines": {
-        "node": ">=8.17.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24263,9 +24248,6 @@
         "@blockly/dev-tools": "^9.0.9",
         "typescript": "^6.0.3"
       },
-      "engines": {
-        "node": ">=8.17.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24277,9 +24259,6 @@
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.12",
         "@blockly/dev-tools": "^9.0.9"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -24297,9 +24276,6 @@
       },
       "bin": {
         "create-package": "bin/create.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "plugins/dev-create/node_modules/ansi-styles": {
@@ -24376,9 +24352,6 @@
       },
       "devDependencies": {
         "typescript": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       },
       "peerDependencies": {
         "typescript": "^4.3.2 || ^5"
@@ -24552,9 +24525,6 @@
         "@blockly/dev-scripts": "^4.0.12",
         "@types/dat.gui": "^0.7.13"
       },
-      "engines": {
-        "node": ">=8.0.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24566,9 +24536,6 @@
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.12",
         "@blockly/dev-tools": "^9.0.9"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -24585,9 +24552,6 @@
         "sinon": "^22.0.0",
         "typescript": "^6.0.3"
       },
-      "engines": {
-        "node": ">=8.0.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24602,9 +24566,6 @@
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
         "typescript": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -24627,9 +24588,6 @@
         "sinon": "^22.0.0",
         "typescript": "^6.0.3"
       },
-      "engines": {
-        "node": ">=8.0.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24648,9 +24606,6 @@
         "jsdom-global": "^3.0.2",
         "typescript": "^6.0.3"
       },
-      "engines": {
-        "node": ">=8.0.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24665,9 +24620,6 @@
         "chai": "^6.2.2",
         "sinon": "^22.0.0",
         "typescript": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -24684,9 +24636,6 @@
         "sinon": "^22.0.0",
         "typescript": "^6.0.3"
       },
-      "engines": {
-        "node": ">=8.0.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24699,9 +24648,6 @@
         "@blockly/dev-scripts": "^4.0.12",
         "@blockly/dev-tools": "^9.0.9",
         "typescript": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -24718,9 +24664,6 @@
         "sinon": "^22.0.0",
         "typescript": "^6.0.3"
       },
-      "engines": {
-        "node": ">=8.0.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24736,9 +24679,6 @@
         "sinon": "^22.0.0",
         "typescript": "^6.0.3"
       },
-      "engines": {
-        "node": ">=8.0.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24750,9 +24690,6 @@
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.12",
         "@blockly/dev-tools": "^9.0.9"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -24777,9 +24714,6 @@
         "chai": "^6.2.2",
         "mocha": "^11.7.6",
         "sinon": "^22.0.0"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       }
     },
     "plugins/migration/node_modules/commander": {
@@ -24815,9 +24749,6 @@
         "mocha": "^11.7.6",
         "sinon": "22.0.0"
       },
-      "engines": {
-        "node": ">=8.17.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24830,9 +24761,6 @@
         "@blockly/dev-scripts": "^4.0.12",
         "@blockly/dev-tools": "^9.0.9",
         "typescript": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -24851,9 +24779,6 @@
         "sinon": "^22.0.0",
         "typescript": "^6.0.3"
       },
-      "engines": {
-        "node": ">=8.0.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24866,9 +24791,6 @@
         "@blockly/dev-scripts": "^4.0.12",
         "@blockly/dev-tools": "^9.0.9",
         "chai": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -24884,9 +24806,6 @@
         "chai": "^6.2.2",
         "sinon": "^22.0.0"
       },
-      "engines": {
-        "node": ">=8.17.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24898,9 +24817,6 @@
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.12"
       },
-      "engines": {
-        "node": ">=8.17.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24911,9 +24827,6 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.12"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -24938,9 +24851,6 @@
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.12"
       },
-      "engines": {
-        "node": ">=8.17.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24952,9 +24862,6 @@
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.12"
       },
-      "engines": {
-        "node": ">=8.17.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -24965,9 +24872,6 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.12"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -25002,9 +24906,6 @@
         "mocha": "^11.7.6",
         "sinon": "22.0.0"
       },
-      "engines": {
-        "node": ">=8.17.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -25017,9 +24918,6 @@
         "@blockly/dev-scripts": "^4.0.12",
         "@blockly/dev-tools": "^9.0.9",
         "typescript": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"
@@ -25051,9 +24949,6 @@
         "sinon": "^22.0.0",
         "typescript": "^6.0.3"
       },
-      "engines": {
-        "node": ">=8.17.0"
-      },
       "peerDependencies": {
         "blockly": "^13.0.0"
       }
@@ -25066,9 +24961,6 @@
         "@blockly/dev-scripts": "^4.0.12",
         "@blockly/dev-tools": "^9.0.9",
         "typescript": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^13.0.0"

--- a/plugins/block-dynamic-connection/package.json
+++ b/plugins/block-dynamic-connection/package.json
@@ -51,8 +51,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/block-plus-minus/package.json
+++ b/plugins/block-plus-minus/package.json
@@ -50,8 +50,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/block-shareable-procedures/package.json
+++ b/plugins/block-shareable-procedures/package.json
@@ -54,8 +54,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/block-test/package.json
+++ b/plugins/block-test/package.json
@@ -46,8 +46,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/content-highlight/package.json
+++ b/plugins/content-highlight/package.json
@@ -52,8 +52,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/continuous-toolbox/package.json
+++ b/plugins/continuous-toolbox/package.json
@@ -48,8 +48,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/cross-tab-copy-paste/package.json
+++ b/plugins/cross-tab-copy-paste/package.json
@@ -47,8 +47,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/dev-create/package.json
+++ b/plugins/dev-create/package.json
@@ -38,8 +38,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=14.0.0"
   }
 }

--- a/plugins/dev-scripts/package.json
+++ b/plugins/dev-scripts/package.json
@@ -45,9 +45,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "engines": {
-    "node": ">=8.0.0"
-  },
   "devDependencies": {
     "typescript": "^6.0.3"
   }

--- a/plugins/dev-tools/package.json
+++ b/plugins/dev-tools/package.json
@@ -59,8 +59,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.0.0"
   }
 }

--- a/plugins/disable-top-blocks/package.json
+++ b/plugins/disable-top-blocks/package.json
@@ -46,8 +46,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/field-angle/package.json
+++ b/plugins/field-angle/package.json
@@ -51,8 +51,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.0.0"
   }
 }

--- a/plugins/field-bitmap/package.json
+++ b/plugins/field-bitmap/package.json
@@ -51,8 +51,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/field-colour-hsv-sliders/package.json
+++ b/plugins/field-colour-hsv-sliders/package.json
@@ -55,8 +55,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.0.0"
   }
 }

--- a/plugins/field-colour/package.json
+++ b/plugins/field-colour/package.json
@@ -55,9 +55,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "engines": {
-    "node": ">=8.0.0"
-  },
   "dependencies": {
     "@blockly/field-grid-dropdown": "^6.0.10"
   }

--- a/plugins/field-date/package.json
+++ b/plugins/field-date/package.json
@@ -53,8 +53,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.0.0"
   }
 }

--- a/plugins/field-dependent-dropdown/package.json
+++ b/plugins/field-dependent-dropdown/package.json
@@ -52,8 +52,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.0.0"
   }
 }

--- a/plugins/field-grid-dropdown/package.json
+++ b/plugins/field-grid-dropdown/package.json
@@ -48,8 +48,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/field-multilineinput/package.json
+++ b/plugins/field-multilineinput/package.json
@@ -51,8 +51,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.0.0"
   }
 }

--- a/plugins/field-slider/package.json
+++ b/plugins/field-slider/package.json
@@ -50,8 +50,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.0.0"
   }
 }

--- a/plugins/fixed-edges/package.json
+++ b/plugins/fixed-edges/package.json
@@ -46,8 +46,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/migration/package.json
+++ b/plugins/migration/package.json
@@ -34,9 +34,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "engines": {
-    "node": ">=8.17.0"
-  },
   "type": "module",
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/plugins/modal/package.json
+++ b/plugins/modal/package.json
@@ -51,8 +51,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/scroll-options/package.json
+++ b/plugins/scroll-options/package.json
@@ -48,8 +48,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/shadow-block-converter/package.json
+++ b/plugins/shadow-block-converter/package.json
@@ -52,8 +52,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.0.0"
   }
 }

--- a/plugins/strict-connection-checker/package.json
+++ b/plugins/strict-connection-checker/package.json
@@ -49,8 +49,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/suggested-blocks/package.json
+++ b/plugins/suggested-blocks/package.json
@@ -50,8 +50,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/theme-dark/package.json
+++ b/plugins/theme-dark/package.json
@@ -47,8 +47,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/theme-deuteranopia/package.json
+++ b/plugins/theme-deuteranopia/package.json
@@ -47,8 +47,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/theme-highcontrast/package.json
+++ b/plugins/theme-highcontrast/package.json
@@ -47,8 +47,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/theme-modern/package.json
+++ b/plugins/theme-modern/package.json
@@ -47,8 +47,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/theme-tritanopia/package.json
+++ b/plugins/theme-tritanopia/package.json
@@ -47,8 +47,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/typed-variable-modal/package.json
+++ b/plugins/typed-variable-modal/package.json
@@ -54,8 +54,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/workspace-backpack/package.json
+++ b/plugins/workspace-backpack/package.json
@@ -49,8 +49,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/workspace-search/package.json
+++ b/plugins/workspace-search/package.json
@@ -51,8 +51,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }

--- a/plugins/zoom-to-fit/package.json
+++ b/plugins/zoom-to-fit/package.json
@@ -47,8 +47,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "engines": {
-    "node": ">=8.17.0"
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #1531 

### Proposed Changes
This PR removes the `engines` field from the various package.json files. We weren't keeping up with it, in general don't have much in the way of direct dependencies on specific node versions, and we don't specify it in core.