### PR TITLE
feat: fix keyboard nav for minimap

### DIFF
--- a/plugins/workspace-minimap/README.md
+++ b/plugins/workspace-minimap/README.md
@@ -73,6 +73,28 @@ minimap.init();
 The minimap takes a workspace as input and it inherits its RTL and theme properties (so that they don't need to be configured manually).
 Additional styling of the minimap is possible with CSS. Use the `blockly-minimap` class for the minimap (box-shadow, etc.) and `blockly-focus-region` for the focus region (fill color, etc.).
 
+## Keyboard accessibility
+
+The minimap is a single tab stop in the page tab order. When focused, the arrow
+keys pan the main workspace:
+
+| Key          | Action                  |
+| ------------ | ----------------------- |
+| `ArrowUp`    | Pan the workspace up    |
+| `ArrowDown`  | Pan the workspace down  |
+| `ArrowLeft`  | Pan the workspace left  |
+| `ArrowRight` | Pan the workspace right |
+
+Modifier key combinations (Ctrl, Alt, Shift, Meta) are passed through without
+panning.
+
+The default pan distance is 40 workspace pixels per keypress and is
+configurable:
+
+```js
+minimap.setKeyboardPanStep(80); // pan 80px per arrow press
+```
+
 ## API
 
 - `init`: Initializes the minimap.
@@ -81,6 +103,11 @@ Additional styling of the minimap is possible with CSS. Use the `blockly-minimap
 - `isFocusEnabled`: Returns whether the focus region is enabled.
 - `enableFocusRegion`: Turns on the focus region in the minimap.
 - `disableFocusRegion`: Turns off the focus region in the minimap.
+
+- `setKeyboardPanStep(stepPixels)`: Sets how far (in primary-workspace pixels)
+  each arrow keypress pans the workspace when the minimap is focused.
+- `getKeyboardPanStep()`: Returns the current keyboard pan step in
+  primary-workspace pixels.
 
 The following methods are also accessible with PositionedMinimap instances.
 

--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -142,13 +142,13 @@ export class Minimap {
       this.minimapWrapper,
       'focus',
       this,
-      this.onWrapperFocus,
+      this.onMinimapFocus,
     );
     this.onBlurWrapper = Blockly.browserEvents.bind(
       this.minimapWrapper,
       'blur',
       this,
-      this.onWrapperBlur,
+      this.onMinimapBlur,
     );
 
     this.minimapWorkspace.scrollbar?.setContainerVisible(false);
@@ -351,7 +351,7 @@ export class Minimap {
     this.primaryScroll(event);
   }
 
-  private onWrapperFocus(): void {
+  private onMinimapFocus(): void {
     if (this.minimapWrapper?.matches(':focus-visible')) {
       this.minimapWrapper.style.setProperty(
         'outline-width',
@@ -365,7 +365,7 @@ export class Minimap {
     }
   }
 
-  private onWrapperBlur(): void {
+  private onMinimapBlur(): void {
     if (this.minimapWrapper) {
       this.minimapWrapper.style.removeProperty('outline-width');
       this.minimapWrapper.style.removeProperty('outline-style');

--- a/plugins/workspace-minimap/src/minimap.ts
+++ b/plugins/workspace-minimap/src/minimap.ts
@@ -23,6 +23,9 @@ const blockEvents = new Set<string>([
   Blockly.Events.BLOCK_MOVE,
 ]);
 
+/** Default primary-workspace pixels to pan per arrow keypress. */
+const DEFAULT_PAN_STEP = 40;
+
 /**
  * A minimap is a miniature version of your blocks that appears on
  * top of your main workspace. This gives you an overview of what
@@ -36,6 +39,10 @@ export class Minimap {
   protected onMouseDownWrapper: Blockly.browserEvents.Data | null = null;
   protected onMouseUpWrapper: Blockly.browserEvents.Data | null = null;
   protected minimapWrapper: HTMLDivElement | null = null;
+  private onKeyDownWrapper: Blockly.browserEvents.Data | null = null;
+  private onFocusWrapper: Blockly.browserEvents.Data | null = null;
+  private onBlurWrapper: Blockly.browserEvents.Data | null = null;
+  protected panStep = DEFAULT_PAN_STEP;
 
   /**
    * Constructor for a minimap.
@@ -88,6 +95,61 @@ export class Minimap {
       theme: this.primaryWorkspace.getTheme(),
       renderer: this.primaryWorkspace.options.renderer,
     });
+
+    // Remove the minimap workspace from the focus manager so keyboard focus
+    // can never land inside it.
+    // `unregisterTree` also removes the tabIndex that inject
+    // set on the minimap SVG, dropping it from the tab order.
+    const focusManager = Blockly.getFocusManager();
+    if (focusManager.isRegistered(this.minimapWorkspace)) {
+      focusManager.unregisterTree(this.minimapWorkspace);
+    }
+
+    // The focus-ring CSS variables are defined on .injectionDiv. The wrapper is
+    // a sibling of that element, not a descendant, so var() references won't
+    // resolve there. Copy the values onto the wrapper so the focus handler can
+    // use them.
+    const injectionStyle = getComputedStyle(
+      this.primaryWorkspace.getInjectionDiv(),
+    );
+    for (const prop of [
+      '--blockly-active-tree-color',
+      '--blockly-selection-width',
+    ]) {
+      const value = injectionStyle.getPropertyValue(prop).trim();
+      if (value) this.minimapWrapper.style.setProperty(prop, value);
+    }
+
+    const label =
+      Blockly.Msg['MINIMAP_ARIA_LABEL'] ||
+      'Workspace minimap. Use the arrow keys to pan the workspace.';
+    this.minimapWrapper.tabIndex = 0;
+    this.minimapWrapper.setAttribute('role', 'application');
+    this.minimapWrapper.setAttribute('aria-label', label);
+
+    // Bind arrow-key panning on the wrapper (where focus lives).
+    this.onKeyDownWrapper = Blockly.browserEvents.bind(
+      this.minimapWrapper,
+      'keydown',
+      this,
+      this.onKeyDown,
+    );
+
+    // Apply a focus ring matching the workspace when focused via keyboard.
+    // Ideally this would just be done with CSS, but our CSS management system
+    // doesn't allow us to inject CSS after workspace creation, so deal with it.
+    this.onFocusWrapper = Blockly.browserEvents.bind(
+      this.minimapWrapper,
+      'focus',
+      this,
+      this.onWrapperFocus,
+    );
+    this.onBlurWrapper = Blockly.browserEvents.bind(
+      this.minimapWrapper,
+      'blur',
+      this,
+      this.onWrapperBlur,
+    );
 
     this.minimapWorkspace.scrollbar?.setContainerVisible(false);
     this.primaryWorkspace.addChangeListener((e) => void this.mirror(e));
@@ -151,6 +213,18 @@ export class Minimap {
     }
     if (this.onMouseUpWrapper) {
       Blockly.browserEvents.unbind(this.onMouseUpWrapper);
+    }
+    if (this.onKeyDownWrapper) {
+      Blockly.browserEvents.unbind(this.onKeyDownWrapper);
+      this.onKeyDownWrapper = null;
+    }
+    if (this.onFocusWrapper) {
+      Blockly.browserEvents.unbind(this.onFocusWrapper);
+      this.onFocusWrapper = null;
+    }
+    if (this.onBlurWrapper) {
+      Blockly.browserEvents.unbind(this.onBlurWrapper);
+      this.onBlurWrapper = null;
     }
   }
 
@@ -275,6 +349,80 @@ export class Minimap {
    */
   private onMouseMove(event: PointerEvent): void {
     this.primaryScroll(event);
+  }
+
+  private onWrapperFocus(): void {
+    if (this.minimapWrapper?.matches(':focus-visible')) {
+      this.minimapWrapper.style.setProperty(
+        'outline-width',
+        'var(--blockly-selection-width)',
+      );
+      this.minimapWrapper.style.setProperty('outline-style', 'solid');
+      this.minimapWrapper.style.setProperty(
+        'outline-color',
+        'var(--blockly-active-tree-color)',
+      );
+    }
+  }
+
+  private onWrapperBlur(): void {
+    if (this.minimapWrapper) {
+      this.minimapWrapper.style.removeProperty('outline-width');
+      this.minimapWrapper.style.removeProperty('outline-style');
+      this.minimapWrapper.style.removeProperty('outline-color');
+    }
+  }
+
+  /**
+   * Pans the primary workspace when an arrow key is pressed on the minimap
+   * wrapper.
+   *
+   * @param event The keyboard event.
+   */
+  private onKeyDown(event: KeyboardEvent): void {
+    if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey)
+      return;
+    let dx = 0;
+    let dy = 0;
+    switch (event.key) {
+      case 'ArrowUp':
+        dy = this.panStep;
+        break;
+      case 'ArrowDown':
+        dy = -this.panStep;
+        break;
+      case 'ArrowLeft':
+        dx = this.panStep;
+        break;
+      case 'ArrowRight':
+        dx = -this.panStep;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    const ws = this.primaryWorkspace;
+    ws.scroll(ws.scrollX + dx, ws.scrollY + dy);
+  }
+
+  /**
+   * Sets how far (in primary-workspace pixels) each arrow keypress pans the
+   * workspace when the minimap is focused.
+   *
+   * @param stepPixels Pixels to pan per keypress.
+   */
+  setKeyboardPanStep(stepPixels: number): void {
+    this.panStep = stepPixels;
+  }
+
+  /**
+   * Returns the current keyboard pan step in primary-workspace pixels.
+   *
+   * @returns The pan step in pixels.
+   */
+  getKeyboardPanStep(): number {
+    return this.panStep;
   }
 
   /**

--- a/plugins/workspace-minimap/test/minimap_tests.mocha.js
+++ b/plugins/workspace-minimap/test/minimap_tests.mocha.js
@@ -6,6 +6,7 @@
 
 const chai = require('chai');
 const assert = chai.assert;
+const sinon = require('sinon');
 const Blockly = require('blockly');
 const {Minimap} = require('../src/minimap');
 const {PositionedMinimap} = require('../src/positioned_minimap');
@@ -431,5 +432,148 @@ suite('Positioning the minimap in the primary workspace', function () {
       'RTL Horizontal End: Incorrect top',
     );
     assert.equal(position.left, 35, 'RTL Horizontal End: Incorrect left');
+  });
+});
+
+suite('Keyboard navigation', function () {
+  setup(function () {
+    this.jsdomCleanup = require('jsdom-global')(
+      '<!DOCTYPE html><div id="blocklyDiv"></div>',
+    );
+    // jsdom does not implement SVGElement natively; expose the shim.
+    global.SVGElement = window.SVGElement;
+    this.workspace = Blockly.inject('blocklyDiv', {
+      move: {scrollbars: true},
+    });
+    this.minimap = new Minimap(this.workspace);
+    this.minimap.init();
+  });
+
+  teardown(function () {
+    this.minimap.dispose();
+    this.workspace.dispose();
+    this.jsdomCleanup();
+  });
+
+  test('minimap workspace is not registered with FocusManager after init()', function () {
+    const focusManager = Blockly.getFocusManager();
+    assert.isFalse(
+      focusManager.isRegistered(this.minimap.minimapWorkspace),
+      'Minimap workspace should not be registered with FocusManager',
+    );
+  });
+
+  test('minimap wrapper has tabIndex 0 and aria-label', function () {
+    const wrapper = this.minimap.minimapWrapper;
+    assert.equal(wrapper.tabIndex, 0, 'minimapWrapper tabIndex should be 0');
+    assert.isNotEmpty(
+      wrapper.getAttribute('aria-label'),
+      'minimapWrapper aria-label should describe keyboard usage',
+    );
+  });
+
+  suite('Arrow key panning', function () {
+    setup(function () {
+      this.scrollStub = sinon.stub(this.workspace, 'scroll');
+    });
+
+    teardown(function () {
+      this.scrollStub.restore();
+    });
+
+    /**
+     * Fires a keydown event on the given wrapper.
+     * @param {*} wrapper The element to fire the event on.
+     * @param {*} key The key to simulate.
+     * @param {*} modifiers Any modifier keys (e.g., {ctrlKey: true}).
+     * @returns {Event} The fired event.
+     */
+    function fireKey(wrapper, key, modifiers = {}) {
+      const event = new window.KeyboardEvent('keydown', {
+        key,
+        bubbles: true,
+        cancelable: true,
+        ...modifiers,
+      });
+      wrapper.dispatchEvent(event);
+      return event;
+    }
+
+    test('ArrowDown scrolls Y by -panStep', function () {
+      const step = this.minimap.getKeyboardPanStep();
+      this.workspace.scrollX = 0;
+      this.workspace.scrollY = 0;
+      fireKey(this.minimap.minimapWrapper, 'ArrowDown');
+      assert.isTrue(
+        this.scrollStub.calledOnce,
+        'scroll() should be called on ArrowDown',
+      );
+      const [, dy] = this.scrollStub.firstCall.args;
+      assert.equal(dy, -step, 'ArrowDown should pass scrollY - panStep');
+    });
+
+    test('ArrowUp scrolls Y by +panStep', function () {
+      const step = this.minimap.getKeyboardPanStep();
+      this.workspace.scrollX = 0;
+      this.workspace.scrollY = 0;
+      fireKey(this.minimap.minimapWrapper, 'ArrowUp');
+      assert.isTrue(this.scrollStub.calledOnce);
+      const [, dy] = this.scrollStub.firstCall.args;
+      assert.equal(dy, step);
+    });
+
+    test('ArrowRight scrolls X by -panStep', function () {
+      const step = this.minimap.getKeyboardPanStep();
+      this.workspace.scrollX = 0;
+      this.workspace.scrollY = 0;
+      fireKey(this.minimap.minimapWrapper, 'ArrowRight');
+      assert.isTrue(this.scrollStub.calledOnce);
+      const [dx] = this.scrollStub.firstCall.args;
+      assert.equal(dx, -step);
+    });
+
+    test('ArrowLeft scrolls X by +panStep', function () {
+      const step = this.minimap.getKeyboardPanStep();
+      this.workspace.scrollX = 0;
+      this.workspace.scrollY = 0;
+      fireKey(this.minimap.minimapWrapper, 'ArrowLeft');
+      assert.isTrue(this.scrollStub.calledOnce);
+      const [dx] = this.scrollStub.firstCall.args;
+      assert.equal(dx, step);
+    });
+
+    test('Arrow key calls preventDefault and stopPropagation', function () {
+      let propagated = false;
+      this.minimap.minimapWrapper.parentElement.addEventListener(
+        'keydown',
+        () => {
+          propagated = true;
+        },
+      );
+      const event = fireKey(this.minimap.minimapWrapper, 'ArrowUp');
+      assert.isTrue(event.defaultPrevented, 'preventDefault should be called');
+      assert.isFalse(propagated, 'stopPropagation should prevent bubbling');
+    });
+
+    test('Non-arrow keys do not scroll', function () {
+      fireKey(this.minimap.minimapWrapper, 'Enter');
+      fireKey(this.minimap.minimapWrapper, 'Tab');
+      fireKey(this.minimap.minimapWrapper, 'a');
+      assert.isFalse(
+        this.scrollStub.called,
+        'Non-arrow keys should not scroll',
+      );
+    });
+
+    test('Arrow keys with modifier keys do not scroll', function () {
+      fireKey(this.minimap.minimapWrapper, 'ArrowUp', {ctrlKey: true});
+      fireKey(this.minimap.minimapWrapper, 'ArrowDown', {metaKey: true});
+      fireKey(this.minimap.minimapWrapper, 'ArrowLeft', {altKey: true});
+      fireKey(this.minimap.minimapWrapper, 'ArrowRight', {shiftKey: true});
+      assert.isFalse(
+        this.scrollStub.called,
+        'Arrow keys with modifiers should not scroll',
+      );
+    });
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes buggy minimap keyboard nav where you could keyboard nav into that tiny workspace

### Proposed Changes

- Prevents navigating into the mini workspace
- Adds the ability to use arrow keys to pan the workspace while you're focused on the minimap
- Adds appropriate aria label and role
- Adds tests for new functionality

### Reason for Changes

accessibility!

### Test Coverage

added and manually tested

### Documentation

updated readme 

### Additional Information

<!-- Anything else we should know? -->
