### PR TITLE
chore: update publishing setup for v13

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,13 +5,16 @@ name: publish
 on:
   workflow_dispatch: # Manually trigger. Colon is required.
     inputs:
+      version:
+        description: 'Version to publish all (non-private) plugins as.'
+        required: true
+        type: string
+        default: '13.1.0'
       from-package:
-        description: 'Check to publish from-package instead of the default publish. This is used to publish packages that have already been version bumped and tagged by a previous workflow run, but failed to publish for some reason.'
+        description: 'Check to publish from-package instead of the default publish. This skips versioning and publishes any package whose package.json version is not yet on npm. Use this to retry a partially-failed run, or to publish a plugin that was previously held back as private (set its version + remove private first).'
         required: false
         type: boolean
         default: false
-  schedule:
-    - cron: '5 17 * * 4' # Thursdays at 17:05 UTC (09:05 PST / 10:05 PDT)
 
 permissions:
   id-token: write # Required for OIDC.
@@ -62,12 +65,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FROM_PACKAGE: ${{ github.event.inputs['from-package'] }}
+          VERSION: ${{ github.event.inputs.version }}
         run: |
           cd plugins
           if [ "${FROM_PACKAGE}" = "true" ]; then
-            npx lerna publish from-package --yes --loglevel silly
+            npx lerna publish from-package --no-private --yes --loglevel silly
           else
-            npx lerna publish --no-private --conventional-commits --create-release github --yes --loglevel silly
+            npx lerna publish "${VERSION}" --no-private --force-publish --conventional-commits --create-release github --yes --loglevel silly
           fi
 
   update-gh-pages:

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "independent",
+  "version": "13.1.0",
   "npmClient": "npm",
   "changelogPreset": {
     "name": "conventionalcommits"

--- a/plugins/field-bitmap/package.json
+++ b/plugins/field-bitmap/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blockly/field-bitmap",
   "version": "6.0.9",
+  "private": true,
   "description": "A field that lets users input a pixel grid with their mouse.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",

--- a/plugins/field-colour-hsv-sliders/package.json
+++ b/plugins/field-colour-hsv-sliders/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blockly/field-colour-hsv-sliders",
   "version": "6.0.12",
+  "private": true,
   "description": "A Blockly colour field using HSV sliders.",
   "scripts": {
     "audit:fix": "blockly-scripts auditFix",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

Allows us to publish all the plugins we want to at v13.1.0, matching the latest release of Blockly.

### Proposed Changes

- Changes lerna from independent to locked versioning.
- Sets two field plugins that aren't ready to be published yet as private.
- Updates the publish workflow to take in a proposed value and publish all plugins as that value.
- A byproduct of this change is that there will now just be one tag per version, not one tag per plugin per version. This is a welcome change as having 4000 tags noticeably slows down the download time for the repo.

changed outside of this pr:
- added a tag `v13.0.0` tagged on the last release we did. this enables the changelog tobe calculated correctly given the last bullet point above.

notably NOT changed:
- the manual publish scripts meant to be run from CLI. these are out of date and should not be used and most people will lack the credentials to use them anyway.



### Reason for Changes

- Publishing all plugins at a fixed version number that matches Blockly allows developers to have a clearer understanding of which version of plugins + Blockly to use.

### Test Coverage

Tested locally with dry-runs of `lerna version` and verified that:

- plugin versions are bumped as expected
- private plugins are not bumped
- changelog generation is correct

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

<!-- Anything else we should know? -->
