### PR TITLE
fix: FieldGridDropdown recomputeAriaContext no longer throws an error

### DIFF
--- a/plugins/field-grid-dropdown/src/index.ts
+++ b/plugins/field-grid-dropdown/src/index.ts
@@ -131,7 +131,8 @@ export class FieldGridDropdown extends Blockly.FieldDropdown {
    * Updates the ARIA roles and label for this field.
    */
   override recomputeAriaContext(): boolean {
-    super.recomputeAriaContext();
+    const shouldCustomize = super.recomputeAriaContext();
+    if (!shouldCustomize) return false;
     Blockly.utils.aria.setState(
       this.getFocusableElement(),
       Blockly.utils.aria.State.HASPOPUP,


### PR DESCRIPTION
This occured when the zelos renderer was used and the focusable element had not yet been rendered. This change follows the existing pattern in core.

<!--
  - Thanks for submitting code to Blockly!  Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## The basics

<!-- TODO: Verify the following, checking each box with an 'x' between the brackets: [x] -->

- [x] I [validated my changes](https://developers.google.com/blockly/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes https://github.com/RaspberryPiFoundation/blockly-samples/issues/2740

### Proposed Changes

Follow the pattern in core so that recomputeAriaContext doesn't throw if the element has not yet been rendered.

### Reason for Changes

Prevents error when the zelos renderer is used.

### Test Coverage

None added

### Documentation

None

### Additional Information

N/A
