### PR TITLE
chore: update developer-tools for ts 6 and webpack 7

### DIFF
--- a/examples/developer-tools/package.json
+++ b/examples/developer-tools/package.json
@@ -6,9 +6,9 @@
   "main": "index.js",
   "scripts": {
     "start": "webpack serve --open --mode=development",
-    "build": "webpack --mode=production --node-env=production",
+    "build": "NODE_ENV=production webpack --mode=production",
     "build:dev": "webpack --mode=development",
-    "build:prod": "webpack --mode=production --node-env=production",
+    "build:prod": "NODE_ENV=production webpack --mode=production",
     "watch": "webpack --watch",
     "serve": "webpack serve",
     "predeploy": "npm run build:prod"

--- a/examples/developer-tools/src/declarations.d.ts
+++ b/examples/developer-tools/src/declarations.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Allow side-effect imports of CSS, which are handled by webpack loaders.
+declare module '*.css';

--- a/examples/developer-tools/src/index.ts
+++ b/examples/developer-tools/src/index.ts
@@ -28,7 +28,7 @@ import {generatorStubGenerator} from './output-generators/generator_stub_generat
 
 // Even though En should be loaded by default,
 // if you don't load it specifically, you'll get spurious message warnings.
-Blockly.setLocale(En);
+Blockly.setLocale(En as unknown as {[key: string]: string});
 
 registerAllBlocks();
 

--- a/examples/developer-tools/tsconfig.json
+++ b/examples/developer-tools/tsconfig.json
@@ -2,10 +2,12 @@
   "include": ["src/**/*"],
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "strict": false,
     "noImplicitAny": true,
     "module": "es6",
     "target": "ES6",
     "allowJs": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0"
   }
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes developer-tools not building

### Proposed Changes

- sets strict mode to off because hella errors with strict mode on
- sets node env via environment variable instead of flag
- fixes type error with v13 locale
- adds declaration for css file that ts wants now

### Reason for Changes

samples was updated to typescript version 6, which among other things set strict mode to true by default. there are lots of errors with strict mode so turning it off for now.

also was updated to webpack 7 which removed support for the `--node-environment` flag we were using.


### Test Coverage

developer-tools builds

### Documentation

<!-- TODO: Does any documentation need to be created or updated because of this PR?
  -        If so please explain.
  -->

### Additional Information

I think the issue with `setLocale` needing the `any` cast is a legit problem in v13, will investigate and fix separately.
