### PR TITLE
fix: Improve keyboard accessibility of slider field

### DIFF
--- a/plugins/field-slider/src/field_slider.ts
+++ b/plugins/field-slider/src/field_slider.ts
@@ -124,9 +124,13 @@ export class FieldSlider extends Blockly.FieldNumber {
 
     // Focus on the slider field, unless quietInput is passed.
     if (!quietInput) {
-      (editor.firstChild as HTMLInputElement).focus({
-        preventScroll: true,
-      });
+      // Wait for the dropdown to animate in before attempting to focus the
+      // slider.
+      setTimeout(() => {
+        this.sliderInput?.focus({
+          preventScroll: true,
+        });
+      }, 250);
     }
   }
 
@@ -153,7 +157,27 @@ export class FieldSlider extends Blockly.FieldNumber {
     sliderInput.setAttribute('step', `${this.precision_}`);
     sliderInput.setAttribute('value', `${this.getValue()}`);
     sliderInput.setAttribute('tabindex', '0');
+    sliderInput.setAttribute('data-untyped-default-value', String(this.value_));
     sliderInput.className = 'fieldSlider';
+    sliderInput.addEventListener('keydown', (e) => {
+      let handled = false;
+      if (e.key === 'Enter') {
+        handled = true;
+      } else if (e.key === 'Escape') {
+        this.isBeingEdited_ = false;
+        this.setValue(
+          sliderInput.getAttribute('data-untyped-default-value'),
+          false,
+        );
+        handled = true;
+      }
+
+      if (handled) {
+        Blockly.WidgetDiv.hideIfOwner(this);
+        Blockly.DropDownDiv.hideIfOwner(this);
+        e.stopPropagation();
+      }
+    });
     wrapper.appendChild(sliderInput);
     this.sliderInput = sliderInput;
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details

### Proposed Changes
This PR improves the keyboard accessibility of the slider field. Specifically, it:

* Waits for the dropdown to animate in before focusing the slider, which fixes screenreader readouts
* Adds a keyboard listener that commits the value on enter and reverts it on Escape