### PR TITLE
chore: update github pages for plugins

### DIFF
--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -26,20 +26,20 @@ jobs:
 
     steps:
       - name: Checkout Blockly-Samples
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.samples_branch || 'main' }}
           path: blockly-samples
 
       - name: Checkout Blockly
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           repository: 'RaspberryPiFoundation/blockly'
           ref: ${{ inputs.core_branch || 'main' }}
           path: blockly
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -48,6 +48,13 @@ jobs:
         working-directory: blockly-samples
         run: |
           npm ci
+
+      - name: Pepare Plugins for deployment
+        working-directory: blockly
+        run: |
+            npx nx reset && lerna run clean --scope '@blockly/*' && \
+            lerna run build --scope '@blockly/*' && \
+            lerna run predeploy --scope '@blockly/*' 
 
       - name: Deploy to GH Pages
         env:

--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -5,8 +5,13 @@ name: Update GitHub Pages
 on:
   workflow_dispatch: # Manually trigger. Colon is required.
     inputs:
-      branch:
-        description: 'Branch to publish from'
+      samples_branch:
+        description: 'Blockly-Samples branch to publish from (for examples)'
+        required: true
+        default: 'main'
+        type: string
+      core_branch:
+        description: 'Blockly core branch to publish from for (plugins)'
         required: true
         default: 'main'
         type: string
@@ -20,10 +25,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout Blockly-Samples
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.branch || 'main' }}
+          ref: ${{ inputs.samples_branch || 'main' }}
+          path: blockly-samples
+
+      - name: Checkout Blockly
+        uses: actions/checkout@v3
+        with:
+          repository: 'RaspberryPiFoundation/blockly'
+          ref: ${{ inputs.core_branch || 'main' }}
+          path: blockly
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -11,7 +11,7 @@ on:
         default: 'main'
         type: string
       core_branch:
-        description: 'Blockly core branch to publish from for (plugins)'
+        description: 'Blockly core branch to publish from (for plugins)'
         required: true
         default: 'main'
         type: string

--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -52,9 +52,9 @@ jobs:
       - name: Pepare Plugins for deployment
         working-directory: blockly
         run: |
-            npx nx reset && lerna run clean --scope '@blockly/*' && \
-            lerna run build --scope '@blockly/*' && \
-            lerna run predeploy --scope '@blockly/*' 
+          npx nx reset && lerna run clean --scope '@blockly/*' && \
+          lerna run build --scope '@blockly/*' && \
+          lerna run predeploy --scope '@blockly/*'
 
       - name: Deploy to GH Pages
         env:

--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: NPM install
         # Use CI so that we don't update dependencies in this step.
+        working-directory: blockly-samples
         run: |
           npm ci
 
@@ -53,6 +54,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # deploys to the current repo,
         # so you can use this workflow from a fork to update your personal gh-pages
+        working-directory: blockly-samples
         run: |
           npm run deploy:prepare
           git remote set-url origin https://git:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git

--- a/.github/workflows/update_gh_pages.yml
+++ b/.github/workflows/update_gh_pages.yml
@@ -43,9 +43,15 @@ jobs:
         with:
           node-version: 24
 
-      - name: NPM install
+      - name: NPM install - Samples
         # Use CI so that we don't update dependencies in this step.
         working-directory: blockly-samples
+        run: |
+          npm ci
+
+      - name: NPM install - Blockly
+        # Use CI so that we don't update dependencies in this step.
+        working-directory: blockly
         run: |
           npm ci
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
   "scripts": {
     "build": "lerna run build --scope '@blockly/*'",
     "clean": "lerna run clean --scope '@blockly/*'",
-    "deploy:prepare": "npm run deploy:prepare:plugins && npm run deploy:prepare:examples && gulp predeploy",
+    "deploy:prepare": "npm run deploy:prepare:examples && gulp predeploy",
     "deploy:prepare:examples": "npm install --workspace=examples && npm run prepare-examples && npm run predeploy --if-present --workspace=examples",
-    "deploy:prepare:plugins": "cd ../blockly && npx nx reset && lerna run clean --scope '@blockly/*' && lerna run build --scope '@blockly/*' && lerna run predeploy --scope '@blockly/*'",
     "deploy": "npm run deploy:prepare && gulp deploy",
     "deploy:upstream": "npm run deploy:prepare && gulp deployUpstream",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "lerna run clean --scope '@blockly/*'",
     "deploy:prepare": "npm run deploy:prepare:plugins && npm run deploy:prepare:examples && gulp predeploy",
     "deploy:prepare:examples": "npm install --workspace=examples && npm run prepare-examples && npm run predeploy --if-present --workspace=examples",
-    "deploy:prepare:plugins": "npm run clean && npm run build && lerna run predeploy --scope '@blockly/*'",
+    "deploy:prepare:plugins": "cd ../blockly && npx nx reset && lerna run clean --scope '@blockly/*' && lerna run build --scope '@blockly/*' && lerna run predeploy --scope '@blockly/*'",
     "deploy": "npm run deploy:prepare && gulp deploy",
     "deploy:upstream": "npm run deploy:prepare && gulp deployUpstream",
     "format": "prettier --write .",

--- a/scripts/copy-blockly.js
+++ b/scripts/copy-blockly.js
@@ -49,7 +49,14 @@ const {copyDirectoryContents} = require('./copy-helpers');
 
     // Also copy local workspace plugins from the `plugins/` directory (this repo).
     try {
-      const pluginsDir = path.resolve(__dirname, '..', '..', 'blockly', 'packages', 'plugins');
+      const pluginsDir = path.resolve(
+        __dirname,
+        '..',
+        '..',
+        'blockly',
+        'packages',
+        'plugins',
+      );
       const pluginDirs = await fs.readdir(pluginsDir, {withFileTypes: true});
       const copiedLocal = [];
       for (const d of pluginDirs) {

--- a/scripts/copy-blockly.js
+++ b/scripts/copy-blockly.js
@@ -49,7 +49,7 @@ const {copyDirectoryContents} = require('./copy-helpers');
 
     // Also copy local workspace plugins from the `plugins/` directory (this repo).
     try {
-      const pluginsDir = path.resolve(__dirname, '..', 'plugins');
+      const pluginsDir = path.resolve(__dirname, '..', '..', 'blockly', 'packages', 'plugins');
       const pluginDirs = await fs.readdir(pluginsDir, {withFileTypes: true});
       const copiedLocal = [];
       for (const d of pluginDirs) {

--- a/scripts/gh-predeploy.js
+++ b/scripts/gh-predeploy.js
@@ -212,7 +212,9 @@ function createExampleTabs(pageRoot, pages, isLocal) {
  */
 function createPluginPage(pluginDir, isLocal) {
   const pluginPath = path.join(PLUGIN_FOLDER_PATH, pluginDir);
-  const packageJson = require(resolveApp(path.join(pluginPath, 'package.json')));
+  const packageJson = require(
+    resolveApp(path.join(pluginPath, 'package.json')),
+  );
   const initialPath = path.join(pluginPath, 'test', 'index.html');
   const initialContents = fs.readFileSync(initialPath).toString();
 
@@ -239,7 +241,9 @@ function createPluginPage(pluginDir, isLocal) {
  *     building for gh-pages.
  */
 function createReadmePage(pluginDir, isLocal) {
-  const packageJson = require(resolveApp(path.join(PLUGIN_FOLDER_PATH, pluginDir, 'package.json')));
+  const packageJson = require(
+    resolveApp(path.join(PLUGIN_FOLDER_PATH, pluginDir, 'package.json')),
+  );
   const initialContents = fs
     .readFileSync(path.join(PLUGIN_FOLDER_PATH, pluginDir, 'README.md'))
     .toString();
@@ -284,7 +288,11 @@ function createReadmePage(pluginDir, isLocal) {
   // Make sure the directory exists, then write to it.
   const dirPath = path.join('gh-pages', 'plugins', pluginDir);
   fs.mkdirSync(dirPath, {recursive: true});
-  fs.writeFileSync(path.join(dirPath, 'README.html'), modifiedContents, 'utf-8');
+  fs.writeFileSync(
+    path.join(dirPath, 'README.html'),
+    modifiedContents,
+    'utf-8',
+  );
 }
 
 /**
@@ -298,9 +306,23 @@ function preparePlugin(pluginDir, isLocal) {
   console.log(`Preparing ${pluginDir} plugin for deployment.`);
   createPluginPage(pluginDir, isLocal);
   createReadmePage(pluginDir, isLocal);
-  const testBundleFilePath = path.join(PLUGIN_FOLDER_PATH, pluginDir, 'build', 'test_bundle.js');
-  const destinationFilePath = path.join('gh-pages', 'plugins', pluginDir, 'build', 'test_bundle.js');
-  if (fs.existsSync(testBundleFilePath) && fs.statSync(testBundleFilePath).isFile()) {
+  const testBundleFilePath = path.join(
+    PLUGIN_FOLDER_PATH,
+    pluginDir,
+    'build',
+    'test_bundle.js',
+  );
+  const destinationFilePath = path.join(
+    'gh-pages',
+    'plugins',
+    pluginDir,
+    'build',
+    'test_bundle.js',
+  );
+  if (
+    fs.existsSync(testBundleFilePath) &&
+    fs.statSync(testBundleFilePath).isFile()
+  ) {
     fs.mkdirSync(path.dirname(destinationFilePath), {recursive: true});
     fs.copyFileSync(testBundleFilePath, destinationFilePath);
   }
@@ -486,7 +508,12 @@ function prepareExample(exampleDir, isLocal, done) {
   const pages = fileList.filter((f) => pageRegex.test(f));
   // Add headers and footers to HTML pages.
   pages.forEach((page) =>
-    createExamplePage(path.join(baseDir, exampleDir), page, demoConfig, isLocal),
+    createExamplePage(
+      path.join(baseDir, exampleDir),
+      page,
+      demoConfig,
+      isLocal,
+    ),
   );
 
   // Copy over all other files mentioned in the demoConfig to the

--- a/scripts/gh-predeploy.js
+++ b/scripts/gh-predeploy.js
@@ -20,6 +20,8 @@ const {copyFilesWithBase, copyDirectoryContents} = require('./copy-helpers');
 const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
 
+const PLUGIN_FOLDER_PATH = path.join('..', 'blockly', 'packages', 'plugins');
+
 /**
  * Inject head HTML for a plugin or example page on gh-pages.
  * @param {string} initialContents The initial page HTML, as a string.
@@ -209,8 +211,9 @@ function createExampleTabs(pageRoot, pages, isLocal) {
  *     building for gh-pages.
  */
 function createPluginPage(pluginDir, isLocal) {
-  const packageJson = require(resolveApp(`plugins/${pluginDir}/package.json`));
-  const initialPath = path.join('plugins', pluginDir, 'test', 'index.html');
+  const pluginPath = path.join(PLUGIN_FOLDER_PATH, pluginDir);
+  const packageJson = require(resolveApp(path.join(pluginPath, 'package.json')));
+  const initialPath = path.join(pluginPath, 'test', 'index.html');
   const initialContents = fs.readFileSync(initialPath).toString();
 
   let contents = injectHeader(
@@ -236,9 +239,9 @@ function createPluginPage(pluginDir, isLocal) {
  *     building for gh-pages.
  */
 function createReadmePage(pluginDir, isLocal) {
-  const packageJson = require(resolveApp(`plugins/${pluginDir}/package.json`));
+  const packageJson = require(resolveApp(path.join(PLUGIN_FOLDER_PATH, pluginDir, 'package.json')));
   const initialContents = fs
-    .readFileSync(`./plugins/${pluginDir}/README.md`)
+    .readFileSync(path.join(PLUGIN_FOLDER_PATH, pluginDir, 'README.md'))
     .toString();
 
   const converter = new showdown.Converter();
@@ -279,9 +282,9 @@ function createReadmePage(pluginDir, isLocal) {
   modifiedContents = injectFooter(modifiedContents);
 
   // Make sure the directory exists, then write to it.
-  const dirString = `./gh-pages/plugins/${pluginDir}/`;
-  fs.mkdirSync(dirString, {recursive: true});
-  fs.writeFileSync(`${dirString}/README.html`, modifiedContents, 'utf-8');
+  const dirPath = path.join('gh-pages', 'plugins', pluginDir);
+  fs.mkdirSync(dirPath, {recursive: true});
+  fs.writeFileSync(path.join(dirPath, 'README.html'), modifiedContents, 'utf-8');
 }
 
 /**
@@ -295,11 +298,12 @@ function preparePlugin(pluginDir, isLocal) {
   console.log(`Preparing ${pluginDir} plugin for deployment.`);
   createPluginPage(pluginDir, isLocal);
   createReadmePage(pluginDir, isLocal);
-  copyFilesWithBase(
-    [path.join('plugins', pluginDir, 'build', 'test_bundle.js')],
-    'plugins',
-    path.join('gh-pages', 'plugins'),
-  );
+  const testBundleFilePath = path.join(PLUGIN_FOLDER_PATH, pluginDir, 'build', 'test_bundle.js');
+  const destinationFilePath = path.join('gh-pages', 'plugins', pluginDir, 'build', 'test_bundle.js');
+  if (fs.existsSync(testBundleFilePath) && fs.statSync(testBundleFilePath).isFile()) {
+    fs.mkdirSync(path.dirname(destinationFilePath), {recursive: true});
+    fs.copyFileSync(testBundleFilePath, destinationFilePath);
+  }
 }
 
 /**
@@ -308,13 +312,12 @@ function preparePlugin(pluginDir, isLocal) {
  *   for deployment to GitHub Pages.
  */
 function getPluginFolders() {
-  const dir = 'plugins';
-  return fs.readdirSync(dir).filter(function (file) {
+  return fs.readdirSync(PLUGIN_FOLDER_PATH).filter(function (file) {
     return (
-      fs.statSync(path.join(dir, file)).isDirectory() &&
-      fs.existsSync(path.join(dir, file, 'package.json')) &&
+      fs.statSync(path.join(PLUGIN_FOLDER_PATH, file)).isDirectory() &&
+      fs.existsSync(path.join(PLUGIN_FOLDER_PATH, file, 'package.json')) &&
       // Only prepare plugins with test pages.
-      fs.existsSync(path.join(dir, file, '/test/index.html'))
+      fs.existsSync(path.join(PLUGIN_FOLDER_PATH, file, '/test/index.html'))
     );
   });
 }
@@ -483,7 +486,7 @@ function prepareExample(exampleDir, isLocal, done) {
   const pages = fileList.filter((f) => pageRegex.test(f));
   // Add headers and footers to HTML pages.
   pages.forEach((page) =>
-    createExamplePage(`${baseDir}/${exampleDir}`, page, demoConfig, isLocal),
+    createExamplePage(path.join(baseDir, exampleDir), page, demoConfig, isLocal),
   );
 
   // Copy over all other files mentioned in the demoConfig to the


### PR DESCRIPTION
- [x] I [validated my changes](https://docs.blockly.com/guides/contribute/samples#making_and_verifying_a_change)

## The details
### Resolves

<!-- TODO: What Github issue does this resolve? Please include a link. -->
Fixes [#7767](https://github.com/RaspberryPiFoundation/blockly/issues/7767)

### Proposed Changes

This updates the Blockly-Samples github pages to pull in the code from the core repo but still host on blockly-samples. There are no changes to how examples are hosted or built.

### Reason for Changes

The plugins have moved to core, so we need to pull the code from there rather than from the stale and soon-to-be-deleted directory on the samples repo.