### PR TITLE
chore: Fix build + git infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ node_modules/
 # Generated files
 dist/
 build/
+plugins/*/test/**/*.d.ts
+plugins/*/test/**/*.d.ts.map
 gh-pages/index.html
 gh-pages/plugins
 gh-pages/examples

--- a/plugins/dev-scripts/config/webpack.config.js
+++ b/plugins/dev-scripts/config/webpack.config.js
@@ -114,6 +114,7 @@ module.exports = (env) => {
         isTypescript && {
           test: /\.tsx?$/,
           loader: require.resolve('ts-loader'),
+          options: isProduction ? {} : {compilerOptions: {rootDir: '.'}},
         },
       ].filter(Boolean),
     },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR fixes two issues:

* Autogenerated typings files for test-related files were not being ignored. These aren't published and don't need to be checked in, so they've been added to .gitignore
* Running some plugins would result in Typescript yelling about `rootDir` being `./src` but compiling things (the demo harness) in `./test`. Now, when we're not doing a production build, `rootDir` is overridden to be the top-level directory for the individual plugin. When building for packaging, `rootDir` remains `./src` as specified in the tsconfig.json files so that only the actual plugin files (and not the tests) get published.