### PR TITLE
fix: Fix bug that caused focus to move to parent block when vivifying a shadow

### DIFF
--- a/plugins/shadow-block-converter/src/shadow_block_converter.ts
+++ b/plugins/shadow-block-converter/src/shadow_block_converter.ts
@@ -297,7 +297,9 @@ function reifyEditedShadowBlock(
   );
 
   if (selectNewBlock) {
-    Blockly.getFocusManager().focusNode(regularBlock as Blockly.BlockSvg);
+    Blockly.renderManagement.finishQueuedRenders().then(() => {
+      Blockly.getFocusManager().focusNode(regularBlock as Blockly.BlockSvg);
+    });
   }
 
   return regularBlock;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Proposed Changes
This PR improves the behavior of the shadow block converter plugin. Previously, when a shadow block's field had its value changed, the shadow block would become a regular block, but focus would move to the parent of the now-regular block, rather than the block itself. Now, focus moves to the block-that-was-a-shadow, rather than its parent.