### PR TITLE
fix: Improve accessibility of grid and colour fields

### DIFF
--- a/plugins/field-colour/src/field_colour.ts
+++ b/plugins/field-colour/src/field_colour.ts
@@ -20,7 +20,7 @@ import {
  * An array of colour strings for the palette.
  * Copied from goog.ui.ColorPicker.SIMPLE_GRID_COLORS
  */
-const DEFAULT_COLOURS = {
+const DEFAULT_COLOURS: Record<string, string> = {
   // greys
   '#ffffff': 'White',
   '#cccccc': 'Light Grey',
@@ -116,6 +116,8 @@ export class FieldColour extends FieldGridDropdown {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   protected override isDirty_ = false;
 
+  protected override ariaTypeName = Blockly.Msg['ARIA_TYPE_FIELD_COLOUR'];
+
   /**
    * @param value The initial value of the field.  Should be in '#rrggbb'
    *     format.  Defaults to the first value in the default colour array.  Also
@@ -137,9 +139,7 @@ export class FieldColour extends FieldGridDropdown {
   ) {
     const swatches = makeSwatches(
       config?.colourOptions ?? Object.keys(DEFAULT_COLOURS),
-      config?.colourTitles?.length
-        ? config.colourTitles
-        : Object.values(DEFAULT_COLOURS),
+      config?.colourTitles,
     );
     super(swatches, validator, {...config, columns: config?.columns ?? 7});
 
@@ -195,14 +195,6 @@ export class FieldColour extends FieldGridDropdown {
     }
 
     this.recomputeAriaContext();
-  }
-
-  /**
-   * Returns a description of the type of this field for use in screenreader
-   * labels.
-   */
-  override getAriaTypeName(): string | null {
-    return Blockly.Msg['ARIA_TYPE_FIELD_COLOUR'];
   }
 
   /**
@@ -429,8 +421,7 @@ function makeSwatches(
     if (titles && index < titles.length) {
       swatch.title = titles[index];
     }
-
-    return [swatch, colour, titles?.[index]];
+    return [swatch, colour, titles?.[index] ?? DEFAULT_COLOURS[colour]];
   });
 }
 
@@ -511,7 +502,8 @@ export interface FieldColourConfig extends FieldGridDropdownConfig {
 /**
  * fromJson config options for the colour field.
  */
-export interface FieldColourFromJsonConfig extends FieldGridDropdownFromJsonConfig {
+export interface FieldColourFromJsonConfig
+  extends FieldGridDropdownFromJsonConfig {
   colour?: string;
 }
 

--- a/plugins/field-colour/src/field_colour.ts
+++ b/plugins/field-colour/src/field_colour.ts
@@ -511,8 +511,7 @@ export interface FieldColourConfig extends FieldGridDropdownConfig {
 /**
  * fromJson config options for the colour field.
  */
-export interface FieldColourFromJsonConfig
-  extends FieldGridDropdownFromJsonConfig {
+export interface FieldColourFromJsonConfig extends FieldGridDropdownFromJsonConfig {
   colour?: string;
 }
 

--- a/plugins/field-colour/src/field_colour.ts
+++ b/plugins/field-colour/src/field_colour.ts
@@ -502,8 +502,7 @@ export interface FieldColourConfig extends FieldGridDropdownConfig {
 /**
  * fromJson config options for the colour field.
  */
-export interface FieldColourFromJsonConfig
-  extends FieldGridDropdownFromJsonConfig {
+export interface FieldColourFromJsonConfig extends FieldGridDropdownFromJsonConfig {
   colour?: string;
 }
 

--- a/plugins/field-colour/src/field_colour.ts
+++ b/plugins/field-colour/src/field_colour.ts
@@ -15,92 +15,94 @@ import {
   FieldGridDropdownFromJsonConfig,
 } from '@blockly/field-grid-dropdown';
 
+/* eslint-disable @typescript-eslint/naming-convention */
 /**
  * An array of colour strings for the palette.
  * Copied from goog.ui.ColorPicker.SIMPLE_GRID_COLORS
  */
-const DEFAULT_COLOURS = [
-  // grays
-  '#ffffff',
-  '#cccccc',
-  '#c0c0c0',
-  '#999999',
-  '#666666',
-  '#333333',
-  '#000000',
+const DEFAULT_COLOURS = {
+  // greys
+  '#ffffff': 'White',
+  '#cccccc': 'Light Grey',
+  '#c0c0c0': 'Silver',
+  '#999999': 'Grey',
+  '#666666': 'Dark Grey',
+  '#333333': 'Charcoal',
+  '#000000': 'Black',
   // reds
-  '#ffcccc',
-  '#ff6666',
-  '#ff0000',
-  '#cc0000',
-  '#990000',
-  '#660000',
-  '#330000',
+  '#ffcccc': 'Pale Red',
+  '#ff6666': 'Light Red',
+  '#ff0000': 'Red',
+  '#cc0000': 'Dark Red',
+  '#990000': 'Darker Red',
+  '#660000': 'Maroon',
+  '#330000': 'Darkest Red',
   // oranges
-  '#ffcc99',
-  '#ff9966',
-  '#ff9900',
-  '#ff6600',
-  '#cc6600',
-  '#993300',
-  '#663300',
+  '#ffcc99': 'Peach',
+  '#ff9966': 'Light Orange',
+  '#ff9900': 'Orange',
+  '#ff6600': 'Bright Orange',
+  '#cc6600': 'Dark Orange',
+  '#993300': 'Rust',
+  '#663300': 'Brown',
   // yellows
-  '#ffff99',
-  '#ffff66',
-  '#ffcc66',
-  '#ffcc33',
-  '#cc9933',
-  '#996633',
-  '#663333',
+  '#ffff99': 'Light Yellow',
+  '#ffff66': 'Pale Yellow',
+  '#ffcc66': 'Light Gold',
+  '#ffcc33': 'Gold',
+  '#cc9933': 'Goldenrod',
+  '#996633': 'Light Brown',
+  '#663333': 'Dark Brown',
   // olives
-  '#ffffcc',
-  '#ffff33',
-  '#ffff00',
-  '#ffcc00',
-  '#999900',
-  '#666600',
-  '#333300',
+  '#ffffcc': 'Cream',
+  '#ffff33': 'Bright Yellow',
+  '#ffff00': 'Yellow',
+  '#ffcc00': 'Amber',
+  '#999900': 'Olive',
+  '#666600': 'Dark Olive',
+  '#333300': 'Darkest Olive',
   // greens
-  '#99ff99',
-  '#66ff99',
-  '#33ff33',
-  '#33cc00',
-  '#009900',
-  '#006600',
-  '#003300',
+  '#99ff99': 'Light Green',
+  '#66ff99': 'Mint',
+  '#33ff33': 'Bright Green',
+  '#33cc00': 'Green',
+  '#009900': 'Dark Green',
+  '#006600': 'Darker Green',
+  '#003300': 'Darkest Green',
   // turquoises
-  '#99ffff',
-  '#33ffff',
-  '#66cccc',
-  '#00cccc',
-  '#339999',
-  '#336666',
-  '#003333',
+  '#99ffff': 'Pale Cyan',
+  '#33ffff': 'Bright Cyan',
+  '#66cccc': 'Light Teal',
+  '#00cccc': 'Turquoise',
+  '#339999': 'Teal',
+  '#336666': 'Dark Teal',
+  '#003333': 'Darkest Teal',
   // blues
-  '#ccffff',
-  '#66ffff',
-  '#33ccff',
-  '#3366ff',
-  '#3333ff',
-  '#000099',
-  '#000066',
+  '#ccffff': 'Pale Aqua',
+  '#66ffff': 'Light Cyan',
+  '#33ccff': 'Sky Blue',
+  '#3366ff': 'Blue',
+  '#3333ff': 'Bright Blue',
+  '#000099': 'Dark Blue',
+  '#000066': 'Navy',
   // purples
-  '#ccccff',
-  '#9999ff',
-  '#6666cc',
-  '#6633ff',
-  '#6600cc',
-  '#333399',
-  '#330099',
+  '#ccccff': 'Pale Periwinkle',
+  '#9999ff': 'Periwinkle',
+  '#6666cc': 'Slate Blue',
+  '#6633ff': 'Violet',
+  '#6600cc': 'Purple',
+  '#333399': 'Indigo',
+  '#330099': 'Dark Indigo',
   // violets
-  '#ffccff',
-  '#ff99ff',
-  '#cc66cc',
-  '#cc33cc',
-  '#993399',
-  '#663366',
-  '#330033',
-];
+  '#ffccff': 'Pale Magenta',
+  '#ff99ff': 'Light Magenta',
+  '#cc66cc': 'Orchid',
+  '#cc33cc': 'Magenta',
+  '#993399': 'Dark Magenta',
+  '#663366': 'Plum',
+  '#330033': 'Darkest Purple',
+};
+/* eslint-enable @typescript-eslint/naming-convention */
 
 /**
  * Class for a colour input field.
@@ -133,7 +135,12 @@ export class FieldColour extends FieldGridDropdown {
     validator?: FieldColourValidator,
     config?: FieldColourConfig,
   ) {
-    const swatches = makeSwatches(config?.colourOptions ?? DEFAULT_COLOURS);
+    const swatches = makeSwatches(
+      config?.colourOptions ?? Object.keys(DEFAULT_COLOURS),
+      config?.colourTitles?.length
+        ? config.colourTitles
+        : Object.values(DEFAULT_COLOURS),
+    );
     super(swatches, validator, {...config, columns: config?.columns ?? 7});
 
     if (value === Blockly.Field.SKIP_SETUP) return;
@@ -179,10 +186,23 @@ export class FieldColour extends FieldGridDropdown {
     );
     this.createBorderRect_();
     this.getBorderRect().style['fillOpacity'] = '1';
-    this.getBorderRect().setAttribute('stroke', '#fff');
     if (this.isFullBlockField()) {
       this.clickTarget_ = (this.sourceBlock_ as Blockly.BlockSvg).getSvgRoot();
     }
+
+    if (this.fieldGroup_) {
+      this.fieldGroup_.classList.add('blocklyField');
+    }
+
+    this.recomputeAriaContext();
+  }
+
+  /**
+   * Returns a description of the type of this field for use in screenreader
+   * labels.
+   */
+  override getAriaTypeName(): string | null {
+    return Blockly.Msg['ARIA_TYPE_FIELD_COLOUR'];
   }
 
   /**
@@ -255,8 +275,8 @@ export class FieldColour extends FieldGridDropdown {
       // field control the color is unexpected, and could have performance
       // impacts.
       block.pathObject.svgPath.setAttribute('fill', this.getValue() as string);
-      block.pathObject.svgPath.setAttribute('stroke', '#fff');
     }
+    this.recomputeAriaContext();
   }
 
   /**
@@ -410,7 +430,7 @@ function makeSwatches(
       swatch.title = titles[index];
     }
 
-    return [swatch, colour];
+    return [swatch, colour, titles?.[index]];
   });
 }
 
@@ -470,6 +490,14 @@ Blockly.Css.register(`
   border-radius: 0;
   outline: none;
 }
+
+.blocklyKeyboardNavigation .blocklyFieldColour .blocklyFieldGrid .blocklyFieldGridItem:focus {
+  outline: var(--blockly-selection-width) solid var(--blockly-active-node-color);
+  outline-offset: -2px;
+  border: none;
+  box-shadow: none;
+  border-radius: 4px;
+}
 `);
 
 /**
@@ -483,7 +511,8 @@ export interface FieldColourConfig extends FieldGridDropdownConfig {
 /**
  * fromJson config options for the colour field.
  */
-export interface FieldColourFromJsonConfig extends FieldGridDropdownFromJsonConfig {
+export interface FieldColourFromJsonConfig
+  extends FieldGridDropdownFromJsonConfig {
   colour?: string;
 }
 

--- a/plugins/field-colour/tsconfig.json
+++ b/plugins/field-colour/tsconfig.json
@@ -8,7 +8,8 @@
     "module": "es2015",
     "moduleResolution": "bundler",
     "target": "es6",
-    "strict": true
+    "strict": true,
+    "lib": ["ES2020", "dom"]
   },
   // NOTE: `test/**/*` is automatically included in `blockly-scripts start`.
   // Only src matters for production builds.

--- a/plugins/field-grid-dropdown/src/grid.ts
+++ b/plugins/field-grid-dropdown/src/grid.ts
@@ -104,7 +104,7 @@ export class Grid {
         this.root.appendChild(row);
       }
 
-      const [label, value] = item;
+      const [label, value, ariaLabel] = item;
       const content = (() => {
         if (isImageProperties(label)) {
           // Convert ImageProperties to an HTMLImageElement.
@@ -120,6 +120,7 @@ export class Grid {
         row,
         content,
         value,
+        ariaLabel,
         (selectedItem: GridItem) => {
           this.setSelectedValue(selectedItem.getValue());
           this.selectionCallback?.(selectedItem);

--- a/plugins/field-grid-dropdown/src/grid_item.ts
+++ b/plugins/field-grid-dropdown/src/grid_item.ts
@@ -28,15 +28,21 @@ export class GridItem {
    * @param container The parent element of this grid item in the DOM.
    * @param content The content to display in this grid item.
    * @param value The programmatic value of this grid item.
+   * @param ariaLabel An accessibility label that describes the contents of this
+   *     grid item to screenreaders.
    * @param selectionCallback Function to call when this item is selected.
    */
   constructor(
     container: HTMLElement,
     content: string | HTMLElement,
     private readonly value: string,
+    ariaLabel: string | undefined,
     selectionCallback: (selectedItem: GridItem) => void,
   ) {
     this.selectionCallback = selectionCallback;
+
+    const cell = document.createElement('div');
+    utils.aria.setRole(cell, utils.aria.Role.GRIDCELL);
 
     this.element = document.createElement('button');
     this.element.id = utils.idGenerator.getNextUniqueId();
@@ -48,13 +54,16 @@ export class GridItem {
       this.onClick,
       true,
     );
-    container.appendChild(this.element);
+    cell.appendChild(this.element);
+    container.appendChild(cell);
 
     const contentDom =
       typeof content === 'string' ? document.createTextNode(content) : content;
     this.element.appendChild(contentDom);
 
-    utils.aria.setRole(this.element, utils.aria.Role.GRIDCELL);
+    if (ariaLabel) {
+      utils.aria.setState(this.element, utils.aria.State.LABEL, ariaLabel);
+    }
   }
 
   /**

--- a/plugins/field-grid-dropdown/src/index.ts
+++ b/plugins/field-grid-dropdown/src/index.ts
@@ -25,8 +25,7 @@ export interface FieldGridDropdownConfig extends Blockly.FieldDropdownConfig {
 /**
  * Construct a FieldGridDropdown from a JSON arg object.
  */
-export interface FieldGridDropdownFromJsonConfig
-  extends FieldGridDropdownConfig {
+export interface FieldGridDropdownFromJsonConfig extends FieldGridDropdownConfig {
   options?: Blockly.MenuGenerator;
 }
 

--- a/plugins/field-grid-dropdown/src/index.ts
+++ b/plugins/field-grid-dropdown/src/index.ts
@@ -25,7 +25,8 @@ export interface FieldGridDropdownConfig extends Blockly.FieldDropdownConfig {
 /**
  * Construct a FieldGridDropdown from a JSON arg object.
  */
-export interface FieldGridDropdownFromJsonConfig extends FieldGridDropdownConfig {
+export interface FieldGridDropdownFromJsonConfig
+  extends FieldGridDropdownConfig {
   options?: Blockly.MenuGenerator;
 }
 
@@ -127,6 +128,19 @@ export class FieldGridDropdown extends Blockly.FieldDropdown {
     }
   }
 
+  /**
+   * Updates the ARIA roles and label for this field.
+   */
+  override recomputeAriaContext(): boolean {
+    super.recomputeAriaContext();
+    Blockly.utils.aria.setState(
+      this.getFocusableElement(),
+      Blockly.utils.aria.State.HASPOPUP,
+      'grid',
+    );
+    return true;
+  }
+
   /* eslint-disable @typescript-eslint/naming-convention */
   /**
    * Create a dropdown menu under the text.
@@ -217,7 +231,7 @@ Blockly.Css.register(`
      padding: 7px;
      overflow: auto;
    }
-   
+
   .blocklyFieldGrid {
     display: grid;
     grid-gap: 7px;
@@ -234,11 +248,11 @@ Blockly.Css.register(`
    cursor: pointer;
    padding: 6px 15px;
  }
- 
+
  .blocklyFieldGrid .blocklyFieldGridRow {
    display: contents;
  }
- 
+
  .blocklyFieldGrid .blocklyFieldGridItem.blocklyFieldGridItemSelected {
    background-color: rgba(1, 1, 1, 0.25);
  }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR improves the accessibility of the grid and colour fields. Specifically, it:

* Restructures the markup for grid cells such that the button is inside of a div with `role="gridcell"`, rather than itself being the grid cell. This improved readout in several ways:
  * VoiceOver no longer describes the focused cell as being "blank" if it has no textual content (i.e. color swatches)
  * The full textual content of the current row is not read out, in favor of a row/column count
  * Each focused item is described as a button
  * In Safari, items are consistently read out as they are navigated betweem
* `FieldGridDropdown` adds ARIA labels to its items when the `MenuGenerator` it is initialized with includes them
* Describes `FieldGridDropdown` as having a grid popup, rather than a listbox popup
* Gives names to all of the default colors in `FieldColour`, which are passed through as accessibility labels
* Denotes `FieldColour`'s type as "colour" when the field is being read out
* Updates the ARIA label for `FieldColour` in response to initialization/changing the selected color value
* Uses the Blockly keyboard focus highlight ring to indicate the focused color swatch in the grid