### PR TITLE
feat!: make field-multilineinput keyboard navigable and accessible

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -218,6 +218,11 @@ module.exports = [
           modifiers: ['const'],
           format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
         },
+        {
+          selector: 'classProperty',
+          modifiers: ['static', 'readonly'],
+          format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+        },
       ],
       '@typescript-eslint/consistent-type-assertions': 'error',
 

--- a/plugins/field-angle/src/field_angle.ts
+++ b/plugins/field-angle/src/field_angle.ts
@@ -23,11 +23,9 @@ export class FieldAngle extends Blockly.FieldNumber {
    */
   static readonly RADIUS: number = FieldAngle.HALF - 1;
 
-   
   static readonly DEFAULT_PRECISION = 15;
   static readonly DEFAULT_MIN = 0;
   static readonly DEFAULT_MAX = 360;
-   
 
   /**
    * Whether the angle should increase as the angle picker is moved clockwise

--- a/plugins/field-angle/src/field_angle.ts
+++ b/plugins/field-angle/src/field_angle.ts
@@ -23,11 +23,11 @@ export class FieldAngle extends Blockly.FieldNumber {
    */
   static readonly RADIUS: number = FieldAngle.HALF - 1;
 
-  /* eslint-disable @typescript-eslint/naming-convention */
+   
   static readonly DEFAULT_PRECISION = 15;
   static readonly DEFAULT_MIN = 0;
   static readonly DEFAULT_MAX = 360;
-  /* eslint-enable @typescript-eslint/naming-convention */
+   
 
   /**
    * Whether the angle should increase as the angle picker is moved clockwise

--- a/plugins/field-colour-hsv-sliders/src/field_colour_hsv_sliders.ts
+++ b/plugins/field-colour-hsv-sliders/src/field_colour_hsv_sliders.ts
@@ -188,7 +188,6 @@ class HsvColour {
  * Class for a colour input field that displays HSV slider widgets when clicked.
  */
 export class FieldColourHsvSliders extends FieldColour {
-   
   /** The maximum value of the hue slider range. */
   private static readonly HUE_SLIDER_MAX = 360;
 
@@ -206,7 +205,6 @@ export class FieldColourHsvSliders extends FieldColour {
    * the minimum and maximum control points should be.
    */
   static readonly THUMB_RADIUS = 12;
-   
 
   /** Helper colour structures to allow manipulation in the HSV colour space. */
   private static readonly helperHsv: HsvColour = new HsvColour();

--- a/plugins/field-colour-hsv-sliders/src/field_colour_hsv_sliders.ts
+++ b/plugins/field-colour-hsv-sliders/src/field_colour_hsv_sliders.ts
@@ -188,7 +188,7 @@ class HsvColour {
  * Class for a colour input field that displays HSV slider widgets when clicked.
  */
 export class FieldColourHsvSliders extends FieldColour {
-  /* eslint-disable @typescript-eslint/naming-convention */
+   
   /** The maximum value of the hue slider range. */
   private static readonly HUE_SLIDER_MAX = 360;
 
@@ -206,7 +206,7 @@ export class FieldColourHsvSliders extends FieldColour {
    * the minimum and maximum control points should be.
    */
   static readonly THUMB_RADIUS = 12;
-  /* eslint-enable @typescript-eslint/naming-convention */
+   
 
   /** Helper colour structures to allow manipulation in the HSV colour space. */
   private static readonly helperHsv: HsvColour = new HsvColour();

--- a/plugins/field-dependent-dropdown/src/dependent_dropdown_options_change.ts
+++ b/plugins/field-dependent-dropdown/src/dependent_dropdown_options_change.ts
@@ -53,7 +53,7 @@ export interface DependentDropdownOptionsChangeJson
  */
 export class DependentDropdownOptionsChange extends Blockly.Events.BlockBase {
   /** The name to register with Blockly for the type of event. */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
+   
   static readonly EVENT_TYPE: string = 'dropdown_options_change';
 
   /** The name of the change event type for registering with Blockly. */

--- a/plugins/field-dependent-dropdown/src/dependent_dropdown_options_change.ts
+++ b/plugins/field-dependent-dropdown/src/dependent_dropdown_options_change.ts
@@ -53,7 +53,7 @@ export interface DependentDropdownOptionsChangeJson
  */
 export class DependentDropdownOptionsChange extends Blockly.Events.BlockBase {
   /** The name to register with Blockly for the type of event. */
-   
+
   static readonly EVENT_TYPE: string = 'dropdown_options_change';
 
   /** The name of the change event type for registering with Blockly. */

--- a/plugins/field-multilineinput/README.md
+++ b/plugins/field-multilineinput/README.md
@@ -41,11 +41,39 @@ always a valid string, while its text could be any string entered into its
 editor. Unlike a text input field, this field also supports newline characters
 entered in the editor.
 
+#### Editor keyboard shortcuts
+
+The default keyboard mapping is:
+
+| Key | Action |
+|-----|--------|
+| Enter | Commit the value and close the editor |
+| Shift+Enter | Insert a newline at the cursor |
+| Escape | Revert to the original value and close the editor |
+
+With `FieldMultilineInput.enterCommits = false` the mapping is swapped:
+
+| Key | Action |
+|-----|--------|
+| Enter | Insert a newline at the cursor |
+| Shift+Enter | Commit the value and close the editor |
+| Escape | Revert to the original value and close the editor |
+
+`enterCommits` and `showHint` are global (static) settings that apply to all
+fields. Set them once before creating your blocks:
+
+```js
+import {FieldMultilineInput} from '@blockly/field-multilineinput';
+
+FieldMultilineInput.enterCommits = false; // default: true
+FieldMultilineInput.showHint = false;     // default: true
+```
+
 The constructor for this field accepts three optional parameters:
 
 - `value`: The default text. Defaults to `""`.
 - `validator`: A function that is called to validate what the user entered.
-- `config`: An object with three optional properties:
+- `config`: An object with optional properties:
   - `maxLines`: The maximum number of lines displayed before scrolling
     functionality is enabled. Defaults to `Infinity`.
   - `spellcheck`: Whether spell checking is enabled. Defaults to `true`.
@@ -186,12 +214,23 @@ textMultiline.installBlock({
 
 ### API reference
 
+Instance methods:
+
 - `setMaxLines`: Sets the maximum number of displayed lines before
   scrolling functionality is enabled.
 - `getMaxLines`: Returns the maximum number of displayed lines before
   scrolling functionality is enabled.
 - `setSpellcheck`: Sets whether spell checking is enabled.
 - `getSpellcheck`: Returns whether spell checking is enabled.
+
+Static (global) properties:
+
+- `FieldMultilineInput.enterCommits`: Whether pressing Enter commits the
+  value (`true`, default) or inserts a newline (`false`). Applies to all
+  fields.
+- `FieldMultilineInput.showHint`: Whether the keyboard-shortcut hint bar is
+  shown in the editor. When `false`, no space is reserved for the hint bar.
+  Applies to all fields.
 
 ## License
 

--- a/plugins/field-multilineinput/README.md
+++ b/plugins/field-multilineinput/README.md
@@ -45,19 +45,19 @@ entered in the editor.
 
 The default keyboard mapping is:
 
-| Key | Action |
-|-----|--------|
-| Enter | Commit the value and close the editor |
-| Shift+Enter | Insert a newline at the cursor |
-| Escape | Revert to the original value and close the editor |
+| Key         | Action                                            |
+| ----------- | ------------------------------------------------- |
+| Enter       | Commit the value and close the editor             |
+| Shift+Enter | Insert a newline at the cursor                    |
+| Escape      | Revert to the original value and close the editor |
 
 With `FieldMultilineInput.enterCommits = false` the mapping is swapped:
 
-| Key | Action |
-|-----|--------|
-| Enter | Insert a newline at the cursor |
-| Shift+Enter | Commit the value and close the editor |
-| Escape | Revert to the original value and close the editor |
+| Key         | Action                                            |
+| ----------- | ------------------------------------------------- |
+| Enter       | Insert a newline at the cursor                    |
+| Shift+Enter | Commit the value and close the editor             |
+| Escape      | Revert to the original value and close the editor |
 
 `enterCommits` and `showHint` are global (static) settings that apply to all
 fields. Set them once before creating your blocks:
@@ -66,7 +66,7 @@ fields. Set them once before creating your blocks:
 import {FieldMultilineInput} from '@blockly/field-multilineinput';
 
 FieldMultilineInput.enterCommits = false; // default: true
-FieldMultilineInput.showHint = false;     // default: true
+FieldMultilineInput.showHint = false; // default: true
 ```
 
 The constructor for this field accepts three optional parameters:

--- a/plugins/field-multilineinput/src/field_multilineinput.ts
+++ b/plugins/field-multilineinput/src/field_multilineinput.ts
@@ -18,7 +18,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
    * Minimum editor width (in SVG/workspace units) when the field is open.
    * Prevents narrow editors when the initial text is very short.
    */
-   
+
   static readonly EDITOR_MIN_WIDTH = 150;
 
   /**

--- a/plugins/field-multilineinput/src/field_multilineinput.ts
+++ b/plugins/field-multilineinput/src/field_multilineinput.ts
@@ -466,15 +466,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
     const paddingBottomPx = FieldMultilineInput.showHint
       ? paddingY + hintHeightPx
       : paddingY;
-    htmlInput.style.padding =
-      paddingY +
-      'px ' +
-      paddingX +
-      'px ' +
-      paddingBottomPx +
-      'px ' +
-      paddingX +
-      'px';
+    htmlInput.style.padding = `${paddingY}px ${paddingX}px ${paddingBottomPx}px ${paddingX}px`;
     htmlInput.style.lineHeight = lineHeight * scale + 'px';
     div.appendChild(htmlInput);
 
@@ -625,8 +617,8 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
   protected override onHtmlInputKeyDown_(e: KeyboardEvent) {
     if (e.key === 'Enter') {
       if (e.isComposing) {
-        // Let the IME finalize its composition naturally; don't commit or
-        // insert a newline ourselves.
+        // Let the IME (input method editor) finalize its composition naturally;
+        // don't commit or insert a newline ourselves.
         return;
       }
       const shiftPressed = e.shiftKey;

--- a/plugins/field-multilineinput/src/field_multilineinput.ts
+++ b/plugins/field-multilineinput/src/field_multilineinput.ts
@@ -166,6 +166,9 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
       },
       this.fieldGroup_,
     );
+    if (this.fieldGroup_) {
+      Blockly.utils.dom.addClass(this.fieldGroup_, 'blocklyField');
+    }
   }
 
   /**

--- a/plugins/field-multilineinput/src/field_multilineinput.ts
+++ b/plugins/field-multilineinput/src/field_multilineinput.ts
@@ -15,6 +15,12 @@ import * as Blockly from 'blockly/core';
  */
 export class FieldMultilineInput extends Blockly.FieldTextInput {
   /**
+   * Minimum editor width (in SVG/workspace units) when the field is open.
+   * Prevents narrow editors when the initial text is very short.
+   */
+  static readonly EDITOR_MIN_WIDTH = 150;
+
+  /**
    * The SVG group element that will contain a text element for each text row
    *     when initialized.
    */
@@ -30,6 +36,23 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
   /** Whether Y overflow is currently occurring. */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   protected isOverflowedY_ = false;
+
+  /** Whether pressing Enter commits the value (default) or inserts a newline. */
+  static enterCommits = true;
+
+  /** Whether to show the keyboard-shortcut hint bar in the editor. */
+  static showHint = true;
+
+  /** The hint bar DOM element while the editor is open. */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  private hintElement_: HTMLDivElement | null = null;
+
+  /**
+   * Cached natural width of the hint bar in px, keyed by scale.
+   * Invalidated when zoom changes to avoid stale measurements.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  private cachedHintWidth_: {scale: number; widthPx: number} | null = null;
 
   /**
    * @param value The initial content of the field.  Should cast to a string.
@@ -346,6 +369,14 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
       const htmlInput = this.htmlInput_ as HTMLElement;
       const scrollbarWidth = htmlInput.offsetWidth - htmlInput.clientWidth;
       totalWidth += scrollbarWidth;
+
+      if (FieldMultilineInput.showHint) {
+        // Reserve a row at the bottom of the editor for the keyboard hint bar.
+        // The textarea's padding-bottom (set in widgetCreate_) keeps the text
+        // and caret out of this reserved strip.
+        totalHeight +=
+          constants.FIELD_TEXT_HEIGHT + constants.FIELD_BORDER_RECT_Y_PADDING;
+      }
     }
     if (this.borderRect_) {
       totalHeight += constants.FIELD_BORDER_RECT_Y_PADDING * 2;
@@ -353,6 +384,30 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
       // the rounding of the calculated value can result in the line wrapping
       // unintentionally.
       totalWidth += constants.FIELD_BORDER_RECT_X_PADDING * 2 + 1;
+    }
+    if (this.isBeingEdited_) {
+      totalWidth = Math.max(totalWidth, FieldMultilineInput.EDITOR_MIN_WIDTH);
+
+      // Measure the hint bar's natural width to make sure the editor is wide enough.
+      if (FieldMultilineInput.showHint && this.hintElement_?.isConnected) {
+        const scale = (this.workspace_ as Blockly.WorkspaceSvg).getScale();
+        if (!this.cachedHintWidth_ || this.cachedHintWidth_.scale !== scale) {
+          // Temporarily let the element size to its content to measure its
+          // natural width, unaffected by the current WidgetDiv width.
+          this.hintElement_.style.width = 'max-content';
+          const widthPx = this.hintElement_.offsetWidth;
+          this.hintElement_.style.width = '';
+          if (widthPx > 0) this.cachedHintWidth_ = {scale, widthPx};
+        }
+        if (this.cachedHintWidth_) {
+          totalWidth = Math.max(
+            totalWidth,
+            this.cachedHintWidth_.widthPx / scale,
+          );
+        }
+      }
+    }
+    if (this.borderRect_) {
       this.borderRect_.setAttribute('width', `${totalWidth}`);
       this.borderRect_.setAttribute('height', `${totalHeight}`);
     }
@@ -401,12 +456,22 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
     htmlInput.style.borderRadius = borderRadius;
     const paddingX = constants.FIELD_BORDER_RECT_X_PADDING * scale;
     const paddingY = (constants.FIELD_BORDER_RECT_Y_PADDING * scale) / 2;
-    htmlInput.style.padding =
-      paddingY + 'px ' + paddingX + 'px ' + paddingY + 'px ' + paddingX + 'px';
     const lineHeight =
       constants.FIELD_TEXT_HEIGHT + constants.FIELD_BORDER_RECT_Y_PADDING;
+    const hintHeightPx = Math.ceil(lineHeight * scale);
+    // When the hint bar is visible it occupies one text row at the bottom;
+    // pad the textarea by that row so we don't edit text underneath it.
+    const paddingBottomPx = FieldMultilineInput.showHint ? paddingY + hintHeightPx : paddingY;
+    htmlInput.style.padding =
+      paddingY +
+      'px ' +
+      paddingX +
+      'px ' +
+      paddingBottomPx +
+      'px ' +
+      paddingX +
+      'px';
     htmlInput.style.lineHeight = lineHeight * scale + 'px';
-
     div.appendChild(htmlInput);
 
     htmlInput.value = htmlInput.defaultValue = this.getEditorText_(this.value_);
@@ -421,7 +486,101 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
 
     this.bindInputEvents_(htmlInput);
 
+    if (FieldMultilineInput.showHint) {
+      this.hintElement_ = this.createHint_(hintHeightPx);
+      this.hintElement_.style.fontFamily = constants.FIELD_TEXT_FONTFAMILY;
+      div.appendChild(this.hintElement_);
+    }
+
     return htmlInput;
+  }
+
+  /**
+   * Creates the keyboard hint bar shown at the bottom of the editor.
+   *
+   * Keys are rendered as keycaps (bordered boxes).
+   *
+   * @param heightPx The height of the hint bar in pixels.
+   * @returns The hint bar element.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  private createHint_(heightPx: number): HTMLDivElement {
+    const shiftKey = '⇧';
+    const enterKey = '⏎';
+    const hint = document.createElement('div');
+    hint.className = 'blocklyMultilineHint';
+    hint.setAttribute('aria-hidden', 'true');
+    hint.style.height = heightPx + 'px';
+
+    // Plain Enter
+    const enterGroup = document.createElement('div');
+    enterGroup.className = 'blocklyMultilineHintGroup';
+    enterGroup.appendChild(this.createHintKeycap_(enterKey));
+    enterGroup.appendChild(this.createHintColon_());
+    enterGroup.appendChild(
+      this.createHintLabel_(FieldMultilineInput.enterCommits ? 'commit' : 'newline'),
+    );
+    hint.appendChild(enterGroup);
+
+    // Modifier+Enter
+    const modEnterGroup = document.createElement('div');
+    modEnterGroup.className = 'blocklyMultilineHintGroup';
+    modEnterGroup.appendChild(this.createHintKeycap_(shiftKey));
+    modEnterGroup.appendChild(this.createHintKeycap_(enterKey));
+    modEnterGroup.appendChild(this.createHintColon_());
+    modEnterGroup.appendChild(
+      this.createHintLabel_(FieldMultilineInput.enterCommits ? 'newline' : 'commit'),
+    );
+    hint.appendChild(modEnterGroup);
+
+    return hint;
+  }
+
+  /**
+   * Creates a colon separator element used between keycaps and the action icon.
+   *
+   * @returns The colon element.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  private createHintColon_(): HTMLSpanElement {
+    const colon = document.createElement('span');
+    colon.className = 'blocklyMultilineHintColon';
+    colon.textContent = ':';
+    return colon;
+  }
+
+  /**
+   * Creates a keycap element displaying a single key label.
+   *
+   * @param label The key symbol to display.
+   * @returns The keycap element.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  private createHintKeycap_(label: string): HTMLSpanElement {
+    const key = document.createElement('span');
+    key.className = 'blocklyMultilineHintKey';
+    key.textContent = label;
+    return key;
+  }
+
+  /**
+   * Creates a text label describing the result of a key action.
+   *
+   * Uses Blockly.Msg for i18n with hardcoded English fallbacks.
+   *
+   * @param type Either 'commit' or 'newline'.
+   * @returns The label element.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  private createHintLabel_(type: 'commit' | 'newline'): HTMLSpanElement {
+    const label = document.createElement('span');
+    label.className = 'blocklyMultilineHintLabel';
+    label.textContent =
+      type === 'commit'
+        ? Blockly.Msg['FIELD_MULTILINEINPUT_FINISH_EDITING'] ||
+          'Finish editing'
+        : Blockly.Msg['FIELD_MULTILINEINPUT_NEW_LINE'] || 'New line';
+    return label;
   }
 
   /**
@@ -451,16 +610,56 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
   }
 
   /**
-   * Handle key down to the editor.  Override the text input definition of this
-   * so as to not close the editor when enter is typed in.
+   * Handle key down to the editor.
+   *
+   * Enter commits the value and closes the editor (matching FieldTextInput).
+   * Shift+Enter inserts a newline at the cursor.
+   * All other keys are handled by the parent class (Escape reverts, Tab navigates).
    *
    * @param e Keyboard event.
    */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   protected override onHtmlInputKeyDown_(e: KeyboardEvent) {
-    if (e.key !== 'Enter') {
+    if (e.key === 'Enter') {
+      if (e.isComposing) {
+        // Let the IME finalize its composition naturally; don't commit or
+        // insert a newline ourselves.
+        return;
+      }
+      const shiftPressed = e.shiftKey;
+      const shouldCommit = FieldMultilineInput.enterCommits ? !shiftPressed : shiftPressed;
+      if (shouldCommit) {
+        super.onHtmlInputKeyDown_(e);
+      } else {
+        this.insertNewline_();
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    } else {
       super.onHtmlInputKeyDown_(e);
     }
+  }
+
+  /**
+   * Inserts a newline character at the current cursor position in the textarea.
+   *
+   * The browser's default Enter-key behavior inserts a newline, but
+   * Shift+Enter has no default character-insertion action, so we handle it
+   * manually here.  After splicing the character we dispatch an `input` event
+   * to trigger Blockly's onHtmlInputChange handler (programmatic `.value`
+   * assignment doesn't fire `input` on its own).
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  private insertNewline_() {
+    const htmlInput = this.htmlInput_!;
+    const start = htmlInput.selectionStart ?? htmlInput.value.length;
+    const end = htmlInput.selectionEnd ?? start;
+    htmlInput.value =
+      htmlInput.value.substring(0, start) +
+      '\n' +
+      htmlInput.value.substring(end);
+    htmlInput.selectionStart = htmlInput.selectionEnd = start + 1;
+    htmlInput.dispatchEvent(new Event('input'));
   }
 
   /**
@@ -502,6 +701,53 @@ Blockly.Css.register(`
 
 .blocklyHtmlTextAreaInputOverflowedY {
   overflow-y: scroll;
+}
+
+.blocklyMultilineHint {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  padding: 0 4px;
+  box-sizing: border-box;
+  font-size: 0.85em;
+  color: rgba(0, 0, 0, 0.6);
+  background-color: white;
+  border-top: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 0 0 4px 4px;
+  user-select: none;
+  pointer-events: none;
+}
+
+.blocklyMultilineHintGroup {
+  display: inline-flex;
+  align-items: center;
+}
+
+.blocklyMultilineHintKey {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.3em;
+  height: 1.3em;
+  padding: 0 0.25em;
+  margin: 0 0.1em;
+  border: 1px solid rgba(0, 0, 0, 0.35);
+  border-radius: 3px;
+  background-color: #f5f5f5;
+  line-height: 1;
+  box-sizing: border-box;
+}
+
+.blocklyMultilineHintColon {
+  margin: 0 0.15em;
+}
+
+.blocklyMultilineHintLabel {
+  white-space: nowrap;
 }
 `);
 

--- a/plugins/field-multilineinput/src/field_multilineinput.ts
+++ b/plugins/field-multilineinput/src/field_multilineinput.ts
@@ -462,7 +462,9 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
     const hintHeightPx = Math.ceil(lineHeight * scale);
     // When the hint bar is visible it occupies one text row at the bottom;
     // pad the textarea by that row so we don't edit text underneath it.
-    const paddingBottomPx = FieldMultilineInput.showHint ? paddingY + hintHeightPx : paddingY;
+    const paddingBottomPx = FieldMultilineInput.showHint
+      ? paddingY + hintHeightPx
+      : paddingY;
     htmlInput.style.padding =
       paddingY +
       'px ' +
@@ -518,7 +520,9 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
     enterGroup.appendChild(this.createHintKeycap(enterKey));
     enterGroup.appendChild(this.createHintColon());
     enterGroup.appendChild(
-      this.createHintLabel(FieldMultilineInput.enterCommits ? 'commit' : 'newline'),
+      this.createHintLabel(
+        FieldMultilineInput.enterCommits ? 'commit' : 'newline',
+      ),
     );
     hint.appendChild(enterGroup);
 
@@ -529,7 +533,9 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
     modEnterGroup.appendChild(this.createHintKeycap(enterKey));
     modEnterGroup.appendChild(this.createHintColon());
     modEnterGroup.appendChild(
-      this.createHintLabel(FieldMultilineInput.enterCommits ? 'newline' : 'commit'),
+      this.createHintLabel(
+        FieldMultilineInput.enterCommits ? 'newline' : 'commit',
+      ),
     );
     hint.appendChild(modEnterGroup);
 
@@ -574,8 +580,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
     label.className = 'blocklyMultilineHintLabel';
     label.textContent =
       type === 'commit'
-        ? Blockly.Msg['FIELD_MULTILINEINPUT_FINISH_EDITING'] ||
-          'Finish editing'
+        ? Blockly.Msg['FIELD_MULTILINEINPUT_FINISH_EDITING'] || 'Finish editing'
         : Blockly.Msg['FIELD_MULTILINEINPUT_NEW_LINE'] || 'New line';
     return label;
   }
@@ -624,7 +629,9 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
         return;
       }
       const shiftPressed = e.shiftKey;
-      const shouldCommit = FieldMultilineInput.enterCommits ? !shiftPressed : shiftPressed;
+      const shouldCommit = FieldMultilineInput.enterCommits
+        ? !shiftPressed
+        : shiftPressed;
       if (shouldCommit) {
         super.onHtmlInputKeyDown_(e);
       } else {

--- a/plugins/field-multilineinput/src/field_multilineinput.ts
+++ b/plugins/field-multilineinput/src/field_multilineinput.ts
@@ -44,15 +44,13 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
   static showHint = true;
 
   /** The hint bar DOM element while the editor is open. */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  private hintElement_: HTMLDivElement | null = null;
+  private hintElement: HTMLDivElement | null = null;
 
   /**
    * Cached natural width of the hint bar in px, keyed by scale.
    * Invalidated when zoom changes to avoid stale measurements.
    */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  private cachedHintWidth_: {scale: number; widthPx: number} | null = null;
+  private cachedHintWidth: {scale: number; widthPx: number} | null = null;
 
   /**
    * @param value The initial content of the field.  Should cast to a string.
@@ -389,20 +387,20 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
       totalWidth = Math.max(totalWidth, FieldMultilineInput.EDITOR_MIN_WIDTH);
 
       // Measure the hint bar's natural width to make sure the editor is wide enough.
-      if (FieldMultilineInput.showHint && this.hintElement_?.isConnected) {
+      if (FieldMultilineInput.showHint && this.hintElement?.isConnected) {
         const scale = (this.workspace_ as Blockly.WorkspaceSvg).getScale();
-        if (!this.cachedHintWidth_ || this.cachedHintWidth_.scale !== scale) {
+        if (!this.cachedHintWidth || this.cachedHintWidth.scale !== scale) {
           // Temporarily let the element size to its content to measure its
           // natural width, unaffected by the current WidgetDiv width.
-          this.hintElement_.style.width = 'max-content';
-          const widthPx = this.hintElement_.offsetWidth;
-          this.hintElement_.style.width = '';
-          if (widthPx > 0) this.cachedHintWidth_ = {scale, widthPx};
+          this.hintElement.style.width = 'max-content';
+          const widthPx = this.hintElement.offsetWidth;
+          this.hintElement.style.width = '';
+          if (widthPx > 0) this.cachedHintWidth = {scale, widthPx};
         }
-        if (this.cachedHintWidth_) {
+        if (this.cachedHintWidth) {
           totalWidth = Math.max(
             totalWidth,
-            this.cachedHintWidth_.widthPx / scale,
+            this.cachedHintWidth.widthPx / scale,
           );
         }
       }
@@ -487,9 +485,9 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
     this.bindInputEvents_(htmlInput);
 
     if (FieldMultilineInput.showHint) {
-      this.hintElement_ = this.createHint_(hintHeightPx);
-      this.hintElement_.style.fontFamily = constants.FIELD_TEXT_FONTFAMILY;
-      div.appendChild(this.hintElement_);
+      this.hintElement = this.createHint(hintHeightPx);
+      this.hintElement.style.fontFamily = constants.FIELD_TEXT_FONTFAMILY;
+      div.appendChild(this.hintElement);
     }
 
     return htmlInput;
@@ -503,8 +501,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
    * @param heightPx The height of the hint bar in pixels.
    * @returns The hint bar element.
    */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  private createHint_(heightPx: number): HTMLDivElement {
+  private createHint(heightPx: number): HTMLDivElement {
     const shiftKey = '⇧';
     const enterKey = '⏎';
     const hint = document.createElement('div');
@@ -515,21 +512,21 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
     // Plain Enter
     const enterGroup = document.createElement('div');
     enterGroup.className = 'blocklyMultilineHintGroup';
-    enterGroup.appendChild(this.createHintKeycap_(enterKey));
-    enterGroup.appendChild(this.createHintColon_());
+    enterGroup.appendChild(this.createHintKeycap(enterKey));
+    enterGroup.appendChild(this.createHintColon());
     enterGroup.appendChild(
-      this.createHintLabel_(FieldMultilineInput.enterCommits ? 'commit' : 'newline'),
+      this.createHintLabel(FieldMultilineInput.enterCommits ? 'commit' : 'newline'),
     );
     hint.appendChild(enterGroup);
 
     // Modifier+Enter
     const modEnterGroup = document.createElement('div');
     modEnterGroup.className = 'blocklyMultilineHintGroup';
-    modEnterGroup.appendChild(this.createHintKeycap_(shiftKey));
-    modEnterGroup.appendChild(this.createHintKeycap_(enterKey));
-    modEnterGroup.appendChild(this.createHintColon_());
+    modEnterGroup.appendChild(this.createHintKeycap(shiftKey));
+    modEnterGroup.appendChild(this.createHintKeycap(enterKey));
+    modEnterGroup.appendChild(this.createHintColon());
     modEnterGroup.appendChild(
-      this.createHintLabel_(FieldMultilineInput.enterCommits ? 'newline' : 'commit'),
+      this.createHintLabel(FieldMultilineInput.enterCommits ? 'newline' : 'commit'),
     );
     hint.appendChild(modEnterGroup);
 
@@ -541,8 +538,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
    *
    * @returns The colon element.
    */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  private createHintColon_(): HTMLSpanElement {
+  private createHintColon(): HTMLSpanElement {
     const colon = document.createElement('span');
     colon.className = 'blocklyMultilineHintColon';
     colon.textContent = ':';
@@ -555,8 +551,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
    * @param label The key symbol to display.
    * @returns The keycap element.
    */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  private createHintKeycap_(label: string): HTMLSpanElement {
+  private createHintKeycap(label: string): HTMLSpanElement {
     const key = document.createElement('span');
     key.className = 'blocklyMultilineHintKey';
     key.textContent = label;
@@ -571,8 +566,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
    * @param type Either 'commit' or 'newline'.
    * @returns The label element.
    */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  private createHintLabel_(type: 'commit' | 'newline'): HTMLSpanElement {
+  private createHintLabel(type: 'commit' | 'newline'): HTMLSpanElement {
     const label = document.createElement('span');
     label.className = 'blocklyMultilineHintLabel';
     label.textContent =
@@ -631,7 +625,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
       if (shouldCommit) {
         super.onHtmlInputKeyDown_(e);
       } else {
-        this.insertNewline_();
+        this.insertNewline();
         e.preventDefault();
         e.stopPropagation();
       }
@@ -649,8 +643,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
    * to trigger Blockly's onHtmlInputChange handler (programmatic `.value`
    * assignment doesn't fire `input` on its own).
    */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  private insertNewline_() {
+  private insertNewline() {
     const htmlInput = this.htmlInput_!;
     const start = htmlInput.selectionStart ?? htmlInput.value.length;
     const end = htmlInput.selectionEnd ?? start;

--- a/plugins/field-multilineinput/src/field_multilineinput.ts
+++ b/plugins/field-multilineinput/src/field_multilineinput.ts
@@ -18,6 +18,7 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
    * Minimum editor width (in SVG/workspace units) when the field is open.
    * Prevents narrow editors when the initial text is very short.
    */
+   
   static readonly EDITOR_MIN_WIDTH = 150;
 
   /**
@@ -654,7 +655,8 @@ export class FieldMultilineInput extends Blockly.FieldTextInput {
    * assignment doesn't fire `input` on its own).
    */
   private insertNewline() {
-    const htmlInput = this.htmlInput_!;
+    const htmlInput = this.htmlInput_;
+    if (!htmlInput) return;
     const start = htmlInput.selectionStart ?? htmlInput.value.length;
     const end = htmlInput.selectionEnd ?? start;
     htmlInput.value =

--- a/plugins/field-multilineinput/test/field_multilineinput_test.mocha.js
+++ b/plugins/field-multilineinput/test/field_multilineinput_test.mocha.js
@@ -183,20 +183,20 @@ suite('FieldMultilineInput', function () {
       assert.isTrue(this.superStub.calledOnce);
     });
 
-    test('insertNewline_ splices a newline at the cursor', function () {
+    test('insertNewline splices a newline at the cursor', function () {
       this.textarea.value = 'hello world';
       this.textarea.selectionStart = 5;
       this.textarea.selectionEnd = 5;
-      this.field['insertNewline_']();
+      this.field['insertNewline']();
       assert.equal(this.textarea.value, 'hello\n world');
       assert.equal(this.textarea.selectionStart, 6);
     });
 
-    test('insertNewline_ replaces a selection with a newline', function () {
+    test('insertNewline replaces a selection with a newline', function () {
       this.textarea.value = 'hello world';
       this.textarea.selectionStart = 5;
       this.textarea.selectionEnd = 11;
-      this.field['insertNewline_']();
+      this.field['insertNewline']();
       assert.equal(this.textarea.value, 'hello\n');
       assert.equal(this.textarea.selectionStart, 6);
     });

--- a/plugins/field-multilineinput/test/field_multilineinput_test.mocha.js
+++ b/plugins/field-multilineinput/test/field_multilineinput_test.mocha.js
@@ -10,6 +10,7 @@ const {
   registerFieldMultilineInput,
 } = require('../src/index');
 const {assert} = require('chai');
+const sinon = require('sinon');
 
 const {
   assertFieldValue,
@@ -116,6 +117,152 @@ suite('FieldMultilineInput', function () {
         invalidValueTestCases,
         initialValue,
       );
+    });
+  });
+
+  suite('Keyboard behavior', function () {
+    setup(function () {
+      this.jsdomCleanup = require('jsdom-global')('');
+      this.field = new FieldMultilineInput('hello');
+      this.textarea = document.createElement('textarea');
+      this.textarea.value = 'hello';
+      this.textarea.selectionStart = 5;
+      this.textarea.selectionEnd = 5;
+      this.field.htmlInput_ = this.textarea;
+      this.superStub = sinon.stub(
+        Blockly.FieldTextInput.prototype,
+        'onHtmlInputKeyDown_',
+      );
+    });
+
+    teardown(function () {
+      sinon.restore();
+      this.jsdomCleanup();
+    });
+
+    test('Enter calls super to commit the value', function () {
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        ctrlKey: false,
+        metaKey: false,
+      });
+      this.field.onHtmlInputKeyDown_(event);
+      assert.isTrue(this.superStub.calledOnce);
+    });
+
+    test('Shift+Enter inserts a newline without committing', function () {
+      this.textarea.value = 'hello';
+      this.textarea.selectionStart = 3;
+      this.textarea.selectionEnd = 3;
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        shiftKey: true,
+      });
+      this.field.onHtmlInputKeyDown_(event);
+      assert.isFalse(this.superStub.called, 'super should not be called');
+      assert.equal(this.textarea.value, 'hel\nlo');
+      assert.equal(this.textarea.selectionStart, 4);
+    });
+
+    test('Enter during IME composition does not commit or insert newline', function () {
+      this.textarea.value = 'hello';
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        ctrlKey: false,
+        metaKey: false,
+        isComposing: true,
+      });
+      this.field.onHtmlInputKeyDown_(event);
+      assert.isFalse(this.superStub.called, 'super should not be called');
+      assert.equal(this.textarea.value, 'hello', 'value should be unchanged');
+    });
+
+    test('Non-Enter keys call super', function () {
+      const event = new KeyboardEvent('keydown', {key: 'Escape'});
+      this.field.onHtmlInputKeyDown_(event);
+      assert.isTrue(this.superStub.calledOnce);
+    });
+
+    test('insertNewline_ splices a newline at the cursor', function () {
+      this.textarea.value = 'hello world';
+      this.textarea.selectionStart = 5;
+      this.textarea.selectionEnd = 5;
+      this.field['insertNewline_']();
+      assert.equal(this.textarea.value, 'hello\n world');
+      assert.equal(this.textarea.selectionStart, 6);
+    });
+
+    test('insertNewline_ replaces a selection with a newline', function () {
+      this.textarea.value = 'hello world';
+      this.textarea.selectionStart = 5;
+      this.textarea.selectionEnd = 11;
+      this.field['insertNewline_']();
+      assert.equal(this.textarea.value, 'hello\n');
+      assert.equal(this.textarea.selectionStart, 6);
+    });
+
+    suite('enterCommits = false (swapped mode)', function () {
+      setup(function () {
+        FieldMultilineInput.enterCommits = false;
+        this.textarea.value = 'hello';
+        this.textarea.selectionStart = 3;
+        this.textarea.selectionEnd = 3;
+      });
+
+      teardown(function () {
+        FieldMultilineInput.enterCommits = true;
+      });
+
+      test('plain Enter inserts a newline and does not call super', function () {
+        const event = new KeyboardEvent('keydown', {
+          key: 'Enter',
+          ctrlKey: false,
+          metaKey: false,
+        });
+        this.field.onHtmlInputKeyDown_(event);
+        assert.isFalse(this.superStub.called, 'super should not be called');
+        assert.equal(this.textarea.value, 'hel\nlo');
+      });
+
+      test('Shift+Enter calls super to commit and does not modify value', function () {
+        const event = new KeyboardEvent('keydown', {
+          key: 'Enter',
+          shiftKey: true,
+        });
+        this.field.onHtmlInputKeyDown_(event);
+        assert.isTrue(this.superStub.calledOnce, 'super should be called');
+        assert.equal(this.textarea.value, 'hello', 'value should be unchanged');
+      });
+    });
+
+    suite('FieldMultilineInput.enterCommits (global)', function () {
+      teardown(function () {
+        FieldMultilineInput.enterCommits = true;
+      });
+
+      test('defaults to true', function () {
+        assert.isTrue(FieldMultilineInput.enterCommits);
+      });
+
+      test('can be set to false globally', function () {
+        FieldMultilineInput.enterCommits = false;
+        assert.isFalse(FieldMultilineInput.enterCommits);
+      });
+    });
+  });
+
+  suite('FieldMultilineInput.showHint (global)', function () {
+    teardown(function () {
+      FieldMultilineInput.showHint = true;
+    });
+
+    test('defaults to true', function () {
+      assert.isTrue(FieldMultilineInput.showHint);
+    });
+
+    test('can be set to false globally', function () {
+      FieldMultilineInput.showHint = false;
+      assert.isFalse(FieldMultilineInput.showHint);
     });
   });
 

--- a/plugins/field-multilineinput/test/field_multilineinput_test.mocha.js
+++ b/plugins/field-multilineinput/test/field_multilineinput_test.mocha.js
@@ -9,6 +9,7 @@ const {
   FieldMultilineInput,
   registerFieldMultilineInput,
 } = require('../src/index');
+const Blockly = require('blockly');
 const {assert} = require('chai');
 const sinon = require('sinon');
 
@@ -121,14 +122,74 @@ suite('FieldMultilineInput', function () {
   });
 
   suite('Keyboard behavior', function () {
+    /**
+     * Dispatches a keydown event on the editor's textarea, setting the
+     * cursor/selection beforehand.
+     * @param {!HTMLTextAreaElement} textarea The editor's textarea.
+     * @param {!Object} options KeyboardEvent options (key, shiftKey, etc.).
+     * @param {number} [selectionStart] Optional selection start to set first.
+     * @param {number} [selectionEnd] Optional selection end to set first.
+     */
+    const pressKey = function (
+      textarea,
+      options,
+      selectionStart,
+      selectionEnd,
+    ) {
+      if (selectionStart !== undefined) {
+        textarea.selectionStart = selectionStart;
+        textarea.selectionEnd = selectionEnd ?? selectionStart;
+      }
+      textarea.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          ...options,
+        }),
+      );
+    };
+
     setup(function () {
-      this.jsdomCleanup = require('jsdom-global')('');
-      this.field = new FieldMultilineInput('hello');
-      this.textarea = document.createElement('textarea');
-      this.textarea.value = 'hello';
-      this.textarea.selectionStart = 5;
-      this.textarea.selectionEnd = 5;
-      this.field.htmlInput_ = this.textarea;
+      this.jsdomCleanup = require('jsdom-global')(
+        '<!DOCTYPE html><div id="blocklyDiv"></div>',
+      );
+      // See https://github.com/RaspberryPiFoundation/blockly-samples/issues/2528.
+      global.SVGElement = window.SVGElement;
+      // Blockly's focus handling constructs FocusEvent, which jsdom exposes on
+      // window but not as a global.
+      global.FocusEvent = window.FocusEvent;
+      // jsdom doesn't provide requestAnimationFrame/cancelAnimationFrame, which
+      // block rendering relies on. Route them through (faked) timers so they
+      // exist and can be flushed deterministically in teardown.
+      this.clock = sinon.useFakeTimers();
+      window.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+      window.cancelAnimationFrame = (id) => clearTimeout(id);
+      this.workspace = Blockly.inject('blocklyDiv');
+
+      if (!Blockly.Blocks['multiline_block']) {
+        Blockly.defineBlocksWithJsonArray([
+          {
+            type: 'multiline_block',
+            message0: '%1',
+            args0: [
+              {type: 'field_multilinetext', name: 'FIELD', text: 'hello'},
+            ],
+          },
+        ]);
+      }
+      this.block = this.workspace.newBlock('multiline_block');
+      this.block.initSvg();
+      this.block.render();
+      this.field = this.block.getField('FIELD');
+
+      // Open the editor so we exercise the real <textarea> and its bound
+      // event handlers rather than a fabricated stand-in.
+      this.field.showEditor_();
+      this.textarea = this.field.htmlInput_;
+
+      // Stub the parent handler so we can detect when the field delegates to it
+      // (i.e. commits the value). super.onHtmlInputKeyDown_ resolves to this at
+      // call time, so stubbing after binding still works.
       this.superStub = sinon.stub(
         Blockly.FieldTextInput.prototype,
         'onHtmlInputKeyDown_',
@@ -136,77 +197,48 @@ suite('FieldMultilineInput', function () {
     });
 
     teardown(function () {
+      Blockly.WidgetDiv.hide();
+      this.workspace.dispose();
+      this.clock.runAll();
       sinon.restore();
       this.jsdomCleanup();
     });
 
     test('Enter calls super to commit the value', function () {
-      const event = new KeyboardEvent('keydown', {
-        key: 'Enter',
-        ctrlKey: false,
-        metaKey: false,
-      });
-      this.field.onHtmlInputKeyDown_(event);
+      pressKey(this.textarea, {key: 'Enter'});
       assert.isTrue(this.superStub.calledOnce);
     });
 
     test('Shift+Enter inserts a newline without committing', function () {
-      this.textarea.value = 'hello';
-      this.textarea.selectionStart = 3;
-      this.textarea.selectionEnd = 3;
-      const event = new KeyboardEvent('keydown', {
-        key: 'Enter',
-        shiftKey: true,
-      });
-      this.field.onHtmlInputKeyDown_(event);
+      pressKey(this.textarea, {key: 'Enter', shiftKey: true}, 3);
       assert.isFalse(this.superStub.called, 'super should not be called');
       assert.equal(this.textarea.value, 'hel\nlo');
       assert.equal(this.textarea.selectionStart, 4);
     });
 
+    test('Shift+Enter replaces a selection with a newline', function () {
+      this.textarea.value = 'hello world';
+      pressKey(this.textarea, {key: 'Enter', shiftKey: true}, 5, 11);
+      assert.equal(this.textarea.value, 'hello\n');
+      assert.equal(this.textarea.selectionStart, 6);
+    });
+
+    // IME composition is a special case where the browser is still in the process of
+    // composing text, so we don't want to commit or insert a newline when Enter is pressed.
     test('Enter during IME composition does not commit or insert newline', function () {
-      this.textarea.value = 'hello';
-      const event = new KeyboardEvent('keydown', {
-        key: 'Enter',
-        ctrlKey: false,
-        metaKey: false,
-        isComposing: true,
-      });
-      this.field.onHtmlInputKeyDown_(event);
+      pressKey(this.textarea, {key: 'Enter', isComposing: true});
       assert.isFalse(this.superStub.called, 'super should not be called');
       assert.equal(this.textarea.value, 'hello', 'value should be unchanged');
     });
 
     test('Non-Enter keys call super', function () {
-      const event = new KeyboardEvent('keydown', {key: 'Escape'});
-      this.field.onHtmlInputKeyDown_(event);
+      pressKey(this.textarea, {key: 'Escape'});
       assert.isTrue(this.superStub.calledOnce);
-    });
-
-    test('insertNewline splices a newline at the cursor', function () {
-      this.textarea.value = 'hello world';
-      this.textarea.selectionStart = 5;
-      this.textarea.selectionEnd = 5;
-      this.field['insertNewline']();
-      assert.equal(this.textarea.value, 'hello\n world');
-      assert.equal(this.textarea.selectionStart, 6);
-    });
-
-    test('insertNewline replaces a selection with a newline', function () {
-      this.textarea.value = 'hello world';
-      this.textarea.selectionStart = 5;
-      this.textarea.selectionEnd = 11;
-      this.field['insertNewline']();
-      assert.equal(this.textarea.value, 'hello\n');
-      assert.equal(this.textarea.selectionStart, 6);
     });
 
     suite('enterCommits = false (swapped mode)', function () {
       setup(function () {
         FieldMultilineInput.enterCommits = false;
-        this.textarea.value = 'hello';
-        this.textarea.selectionStart = 3;
-        this.textarea.selectionEnd = 3;
       });
 
       teardown(function () {
@@ -214,55 +246,16 @@ suite('FieldMultilineInput', function () {
       });
 
       test('plain Enter inserts a newline and does not call super', function () {
-        const event = new KeyboardEvent('keydown', {
-          key: 'Enter',
-          ctrlKey: false,
-          metaKey: false,
-        });
-        this.field.onHtmlInputKeyDown_(event);
+        pressKey(this.textarea, {key: 'Enter'}, 3);
         assert.isFalse(this.superStub.called, 'super should not be called');
         assert.equal(this.textarea.value, 'hel\nlo');
       });
 
       test('Shift+Enter calls super to commit and does not modify value', function () {
-        const event = new KeyboardEvent('keydown', {
-          key: 'Enter',
-          shiftKey: true,
-        });
-        this.field.onHtmlInputKeyDown_(event);
+        pressKey(this.textarea, {key: 'Enter', shiftKey: true}, 3);
         assert.isTrue(this.superStub.calledOnce, 'super should be called');
         assert.equal(this.textarea.value, 'hello', 'value should be unchanged');
       });
-    });
-
-    suite('FieldMultilineInput.enterCommits (global)', function () {
-      teardown(function () {
-        FieldMultilineInput.enterCommits = true;
-      });
-
-      test('defaults to true', function () {
-        assert.isTrue(FieldMultilineInput.enterCommits);
-      });
-
-      test('can be set to false globally', function () {
-        FieldMultilineInput.enterCommits = false;
-        assert.isFalse(FieldMultilineInput.enterCommits);
-      });
-    });
-  });
-
-  suite('FieldMultilineInput.showHint (global)', function () {
-    teardown(function () {
-      FieldMultilineInput.showHint = true;
-    });
-
-    test('defaults to true', function () {
-      assert.isTrue(FieldMultilineInput.showHint);
-    });
-
-    test('can be set to false globally', function () {
-      FieldMultilineInput.showHint = false;
-      assert.isFalse(FieldMultilineInput.showHint);
     });
   });
 

--- a/plugins/field-multilineinput/test/index.ts
+++ b/plugins/field-multilineinput/test/index.ts
@@ -15,7 +15,7 @@ import {phpGenerator} from 'blockly/php';
 import {pythonGenerator} from 'blockly/python';
 import {luaGenerator} from 'blockly/lua';
 import {createPlayground} from '@blockly/dev-tools';
-import {textMultiline} from '../src/index';
+import {FieldMultilineInput, textMultiline} from '../src/index';
 
 /**
  * An array of blocks that are defined only for the purposes of
@@ -209,8 +209,7 @@ function createWorkspace(
     python: pythonGenerator,
     php: phpGenerator,
   });
-  const workspace = Blockly.inject(blocklyDiv, options);
-  return workspace;
+  return Blockly.inject(blocklyDiv, options);
 }
 
 document.addEventListener('DOMContentLoaded', function () {
@@ -219,6 +218,25 @@ document.addEventListener('DOMContentLoaded', function () {
   };
   const rootElement = document.getElementById('root');
   if (rootElement) {
-    createPlayground(rootElement, createWorkspace, defaultOptions);
+    createPlayground(rootElement, createWorkspace, defaultOptions).then(
+      (playground) => {
+        playground.addCheckboxAction(
+          'Enter sends newline',
+          (_workspace, value: boolean) => {
+            FieldMultilineInput.enterCommits = !value;
+          },
+          'Field MultilineInput',
+          false,
+        );
+        playground.addCheckboxAction(
+          'Disable hint UI',
+          (_workspace, value: boolean) => {
+            FieldMultilineInput.showHint = !value;
+          },
+          'Field MultilineInput',
+          false,
+        );
+      },
+    );
   }
 });

--- a/plugins/field-multilineinput/test/index.ts
+++ b/plugins/field-multilineinput/test/index.ts
@@ -222,7 +222,7 @@ document.addEventListener('DOMContentLoaded', function () {
       (playground) => {
         playground.addCheckboxAction(
           'Enter sends newline',
-          (_workspace, value: boolean) => {
+          (workspace, value: boolean) => {
             FieldMultilineInput.enterCommits = !value;
           },
           'Field MultilineInput',
@@ -230,7 +230,7 @@ document.addEventListener('DOMContentLoaded', function () {
         );
         playground.addCheckboxAction(
           'Disable hint UI',
-          (_workspace, value: boolean) => {
+          (workspace, value: boolean) => {
             FieldMultilineInput.showHint = !value;
           },
           'Field MultilineInput',

--- a/plugins/shadow-block-converter/src/shadow_block_converter.ts
+++ b/plugins/shadow-block-converter/src/shadow_block_converter.ts
@@ -25,9 +25,8 @@ export class BlockShadowStateChange extends Blockly.Events.BlockBase {
   /**
    * The name of the event type for broadcast and listening purposes.
    */
-   
+
   static readonly EVENT_TYPE = 'block_shadow_state_change';
-   
 
   /**
    * The index of the connection in the parent block's list of connections. If

--- a/plugins/shadow-block-converter/src/shadow_block_converter.ts
+++ b/plugins/shadow-block-converter/src/shadow_block_converter.ts
@@ -25,9 +25,9 @@ export class BlockShadowStateChange extends Blockly.Events.BlockBase {
   /**
    * The name of the event type for broadcast and listening purposes.
    */
-  /* eslint-disable @typescript-eslint/naming-convention */
+   
   static readonly EVENT_TYPE = 'block_shadow_state_change';
-  /* eslint-enable @typescript-eslint/naming-convention */
+   
 
   /**
    * The index of the connection in the parent block's list of connections. If


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes field-multilineinput not keyboard accessible

### Proposed Changes

- Makes `Enter` commit edits, like all other input fields (this is a breaking behavioral change).
- Adds a `Shift+Enter` handler that adds newlines.
- Adds a hint UI that explains these options, with translatable hints + fallbacks because these aren't in core yet.
- Adds 2 new APIs that allow you to control this behavior. if you want enter to add a newline like it used to, you can do that, in which case shift+enter will commit the change.
- Updates the readme with this information.
- Adds the missing keyboard focus ring indicator.
- Adds 2 options in the test playground page UI that control the 2 settings.
- Edits the eslint config to allow UPPER_CASE for static readonly class members, and removes some eslint silencing on existing ones

### Reason for Changes

This plugin couldn't be used with only the keyboard as there was no way to commit a change.

### Test Coverage

Tested manually and added additional unit tests.

### Documentation

updated the readme already

### Additional Information

<img width="323" height="168" alt="Screenshot 2026-06-24 at 1 10 39 PM" src="https://github.com/user-attachments/assets/60e65c3e-ca31-4ac9-b96a-13767bf38da5" />

