### PR TITLE
fix: Fix chaotic glitchiness when using scroll options with keyboard moves

### DIFF
--- a/plugins/scroll-options/src/ScrollBlockDragger.ts
+++ b/plugins/scroll-options/src/ScrollBlockDragger.ts
@@ -155,6 +155,11 @@ export class ScrollBlockDragger extends Blockly.dragging.Dragger {
    * @override
    */
   onDrag(e: PointerEvent, dragDelta: Blockly.utils.Coordinate) {
+    if (Blockly.KeyboardMover.mover.isMoving()) {
+      super.onDrag(e, dragDelta);
+      return;
+    }
+
     const totalDelta = Blockly.utils.Coordinate.sum(
       this.scrollDelta_,
       dragDelta,
@@ -171,6 +176,11 @@ export class ScrollBlockDragger extends Blockly.dragging.Dragger {
    * @override
    */
   onDragEnd(e: PointerEvent) {
+    if (Blockly.KeyboardMover.mover.isMoving()) {
+      super.onDragEnd(e);
+      return;
+    }
+
     super.onDragEnd(e);
     this.stopAutoScrolling();
   }


### PR DESCRIPTION

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes #2710

### Proposed Changes
This PR updates the scroll-options plugin's `Dragger` subclass to be a no-op during keyboard-driven drags. This prevents its behavior and the built-in behavior of moving the workspace when a keyboard-driven block drag reaches the bounds from fighting and causing visual glitches with the scroll position and move indicator. The built-in behavior for keyboard-driven drags is what the plugin provides for mouse-driven drags, so having the plugin disable itself during keyboard drags yields effectively the same behavior as it normally provides.